### PR TITLE
Fix for use of uninitialized memory in osic1p bootstrap.s

### DIFF
--- a/cfg/osic1p-asm.cfg
+++ b/cfg/osic1p-asm.cfg
@@ -11,7 +11,7 @@ SYMBOLS {
 MEMORY {
     # for size of ZP, see runtime/zeropage.s and c1p/extzp.s
     ZP:       file = "", define = yes, start = $0002, size = $001A + $0006;
-    HEAD:     file = %O,               start = $0000, size = $00AA;
+    HEAD:     file = %O,               start = $0000, size = $00B6;
     RAM:      file = %O, define = yes, start = %S, size = __HIMEM__ - __STACKSIZE__ - %S;
 }
 SEGMENTS {

--- a/cfg/osic1p.cfg
+++ b/cfg/osic1p.cfg
@@ -11,7 +11,7 @@ SYMBOLS {
 MEMORY {
     # for size of ZP, see runtime/zeropage.s and c1p/extzp.s
     ZP:       file = "", define = yes, start = $0002, size = $001A + $0006;
-    HEAD:     file = %O,               start = $0000, size = $00AA;
+    HEAD:     file = %O,               start = $0000, size = $00B6;
     RAM:      file = %O, define = yes, start = %S, size = __HIMEM__ - __STACKSIZE__ - %S;
 }
 SEGMENTS {

--- a/libsrc/osic1p/bootstrap.s
+++ b/libsrc/osic1p/bootstrap.s
@@ -45,8 +45,8 @@ GETCHAR         :=      $FFBF           ; gets one character from ACIA
 FIRSTVISC       =       $85             ; Offset of first visible character in video RAM
 LINEDIST        =       $20             ; Offset in video RAM between two lines
 
-		lda		#0
-		sta		load
+        lda     #0
+        sta     load
         lda     #<load_addr
         ldx     #>load_addr
         tay

--- a/libsrc/osic1p/bootstrap.s
+++ b/libsrc/osic1p/bootstrap.s
@@ -45,11 +45,10 @@ GETCHAR         :=      $FFBF           ; gets one character from ACIA
 FIRSTVISC       =       $85             ; Offset of first visible character in video RAM
 LINEDIST        =       $20             ; Offset in video RAM between two lines
 
-        lda     #0
-        sta     load
+        ldy     #<$0000
         lda     #<load_addr
         ldx     #>load_addr
-        tay
+        sta     load
         stx     load+1
         lda     #<load_size
         eor     #$FF
@@ -107,13 +106,12 @@ CR      =       $0D
 ; ASCII-coded hexadecimal translation of the above assembly code.
 ; It was copied from the assembler listing.
 
-        .byte   "A9", CR, "00", CR
-        .byte   "85", CR, "08", CR
+        .byte   "A0", CR, "00", CR
         .byte   "A9", CR
         hex2    <load_addr
         .byte   CR, "A2", CR
         hex2    >load_addr
-        .byte   CR, "A8", CR
+        .byte   CR, "85", CR, "08", CR
         .byte   "86", CR, "09", CR
         .byte   "A9", CR
         hex2    <load_size

--- a/libsrc/osic1p/bootstrap.s
+++ b/libsrc/osic1p/bootstrap.s
@@ -45,6 +45,8 @@ GETCHAR         :=      $FFBF           ; gets one character from ACIA
 FIRSTVISC       =       $85             ; Offset of first visible character in video RAM
 LINEDIST        =       $20             ; Offset in video RAM between two lines
 
+		lda		#0
+		sta		load
         lda     #<load_addr
         ldx     #>load_addr
         tay
@@ -105,6 +107,8 @@ CR      =       $0D
 ; ASCII-coded hexadecimal translation of the above assembly code.
 ; It was copied from the assembler listing.
 
+        .byte   "A9", CR, "00", CR
+        .byte   "85", CR, "08", CR
         .byte   "A9", CR
         hex2    <load_addr
         .byte   CR, "A2", CR


### PR DESCRIPTION
The low byte of address "load" was never initialized in the new bootloader code for the osic1p target. While this accidentally might work with an emulator that implicitly initializes all memory to zero, on a real machine this causes a random displacement where the program will be loaded. Therefore the boot loader fails to load a program on a real machine.

I discussed my original fix with @greg-king5, and the pull request I'm submitting now is improved according to his suggestions. See also the discussion in my [original pull request to Greg](https://github.com/greg-king5/cc65/pull/2).

