### PR TITLE
Add link to Linux packages.

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,9 @@
           </li>
         </ul>
       </li>
+      <li><a href="http://software.opensuse.org/download.html?project=home%3Astrik&package=cc65">Linux packages (DEBian and RPM)</a>
+      </li>
+      <iframe src="http://software.opensuse.org/download.iframe?project=home%3Astrik&package=cc65"></iframe>
       <li><a href="doc/">Documentation</a>
       </li>
       <li><a href="https://github.com/oliverschmidt/cc65/wiki">Wiki</a>


### PR DESCRIPTION
Added link to Linux packages, in two variants:

As conventional link, as well as an iframe.

Which one is better?
