### PR TITLE
Corrected the default upper limits of some mouse drivers' bounding box.

### DIFF
--- a/libsrc/c128/mou/c128-1351.s
+++ b/libsrc/c128/mou/c128-1351.s
@@ -3,7 +3,7 @@
 ; the Commodore 1351 mouse users guide.
 ;
 ; 2009-09-26, Ullrich von Bassewitz
-; 2014-03-15, Greg King
+; 2014-03-17, Greg King
 ;
 
         .include        "zeropage.inc"
@@ -97,8 +97,8 @@ INIT_save:      .res    1
         .word   SCREEN_WIDTH/2          ; XPos
         .word   0                       ; XMin
         .word   0                       ; YMin
-        .word   SCREEN_WIDTH            ; XMax
-        .word   SCREEN_HEIGHT           ; YMax
+        .word   SCREEN_WIDTH - 1        ; XMax
+        .word   SCREEN_HEIGHT - 1       ; YMax
 .endproc
 
 .code

--- a/libsrc/c128/mou/c128-joy.s
+++ b/libsrc/c128/mou/c128-joy.s
@@ -2,7 +2,7 @@
 ; Driver for a "joystick mouse".
 ;
 ; 2009-09-26, Ullrich von Bassewitz
-; 2014-03-15, Greg King
+; 2014-03-17, Greg King
 ;
 
         .include        "zeropage.inc"
@@ -102,8 +102,8 @@ Temp:           .res    1
         .word   SCREEN_WIDTH/2          ; XPos
         .word   0                       ; XMin
         .word   0                       ; YMin
-        .word   SCREEN_WIDTH            ; XMax
-        .word   SCREEN_HEIGHT           ; YMax
+        .word   SCREEN_WIDTH - 1        ; XMax
+        .word   SCREEN_HEIGHT - 1       ; YMax
         .byte   0                       ; Buttons
 .endproc
 

--- a/libsrc/c128/mou/c128-pot.s
+++ b/libsrc/c128/mou/c128-pot.s
@@ -3,7 +3,7 @@
 ;
 ; 2006-08-20, Stefan Haubenthal
 ; 2009-09-26, Ullrich von Bassewitz
-; 2014-03-15, Greg King
+; 2014-03-17, Greg King
 ;
 
         .include        "zeropage.inc"
@@ -99,8 +99,8 @@ Temp:           .res    1
         .word   SCREEN_WIDTH/2          ; XPos
         .word   0                       ; XMin
         .word   0                       ; YMin
-        .word   SCREEN_WIDTH            ; XMax
-        .word   SCREEN_HEIGHT           ; YMax
+        .word   SCREEN_WIDTH - 1        ; XMax
+        .word   SCREEN_HEIGHT - 1       ; YMax
         .byte   0                       ; Buttons
 .endproc
 

--- a/libsrc/c64/mou/c64-joy.s
+++ b/libsrc/c64/mou/c64-joy.s
@@ -2,7 +2,7 @@
 ; Driver for a "joystick mouse".
 ;
 ; Ullrich von Bassewitz, 2004-03-29, 2009-09-26
-; 2010-02-08, Greg King
+; 2014-03-17, Greg King
 ;
 ; The driver prevents the keyboard from interfering by changing the
 ; keyboard's output port into an input port while the driver reads its
@@ -118,8 +118,8 @@ Temp:           .res    1
         .word   SCREEN_WIDTH/2          ; XPos
         .word   0                       ; XMin
         .word   0                       ; YMin
-        .word   SCREEN_WIDTH            ; XMax
-        .word   SCREEN_HEIGHT           ; YMax
+        .word   SCREEN_WIDTH - 1        ; XMax
+        .word   SCREEN_HEIGHT - 1       ; YMax
         .byte   0                       ; Buttons
 .endproc
 

--- a/libsrc/c64/mou/c64-pot.s
+++ b/libsrc/c64/mou/c64-pot.s
@@ -1,8 +1,9 @@
 ;
-; Driver for a potentiometer "mouse" e.g. Koala Pad
+; Driver for a potentiometer "mouse", e.g. Koala Pad
 ;
-; Ullrich von Bassewitz, 2004-03-29, 2009-09-26
-; Stefan Haubenthal, 2006-08-20
+; 2006-08-20, Stefan Haubenthal
+; 2009-09-26, Ullrich von Bassewitz
+; 2014-03-17, Greg King
 ;
 
         .include        "zeropage.inc"
@@ -96,8 +97,8 @@ Temp:           .res    1
         .word   SCREEN_WIDTH/2          ; XPos
         .word   0                       ; XMin
         .word   0                       ; YMin
-        .word   SCREEN_WIDTH            ; XMax
-        .word   SCREEN_HEIGHT           ; YMax
+        .word   SCREEN_WIDTH - 1        ; XMax
+        .word   SCREEN_HEIGHT - 1       ; YMax
         .byte   0                       ; Buttons
 .endproc
 


### PR DESCRIPTION
The upper limits need to be one less than the screen sizes because the co-ordinate system is zero-based.
