### PR TITLE
New src/Makefile variables: USER_CFLAGS and PROGEXT

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -29,7 +29,8 @@ endif
 CFLAGS += -MMD -MP -O -std=c89 -I common \
           -Wall -Wextra -Wno-char-subscripts -Werror \
           -DCA65_INC=$(CA65_INC) -DCC65_INC=$(CC65_INC) \
-          -DLD65_LIB=$(LD65_LIB) -DLD65_OBJ=$(LD65_OBJ) -DLD65_CFG=$(LD65_CFG)
+          -DLD65_LIB=$(LD65_LIB) -DLD65_OBJ=$(LD65_OBJ) -DLD65_CFG=$(LD65_CFG) \
+          $(USER_CFLAGS)
 
 LDLIBS += -lm
 
@@ -88,10 +89,10 @@ define PROG_template
 
 $$(eval $$(call OBJS_template,$1))
 
-../bin/$1: $$($1_OBJS) ../wrk/common/common.a | ../bin
+../bin/$1$(PROGEXT): $$($1_OBJS) ../wrk/common/common.a | ../bin
 	$$(CC) $$(LDFLAGS) -o $$@ $$^ $$(LDLIBS)
 
-$1: ../bin/$1
+$1: ../bin/$1$(PROGEXT)
 
 endef
 


### PR DESCRIPTION
USER_CFLAGS can be used to specify additional compiler switches on the "make" command line. I tried to compile the Windows version with the Mingw compiler, but it gives warnings when it encounters "%m" printf formats.
One can disable the warnings now e.g. with "make USER_CFLAGS=-Wno-format".

When I tried to cross-compile the Windows version on Linux, I've noticed that the exe files don't have an ".exe" extension. You can add an extension with PROGEXT.
For example, to compile Windows version on Linux, type

make CC="i686-w64-mingw32-gcc" AR=i686-w64-mingw32-ar USER_CFLAGS=-Wno-format PROGEXT=.exe
