### PR TITLE
fix '_sysrmdir' for SpartaDOS

### DIFF
--- a/asminc/atari.inc
+++ b/asminc/atari.inc
@@ -55,6 +55,7 @@ NOTE    = $26           ;note sector
 GETFL   = $27           ;get file length
 CHDIR_MYDOS     = $29   ;change directory (MyDOS)
 MKDIR   = $2A           ;make directory (MyDOS/SpartaDOS)
+RMDIR   = $2B           ;remove directory (SpartaDOS)
 CHDIR_SPDOS     = $2C   ;change directory (SpartaDOS)
 FORMAT  = $FE           ;format
 

--- a/libsrc/atari/sysrmdir.s
+++ b/libsrc/atari/sysrmdir.s
@@ -1,10 +1,97 @@
 ;
 ; Stefan Haubenthal, 2005-12-24
+; Christian Groessler, 2013-07-16
 ;
 ; unsigned char __fastcall__ _sysrmdir (const char* name);
 ;
+; for SpartaDOS and MyDOS
+;
 
+        .include        "atari.inc"
+        .include        "errno.inc"
         .export         __sysrmdir
         .import         __sysremove
+        .import         __dos_type
+        .import         ucase_fn
+        .import         findfreeiocb
+        .import         addysp
+        .importzp       sreg
+        .importzp       tmp3
+        .importzp       tmp4
 
-__sysrmdir := __sysremove
+.proc   __sysrmdir
+
+        pha
+        lda     __dos_type
+        beq     not_impl                ; AtariDOS
+        cmp     #OSADOS+1
+        bcc     do_sparta               ; OS/A and SpartaDOS
+        pla
+        jmp     __sysremove             ; MyDOS and others (TODO: check XDOS)
+
+not_impl:
+        pla
+        lda     #NVALID
+        rts
+
+iocberr:
+        pla                             ; cleanup stack
+        pla
+        lda     #TMOF
+        rts
+
+do_sparta:
+        txa
+        pha
+        jsr     findfreeiocb
+        bne     iocberr                 ; no IOCB available
+
+        stx     tmp4                    ; remember IOCB
+        pla
+        tax
+        pla
+
+.ifdef  UCASE_FILENAME
+
+        jsr     ucase_fn
+        bcc     ucok1
+
+        lda     #183                    ; see oserror.s
+        rts
+ucok1:
+
+.endif  ; defined UCASE_FILENAME
+
+        ldy     tmp4                    ; IOCB index
+        sta     ICBAL,y                 ; store pointer to filename
+        txa
+        sta     ICBAH,y
+        tya
+        tax
+        lda     #RMDIR
+        sta     ICCOM,x
+        lda     #0
+        sta     ICAX1,x
+        lda     #0
+        sta     ICAX2,x
+        sta     ICBLL,x
+        sta     ICBLH,x
+        jsr     CIOV
+
+.ifdef  UCASE_FILENAME
+        tya
+        pha
+        ldy     tmp3                    ; get size
+        jsr     addysp                  ; free used space on the stack
+        pla
+        tay
+.endif  ; defined UCASE_FILENAME
+
+        bmi     cioerr
+        lda     #0
+        rts
+
+cioerr: tya
+        rts
+
+.endproc        ; __sysrmdir


### PR DESCRIPTION
The current implementation of _sysrmdir uses the same CIO command code as for removing files. This works for MyDOS, but SpartaDOS uses a different command to remove directories.
This patch changes the _sysrmdir function to issue the correct command on SpartaDOS.
