### PR TITLE
close IOCB if open failed -- otherwise it is still marked as "in use"

### DIFF
--- a/libsrc/atari/graphics.s
+++ b/libsrc/atari/graphics.s
@@ -10,7 +10,7 @@
         .export __graphics
 
         .import findfreeiocb
-        .import __do_oserror,__oserror
+        .import __oserror
         .import fddecusage
         .import clriocb
         .import fdtoiocb
@@ -96,8 +96,13 @@ doopen: txa
         stx     __oserror
         rts
 
-cioerr: jsr     fddecusage      ; decrement usage counter of fd as open failed
-        jmp     __do_oserror
+cioerr: sty     tmp3            ; remember error code
+        lda     #CLOSE
+        sta     ICCOM,x
+        jsr     CIOV            ; close IOCB again since open failed
+        jsr     fddecusage      ; and decrement usage counter of fd
+        lda     tmp3            ; put error code into A
+        jmp     __mappederrno
 
 .endproc        ; __graphics
 

--- a/libsrc/atari/open.s
+++ b/libsrc/atari/open.s
@@ -140,8 +140,12 @@ finish: php
         plp
 
         bpl     ok
-        jsr     fddecusage      ; decrement usage counter of fd as open failed
-        tya                     ; put error code into A
+        sty     tmp3            ; remember error code
+        lda     #CLOSE
+        sta     ICCOM,x
+        jsr     CIOV            ; close IOCB again since open failed
+        jsr     fddecusage      ; and decrement usage counter of fd
+        lda     tmp3            ; put error code into A
         jmp     __mappederrno
 
 ok:     lda     tmp2            ; get fd

--- a/libsrc/atari/posixdirent.s
+++ b/libsrc/atari/posixdirent.s
@@ -63,6 +63,9 @@
 .endproc
 
 cioerr:         sty     __oserror
+                lda     #CLOSE
+                sta     ICCOM,x
+                jsr     CIOV            ; close IOCB again since open failed
                 jmp     return0
 
 .proc   _readdir


### PR DESCRIPTION
You never cease to learn...

On the Atari, if an "open" call fails, the IOCB is still marked to be in use and needs to be closed in order to release it.
This patch implements this for the "open" calls in the runtime library except for the calls in the TGI drivers. There the return status of "open" currently isn't checked at all, which needs to be addressed in the future.
