### PR TITLE
Added code that disables C128 BASIC's sprite-motion interrupt-handler.

### DIFF
--- a/libsrc/c128/mou/c128-1351.s
+++ b/libsrc/c128/mou/c128-1351.s
@@ -2,7 +2,8 @@
 ; Driver for the 1351 proportional mouse. Parts of the code are from
 ; the Commodore 1351 mouse users guide.
 ;
-; Ullrich von Bassewitz, 2003-12-29, 2009-09-26
+; 2009-09-26, Ullrich von Bassewitz
+; 2014-03-15, Greg King
 ;
 
         .include        "zeropage.inc"
@@ -83,6 +84,8 @@ YMax:           .res    2               ; Y2 value of bounding box
 OldValue:       .res    1               ; Temp for MoveCheck routine
 NewValue:       .res    1               ; Temp for MoveCheck routine
 
+INIT_save:      .res    1
+
 .rodata
 
 ; Default values for above variables
@@ -106,6 +109,14 @@ NewValue:       .res    1               ; Temp for MoveCheck routine
 ; Must return an MOUSE_ERR_xx code in a/x.
 
 INSTALL:
+
+; Disable the BASIC interpreter's interrupt-driven sprite-motion code.
+; That allows direct access to the VIC-IIe's sprite registers.
+
+        lda     INIT_STATUS
+        sta     INIT_save
+        lda     #%11000000
+        sta     INIT_STATUS
 
 ; Initialize variables. Just copy the default stuff over
 
@@ -133,13 +144,17 @@ INSTALL:
 
         ldx     #$00
         txa
-        rts                             ; Run into UNINSTALL instead
+        rts
 
 ;----------------------------------------------------------------------------
 ; UNINSTALL routine. Is called before the driver is removed from memory.
 ; No return code required (the driver is removed from memory on return).
 
-UNINSTALL       = HIDE                  ; Hide cursor on exit
+UNINSTALL:
+        jsr     HIDE                    ; Hide cursor on exit
+        lda     INIT_save
+        sta     INIT_STATUS
+        rts
 
 ;----------------------------------------------------------------------------
 ; HIDE routine. Is called to hide the mouse pointer. The mouse kernel manages

--- a/libsrc/c128/mou/c128-joy.s
+++ b/libsrc/c128/mou/c128-joy.s
@@ -1,7 +1,8 @@
 ;
 ; Driver for a "joystick mouse".
 ;
-; Ullrich von Bassewitz, 2004-04-05, 2009-09-26
+; 2009-09-26, Ullrich von Bassewitz
+; 2014-03-15, Greg King
 ;
 
         .include        "zeropage.inc"
@@ -85,6 +86,8 @@ XMax:           .res    2               ; X2 value of bounding box
 YMax:           .res    2               ; Y2 value of bounding box
 Buttons:        .res    1               ; Button mask
 
+INIT_save:      .res    1
+
 ; Temporary value used in the int handler
 
 Temp:           .res    1
@@ -112,6 +115,14 @@ Temp:           .res    1
 ; Must return an MOUSE_ERR_xx code in a/x.
 
 INSTALL:
+
+; Disable the BASIC interpreter's interrupt-driven sprite-motion code.
+; That allows direct access to the VIC-IIe's sprite registers.
+
+        lda     INIT_STATUS
+        sta     INIT_save
+        lda     #%11000000
+        sta     INIT_STATUS
 
 ; Initialize variables. Just copy the default stuff over
 
@@ -145,7 +156,11 @@ INSTALL:
 ; UNINSTALL routine. Is called before the driver is removed from memory.
 ; No return code required (the driver is removed from memory on return).
 
-UNINSTALL       = HIDE                  ; Hide cursor on exit
+UNINSTALL:
+        jsr     HIDE                    ; Hide cursor on exit
+        lda     INIT_save
+        sta     INIT_STATUS
+        rts
 
 ;----------------------------------------------------------------------------
 ; HIDE routine. Is called to hide the mouse pointer. The mouse kernel manages

--- a/libsrc/c128/mou/c128-pot.s
+++ b/libsrc/c128/mou/c128-pot.s
@@ -1,8 +1,9 @@
 ;
-; Driver for a potentiometer "mouse" e.g. Koala Pad
+; Driver for a potentiometer "mouse", e.g. Koala Pad
 ;
-; Ullrich von Bassewitz, 2004-03-29, 2009-09-26
-; Stefan Haubenthal, 2006-08-20
+; 2006-08-20, Stefan Haubenthal
+; 2009-09-26, Ullrich von Bassewitz
+; 2014-03-15, Greg King
 ;
 
         .include        "zeropage.inc"
@@ -82,6 +83,8 @@ XMax:           .res    2               ; X2 value of bounding box
 YMax:           .res    2               ; Y2 value of bounding box
 Buttons:        .res    1               ; Button mask
 
+INIT_save:      .res    1
+
 ; Temporary value used in the int handler
 
 Temp:           .res    1
@@ -109,6 +112,14 @@ Temp:           .res    1
 ; Must return an MOUSE_ERR_xx code in a/x.
 
 INSTALL:
+
+; Disable the BASIC interpreter's interrupt-driven sprite-motion code.
+; That allows direct access to the VIC-IIe's sprite registers.
+
+        lda     INIT_STATUS
+        sta     INIT_save
+        lda     #%11000000
+        sta     INIT_STATUS
 
 ; Initialize variables. Just copy the default stuff over
 
@@ -142,7 +153,11 @@ INSTALL:
 ; UNINSTALL routine. Is called before the driver is removed from memory.
 ; No return code required (the driver is removed from memory on return).
 
-UNINSTALL       = HIDE                  ; Hide cursor on exit
+UNINSTALL:
+        jsr     HIDE                    ; Hide cursor on exit
+        lda     INIT_save
+        sta     INIT_STATUS
+        rts
 
 ;----------------------------------------------------------------------------
 ; HIDE routine. Is called to hide the mouse pointer. The mouse kernel manages


### PR DESCRIPTION
The mouse drivers can control the sprite pointer.  This fix solves one of Christian Groessler's `mousetest` problems (an invisible pointer).
