### PR TITLE
Atari documentation update

### DIFF
--- a/doc/atari-10.html
+++ b/doc/atari-10.html
@@ -2,7 +2,7 @@
 <HTML>
 <HEAD>
  <META NAME="GENERATOR" CONTENT="LinuxDoc-Tools 0.9.69">
- <TITLE>Atari specific information for cc65: Technical details</TITLE>
+ <TITLE>Atari specific information for cc65: Other hints</TITLE>
  <LINK HREF="atari-11.html" REL=next>
  <LINK HREF="atari-9.html" REL=previous>
  <LINK HREF="atari.html#toc10" REL=contents>
@@ -12,125 +12,330 @@
 <A HREF="atari-9.html">Previous</A>
 <A HREF="atari.html#toc10">Contents</A>
 <HR>
-<H2><A NAME="s10">10.</A> <A HREF="atari.html#toc10">Technical details</A></H2>
+<H2><A NAME="s10">10.</A> <A HREF="atari.html#toc10">Other hints</A></H2>
 
 
 
-<H2><A NAME="ss10.1">10.1</A> <A HREF="atari.html#toc10.1"><CODE>atarixl</CODE></A>
+
+<H2><A NAME="ss10.1">10.1</A> <A HREF="atari.html#toc10.1">Function keys</A>
 </H2>
 
 
-
-<H3>General operation</H3>
-
-
-<P>The <CODE>atarixl</CODE> target banks out the ROM while the program is running in
-order to make more memory available to the program.</P>
-<P>The screen memory is by default located at the top of available memory,
-$BFFF if BASIC is not enabled, $9FFF if BASIC is enabled.
-Therefore, in order to create a largest possible continuous memory area,
-the screen memory is moved below the program load address.  This gives
-a memory area from &lt;program load addr&gt; to $CFFF.</P>
-<P>The startup code installs wrappers for interrupt handlers and ROM routines.
-When an interrupt or call to a ROM routine happens, the wrappers enable the
-ROM, call the handler or routine, and disable the ROM again.</P>
-<P>The "wrapping" of the ROM routines is done by changing the ROM entry
-point symbols in <CODE>atari.inc</CODE> to point to the wrapper functions.</P>
-<P>For ROM functions which require input or output buffers, the wrappers
-copy the data as required to buffers in low memory.</P>
-
-<H3><A NAME="xlchunks"></A> Load chunks</H3>
+<P>Function keys are mapped to Atari + number key.</P>
 
 
-<P>An <CODE>atarixl</CODE> program contains three load chunks.</P>
+<H2><A NAME="ss10.2">10.2</A> <A HREF="atari.html#toc10.2">Passing arguments to the program</A>
+</H2>
+
+
+<P>Command line arguments can be passed to <CODE>main()</CODE> when DOS supports it.</P>
 <P>
 <OL>
-<LI>"system check"<BR>
-This load chunk is always loaded at address $2E00, and checks if the system is
-suitable for running the program. It also checks if there is enough room between MEMLO
-and the program start address to move the text mode screen buffer there. If any of the
-checks return false, the loading of the program is aborted.<BR>
-The contents of this chunk come from the SYSCHKCHNK memory area of the linker config file.</LI>
-<LI>"shadow RAM prepare"<BR>
-The second load chunk gets loaded to the selected program load address (default $2400).
-It moves the screen memory below the program load address, copies the character generator
-from ROM to its new place in RAM, and copies the parts of the program which reside in
-high memory below the ROM to their place. The high memory parts are included in this load chunk.<BR>
-At the beginning of this load chunk there is a .bss area, which is not part of the
-EXE file. Therefore the on-disk start address of this load chunk will be higher than the
-selected start address. This .bss area (segment LOWDATA) contains the buffers for the
-double buffering of ROM input and output data.  If you add contents to this segment be aware
-that the contents won't be zero initialized by the startup code.<BR>
-The contents of this chunk come from the SRPREPCHNK memory area of the linker config file.</LI>
-<LI>main program<BR>
-This load chunk is loaded just above the LOWDATA segment, replacing the code of
-the previous load chunk. It contains all remaining code and data sections of the program,
-including the startup code.<BR>
-The contents of this chunk come from the RAM memory area of the linker config file.</LI>
+<LI>Arguments are separated by spaces.</LI>
+<LI>Leading and trailing spaces around an argument are ignored.</LI>
+<LI>The first argument passed to <CODE>main</CODE> is the program name.</LI>
+<LI>A maximum number of 16 arguments (including the program name) are
+supported.                                                       </LI>
 </OL>
 </P>
 
-<H3>Moving screen memory below the program start address</H3>
+
+<H2><A NAME="ss10.3">10.3</A> <A HREF="atari.html#toc10.3">Interrupts</A>
+</H2>
 
 
-<P>When setting a graphics mode, the ROM looks at the RAMTOP location. RAMTOP
-describes the amount of installed memory in pages (RAMTOP is only one byte).
-The screen memory and display list are placed immediately below RAMTOP.</P>
-<P>Now in order to relocate the screen memory to lower memory, the startup code
-puts a value into RAMTOP which causes the ROM routines to allocate the display
-memory below the program start address and then it issues a ROM call to setup
-the regular text mode.</P>
-
-<H3><A NAME="loadaddr"></A> Selecting a good program load address</H3>
+<P>The runtime for the Atari uses routines marked as <CODE>.INTERRUPTOR</CODE> for
+interrupt handlers. Such routines must be written as simple machine language
+subroutines and will be called automatically by the VBI handler code
+when they are linked into a program. See the discussion of the <CODE>.CONDES</CODE>
+feature in the 
+<A HREF="ca65.html">assembler manual</A>.</P>
 
 
-<P>Due to the movement of the screen memory below the program start, there are some
-load addresses which are sub-optimal because they waste memory or prevent a
-higher resolution graphics mode from being enabled.</P>
-<P>There are restrictions at which addresses screen memory (display buffer and display
-list) can be placed. The display buffer cannot cross a 4K boundary and a display
-list cannot cross a 1K boundary.</P>
-<P>The startup code takes this into account when moving the screen memory down.
-If the program start address (aligned to the next lower page boundary) minus
-the screen buffer size would result in a screen buffer which spans a 4K
-boundary, the startup code lowers RAMTOP to this 4K boundary.<BR>
-The size of the screen buffer in text mode is 960 ($3C0) bytes. So, for
-example, a selected start address of $2300 would span the 4K boundary
-at $2000. The startup code would adjust the RAMTOP value in such way that
-the screen memory would be located just below this boundary (at $1C40).
-This results in the area [$2000-$22FF] being wasted.
-Additionally, the program might fail to load since the lowest address used
-by the screen memory could be below MEMLO. (The lowest address used in this
-example would be at $1C20, where the display list would allocated.)</P>
-<P>These calculations are performed by the startup code (in the first two
-load chunks), but the startup code only takes the default 40x24 text mode
-into account. If the program later wants to load TGI drivers which set
-a more memory consuming graphics mode, the user has to pick a higher
-load address.
-Using higher resolution modes there is a restriction in the ROM that it
-doesn't expect RAMTOP to be at arbitrary values. The Atari memory modules
-came only in 8K or 16K sizes, so the ROM expects RAMTOP to only have
-values in 8K steps. Therefore, when using the highest resolution modes
-the program start address must be at an 8K boundary.</P>
+<H2><A NAME="memhole"></A> <A NAME="ss10.4">10.4</A> <A HREF="atari.html#toc10.4">Reserving a memory area inside a program</A>
+</H2>
 
 
-<H3><A NAME="chargenloc"></A> Character generator location</H3>
+<P>(This section is primarily applicable to the <CODE>atari</CODE> target, but the
+principles apply to <CODE>atatixl</CODE> as well.)</P>
+<P>The Atari 130XE maps its additional memory into CPU memory in 16K
+chunks at address $4000 to $7FFF. One might want to
+prevent this memory area from being used by cc65. Other reasons to
+prevent the use of some memory area could be to reserve space for the
+buffers for display lists and screen memory.</P>
+<P>The Atari executable format allows holes inside a program, e.g. one
+part loads into $2E00 to $3FFF, going below the reserved
+memory area (assuming a reserved area from $4000 to
+$7FFF), and another part loads into $8000 to
+$BC1F.</P>
+<P>Each load chunk of the executable starts with a 4 byte header which
+defines its load address and size. In the following linker config files
+these headers are named HEADER and SECHDR (for the MEMORY layout), and
+accordingly NEXEHDR and CHKHDR (for the SEGMENTS layout).</P>
+
+<H3>Low code and high data example</H3>
+
+<P>Goal: Create an executable with 2 load chunks which doesn't use the
+memory area from $4000 to $7FFF. The CODE segment of
+the program should go below $4000 and the DATA and RODATA
+segments should go above $7FFF.</P>
+<P>The main problem is that the EXE header generated by the cc65 runtime
+lib is wrong. It defines a single load chunk with the sizes/addresses
+of the STARTUP, LOWCODE, INIT, CODE, RODATA, and DATA segments (the whole user
+program).</P>
+<P>The contents of the EXE header come from the EXEHDR segment, which is
+defined in crt0.s. This cannot be changed without modifying and
+recompiling the cc65 atari runtime lib. Therefore the original EXE
+header must be discarded. It will be replaced by a user created
+one. The discarding is done by assigning the EXEHDR segment to the
+BANK memory area. The BANK memory area is discarded in the new linker
+config file (written to file "").</P>
+<P>The user needs to create a customized linker config file which adds
+new memory areas and segments to hold the new EXE header and the
+header data for the second load chunk. Also an assembly source file
+needs to be created which defines the contents of the new EXE header
+and the second load chunk header.</P>
+
+<P>This is an example of a modified cc65 Atari linker configuration file
+(split.cfg):
+<BLOCKQUOTE><CODE>
+<PRE>
+SYMBOLS {
+    __STACKSIZE__ = $800;                               # 2K stack
+    __RESERVED_MEMORY__: value = $0000, weak = yes;
+}
+FEATURES {
+    STARTADDRESS: default = $2E00;
+}
+MEMORY {
+    ZP: start = $82, size = $7E, type = rw, define = yes;
+
+    HEADER: start = $0000, size = $6, file = %O;        # first load chunk
+    RAMLO: start = %S, size = $4000 - %S, file = %O;
+
+    BANK: start = $4000, size = $4000, file = "";
+
+    SECHDR: start = $0000, size = $4, file = %O;        # second load chunk
+    RAM: start = $8000, size = $3C20, file = %O;        # $3C20: matches upper bound $BC1F
+}
+SEGMENTS {
+    EXEHDR: load = BANK, type = ro;
+
+    NEXEHDR: load = HEADER, type = ro;                  # first load chunk
+    STARTUP: load = RAMLO, type = ro, define = yes;
+    LOWCODE: load = RAMLO, type = ro, define = yes, optional = yes;
+    INIT: load = RAMLO, type = ro, optional = yes;
+    CODE: load = RAMLO, type = ro, define = yes;
+
+    CHKHDR: load = SECHDR, type = ro;                   # second load chunk
+    RODATA: load = RAM, type = ro, define = yes;
+    DATA: load = RAM, type = rw, define = yes;
+    BSS: load = RAM, type = bss, define = yes;
+    ZPSAVE: load = RAM, type = bss, define = yes;
+
+    ZEROPAGE: load = ZP, type = zp;
+    AUTOSTRT: load = RAM, type = ro;                    # defines program entry point
+}
+FEATURES {
+    CONDES: segment = RODATA,
+            type = constructor,
+            label = __CONSTRUCTOR_TABLE__,
+            count = __CONSTRUCTOR_COUNT__;
+    CONDES: segment = RODATA,
+            type = destructor,
+            label = __DESTRUCTOR_TABLE__,
+            count = __DESTRUCTOR_COUNT__;
+}
+</PRE>
+</CODE></BLOCKQUOTE>
+</P>
+
+<P>A new memory area BANK was added which describes the reserved area.
+It gets loaded with the contents of the old EXEHDR segment. But the
+memory area isn't written to the output file. This way the contents of
+the EXEHDR segment get discarded.</P>
+<P>The newly added NEXEHDR segment defines the correct EXE header. It
+puts the STARTUP, LOWCODE, INIT, and CODE segments, which are the
+segments containing only code, into load chunk #1 (RAMLO memory area).</P>
+<P>The header for the second load chunk comes from the new CHKHDR
+segment. It puts the RODATA, DATA, BSS, and ZPSAVE segments into load
+chunk #2 (RAM memory area).</P>
+
+<P>The contents of the new NEXEHDR and CHKHDR segments come from this
+file (split.s):
+<BLOCKQUOTE><CODE>
+<PRE>
+        .import __CODE_LOAD__, __BSS_LOAD__, __CODE_SIZE__
+        .import __DATA_LOAD__, __RODATA_LOAD__, __STARTUP_LOAD__
+
+        .segment "NEXEHDR"
+        .word    $FFFF
+        .word    __STARTUP_LOAD__
+        .word    __CODE_LOAD__ + __CODE_SIZE__ - 1
+
+        .segment "CHKHDR"
+        .word    __RODATA_LOAD__
+        .word    __BSS_LOAD__ - 1
+</PRE>
+</CODE></BLOCKQUOTE>
+</P>
+<P>Compile with
+<BLOCKQUOTE><CODE>
+<PRE>
+cl65 -t atari -C split.cfg -o prog.com prog.c split.s
+</PRE>
+</CODE></BLOCKQUOTE>
+</P>
+
+<H3>Low data and high code example</H3>
 
 
-<P>The default <CODE>atarixl</CODE> linker config file (<CODE>atarixl.cfg</CODE>) leaves the
-character generator location at the same address where it is in ROM
-($E000). This has the disadvatage to split the upper memory into
-two parts ([$D800-$DFFF] and
-[$E400-$FFF9]). For applications which
-require a large continuous upper memory area, an alternative linker
-config file (<CODE>atarixl-largehimem.cfg</CODE>) is provided. It relocates the
-character generator to $D800, providing a single big upper
-memory area at [$DC00-$FFF9].</P>
-<P>With the character generator at a different address as in ROM, the routines
-which enable and disable the ROM also have to update the chargen pointer.
-This code is not enabled by default, in order to enable it,
-uncomment the line which sets CHARGEN_RELOC in <CODE>libsrc</CODE>atari/Makefile.inc/
-and recompile the <CODE>atarixl</CODE> runtime library.</P>
+
+<P>Goal: Put RODATA and DATA into low memory and STARTUP, LOWCODE, INIT,
+CODE, BSS, ZPSAVE into high memory (split2.cfg):</P>
+<P>
+<BLOCKQUOTE><CODE>
+<PRE>
+SYMBOLS {
+    __STACKSIZE__ = $800;       # 2K stack
+    __RESERVED_MEMORY__: value = $0000, weak = yes;
+}
+FEATURES {
+    STARTADDRESS: default = $2E00;
+}
+MEMORY {
+    ZP: start = $82, size = $7E, type = rw, define = yes;
+
+    HEADER: start = $0000, size = $6, file = %O;        # first load chunk
+    RAMLO: start = %S, size = $4000 - %S, file = %O;
+
+    BANK: start = $4000, size = $4000, file = "";
+
+    SECHDR: start = $0000, size = $4, file = %O;        # second load chunk
+    RAM: start = $8000, size = $3C20, file = %O;        # $3C20: matches upper bound $BC1F
+}
+SEGMENTS {
+    EXEHDR: load = BANK, type = ro;                     # discarded old EXE header
+
+    NEXEHDR: load = HEADER, type = ro;                  # first load chunk
+    RODATA: load = RAMLO, type = ro, define = yes;
+    DATA: load = RAMLO, type = rw, define = yes;
+
+    CHKHDR: load = SECHDR, type = ro;                   # second load chunk
+    STARTUP: load = RAM, type = ro, define = yes;
+    INIT: load = RAM, type = ro, optional = yes;
+    CODE: load = RAM, type = ro, define = yes;
+    ZPSAVE: load = RAM, type = bss, define = yes;
+    BSS: load = RAM, type = bss, define = yes;
+
+    ZEROPAGE: load = ZP, type = zp;
+    AUTOSTRT: load = RAM, type = ro;                    # defines program entry point
+}
+FEATURES {
+    CONDES: segment = RODATA,
+            type = constructor,
+            label = __CONSTRUCTOR_TABLE__,
+            count = __CONSTRUCTOR_COUNT__;
+    CONDES: segment = RODATA,
+            type = destructor,
+            label = __DESTRUCTOR_TABLE__,
+            count = __DESTRUCTOR_COUNT__;
+}
+</PRE>
+</CODE></BLOCKQUOTE>
+</P>
+<P>New contents for NEXEHDR and CHKHDR are needed (split2.s):
+<BLOCKQUOTE><CODE>
+<PRE>
+        .import __STARTUP_LOAD__, __ZPSAVE_LOAD__, __DATA_SIZE__
+        .import __DATA_LOAD__, __RODATA_LOAD__
+
+        .segment "NEXEHDR"
+        .word    $FFFF
+        .word    __RODATA_LOAD__
+        .word    __DATA_LOAD__ + __DATA_SIZE__ - 1
+
+        .segment "CHKHDR"
+        .word    __STARTUP_LOAD__
+        .word    __ZPSAVE_LOAD__ - 1
+</PRE>
+</CODE></BLOCKQUOTE>
+</P>
+<P>Compile with
+<BLOCKQUOTE><CODE>
+<PRE>
+cl65 -t atari -C split2.cfg -o prog.com prog.c split2.s
+</PRE>
+</CODE></BLOCKQUOTE>
+</P>
+
+<H3><A NAME="memhole_final_note"></A> Final note</H3>
+
+
+<P>There are two other memory areas which don't appear directly in the
+linker config file. They are the stack and the heap.</P>
+<P>The cc65 runtime lib places the stack location at the end of available
+memory. This is dynamically set from the MEMTOP system variable at
+startup. The heap is located in the area between the end of the BSS
+segment and the top of the stack as defined by __STACKSIZE__.</P>
+<P>If BSS and/or the stack shouldn't stay at the end of the program,
+some parts of the cc65 runtime lib need to be replaced/modified.</P>
+<P>common/_heap.s defines the location of the heap and atari/crt0.s
+defines the location of the stack by initializing sp.</P>
+
+
+<H2><A NAME="ss10.5">10.5</A> <A HREF="atari.html#toc10.5">Upgrading from an older cc65 version</A>
+</H2>
+
+
+<P>If you are using a customized linker config file you might get some errors
+regarding the MAINHDR segment. Like this:</P>
+<P>
+<BLOCKQUOTE><CODE>
+<PRE>
+ld65: Error: Missing memory area assignment for segment `MAINHDR'
+</PRE>
+</CODE></BLOCKQUOTE>
+</P>
+<P>The old "HEADER" memory description contained six bytes: $FFFF
+and the first and last memory addess of the program. For the "system
+check" load chunk this had to be split into two memory assigments. The
+"HEADER" now only contains the $FFFF. The main program's first
+and last memory address were moved to a new segment, called "MAINHDR",
+which in the new linker config file goes into its own memory area (also
+called "MAINHDR").<BR><BR>
+A simple way to adapt your linker config file is to add the
+following line to the "SEGMENTS" section:</P>
+<P>
+<BLOCKQUOTE><CODE>
+<PRE>
+MAINHDR: load = HEADER, type = ro;
+</PRE>
+</CODE></BLOCKQUOTE>
+</P>
+
+
+
+<H2><A NAME="ss10.6">10.6</A> <A HREF="atari.html#toc10.6">Getting rid of the "system check" load chunk</A>
+</H2>
+
+
+<P>If, for some reason, you don't want to include the "system check" load
+chunk, you can do so by defining the symbol <CODE>syschk</CODE> when linking the
+program. The "system check" chunk doesn't include vital parts of the
+program. So if you don't want the system checks, it is save to leave them out.
+This is probably mostly interesting for debugging.</P>
+<P>When using cl65, you can leave it out with this command line:</P>
+<P>
+<BLOCKQUOTE><CODE>
+<PRE>
+cl65 -Wl -Dsyschk=1 &lt;arguments>
+</PRE>
+</CODE></BLOCKQUOTE>
+</P>
+
+
+
 
 <HR>
 <A HREF="atari-11.html">Next</A>

--- a/doc/atari-2.html
+++ b/doc/atari-2.html
@@ -25,17 +25,17 @@ A run vector is added to the end of the
 file ($02E0 $02E1 &lt;run vector&gt;) and is calculated using
 the <CODE>start</CODE> label in crt0.s.  (Technically the run vector is also a load chunk,
 but is not regarded as such here.)</P>
-<P>An <CODE>atari</CODE> program has one load chunk, an <CODE>atarixl</CODE> program has three load
+<P>An <CODE>atari</CODE> program has two load chunks, an <CODE>atarixl</CODE> program has three load
 chunks.  The load chunks are defined in the linker configuration files.  For more
-detailed information about the three <CODE>atarixl</CODE> load chunks see
-<A HREF="atari-10.html#xlchunks">atarixl load chunks</A>, for the discussion here it's
-sufficient to know that the first two load chunks do preparation work and the
-main part of the program is in load chunk #3.</P>
+detailed information about the load chunks see the chapter
+<A HREF="atari-9.html#techdetail">Technical details</A>. For the discussion here it's
+sufficient to know that the first load chunk(s) do preparation work and the
+main part of the program is in the last load chunk.</P>
 <P>The values determining the size of the main part of the program (the only load
 chunk for <CODE>atari</CODE>, the third load chunk for <CODE>atarixl</CODE>) are calculated in
 the crt0.s file from the __STARTUP_LOAD__ and __BSS_LOAD__ values.
 Be aware of that if you create a custom linker config file and start moving segments around (see section
-<A HREF="atari-9.html#memhole">Reserving a memory area inside the program</A>).</P>
+<A HREF="atari-10.html#memhole">Reserving a memory area inside the program</A>).</P>
 
 
 <HR>

--- a/doc/atari-3.html
+++ b/doc/atari-3.html
@@ -22,16 +22,19 @@
 
 <P>The default linker config file assumes that the BASIC ROM is disabled (or
 the BASIC cartridge unplugged). This gives a usable memory range of
-[$2E00-$BC1F]. The library startup code examines the
+[$2000-$BC1F]. The library startup code examines the
 current memory configuration, which depends on the size of the
-installed memory and cartridges, by inspecting the value in
-the MEMTOP ($2E5) variable. Then the initial stack pointer,
-which indicates the upper bound of memory used, is adjusted. The
-default load address of $2E00 was chosen to accommodate having
-a DOS loaded and a driver that resides in low memory such as the 850
-R: handler. You can override this behaviour by creating a custom
+installed memory and cartridges. It does so by using the value in
+the MEMTOP ($2E5) variable as highest memory address the program
+can use. The initial stack pointer, which is the upper bound of
+memory used by the program, is set to this value, minus an optionally
+defined __RESERVED_MEMORY__ value.</P>
+<P>The default load address of $2000 can be changed by creating a custom
 linker config file or by using the "--start-addr" cl65 command line
 argument or the "--start-addr" or "-S" ld65 command line arguments.</P>
+<P>Please note that the first load chunk (which checks the available memory)
+will always be loaded at $2E00, regardless of the specified start
+address. This address can only be changed by a custom linker config file.</P>
 <P>Special locations:</P>
 <P>
 <DL>
@@ -46,7 +49,7 @@ accommodates the different memory configurations of the Atari
 machines, as well as having a cartridge installed.  You can override
 this behaviour by writing your own crt0.s file and linking it to
 your program (see also 
-<A HREF="atari-9.html#memhole_final_note">Final note</A>).</P>
+<A HREF="atari-10.html#memhole_final_note">Final note</A>).</P>
 
 <DT><B>Heap</B><DD>
 <P>The C heap is located at the end of the program and grows towards the C
@@ -69,7 +72,7 @@ and [$D800-$FFF9] available.</LI>
 <LI>Character generator data is copied from ROM to the CHARGEN location specified in the
 linker config file.  This is (in the default <CODE>atarixl.cfg</CODE> file) at the same address as
 where it is in ROM ($E000, it can be changed, see 
-<A HREF="atari-10.html#chargenloc">atarixl chargen location</A>).  With the character generator at $E000, there are two upper memory
+<A HREF="atari-9.html#chargenloc">atarixl chargen location</A>).  With the character generator at $E000, there are two upper memory
 areas available, [$D800-$DFFF] and [$E400-$FFF9].</LI>
 </OL>
 </P>
@@ -78,7 +81,7 @@ areas available, [$D800-$DFFF] and [$E400-$FFF9].</LI>
 different (and lower) that the default load address for <CODE>atari</CODE>.  This is no problem since
 on the <CODE>atarixl</CODE> target the first load chunk makes sure that the loaded prgram won't overwrite
 memory below MEMLO. See 
-<A HREF="atari-10.html#xlchunks">atarixl load chunks</A>.</P>
+<A HREF="atari-9.html#xlchunks">atarixl load chunks</A>.</P>
 
 <P>Special locations:</P>
 <P>

--- a/doc/atari-5.html
+++ b/doc/atari-5.html
@@ -40,7 +40,8 @@
 <CODE>atr11.tgi (atr11_tgi)</CODE></TD><TD><CODE>atrx11.tgi (atrx11_tgi)</CODE></TD><TD>80x192x16h (CIO mode 11, ANTIC mode F, GTIA mode $C0)</TD><TD>1</TD></TR><TR><TD>
 <CODE>atr14.tgi (atr14_tgi)</CODE></TD><TD><CODE>atrx14.tgi (atrx14_tgi)</CODE></TD><TD>160x192x2 (CIO mode 14, ANTIC mode C)</TD><TD>1</TD></TR><TR><TD>
 <CODE>atr15.tgi (atr15_tgi)</CODE></TD><TD><CODE>atrx15.tgi (atrx15_tgi)</CODE></TD><TD>160x192x4 (CIO mode 15, ANTIC mode E)</TD><TD>1</TD></TR><TR><TD>
-<CODE>atr15p2.tgi (atr15p2_tgi)</CODE></TD><TD><CODE>atrx15p2.tgi (atrx15p2_tgi)</CODE></TD><TD>160x192x4 (CIO mode 15, ANTIC mode E)</TD><TD>2</TD></TR></TABLE>
+<CODE>atr15p2.tgi (atr15p2_tgi)</CODE></TD><TD><CODE>atrx15p2.tgi (atrx15p2_tgi)</CODE></TD><TD>160x192x4 (CIO mode 15, ANTIC mode E)</TD><TD>2
+</TD></TR></TABLE>
 </CENTER><BR>
 </P>
 
@@ -57,7 +58,7 @@ load address.  In order to reserve memory for a graphics mode, one
 simply uses a higher program load address.  There are restrictions on
 selectable load addresses,
 see 
-<A HREF="atari-10.html#loadaddr">Selecting a good program load address</A>.</P>
+<A HREF="atari-9.html#loadaddr">Selecting a good program load address</A>.</P>
 <P>The numbers for the different graphics modes presented below should
 only be seen as a rule of thumb. Since the screen buffer memory needs
 to start at specific boundaries, the numbers depend on the current top
@@ -116,7 +117,8 @@ the Atari ROM code.</P>
 <BR><CENTER>
 <TABLE BORDER><TR><TD>
 <CODE>atari</CODE></TD><TD><CODE>atarixl</CODE></TD></TR><TR><TD>
-<CODE>atr130.emd (atr130_emd)</CODE></TD><TD><CODE>atrx130.emd (atrx130_emd)</CODE></TD></TR></TABLE>
+<CODE>atr130.emd (atr130_emd)</CODE></TD><TD><CODE>atrx130.emd (atrx130_emd)</CODE>
+</TD></TR></TABLE>
 </CENTER><BR>
 </P>
 
@@ -130,7 +132,8 @@ the Atari ROM code.</P>
 <TABLE BORDER><TR><TD>
 <CODE>atari</CODE></TD><TD><CODE>atarixl</CODE></TD><TD>description</TD></TR><TR><TD>
 <CODE>atrstd.joy (atrstd_joy)</CODE></TD><TD><CODE>atrxstd.joy (atrxstd_joy)</CODE></TD><TD>Supports up to two/four standard joysticks connected to the joystick ports of the Atari. (Four on the pre-XL systems, two on XL or newer.)</TD></TR><TR><TD>
-<CODE>atrmj8.joy (atrmj8_joy)</CODE></TD><TD><CODE>atrxmj8.joy (atrxmj8_joy)</CODE></TD><TD>Supports up to eight standard joysticks connected to a MultiJoy adapter.</TD></TR></TABLE>
+<CODE>atrmj8.joy (atrmj8_joy)</CODE></TD><TD><CODE>atrxmj8.joy (atrxmj8_joy)</CODE></TD><TD>Supports up to eight standard joysticks connected to a MultiJoy adapter.
+</TD></TR></TABLE>
 <CAPTION></CAPTION>
 </CENTER><BR>
 </P>

--- a/doc/atari-9.html
+++ b/doc/atari-9.html
@@ -2,7 +2,7 @@
 <HTML>
 <HEAD>
  <META NAME="GENERATOR" CONTENT="LinuxDoc-Tools 0.9.69">
- <TITLE>Atari specific information for cc65: Other hints</TITLE>
+ <TITLE>Atari specific information for cc65: Technical details</TITLE>
  <LINK HREF="atari-10.html" REL=next>
  <LINK HREF="atari-8.html" REL=previous>
  <LINK HREF="atari.html#toc9" REL=contents>
@@ -12,277 +12,149 @@
 <A HREF="atari-8.html">Previous</A>
 <A HREF="atari.html#toc9">Contents</A>
 <HR>
-<H2><A NAME="s9">9.</A> <A HREF="atari.html#toc9">Other hints</A></H2>
+<H2><A NAME="techdetail"></A> <A NAME="s9">9.</A> <A HREF="atari.html#toc9">Technical details</A></H2>
 
 
 
-
-<H2><A NAME="ss9.1">9.1</A> <A HREF="atari.html#toc9.1">Function keys</A>
+<H2><A NAME="ss9.1">9.1</A> <A HREF="atari.html#toc9.1"><CODE>atari</CODE></A>
 </H2>
 
 
-<P>Function keys are mapped to Atari + number key.</P>
+
+<H3>Load chunks</H3>
 
 
-<H2><A NAME="ss9.2">9.2</A> <A HREF="atari.html#toc9.2">Passing arguments to the program</A>
-</H2>
-
-
-<P>Command line arguments can be passed to <CODE>main()</CODE> when DOS supports it.</P>
+<P>An <CODE>atari</CODE> program contains two load chunks.</P>
 <P>
 <OL>
-<LI>Arguments are separated by spaces.</LI>
-<LI>Leading and trailing spaces around an argument are ignored.</LI>
-<LI>The first argument passed to <CODE>main</CODE> is the program name.</LI>
-<LI>A maximum number of 16 arguments (including the program name) are
-supported.                                                       </LI>
+<LI>"system check"<BR>
+This load chunk is always loaded at address $2E00, and checks if the system has
+enough memory to run the program. It also checks if the program start address is not
+below MEMLO. If any of the checks return false, the loading of the program is aborted.<BR>
+The contents of this chunk come from the SYSCHKCHNK memory area of the linker config file.</LI>
+<LI>main program<BR>
+This load chunk is loaded at the selected program start address (default $2000) and
+contains all of the code and data of the program.<BR>
+The contents of this chunk come from the RAM memory area of the linker config file.</LI>
 </OL>
 </P>
 
 
-<H2><A NAME="ss9.3">9.3</A> <A HREF="atari.html#toc9.3">Interrupts</A>
+<H2><A NAME="ss9.2">9.2</A> <A HREF="atari.html#toc9.2"><CODE>atarixl</CODE></A>
 </H2>
 
 
-<P>The runtime for the Atari uses routines marked as <CODE>.INTERRUPTOR</CODE> for
-interrupt handlers. Such routines must be written as simple machine language
-subroutines and will be called automatically by the VBI handler code
-when they are linked into a program. See the discussion of the <CODE>.CONDES</CODE>
-feature in the 
-<A HREF="ca65.html">assembler manual</A>.</P>
+
+<H3>General operation</H3>
 
 
-<H2><A NAME="memhole"></A> <A NAME="ss9.4">9.4</A> <A HREF="atari.html#toc9.4">Reserving a memory area inside a program</A>
-</H2>
+<P>The <CODE>atarixl</CODE> target banks out the ROM while the program is running in
+order to make more memory available to the program.</P>
+<P>The screen memory is by default located at the top of available memory,
+$BFFF if BASIC is not enabled, $9FFF if BASIC is enabled.
+Therefore, in order to create a largest possible continuous memory area,
+the screen memory is moved below the program load address.  This gives
+a memory area from &lt;program load addr&gt; to $CFFF.</P>
+<P>The startup code installs wrappers for interrupt handlers and ROM routines.
+When an interrupt or call to a ROM routine happens, the wrappers enable the
+ROM, call the handler or routine, and disable the ROM again.</P>
+<P>The "wrapping" of the ROM routines is done by changing the ROM entry
+point symbols in <CODE>atari.inc</CODE> to point to the wrapper functions.</P>
+<P>For ROM functions which require input or output buffers, the wrappers
+copy the data as required to buffers in low memory.</P>
+
+<H3><A NAME="xlchunks"></A> Load chunks</H3>
 
 
-<P>(This section is primarily applicable to the <CODE>atari</CODE> target, but the
-principles apply to <CODE>atatixl</CODE> as well.)</P>
-<P>The Atari 130XE maps its additional memory into CPU memory in 16K
-chunks at address $4000 to $7FFF. One might want to
-prevent this memory area from being used by cc65. Other reasons to
-prevent the use of some memory area could be to reserve space for the
-buffers for display lists and screen memory.</P>
-<P>The Atari executable format allows holes inside a program, e.g. one
-part loads into $2E00 to $3FFF, going below the reserved
-memory area (assuming a reserved area from $4000 to
-$7FFF), and another part loads into $8000 to
-$BC1F.</P>
-<P>Each load chunk of the executable starts with a 4 byte header which
-defines its load address and size. In the following linker config files
-these headers are named HEADER and SECHDR (for the MEMORY layout), and
-accordingly NEXEHDR and CHKHDR (for the SEGMENTS layout).</P>
-
-<H3>Low code and high data example</H3>
-
-<P>Goal: Create an executable with 2 load chunks which doesn't use the
-memory area from $4000 to $7FFF. The CODE segment of
-the program should go below $4000 and the DATA and RODATA
-segments should go above $7FFF.</P>
-<P>The main problem is that the EXE header generated by the cc65 runtime
-lib is wrong. It defines a single load chunk with the sizes/addresses
-of the STARTUP, LOWCODE, INIT, CODE, RODATA, and DATA segments (the whole user
-program).</P>
-<P>The contents of the EXE header come from the EXEHDR segment, which is
-defined in crt0.s. This cannot be changed without modifying and
-recompiling the cc65 atari runtime lib. Therefore the original EXE
-header must be discarded. It will be replaced by a user created
-one. The discarding is done by assigning the EXEHDR segment to the
-BANK memory area. The BANK memory area is discarded in the new linker
-config file (written to file "").</P>
-<P>The user needs to create a customized linker config file which adds
-new memory areas and segments to hold the new EXE header and the
-header data for the second load chunk. Also an assembly source file
-needs to be created which defines the contents of the new EXE header
-and the second load chunk header.</P>
-
-<P>This is an example of a modified cc65 Atari linker configuration file
-(split.cfg):
-<BLOCKQUOTE><CODE>
-<PRE>
-SYMBOLS {
-    __STACKSIZE__ = $800;                               # 2K stack
-    __RESERVED_MEMORY__: value = $0000, weak = yes;
-}
-FEATURES {
-    STARTADDRESS: default = $2E00;
-}
-MEMORY {
-    ZP: start = $82, size = $7E, type = rw, define = yes;
-
-    HEADER: start = $0000, size = $6, file = %O;        # first load chunk
-    RAMLO: start = %S, size = $4000 - %S, file = %O;
-
-    BANK: start = $4000, size = $4000, file = "";
-
-    SECHDR: start = $0000, size = $4, file = %O;        # second load chunk
-    RAM: start = $8000, size = $3C20, file = %O;        # $3C20: matches upper bound $BC1F
-}
-SEGMENTS {
-    EXEHDR: load = BANK, type = ro;
-
-    NEXEHDR: load = HEADER, type = ro;                  # first load chunk
-    STARTUP: load = RAMLO, type = ro, define = yes;
-    LOWCODE: load = RAMLO, type = ro, define = yes, optional = yes;
-    INIT: load = RAMLO, type = ro, optional = yes;
-    CODE: load = RAMLO, type = ro, define = yes;
-
-    CHKHDR: load = SECHDR, type = ro;                   # second load chunk
-    RODATA: load = RAM, type = ro, define = yes;
-    DATA: load = RAM, type = rw, define = yes;
-    BSS: load = RAM, type = bss, define = yes;
-    ZPSAVE: load = RAM, type = bss, define = yes;
-
-    ZEROPAGE: load = ZP, type = zp;
-    AUTOSTRT: load = RAM, type = ro;                    # defines program entry point
-}
-FEATURES {
-    CONDES: segment = RODATA,
-            type = constructor,
-            label = __CONSTRUCTOR_TABLE__,
-            count = __CONSTRUCTOR_COUNT__;
-    CONDES: segment = RODATA,
-            type = destructor,
-            label = __DESTRUCTOR_TABLE__,
-            count = __DESTRUCTOR_COUNT__;
-}
-</PRE>
-</CODE></BLOCKQUOTE>
-</P>
-
-<P>A new memory area BANK was added which describes the reserved area.
-It gets loaded with the contents of the old EXEHDR segment. But the
-memory area isn't written to the output file. This way the contents of
-the EXEHDR segment get discarded.</P>
-<P>The newly added NEXEHDR segment defines the correct EXE header. It
-puts the STARTUP, LOWCODE, INIT, and CODE segments, which are the
-segments containing only code, into load chunk #1 (RAMLO memory area).</P>
-<P>The header for the second load chunk comes from the new CHKHDR
-segment. It puts the RODATA, DATA, BSS, and ZPSAVE segments into load
-chunk #2 (RAM memory area).</P>
-
-<P>The contents of the new NEXEHDR and CHKHDR segments come from this
-file (split.s):
-<BLOCKQUOTE><CODE>
-<PRE>
-        .import __CODE_LOAD__, __BSS_LOAD__, __CODE_SIZE__
-        .import __DATA_LOAD__, __RODATA_LOAD__, __STARTUP_LOAD__
-
-        .segment "NEXEHDR"
-        .word    $FFFF
-        .word    __STARTUP_LOAD__
-        .word    __CODE_LOAD__ + __CODE_SIZE__ - 1
-
-        .segment "CHKHDR"
-        .word    __RODATA_LOAD__
-        .word    __BSS_LOAD__ - 1
-</PRE>
-</CODE></BLOCKQUOTE>
-</P>
-<P>Compile with
-<BLOCKQUOTE><CODE>
-<PRE>
-cl65 -t atari -C split.cfg -o prog.com prog.c split.s
-</PRE>
-</CODE></BLOCKQUOTE>
-</P>
-
-<H3>Low data and high code example</H3>
-
-
-
-<P>Goal: Put RODATA and DATA into low memory and STARTUP, LOWCODE, INIT,
-CODE, BSS, ZPSAVE into high memory (split2.cfg):</P>
+<P>An <CODE>atarixl</CODE> program contains three load chunks.</P>
 <P>
-<BLOCKQUOTE><CODE>
-<PRE>
-SYMBOLS {
-    __STACKSIZE__ = $800;       # 2K stack
-    __RESERVED_MEMORY__: value = $0000, weak = yes;
-}
-FEATURES {
-    STARTADDRESS: default = $2E00;
-}
-MEMORY {
-    ZP: start = $82, size = $7E, type = rw, define = yes;
-
-    HEADER: start = $0000, size = $6, file = %O;        # first load chunk
-    RAMLO: start = %S, size = $4000 - %S, file = %O;
-
-    BANK: start = $4000, size = $4000, file = "";
-
-    SECHDR: start = $0000, size = $4, file = %O;        # second load chunk
-    RAM: start = $8000, size = $3C20, file = %O;        # $3C20: matches upper bound $BC1F
-}
-SEGMENTS {
-    EXEHDR: load = BANK, type = ro;                     # discarded old EXE header
-
-    NEXEHDR: load = HEADER, type = ro;                  # first load chunk
-    RODATA: load = RAMLO, type = ro, define = yes;
-    DATA: load = RAMLO, type = rw, define = yes;
-
-    CHKHDR: load = SECHDR, type = ro;                   # second load chunk
-    STARTUP: load = RAM, type = ro, define = yes;
-    INIT: load = RAM, type = ro, optional = yes;
-    CODE: load = RAM, type = ro, define = yes;
-    ZPSAVE: load = RAM, type = bss, define = yes;
-    BSS: load = RAM, type = bss, define = yes;
-
-    ZEROPAGE: load = ZP, type = zp;
-    AUTOSTRT: load = RAM, type = ro;                    # defines program entry point
-}
-FEATURES {
-    CONDES: segment = RODATA,
-            type = constructor,
-            label = __CONSTRUCTOR_TABLE__,
-            count = __CONSTRUCTOR_COUNT__;
-    CONDES: segment = RODATA,
-            type = destructor,
-            label = __DESTRUCTOR_TABLE__,
-            count = __DESTRUCTOR_COUNT__;
-}
-</PRE>
-</CODE></BLOCKQUOTE>
-</P>
-<P>New contents for NEXEHDR and CHKHDR are needed (split2.s):
-<BLOCKQUOTE><CODE>
-<PRE>
-        .import __STARTUP_LOAD__, __ZPSAVE_LOAD__, __DATA_SIZE__
-        .import __DATA_LOAD__, __RODATA_LOAD__
-
-        .segment "NEXEHDR"
-        .word    $FFFF
-        .word    __RODATA_LOAD__
-        .word    __DATA_LOAD__ + __DATA_SIZE__ - 1
-
-        .segment "CHKHDR"
-        .word    __STARTUP_LOAD__
-        .word    __ZPSAVE_LOAD__ - 1
-</PRE>
-</CODE></BLOCKQUOTE>
-</P>
-<P>Compile with
-<BLOCKQUOTE><CODE>
-<PRE>
-cl65 -t atari -C split2.cfg -o prog.com prog.c split2.s
-</PRE>
-</CODE></BLOCKQUOTE>
+<OL>
+<LI>"system check"<BR>
+This load chunk is always loaded at address $2E00, and checks if the system is
+suitable for running the program. It also checks if there is enough room between MEMLO
+and the program start address to move the text mode screen buffer there. If any of the
+checks return false, the loading of the program is aborted.<BR>
+The contents of this chunk come from the SYSCHKCHNK memory area of the linker config file.</LI>
+<LI>"shadow RAM prepare"<BR>
+The second load chunk gets loaded to the selected program load address (default $2400).
+It moves the screen memory below the program load address, copies the character generator
+from ROM to its new place in RAM, and copies the parts of the program which reside in
+high memory below the ROM to their place. The high memory parts are included in this load chunk.<BR>
+At the beginning of this load chunk there is a .bss area, which is not part of the
+EXE file. Therefore the on-disk start address of this load chunk will be higher than the
+selected start address. This .bss area (segment LOWDATA) contains the buffers for the
+double buffering of ROM input and output data.  If you add contents to this segment be aware
+that the contents won't be zero initialized by the startup code.<BR>
+The contents of this chunk come from the SRPREPCHNK memory area of the linker config file.</LI>
+<LI>main program<BR>
+This load chunk is loaded just above the LOWDATA segment, replacing the code of
+the previous load chunk. It contains all remaining code and data sections of the program,
+including the startup code.<BR>
+The contents of this chunk come from the RAM memory area of the linker config file.</LI>
+</OL>
 </P>
 
-<H3><A NAME="memhole_final_note"></A> Final note</H3>
+<H3>Moving screen memory below the program start address</H3>
 
 
-<P>There are two other memory areas which don't appear directly in the
-linker config file. They are the stack and the heap.</P>
-<P>The cc65 runtime lib places the stack location at the end of available
-memory. This is dynamically set from the MEMTOP system variable at
-startup. The heap is located in the area between the end of the BSS
-segment and the top of the stack as defined by __STACKSIZE__.</P>
-<P>If BSS and/or the stack shouldn't stay at the end of the program,
-some parts of the cc65 runtime lib need to be replaced/modified.</P>
-<P>common/_heap.s defines the location of the heap and atari/crt0.s
-defines the location of the stack by initializing sp.</P>
+<P>When setting a graphics mode, the ROM looks at the RAMTOP location. RAMTOP
+describes the amount of installed memory in pages (RAMTOP is only one byte).
+The screen memory and display list are placed immediately below RAMTOP.</P>
+<P>Now in order to relocate the screen memory to lower memory, the startup code
+puts a value into RAMTOP which causes the ROM routines to allocate the display
+memory below the program start address and then it issues a ROM call to setup
+the regular text mode.</P>
 
+<H3><A NAME="loadaddr"></A> Selecting a good program load address</H3>
+
+
+<P>Due to the movement of the screen memory below the program start, there are some
+load addresses which are sub-optimal because they waste memory or prevent a
+higher resolution graphics mode from being enabled.</P>
+<P>There are restrictions at which addresses screen memory (display buffer and display
+list) can be placed. The display buffer cannot cross a 4K boundary and a display
+list cannot cross a 1K boundary.</P>
+<P>The startup code takes this into account when moving the screen memory down.
+If the program start address (aligned to the next lower page boundary) minus
+the screen buffer size would result in a screen buffer which spans a 4K
+boundary, the startup code lowers RAMTOP to this 4K boundary.<BR>
+The size of the screen buffer in text mode is 960 ($3C0) bytes. So, for
+example, a selected start address of $2300 would span the 4K boundary
+at $2000. The startup code would adjust the RAMTOP value in such way that
+the screen memory would be located just below this boundary (at $1C40).
+This results in the area [$2000-$22FF] being wasted.
+Additionally, the program might fail to load since the lowest address used
+by the screen memory could be below MEMLO. (The lowest address used in this
+example would be at $1C20, where the display list would allocated.)</P>
+<P>These calculations are performed by the startup code (in the first two
+load chunks), but the startup code only takes the default 40x24 text mode
+into account. If the program later wants to load TGI drivers which set
+a more memory consuming graphics mode, the user has to pick a higher
+load address.
+Using higher resolution modes there is a restriction in the ROM that it
+doesn't expect RAMTOP to be at arbitrary values. The Atari memory modules
+came only in 8K or 16K sizes, so the ROM expects RAMTOP to only have
+values in 8K steps. Therefore, when using the highest resolution modes
+the program start address must be at an 8K boundary.</P>
+
+
+<H3><A NAME="chargenloc"></A> Character generator location</H3>
+
+
+<P>The default <CODE>atarixl</CODE> linker config file (<CODE>atarixl.cfg</CODE>) leaves the
+character generator location at the same address where it is in ROM
+($E000). This has the disadvatage to split the upper memory into
+two parts ([$D800-$DFFF] and
+[$E400-$FFF9]). For applications which
+require a large continuous upper memory area, an alternative linker
+config file (<CODE>atarixl-largehimem.cfg</CODE>) is provided. It relocates the
+character generator to $D800, providing a single big upper
+memory area at [$DC00-$FFF9].</P>
+<P>With the character generator at a different address than in ROM, the routines
+which enable and disable the ROM also have to update the chargen pointer.
+This code is not enabled by default. In order to enable it,
+uncomment the line which sets CHARGEN_RELOC in <CODE>libsrc/atari/Makefile.inc</CODE>
+and recompile the <CODE>atarixl</CODE> runtime library.</P>
 
 <HR>
 <A HREF="atari-10.html">Next</A>

--- a/doc/atari.html
+++ b/doc/atari.html
@@ -65,19 +65,22 @@ compiler.</EM>
 <H2><A NAME="toc8">8.</A> <A HREF="atari-8.html">CONIO implementation</A></H2>
 
 <P>
-<H2><A NAME="toc9">9.</A> <A HREF="atari-9.html">Other hints</A></H2>
+<H2><A NAME="toc9">9.</A> <A HREF="atari-9.html">Technical details</A></H2>
 
 <UL>
-<LI><A NAME="toc9.1">9.1</A> <A HREF="atari-9.html#ss9.1">Function keys</A>
-<LI><A NAME="toc9.2">9.2</A> <A HREF="atari-9.html#ss9.2">Passing arguments to the program</A>
-<LI><A NAME="toc9.3">9.3</A> <A HREF="atari-9.html#ss9.3">Interrupts</A>
-<LI><A NAME="toc9.4">9.4</A> <A HREF="atari-9.html#ss9.4">Reserving a memory area inside a program</A>
+<LI><A NAME="toc9.1">9.1</A> <A HREF="atari-9.html#ss9.1"><CODE>atari</CODE></A>
+<LI><A NAME="toc9.2">9.2</A> <A HREF="atari-9.html#ss9.2"><CODE>atarixl</CODE></A>
 </UL>
 <P>
-<H2><A NAME="toc10">10.</A> <A HREF="atari-10.html">Technical details</A></H2>
+<H2><A NAME="toc10">10.</A> <A HREF="atari-10.html">Other hints</A></H2>
 
 <UL>
-<LI><A NAME="toc10.1">10.1</A> <A HREF="atari-10.html#ss10.1"><CODE>atarixl</CODE></A>
+<LI><A NAME="toc10.1">10.1</A> <A HREF="atari-10.html#ss10.1">Function keys</A>
+<LI><A NAME="toc10.2">10.2</A> <A HREF="atari-10.html#ss10.2">Passing arguments to the program</A>
+<LI><A NAME="toc10.3">10.3</A> <A HREF="atari-10.html#ss10.3">Interrupts</A>
+<LI><A NAME="toc10.4">10.4</A> <A HREF="atari-10.html#ss10.4">Reserving a memory area inside a program</A>
+<LI><A NAME="toc10.5">10.5</A> <A HREF="atari-10.html#ss10.5">Upgrading from an older cc65 version</A>
+<LI><A NAME="toc10.6">10.6</A> <A HREF="atari-10.html#ss10.6">Getting rid of the "system check" load chunk</A>
 </UL>
 <P>
 <H2><A NAME="toc11">11.</A> <A HREF="atari-11.html">License</A></H2>


### PR DESCRIPTION
Add information about "system check" load chunk (now also in the regular atari target).
Add information about problems when upgrading (MAINHDR).
Add information about to get rid of "system check" load chunk.
Move "Technical details" in front of "Other hints".
