### PR TITLE
Fix writing one byte beyond screen buffer.

### DIFF
--- a/libsrc/atari/clrscr.s
+++ b/libsrc/atari/clrscr.s
@@ -9,26 +9,26 @@
         .importzp       ptr1
         .import         setcursor
 
+SCRSIZE =       960             ; 40x24: size of default atari screen
+
 _clrscr:lda     SAVMSC          ; screen memory
         sta     ptr1
         lda     SAVMSC+1
         clc
-        adc     #>(40*24)
+        adc     #>(SCRSIZE-1)
         sta     ptr1+1
         lda     #0              ; screen code of space char
         sta     OLDCHR
-        ldy     #<(40*24)       ; 40x24: size of default atari screen
-        ldx     #>(40*24)
+        ldy     #<(SCRSIZE-1)
+        ldx     #>(SCRSIZE-1)
 _clr1:  sta     (ptr1),y
         dey
         bne     _clr1
         sta     (ptr1),y
         dex
         bmi     done
-        ldy     ptr1+1
+        dec     ptr1+1
         dey
-        sty     ptr1+1
-        ldy     #255
         jmp     _clr1
 
 done:   sta     COLCRS


### PR DESCRIPTION
This fixes a > 10yr old bug writing one byte beyond the screen buffer.
It also add a small optimization.
