### PR TITLE
Fix for: cc65 forgetting to emit labels (Alan Cox)

### DIFF
--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -268,7 +268,9 @@ void EnterFunctionLevel (void)
     TagTab  = S;
 
     /* Create and assign a new label table */
-    LabelTab = NewSymTable (SYMTAB_SIZE_LABEL);
+    S = NewSymTable (SYMTAB_SIZE_LABEL);
+    S->PrevTab = LabelTab;
+    LabelTab = S;
 }
 
 
@@ -286,6 +288,7 @@ void RememberFunctionLevel (struct FuncDesc* F)
     /* Don't delete the tables */
     SymTab = SymTab->PrevTab;
     TagTab = TagTab->PrevTab;
+    LabelTab = LabelTab->PrevTab;
 }
 
 


### PR DESCRIPTION
Alan Cox provided this on 2014-10-02 on the cc65.org mailing list:

http://www.cc65.org/mailarchive/2014-10/11673.html
[...]
It breaks in several spots with cc65 where cc65 forgets to emit the
labels for the goto statements - the code is there but with no label
and it them blows up linking
[...]

He also provided a fix:
http://www.cc65.org/mailarchive/2014-10/11675.html

which was approved by Uz:
http://www.cc65.org/mailarchive/2014-10/11679.html

This is the patch of Alan Cox, adjusted only to the new locations on
cc65/github.
