### PR TITLE
Document the C64 and the C128 Inkwell lightpen drivers.

### DIFF
--- a/doc/c128-5.html
+++ b/doc/c128-5.html
@@ -127,17 +127,7 @@ the C128.</P>
 C128.  It can read both the one-button 170-C and the two-button 184-C pens.
 (It can read other lightpens and light-guns that send their button signal to
 the joystick left-button pin or the paddle Y [up/down] pin.)  It works on
-only the 40-column screen &mdash; it will change the C128 over to that
-screen if necessary!</P>
-<P>When the driver is installed, it shows a white bar across the screen, with a
-dark line drawn down the center.  Point the lightpen at that center line,
-and tap the primary button.  That action will calibrate the driver to the
-video display and the lightpen.  Then, point the pen at either blue region
-(above or below the white bar), and tap the primary button to continue with
-the program.</P>
-<P>Note:  A program that creates a sprite pointer for this driver should do it
-<EM>before</EM> installing the driver, so that the pointer can be seen during the
-calibration act.</P>
+only the 40-column screen.</P>
 
 <DT><B><CODE>c128-joy.mou (c128_joy_mou)</CODE></B><DD>
 <P>Supports a mouse emulated by a standard joystick e.g. 1350 mouse in port

--- a/doc/c64-6.html
+++ b/doc/c64-6.html
@@ -136,15 +136,6 @@ the firebutton is labeled &#34;5&#34; and ENTER.</P>
 It can read both the one-button 170-C and the two-button 184-C pens.  (It can
 read other lightpens and light-guns that send their button signal to the
 joystick left-button pin or the paddle Y [up/down] pin.)</P>
-<P>When the driver is installed, it shows a white bar across the screen, with a
-dark line drawn down the center.  Point the lightpen at that center line,
-and tap the primary button.  That action will calibrate the driver to the
-video display and the lightpen.  Then, point the pen at either blue region
-(above or below the white bar), and tap the primary button to continue with
-the program.</P>
-<P>Note:  A program that creates a sprite pointer for this driver should do it
-<EM>before</EM> installing the driver, so that the pointer can be seen during the
-calibration act.</P>
 
 <DT><B><CODE>c64-joy.mou (c64_joy_mou)</CODE></B><DD>
 <P>Supports a mouse emulated by a standard joystick e.g. 1350 mouse in port


### PR DESCRIPTION
Here are the doc/ files that go with pull request #12.
