### PR TITLE
CBM stdin Console RETURN-key Echo

### DIFF
--- a/libsrc/cbm/read.s
+++ b/libsrc/cbm/read.s
@@ -1,6 +1,6 @@
 ;
 ; 2002-11-16, Ullrich von Bassewitz
-; 2013-12-18, Greg King
+; 2013-12-23, Greg King
 ;
 ; int read (int fd, void* buf, unsigned count);
 ;
@@ -52,12 +52,13 @@
         adc     #LFN_OFFS       ; Carry is already clear
         tax
         lda     fdtab-LFN_OFFS,x; Get flags for this handle
+        tay
         and     #LFN_READ       ; File open for writing?
         beq     invalidfd
 
 ; Check the EOF flag. If it is set, don't read anything
 
-        lda     fdtab-LFN_OFFS,x; Get flags for this handle
+        tya                     ; Get flags again
         bmi     eof
 
 ; Remember the device number.


### PR DESCRIPTION
When Commodore consoles were used through `stdin`, they echoed every key except the `RETURN` key.  But, the `stdin` consoles on other platforms usually do echo their `RETURN`/`ENTER` keys.  We want CC65's libraries to be consistent with each other.  And, we want them to be reasonably similar to other platforms (that aren't supported by CC65).

Therefore, this pull request makes CBM `stdin` echo `RETURN` too.
