### PR TITLE
Made geos-apple's file-converter depend on apple2enh's library.

### DIFF
--- a/libsrc/geos-apple/targetutil/Makefile.inc
+++ b/libsrc/geos-apple/targetutil/Makefile.inc
@@ -5,7 +5,10 @@ DEPS += ../wrk/$(TARGET)/convert.d
 ../wrk/$(TARGET)/convert.o: $(SRCDIR)/targetutil/convert.c | ../wrk/$(TARGET)
 	$(COMPILE_recipe)
 
-../targetutil/convert.system: ../wrk/$(TARGET)/convert.o | ../targetutil
-	$(LD) -o $@ -C apple2enh-system.cfg $^ apple2enh.lib
+../lib/apple2enh.lib:
+	@$(MAKE) --no-print-directory apple2enh
+
+../targetutil/convert.system: ../wrk/$(TARGET)/convert.o ../lib/apple2enh.lib | ../targetutil
+	$(LD) -o $@ -C apple2enh-system.cfg $^
 
 $(TARGET): ../targetutil/convert.system


### PR DESCRIPTION
The geos-apple target will build that library if it doesn't exist.  The `apple2enh.lib` rule in the `Makefile.inc` file doesn't conflict with the library rule in `libsrc/Makefile` because they have different `$(TARGET)` directories when both rules exist.

P.S., We _can_ just add a simple dependency, because the use of individual make instances isolates the processed makefiles, and avoids complications.
