### PR TITLE
fixed timep handling in time()

### DIFF
--- a/libsrc/common/time.s
+++ b/libsrc/common/time.s
@@ -27,10 +27,10 @@
 ; Restore timep and check if it is NULL
 
         pla
-        sta     ptr1
+        sta     ptr1+1
         pla
-        sta     ptr1+1          ; Restore timep
-        ora     ptr1            ; timep == 0?
+        sta     ptr1            ; Restore timep
+        ora     ptr1+1          ; timep == 0?
         beq     @L1
 
 ; timep is not NULL, store the result there


### PR DESCRIPTION
With the original time.s, the following code (on C64):

```
#include <stdio.h>
#include <time.h>
time_t _systime(void) {
    return 999;
}
void main(void) {
    time_t t0 = 100, t1 = 200;
    t0 = time(&t1);
    printf("%ld %ld\n", t0, t1);
}
```

leaves t1 unchanged.
