### PR TITLE
Atari: read.s: fix uninitialized use of 'buflen'

### DIFF
--- a/libsrc/atari/read.s
+++ b/libsrc/atari/read.s
@@ -48,13 +48,13 @@ _inviocb:
         .segment        "EXTZP" : zeropage
 
 index:  .res    1               ; index into line buffer
-buflen: .res    1               ; length of used part of buffer
 cbs:    .res    1               ; current buffer size: buflen - index
 dataptr:.res    2               ; temp pointer to user buffer
 copylen:.res    1               ; temp counter
 
         .bss
 
+buflen: .res    1               ; length of used part of buffer
 linebuf:.res    LINEBUF         ; the line buffer
 
         .code


### PR DESCRIPTION
I noticed that when I ran BASIC before and then start a program, the read() function behaved strange.
