### PR TITLE
Fixes a bug that links the interruptor dispatcher even when there are no interruptors.

### DIFF
--- a/src/ld65/exports.c
+++ b/src/ld65/exports.c
@@ -399,20 +399,25 @@ Export* ReadExport (FILE* F, ObjData* O)
      */
     for (I = 0; I < CD_TYPE_COUNT; ++I) {
         const ConDesImport* CDI;
-        if (E->ConDes[I] != CD_PRIO_NONE && (CDI = ConDesGetImport (I)) != 0) {
 
+        if (E->ConDes[I] != CD_PRIO_NONE && (CDI = ConDesGetImport (I)) != 0) {
             unsigned J;
 
-            /* Generate a new import and insert it */
-            Import* Imp = InsertImport (GenImport (CDI->Name, CDI->AddrSize));
+            /* Generate a new import, and add it to the module's import list. */
+            Import* Imp = GenImport (CDI->Name, CDI->AddrSize);
 
-            /* Add line info for the config file and for the export that is
-             * actually the condes that forces the import.
+            Imp->Obj = O;
+            CollAppend (&O->Imports, Imp);
+
+            /* Add line info for the export that is actually the condes that
+             * forces the import.  Then, add line info for the config. file.
+             * The export's info is added first because the import pretends
+             * that it came from the object module instead of the config. file.
              */
-            CollAppend (&Imp->RefLines, GenLineInfo (&CDI->Pos));
             for (J = 0; J < CollCount (&E->DefLines); ++J) {
                 CollAppend (&Imp->RefLines, DupLineInfo (CollAt (&E->DefLines, J)));
             }
+            CollAppend (&Imp->RefLines, GenLineInfo (&CDI->Pos));
         }
     }
 


### PR DESCRIPTION
If a program is built, for most of the targets, without any interruptors in it, then it will crash as soon as an interrupt occurs.

When interruptors (interrupt handler subroutines) are linked into a program, a piece of code that calls each of those interruptors should be included in that program.  When they aren't linked in, that piece of code shouldn't be included.  That decision is done indirectly.  A target's linker configuration file defines a symbol name that's supposed to be imported from the function library _only if_ a CONDES actor (e.g., an interruptor) is linked.  The module (e.g., a dispatcher) that exports that name will be linked, too, when the symbol name exists.

But, a bug in ld65 _always_ imports those names!  Therefore, the interruptor dispatcher always is in a program.  When an interrupt occurs (while the program is running), the dispatcher tries to call an interruptor.  But, if there aren't any interruptors in the program, then garbage code is called!

While a program is being built, ld65 will notice when CONDES actors are used; and, it will generate the requested symbol name.  The bug puts that import symbol into the wrong list.  It's put into the list of linker-generated, therefore permanent, names.  It should go into the temporary list of names from the (library) object module that triggerred that import.  (That list is discarded if the module isn't linked into the program.)  (So, the name `__CALLIRQ__` is created by the linker; but, we don't want it to act that way.  We want it to disappear if the interruptor isn't used.)

This patch (commit) sends those names to the proper list.  Therefore, programs without interruptors won't be built to crash.
