### PR TITLE
Added two useful opcode mnemonic aliases.

### DIFF
--- a/asminc/generic.mac
+++ b/asminc/generic.mac
@@ -43,3 +43,13 @@ L:
         bcc     Arg
 .endmacro
 
+; bnz - jump if not zero
+.macro  bnz     Arg
+        bne     Arg
+.endmacro
+
+; bze - jump if zero
+.macro  bze     Arg
+        beq     Arg
+.endmacro
+


### PR DESCRIPTION
`bnz` -- jump if not zero.
`bze` -- jump if zero.

Those mnemonics are useful in some code contexts, such as loops:

``` asm
    ldx #0
loop:
    lda string,x
    bze exit
    sta buffer,x
    inx
    bnz loop
exit:
    rts
```

Their meanings make more sense there than the original mnemonics, `beq` and `bne`, do.
