### PR TITLE
move findfreeiocb function into its own object file

### DIFF
--- a/libsrc/atari/fdtable.s
+++ b/libsrc/atari/fdtable.s
@@ -11,7 +11,6 @@
         .import fdt_to_fdi
         .export clriocb
         .export fdtoiocb_down
-        .export findfreeiocb
         .export fddecusage
         .export newfd
 
@@ -85,31 +84,6 @@ loop:   sta     ICHID,x
         rts
 
 .endproc
-
-
-; find a free iocb
-; no entry parameters
-; return ZF = 0/1 for not found/found
-;        index in X if found
-; all registers destroyed
-
-.proc   findfreeiocb
-
-        ldx     #0
-        ldy     #$FF
-loop:   tya
-        cmp     ICHID,x
-        beq     found
-        txa
-        clc
-        adc     #$10
-        tax
-        cmp     #$80
-        bcc     loop
-        inx                     ; return ZF cleared
-found:  rts
-
-.endproc        ; findfreeiocb
 
 
 ; decrements usage counter for fd

--- a/libsrc/atari/findfreeiocb.inc
+++ b/libsrc/atari/findfreeiocb.inc
@@ -1,0 +1,23 @@
+; find a free iocb
+; no entry parameters
+; return ZF = 0/1 for not found/found
+;        index in X if found
+; all registers destroyed
+
+.proc   findfreeiocb
+
+        ldx     #0
+        ldy     #$FF
+loop:   tya
+        cmp     ICHID,x
+        beq     found
+        txa
+        clc
+        adc     #$10
+        tax
+        cmp     #$80
+        bcc     loop
+        inx                     ; return ZF cleared
+found:  rts
+
+.endproc        ; findfreeiocb

--- a/libsrc/atari/findfreeiocb.s
+++ b/libsrc/atari/findfreeiocb.s
@@ -1,0 +1,7 @@
+;
+; Christian Groessler, June-2013
+;
+
+        .include "atari.inc"
+        .export findfreeiocb
+        .include "findfreeiocb.inc"


### PR DESCRIPTION
Makes sense anyway in order not to pull in all the stuff from fdtable.s.
Implemented with this .inc file because it will also be used by the 2nd load chunk in the xl target.
