### PR TITLE
Improved CBM scrcode assembly-macroes.

### DIFF
--- a/asminc/cbm.mac
+++ b/asminc/cbm.mac
@@ -2,20 +2,8 @@
 
 ; Helper macro that converts and outputs one character
 .macro _scrcode char
-        .if (char >= '@' .and char <= 'z')
-                .byte   (char - '@')
-        .elseif (char >= 'A' .and char <= 'Z')
-                .byte   (char - 'A' + 65)
-        .elseif (char = '[')
-                .byte   27
-        .elseif (char = ']')
-                .byte   29
-        .elseif (char = '^')
-                .byte   30
-        .elseif (char = '_')
-                .byte   31
-        .elseif (char < 256)
-                .byte   char
+        .if (char < 256)
+                .byte   <(.strat ("h@dbdlhh", char >> 5) << 4) ^ char
         .else
                 .error  "scrcode: Character constant out of range"
         .endif
@@ -24,7 +12,7 @@
 .macro  scrcode arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9
 
         ; Bail out if next argument is empty
-        .if     .blank (arg1)
+        .if     .blank ({arg1})
                 .exitmacro
         .endif
 


### PR DESCRIPTION
CBM (and Atari) machines have two character-encodings:
- PetSCII (and AtASCII) that is used in programs and files,
- screen-codes that are put in the screen RAM (they are subscripts into an array of font data).  The scrcode macroes translate that first encoding into the second one during assembly, so that programs can store text directly onto the screen, instead of sending it through output functions.

The new CBM _scrcode macro is smaller because it takes advantage of the fact that:
- the encodings can be divided into groups;
- the size of those groups is a power of two;
- within each group, the encodings are related by a simple exclusive-or with a constant
  value.
