### PR TITLE
mousetest.c: don't set DYN_DRV to 1 for targets which don't predefine it

### DIFF
--- a/samples/mousetest.c
+++ b/samples/mousetest.c
@@ -30,12 +30,6 @@
 */
 #  undef DYN_DRV
 #  define DYN_DRV       0
-#else
-
-/* Use a dynamically loaded driver, by default. */
-#  ifndef DYN_DRV
-#    define DYN_DRV     1
-#  endif
 #endif
 
 


### PR DESCRIPTION
since they won't have a dynamic driver....
