### PR TITLE
fix for info file generation

### DIFF
--- a/doc/atari.sgml
+++ b/doc/atari.sgml
@@ -462,7 +462,7 @@ interface module.
 
 <sect>Limitations<p>
 
-<sect1><tt/atarixl/<label id="limitations"<p>
+<sect1><tt/atarixl/<#if output="info|latex2e"> limitations</#if><label id="limitations"<p>
 
 <itemize>
 <item>The display is cleared at program start and at program termination.  This is a side
@@ -491,9 +491,9 @@ or f80.com software is missing. Of course you may use stdio.h functions.
 
 <sect>Technical details<label id="techdetail"><p>
 
-<sect1><tt/atari/<p>
+<sect1><tt/atari/<#if output="info|latex2e"> details</#if><p>
 
-<sect2>Load chunks<p>
+<sect2><#if output="info|latex2e"><tt/atari/ </#if>Load chunks<p>
 
 An <tt/atari/ program contains two load chunks.
 
@@ -510,7 +510,7 @@ The contents of this chunk come from the RAM memory area of the linker config fi
 </enum>
 
 
-<sect1><tt/atarixl/<p>
+<sect1><tt/atarixl/<#if output="info|latex2e"> details</#if><p>
 
 <sect2>General operation<p>
 
@@ -533,7 +533,7 @@ point symbols in <tt/atari.inc/ to point to the wrapper functions.
 For ROM functions which require input or output buffers, the wrappers
 copy the data as required to buffers in low memory.
 
-<sect2>Load chunks<label id="xlchunks"><p>
+<sect2><#if output="info|latex2e"><tt/atarixl/ </#if>Load chunks<label id="xlchunks"><p>
 
 An <tt/atarixl/ program contains three load chunks.
 


### PR DESCRIPTION
Every chapter name is converted to a 'node' when generating info (or tex) output. So no two chapters should have the same heading.
This change only changes chapter headings for info and latex output. The html output stays the same.
