### PR TITLE
Undefine __STRICT_ANSI__

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ LD65_LIB = $(datadir)/lib
 LD65_OBJ = $(datadir)/lib
 LD65_CFG = $(datadir)/cfg
 
-CFLAGS += -MMD -MP -O -std=c89 -D_SVID_SOURCE -I common \
+CFLAGS += -MMD -MP -O -std=c89 -D_SVID_SOURCE -U__STRICT_ANSI__ -I common \
           -Wall -Wextra -Wno-char-subscripts $(USER_CFLAGS) \
           -DCA65_INC=$(CA65_INC) -DCC65_INC=$(CC65_INC) \
           -DLD65_LIB=$(LD65_LIB) -DLD65_OBJ=$(LD65_OBJ) -DLD65_CFG=$(LD65_CFG)


### PR DESCRIPTION
- `__STRICT_ANSI__` is implied by `-std=c89`
- on some versions of mingw, `__STRICT_ANSI__` removes `tempnam`

Additional references:
- http://gcc.gnu.org/onlinedocs/gcc/C-Dialect-Options.html
- http://sourceforge.net/p/mingw/mingw-org-wsl/ci/master/tree/include/stdio.h#l175

I'm not sure what versions of mingw are strict about the definition of `tempnam`, but I started having the problem when I updated my mingw installation. The second link above is the current HEAD for mingw's standard C library, where you can see the `#ifndef __STRICT_ANSI__`.

Of course there are other ways to address this:
- using `-std=gnu89` instead of `c89` doesn't imply `__STRICT_ANSI__` (tested)
- switch to something else, such as `mkstemp`:
  - pros: `tempnam` is deprecated as of [POSIX 2008](http://linux.die.net/man/3/tempnam), whereas `mkstemp` is not.
  - cons: Windows calls it `_mktemp`, but deprecates it. We'd have to manually add the cleverness of `tempnam` back in (not hard, but it's more code to maintain).

I made the change that seemed the simplest to me, but I'll let you decide how you want to handle this. I assume that you have the standard set to C89 to help maintain compatibility with Visual Studio. Otherwise, I would have changed to gnu89 and left `__STRICT_ANSI__` as it was.

Thanks.
