### PR TITLE
Hide an unneeded ar65 status message.

### DIFF
--- a/src/ar65/library.c
+++ b/src/ar65/library.c
@@ -6,7 +6,7 @@
 /*                                                                           */
 /*                                                                           */
 /*                                                                           */
-/* (C) 1998-2012, Ullrich von Bassewitz                                      */
+/* (C) 1998-2013, Ullrich von Bassewitz                                      */
 /*                Roemerstrasse 52                                           */
 /*                D-70794 Filderstadt                                        */
 /* EMail:         uz@cc65.org                                                */
@@ -38,6 +38,7 @@
 #include <errno.h>
 
 /* common */
+#include "cmdline.h"
 #include "exprdefs.h"
 #include "libdefs.h"
 #include "print.h"
@@ -60,7 +61,7 @@
 /*****************************************************************************/
 
 
-                        
+
 /* Name of the library file */
 const char*             LibName = 0;
 
@@ -101,7 +102,7 @@ static void ReadHeader (void)
     }
     Header.Flags   = Read16 (Lib);
     Header.IndexOffs = Read32 (Lib);
-}                                                  
+}
 
 
 
@@ -229,7 +230,9 @@ void LibOpen (const char* Name, int MustExist, int NeedTemp)
         if (MustExist) {
             Error ("Library `%s' does not exist", Name);
         } else {
-            Warning ("Library `%s' not found - will be created", Name);
+            /* Announce the library's creation if ar65 is verbose. */
+            Print (stdout, 1,
+                   "%s: Library `%s' will be created.\n", ProgName, Name);
         }
 
     } else {
@@ -307,7 +310,7 @@ static void LibCheckExports (ObjData* O)
     unsigned I;
 
     /* Let the user know what we do */
-    Print (stdout, 1, "Module `%s' (%u exports):\n", O->Name, CollCount (&O->Exports));
+    Print (stdout, 2, "Module `%s' (%u exports):\n", O->Name, CollCount (&O->Exports));
 
     /* Insert the exports into the global table */
     for (I = 0; I < CollCount (&O->Exports); ++I) {
@@ -316,7 +319,7 @@ static void LibCheckExports (ObjData* O)
         const char* Name = CollConstAt (&O->Exports, I);
 
         /* Insert the name into the hash table */
-        Print (stdout, 1, "  %s\n", Name);
+        Print (stdout, 2, "  %s\n", Name);
         ExpInsert (Name, O);
     }
 }

--- a/src/ar65/main.c
+++ b/src/ar65/main.c
@@ -6,7 +6,7 @@
 /*                                                                           */
 /*                                                                           */
 /*                                                                           */
-/* (C) 1998-2012, Ullrich von Bassewitz                                      */
+/* (C) 1998-2013, Ullrich von Bassewitz                                      */
 /*                Roemerstrasse 52                                           */
 /*                D-70794 Filderstadt                                        */
 /* EMail:         uz@cc65.org                                                */
@@ -60,11 +60,12 @@
 static void Usage (void)
 /* Print usage information and exit */
 {
-    printf ("Usage: %s <operation> lib file|module ...\n"
-            "Operation is one of:\n"
+    fprintf (stderr, "Usage: %s <operation ...> lib file|module ...\n"
+            "Operations are some of:\n"
             "\ta\tAdd modules\n"
             "\td\tDelete modules\n"
             "\tl\tList library contents\n"
+            "\tv\tIncrease verbosity (put before other operation)\n"
             "\tx\tExtract modules\n"
             "\tV\tPrint the archiver version\n",
             ProgName);


### PR DESCRIPTION
If **ar65** must create a library file, then it gives us a warinig message.  But, a warning should be given only if an event is something that we prefer didn't happen (even though it isn't fatal).  However, we want library files to be created when they don't exist already.   It's a normal event; we don't need to be told about it.

Therefore, this commit makes the archiver inform, not warn, us about libraries.  And, it shows the line only if we ask to see it (by telling ar65 to be verbose).
