### PR TITLE
Changes needed to get things building under mingw

### DIFF
--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -199,6 +199,19 @@ endef
 
 ##########
 
+##########
+# From here: http://blog.melski.net/2012/01/03/makefile-hacks-automatically-split-long-command-lines/
+define max_args
+  $(eval _args:=)
+  $(foreach obj,$3,$(eval _args+=$(obj))$(if $(word $2,$(_args)),$1$(_args)$(EOL)$(eval _args:=)))
+  $(if $(_args),$1$(_args))
+endef
+define EOL
+
+
+endef
+##########
+
 $(foreach drvtype,$(DRVTYPES),$(eval $(call DRVTYPE_template,$(drvtype))))
 
 AR65 := $(if $(wildcard ../bin/ar65*),../bin/ar65,ar65)
@@ -241,7 +254,7 @@ $(EXTRA_OBJPAT): $(EXTRA_SRCPAT) | ../lib
 	@$(CA65) -t $(TARGET) $(CA65FLAGS) -o $@ $<
 
 ../lib/$(TARGET).lib: $(OBJS) | ../lib
-	$(AR65) a $@ $?
+	$(call max_args,$(AR65) a $@,50,$?)
 
 ../wrk/$(TARGET) ../lib ../targetutil:
 	@$(call MKDIR,$@)

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,7 +27,7 @@ else
 endif
 
 CFLAGS += -MMD -MP -O -std=c89 -I common \
-          -Wall -Wextra -Wno-char-subscripts -Werror $(USER_CFLAGS) \
+          -Wall -Wextra -Wno-char-subscripts $(USER_CFLAGS) \
           -DCA65_INC=$(CA65_INC) -DCC65_INC=$(CC65_INC) \
           -DLD65_LIB=$(LD65_LIB) -DLD65_OBJ=$(LD65_OBJ) -DLD65_CFG=$(LD65_CFG)
 

--- a/src/ar65/library.c
+++ b/src/ar65/library.c
@@ -247,7 +247,12 @@ void LibOpen (const char* Name, int MustExist, int NeedTemp)
 
     if (NeedTemp) {
         /* Create the temporary library */
-        NewLib = tmpfile ();
+        /* We don't use tmpfile() as that requires root on Windows */
+        char * name = NULL;
+        if( ( name = tmpnam( NULL ) ) == NULL ) {
+            Error ("Cannot create temporary file: %s", strerror (errno));
+        }
+        NewLib = fopen (name, "w+b");
         if (NewLib == 0) {
             Error ("Cannot create temporary file: %s", strerror (errno));
         }


### PR DESCRIPTION
I had to make 3 changes to get cc65 building on windows under mingw. I haven't tested if it breaks the Visual Studio build, but I don't think it will. I also haven't tested on OSX/linux but I don't expect any breakage there either.

The first thing I changed is simple and shouldn't be controversial at all. The command line was too big for windows and so I added some make magic to break up the command line. That's the `max_args` macro.

The second change is less great, but should be fine. `tmpfile` on Windows requires root permissions. I found an MSDN article that said to use `tmpnam`/`fopen` instead. That fixed that problem. It's not terribly secure but hopefully C compilers are not installed in a way that security matters :)

The third change is not great. MinGW's C library doesn't support the `%m` format string so the calls to `Error` generate a warning that says `%m` is not a valid format string. Because of -Werror this was breaking the build. So I disabled -Werror. I think that's a bad thing. I would love to have a more specific flag to use here. We could disable the format string checking, but it's very useful. Maybe just disable it on mingw?

What do you think?

Thanks!
