### PR TITLE
another small atarixl change

### DIFF
--- a/cfg/atarixl-largehimem.cfg
+++ b/cfg/atarixl-largehimem.cfg
@@ -13,7 +13,6 @@ SYMBOLS {
     __AUTOSTART__:       type = import;  # force inclusion of autostart "trailer"
     __STACKSIZE__:       type = weak, value = $0800; # 2k stack
     __STARTADDRESS__:    type = export, value = %S;
-    sramprep:            type = import;  # force inclusion of SRPREP
 }
 
 MEMORY {

--- a/cfg/atarixl-overlay.cfg
+++ b/cfg/atarixl-overlay.cfg
@@ -9,7 +9,6 @@ SYMBOLS {
     __STACKSIZE__:       type = weak, value = $0800; # 2k stack
     __OVERLAYSIZE__:     type = weak, value = $1000; # 4k overlay
     __STARTADDRESS__:    type = export, value = %S;
-    sramprep:            type = import;  # force inclusion of SRPREP
 }
 
 MEMORY {

--- a/cfg/atarixl.cfg
+++ b/cfg/atarixl.cfg
@@ -8,7 +8,6 @@ SYMBOLS {
     __AUTOSTART__:       type = import;  # force inclusion of autostart "trailer"
     __STACKSIZE__:       type = weak, value = $0800; # 2k stack
     __STARTADDRESS__:    type = export, value = %S;
-    sramprep:            type = import;  # force inclusion of SRPREP
 }
 
 MEMORY {

--- a/libsrc/atari/crt0.s
+++ b/libsrc/atari/crt0.s
@@ -20,6 +20,7 @@
         .import         sram_init
         .import         scrdev
         .import         findfreeiocb
+        .forceimport    sramprep                        ; force inclusion of the "shadow RAM preparation" load chunk
         .include        "save_area.inc"
 .endif
 

--- a/libsrc/atari/shadow_ram_prepare.s
+++ b/libsrc/atari/shadow_ram_prepare.s
@@ -14,6 +14,7 @@
 .ifdef __ATARIXL__
 
         .export         sramprep
+
         .import         __SRPREP_LOAD__, __SRPREPCHNK_LAST__
         .import         __SHADOW_RAM_LOAD__, __SHADOW_RAM_SIZE__, __SHADOW_RAM_RUN__
         .import         __SHADOW_RAM2_LOAD__, __SHADOW_RAM2_SIZE__, __SHADOW_RAM2_RUN__


### PR DESCRIPTION
Force inclusion of the "shadow ram prepare" load chunk in crt0.s and not in the linker script.
This load chunk is always required and not optional in order for correct operation.
