### PR TITLE
Fixed two <ctype.h> functions.

### DIFF
--- a/include/ctype.h
+++ b/include/ctype.h
@@ -6,7 +6,7 @@
 /*                                                                           */
 /*                                                                           */
 /*                                                                           */
-/* (C) 1998-2009, Ullrich von Bassewitz                                      */
+/* (C) 1998-2013, Ullrich von Bassewitz                                      */
 /*                Roemerstrasse 52                                           */
 /*                D-70794 Filderstadt                                        */
 /* EMail:         uz@cc65.org                                                */
@@ -40,14 +40,14 @@
 /* The array containing character classification data */
 extern unsigned char _ctype[256];
 
-/* Bits used to specify characters classes */
+/* Bits used to specify character classes */
 #define _CT_LOWER      	0x01   	/* 0 - Lower case char */
 #define _CT_UPPER   	0x02   	/* 1 - Upper case char */
 #define _CT_DIGIT   	0x04	/* 2 - Numeric digit */
-#define _CT_XDIGIT     	0x08	/* 3 - Hex digit (both, lower and upper) */
+#define _CT_XDIGIT     	0x08	/* 3 - Hex digit (both lower and upper) */
 #define _CT_CNTRL      	0x10	/* 4 - Control character */
 #define _CT_SPACE   	0x20	/* 5 - The space character itself */
-#define _CT_OTHER_WS	0x40 	/* 6 - Other whitespace ('\f', '\n', '\r', '\t' and '\v') */
+#define _CT_OTHER_WS	0x40 	/* 6 - Other whitespace ('\f', '\n', '\r', '\t', and '\v') */
 #define _CT_SPACE_TAB	0x80 	/* 7 - Space or tab character */
 
 /* Bit combinations */
@@ -79,17 +79,17 @@ int __fastcall__ tolower (int c); 	/* Always external */
 
 #if __CC65_STD__ >= __CC65_STD_CC65__
 unsigned char __fastcall__ toascii (unsigned char c);
-/* Convert a target specific character to ascii */
+/* Convert a target-specific character to ASCII. */
 #endif
 
 
 
-/* When inlining of known function is enabled, overload most of the above
- * functions by macros. The function prototypes are again available after
- * #undef'ing the macros.
- * Please note that the following macros do NOT handle EOF correctly, as
+/* When inlining-of-known-functions is enabled, overload most of the above
+ * functions by macroes. The function prototypes are available again after
+ * #undef'ing the macroes.
+ * Please note that the following macroes do NOT handle EOF correctly, as
  * stated in the manual. If you need correct behaviour for EOF, don't
- * use -Os, or #undefine the following macros.
+ * use -Os, or #undefine the following macroes.
  */
 #ifdef __OPT_s__
 
@@ -128,8 +128,10 @@ unsigned char __fastcall__ toascii (unsigned char c);
 #define isgraph(c)  (__AX__ = (c),                      \
                     __asm__ ("tay"),                    \
 	       	    __asm__ ("lda %v,y", _ctype),       \
-		    __asm__ ("eor #%b", _CT_NOT_GRAPH), \
-	       	    __asm__ ("and #%b", _CT_NOT_GRAPH), \
+		    __asm__ ("and #%b", _CT_NOT_GRAPH), \
+	       	    __asm__ ("cmp #1"),                 \
+	       	    __asm__ ("lda #1"),                 \
+	       	    __asm__ ("sbc #1"),                 \
                     __AX__)
 
 #define islower(c)  (__AX__ = (c),                      \
@@ -141,15 +143,17 @@ unsigned char __fastcall__ toascii (unsigned char c);
 #define isprint(c)  (__AX__ = (c),                      \
                     __asm__ ("tay"),                    \
 	       	    __asm__ ("lda %v,y", _ctype),       \
-	       	    __asm__ ("eor #%b", _CT_NOT_PRINT), \
 	       	    __asm__ ("and #%b", _CT_NOT_PRINT), \
+	       	    __asm__ ("eor #%b", _CT_NOT_PRINT), \
                     __AX__)
 
 #define ispunct(c)  (__AX__ = (c),                      \
                     __asm__ ("tay"),                    \
 	       	    __asm__ ("lda %v,y", _ctype),       \
-	       	    __asm__ ("eor #%b", _CT_NOT_PUNCT), \
 	       	    __asm__ ("and #%b", _CT_NOT_PUNCT), \
+	       	    __asm__ ("cmp #1"),                 \
+	       	    __asm__ ("lda #1"),                 \
+	       	    __asm__ ("sbc #1"),                 \
                     __AX__)
 
 #define isspace(c)  (__AX__ = (c),                      \

--- a/libsrc/common/isgraph.s
+++ b/libsrc/common/isgraph.s
@@ -1,5 +1,6 @@
 ;
-; Ullrich von Bassewitz, 02.06.1998
+; 1998-06-02, Ullrich von Bassewitz
+; 2013-05-01, Greg King
 ;
 ; int isgraph (int c);
 ;
@@ -8,15 +9,17 @@
 	.include	"ctype.inc"
 
 _isgraph:
-	cpx	#$00		; Char range ok?
+	cpx	#>0		; Char range OK?
 	bne	@L1		; Jump if no
 	tay
 	lda	__ctype,y	; Get character classification
-       	eor    	#CT_CTRL_SPACE	; NOT control and NOT space
-	and 	#CT_CTRL_SPACE	; Mask character bits
-	rts
+	and	#CT_CTRL_SPACE	; Mask character bits
+	cmp	#1		; If false, then set "borrow" flag
+	lda	#0
+	sbc	#0		; Invert logic
+	rts			; Return NOT control and NOT space
 
-@L1:	lda	#$00		; Return false
+@L1:	lda	#<0		; Return false
 	tax
 	rts
 

--- a/libsrc/common/ispunct.s
+++ b/libsrc/common/ispunct.s
@@ -1,22 +1,25 @@
 ;
-; Ullrich von Bassewitz, 02.06.1998
+; 1998-06-02, Ullrich von Bassewitz
+; 2013-05-01, Greg King
 ;
 ; int ispunct (int c);
 ;
 
 	.export		_ispunct
-       	.include	"ctype.inc"
+	.include	"ctype.inc"
 
 _ispunct:
-	cpx	#$00		; Char range ok?
+	cpx	#>0		; Char range OK?
 	bne	@L1		; Jump if no
 	tay
 	lda	__ctype,y	; Get character classification
-       	eor    	#CT_NOT_PUNCT	; NOT (space | control | digit | alpha)
-       	and    	#CT_NOT_PUNCT	; Mask relevant bits
-	rts
+	and	#CT_NOT_PUNCT	; Mask relevant bits
+	cmp	#1		; If false, then set "borrow" flag
+	lda	#0
+	sbc	#0		; Invert logic
+	rts			; Return NOT (space | control | digit | alpha)
 
-@L1:	lda	#$00		; Return false
+@L1:	lda	#<0		; Return false
 	tax
 	rts
 


### PR DESCRIPTION
My first conclusion about Eric's patch is half wrong.  His "fix" actually made things worse (it gave wrong results for more characters).  So, I created my own fix.

`isgraph(),` `isprint(),` and `ispunct()` are "negative" functions.  They ask the question, "Is this character _not_ what I want?"  Then, they negate the answer.  The old code used a bit-wise operator to do that negation.  It works for `isprint()` because that function tests only one bit in the `_ctype` table.  It doesn't work for the other functions because they test several bits at the same time (the bit-wise operator negates all of those bits &ndash; including bits that aren't relevant for a particular character).

I replaced that operator with a boolean negation.  A comparison operator sets the virtual "borrow" flag to a state that is the opposite of the accumulator (e.g., the flag becomes zero when the `A` register is _any_ non-zero value).  A subtraction operator translates that borrow flag into an accumulator value that is the function's result.
