### PR TITLE
override _sys() function for Atari targets

### DIFF
--- a/libsrc/atari/_sys.s
+++ b/libsrc/atari/_sys.s
@@ -6,7 +6,7 @@
 ;   'atarixl'  doesn't support the _sys() function
 ;
 
-.if .not .defined(__ATARIXL__)
+.ifndef __ATARIXL__
 
 .include "../common/_sys.s"
 


### PR DESCRIPTION
The _sys() function is not supported in the upcoming atarixl target.
This change makes sure that the user gets a link error if (s)he tries to use _sys() in an atarixl program.
