### PR TITLE
Removed useless command-line option.

### DIFF
--- a/src/ca65/incpath.c
+++ b/src/ca65/incpath.c
@@ -55,15 +55,6 @@ SearchPath*     BinSearchPath;          /* Binary include path */
 
 
 
-void ForgetAllIncludePaths (void)
-/* Remove all include search paths. */
-{
-    ForgetSearchPath (IncSearchPath);
-    ForgetSearchPath (BinSearchPath);
-}
-
-
-
 void InitIncludePaths (void)
 /* Initialize the include path search list */
 {

--- a/src/ca65/incpath.h
+++ b/src/ca65/incpath.h
@@ -60,9 +60,6 @@ extern SearchPath*      BinSearchPath;          /* Binary include path */
 
 
 
-void ForgetAllIncludePaths (void);
-/* Remove all include search paths. */
-
 void InitIncludePaths (void);
 /* Initialize the include path search list */
 

--- a/src/ca65/main.c
+++ b/src/ca65/main.c
@@ -116,7 +116,6 @@ static void Usage (void)
             "  --debug\t\t\tDebug mode\n"
             "  --debug-info\t\t\tAdd debug info to object file\n"
             "  --feature name\t\tSet an emulation feature\n"
-            "  --forget-inc-paths\t\tForget include search paths\n"
             "  --help\t\t\tHelp (this text)\n"
             "  --ignore-case\t\t\tIgnore case of symbols\n"
             "  --include-dir dir\t\tSet an include directory search path\n"
@@ -434,15 +433,6 @@ static void OptFeature (const char* Opt attribute ((unused)), const char* Arg)
     if (SetFeature (SB_InitFromString (&Feature, Arg)) == FEAT_UNKNOWN) {
       	AbEnd ("Illegal emulation feature: `%s'", Arg);
     }
-}
-
-
-
-static void OptForgetIncPaths (const char* Opt attribute ((unused)),
-                               const char* Arg attribute ((unused)))
-/* Forget all currently defined include paths */
-{
-    ForgetAllIncludePaths ();
 }
 
 
@@ -868,7 +858,6 @@ int main (int argc, char* argv [])
        	{ "--debug",           	0,     	OptDebug     		},
 	{ "--debug-info",      	0,	OptDebugInfo		},
 	{ "--feature",		1,	OptFeature		},
-       	{ "--forget-inc-paths",	0,     	OptForgetIncPaths       },
 	{ "--help",    		0,	OptHelp			},
 	{ "--ignore-case",     	0,	OptIgnoreCase 		},
 	{ "--include-dir",     	1,	OptIncludeDir		},

--- a/src/cc65/incpath.c
+++ b/src/cc65/incpath.c
@@ -55,15 +55,6 @@ SearchPath*     UsrIncSearchPath;       /* User include path */
 
 
 
-void ForgetAllIncludePaths (void)
-/* Remove all include search paths. */
-{
-    ForgetSearchPath (SysIncSearchPath);
-    ForgetSearchPath (UsrIncSearchPath);
-}
-
-
-
 void InitIncludePaths (void)
 /* Initialize the include path search list */
 {

--- a/src/cc65/incpath.h
+++ b/src/cc65/incpath.h
@@ -60,9 +60,6 @@ extern SearchPath*      UsrIncSearchPath;       /* User include path */
 
 
 
-void ForgetAllIncludePaths (void);
-/* Remove all include search paths. */
-
 void InitIncludePaths (void);
 /* Initialize the include path search list */
 

--- a/src/cc65/main.c
+++ b/src/cc65/main.c
@@ -118,7 +118,6 @@ static void Usage (void)
             "  --dep-target target\t\tUse this dependency target\n"
             "  --disable-opt name\t\tDisable an optimization step\n"
             "  --enable-opt name\t\tEnable an optimization step\n"
-            "  --forget-inc-paths\t\tForget include search paths\n"
             "  --help\t\t\tHelp (this text)\n"
             "  --include-dir dir\t\tSet an include directory search path\n"
             "  --list-opt-steps\t\tList all optimizer steps and exit\n"
@@ -537,15 +536,6 @@ static void OptEnableOpt (const char* Opt attribute ((unused)), const char* Arg)
 
 
 
-static void OptForgetIncPaths (const char* Opt attribute ((unused)),
-                               const char* Arg attribute ((unused)))
-/* Forget all currently defined include paths */
-{
-    ForgetAllIncludePaths ();
-}
-
-
-
 static void OptHelp (const char* Opt attribute ((unused)),
 		     const char* Arg attribute ((unused)))
 /* Print usage information and exit */
@@ -792,7 +782,6 @@ int main (int argc, char* argv[])
         { "--dep-target",       1,      OptDepTarget            },
 	{ "--disable-opt",	1,	OptDisableOpt		},
 	{ "--enable-opt",	1,	OptEnableOpt  	       	},
-       	{ "--forget-inc-paths",	0,     	OptForgetIncPaths       },
 	{ "--help",	 	0, 	OptHelp	     		},
 	{ "--include-dir",     	1,   	OptIncludeDir		},
 	{ "--list-opt-steps",   0,      OptListOptSteps         },

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -6,7 +6,7 @@
 /*									     */
 /*									     */
 /*									     */
-/* (C) 1999-2012, Ullrich von Bassewitz                                      */
+/* (C) 1999-2013, Ullrich von Bassewitz                                      */
 /*                Roemerstrasse 52                                           */
 /*                D-70794 Filderstadt                                        */
 /* EMail:         uz@cc65.org                                                */
@@ -732,7 +732,6 @@ static void Usage (void)
             "  --debug-info\t\t\tAdd debug info\n"
             "  --feature name\t\tSet an emulation feature\n"
             "  --force-import sym\t\tForce an import of symbol `sym'\n"
-            "  --forget-inc-paths\t\tForget include search paths (compiler)\n"
             "  --help\t\t\tHelp (this text)\n"
             "  --include-dir dir\t\tSet a compiler include directory path\n"
             "  --ld-args options\t\tPass options to the linker\n"
@@ -969,15 +968,6 @@ static void OptForceImport (const char* Opt attribute ((unused)), const char* Ar
 /* Emulation features for the assembler */
 {
     CmdAddArg2 (&LD65, "-u", Arg);
-}
-
-
-
-static void OptForgetIncPaths (const char* Opt attribute ((unused)),
-                               const char* Arg attribute ((unused)))
-/* Forget all currently defined include paths */
-{
-    CmdAddArg (&CC65, "--forget-inc-paths");
 }
 
 
@@ -1261,7 +1251,6 @@ int main (int argc, char* argv [])
 	{ "--debug-info",    	0,	OptDebugInfo		},
 	{ "--feature",	     	1,	OptFeature		},
         { "--force-import",     1,      OptForceImport          },
-       	{ "--forget-inc-paths",	0,     	OptForgetIncPaths       },
 	{ "--help",	     	0,	OptHelp			},
 	{ "--include-dir",   	1,	OptIncludeDir		},
         { "--ld-args",          1,      OptLdArgs               },

--- a/src/common/searchpath.c
+++ b/src/common/searchpath.c
@@ -6,7 +6,7 @@
 /*                                                                           */
 /*                                                                           */
 /*                                                                           */
-/* (C) 2000-2010, Ullrich von Bassewitz                                      */
+/* (C) 2000-2013, Ullrich von Bassewitz                                      */
 /*                Roemerstrasse 52                                           */
 /*                D-70794 Filderstadt                                        */
 /* EMail:         uz@cc65.org                                                */
@@ -233,18 +233,6 @@ void PopSearchPath (SearchPath* P)
     /* Remove the path at position 0 */
     xfree (CollAt (P, 0));
     CollDelete (P, 0);
-}
-
-
-
-void ForgetSearchPath (SearchPath* P)
-/* Forget all search paths in the given list */
-{
-    unsigned I;
-    for (I = 0; I < CollCount (P); ++I) {
-        xfree (CollAt (P, I));
-    }
-    CollDeleteAll (P);
 }
 
 

--- a/src/common/searchpath.h
+++ b/src/common/searchpath.h
@@ -6,7 +6,7 @@
 /*                                                                           */
 /*                                                                           */
 /*                                                                           */
-/* (C) 2000-2010, Ullrich von Bassewitz                                      */
+/* (C) 2000-2013, Ullrich von Bassewitz                                      */
 /*                Roemerstrasse 52                                           */
 /*                D-70794 Filderstadt                                        */
 /* EMail:         uz@cc65.org                                                */
@@ -93,9 +93,6 @@ int PushSearchPath (SearchPath* P, const char* NewPath);
 
 void PopSearchPath (SearchPath* P);
 /* Remove a search path from the head of an existing search path list */
-
-void ForgetSearchPath (SearchPath* P);
-/* Forget all search paths in the given list */
 
 char* SearchFile (const SearchPath* P, const char* File);
 /* Search for a file in a list of directories. Return a pointer to a malloced


### PR DESCRIPTION
We can forget `--forget-inc-paths`.
