### PR TITLE
Added function .ADDRSIZE to ca65

### DIFF
--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -1278,6 +1278,35 @@ writable.
 Pseudo functions expect their arguments in parenthesis, and they have a result,
 either a string or an expression.
 
+<sect1><tt>.ADDRSIZE</tt><label id=".ADDRSIZE"><p>
+
+  The <tt/.ADDRSIZE/ function is used to return the interal address size 
+  associated with a symbol. This can be helpful in macros when knowing the address 
+  size of symbol can allow for custom instructions.
+
+  Example:
+
+  <tscreen><verb>
+        .macro myLDA foo
+
+  	        .if .ADDRSIZE(foo) = 1
+  	          	        ;do custom command based on zeropage addressing:
+  	          	        .byte .A5h, foo
+  	        .elseif .ADDRSIZE(foo) = 2
+  	          	        ;do custom command based on absolute addressing:
+  	          	        .byte .ADh, foo
+  	        .elseif .ADDRSIZE(foo) = 0
+  	          	        ; no address size define for this symbol:
+  	          	        .out .sprinft("Error, address size unknown for symbol %s", .string(foo))
+  	        .endif
+        .endmacro
+  </verb></tscreen>
+
+  This command is new and must be enabled with the <tt/.FEATURE addrsize/ command.
+
+  See: <tt><ref id=".FEATURE" name=".FEATURE"></tt>
+
+
 
 <sect1><tt>.BANK</tt><label id=".BANK"><p>
 
@@ -2596,6 +2625,12 @@ Here's a list of all control commands and a description, what they do:
 
   <descrip>
 
+  <tag><tt>addrsize</tt><label id="addrsize"></tag>
+
+    Enables the .ADDRSIZE pseudo function. This function is experimental and not enabled by default.
+
+    See also: <tt><ref id=".ADDRSIZE" name=".ADDRSIZE"></tt>
+
   <tag><tt>at_in_identifiers</tt><label id="at_in_identifiers"></tag>
 
     Accept the at character (`@') as a valid character in identifiers. The
@@ -2647,11 +2682,6 @@ Here's a list of all control commands and a description, what they do:
     reserved keywords built into the assembler, that starts with a dot, may be
     overridden. When using this feature, you may also get into trouble if
     later versions of the assembler define new keywords starting with a dot.
-
-  <tag><tt>loose_char_term</tt><label id="loose_char_term"></tag>
-
-    Accept single quotes as well as double quotes as terminators for char
-    constants.
 
   <tag><tt>loose_string_term</tt><label id="loose_string_term"></tag>
 

--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -1297,7 +1297,7 @@ either a string or an expression.
                         .byte 0ADh
                         .word foo
                 .elseif .ADDRSIZE(foo) = 0
-                        ; no address size define for this symbol:
+                        ; no address size defined for this symbol:
                         .out .sprintf("Error, address size unknown for symbol %s", .string(foo))
                 .endif
         .endmacro

--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -1278,34 +1278,34 @@ writable.
 Pseudo functions expect their arguments in parenthesis, and they have a result,
 either a string or an expression.
 
+
 <sect1><tt>.ADDRSIZE</tt><label id=".ADDRSIZE"><p>
 
   The <tt/.ADDRSIZE/ function is used to return the interal address size 
   associated with a symbol. This can be helpful in macros when knowing the address 
-  size of symbol can allow for custom instructions.
+  size of symbol can help with custom instructions.
 
   Example:
 
   <tscreen><verb>
         .macro myLDA foo
-
-  	        .if .ADDRSIZE(foo) = 1
-  	          	        ;do custom command based on zeropage addressing:
-  	          	        .byte .A5h, foo
-  	        .elseif .ADDRSIZE(foo) = 2
-  	          	        ;do custom command based on absolute addressing:
-  	          	        .byte .ADh, foo
-  	        .elseif .ADDRSIZE(foo) = 0
-  	          	        ; no address size define for this symbol:
-  	          	        .out .sprinft("Error, address size unknown for symbol %s", .string(foo))
-  	        .endif
+                .if .ADDRSIZE(foo) = 1
+                        ;do custom command based on zeropage addressing:
+                        .byte 0A5h, foo
+                .elseif .ADDRSIZE(foo) = 2
+                        ;do custom command based on absolute addressing:
+                        .byte 0ADh
+                        .word foo
+                .elseif .ADDRSIZE(foo) = 0
+                        ; no address size define for this symbol:
+                        .out .sprintf("Error, address size unknown for symbol %s", .string(foo))
+                .endif
         .endmacro
   </verb></tscreen>
 
   This command is new and must be enabled with the <tt/.FEATURE addrsize/ command.
 
   See: <tt><ref id=".FEATURE" name=".FEATURE"></tt>
-
 
 
 <sect1><tt>.BANK</tt><label id=".BANK"><p>
@@ -2682,6 +2682,11 @@ Here's a list of all control commands and a description, what they do:
     reserved keywords built into the assembler, that starts with a dot, may be
     overridden. When using this feature, you may also get into trouble if
     later versions of the assembler define new keywords starting with a dot.
+
+  <tag><tt>loose_char_term</tt><label id="loose_char_term"></tag>
+
+    Accept single quotes as well as double quotes as terminators for char
+    constants.
 
   <tag><tt>loose_string_term</tt><label id="loose_string_term"></tag>
 

--- a/src/ca65/expr.c
+++ b/src/ca65/expr.c
@@ -629,7 +629,7 @@ static ExprNode* FuncReferenced (void)
 
 
 
-static ExprNode* FuncAddrSize(void)
+static ExprNode* FuncAddrSize (void)
 /* Handle the .ADDRSIZE function */
 {
     StrBuf    ScopeName = STATIC_STRBUF_INITIALIZER;
@@ -646,71 +646,66 @@ static ExprNode* FuncAddrSize(void)
     if (CurTok.Tok == TOK_LOCAL_IDENT) {
 
         /* Cheap local symbol */
-        Sym = SymFindLocal(SymLast, &CurTok.SVal, SYM_FIND_EXISTING);
+        Sym = SymFindLocal (SymLast, &CurTok.SVal, SYM_FIND_EXISTING);
         if (Sym == 0) {
-            Error("Unknown symbol or scope: `%m%p'", &CurTok.SVal);
-        }
-        else {
+            Error ("Unknown symbol or scope: `%m%p'", &CurTok.SVal);
+        } else {
             AddrSize = Sym->AddrSize;
         }
 
         /* Remember and skip SVal, terminate ScopeName so it is empty */
-        SB_Copy(&Name, &CurTok.SVal);
-        NextTok();
-        SB_Terminate(&ScopeName);
+        SB_Copy (&Name, &CurTok.SVal);
+        NextTok ();
+        SB_Terminate (&ScopeName);
 
-    }
-    else {
+    } else {
 
         /* Parse the scope and the name */
-        SymTable* ParentScope = ParseScopedIdent(&Name, &ScopeName);
+        SymTable* ParentScope = ParseScopedIdent (&Name, &ScopeName);
 
         /* Check if the parent scope is valid */
         if (ParentScope == 0) {
             /* No such scope */
-            SB_Done(&ScopeName);
-            SB_Done(&Name);
-            return GenLiteral0();
+            SB_Done (&ScopeName);
+            SB_Done (&Name);
+            return GenLiteral0 ();
         }
 
         /* If ScopeName is empty, no explicit scope was specified. We have to
-        * search upper scope levels in this case.
+        ** search upper scope levels in this case.
         */
-        NoScope = SB_IsEmpty(&ScopeName);
+        NoScope = SB_IsEmpty (&ScopeName);
 
         /* If we did find a scope with the name, read the symbol defining the
-        * size, otherwise search for a symbol entry with the name and scope.
+        ** size, otherwise search for a symbol entry with the name and scope.
         */
         if (NoScope) {
-            Sym = SymFindAny(ParentScope, &Name);
-        }
-        else {
-            Sym = SymFind(ParentScope, &Name, SYM_FIND_EXISTING);
+            Sym = SymFindAny (ParentScope, &Name);
+        } else {
+            Sym = SymFind (ParentScope, &Name, SYM_FIND_EXISTING);
         }
         /* If we found the symbol retrieve the size, otherwise complain */
         if (Sym) {
             AddrSize = Sym->AddrSize;
-        }
-        else {
-            Error("Unknown symbol or scope: `%m%p%m%p'",
+        } else {
+            Error ("Unknown symbol or scope: `%m%p%m%p'",
                 &ScopeName, &Name);
         }
 
     }
 
-    /* Check if we have a size */
-    /* if we don't know, return it anyway, zero can mean unknown, or uncomment this code for an error
-    if (AddrSize == 0 ) {
-    Error ("Address size of `%m%p%m%p' is unknown", &ScopeName, &Name);
+    if (AddrSize == 0) {
+        Warning(1, "Unknown address size: `%m%p%m%p'",
+            &ScopeName, &Name);
     }
-    */
 
     /* Free the string buffers */
-    SB_Done(&ScopeName);
-    SB_Done(&Name);
+    SB_Done (&ScopeName);
+    SB_Done (&Name);
 
-    /* Return the size */
-    return GenLiteralExpr(AddrSize);
+    /* Return the size. */
+
+    return GenLiteralExpr (AddrSize);
 }
 
 
@@ -1052,7 +1047,7 @@ static ExprNode* Factor (void)
             break;
 
         case TOK_ADDRSIZE:
-            N = Function(FuncAddrSize);
+            N = Function (FuncAddrSize);
             break;
 
         case TOK_BLANK:

--- a/src/ca65/expr.c
+++ b/src/ca65/expr.c
@@ -629,6 +629,92 @@ static ExprNode* FuncReferenced (void)
 
 
 
+static ExprNode* FuncAddrSize(void)
+/* Handle the .ADDRSIZE function */
+{
+    StrBuf    ScopeName = STATIC_STRBUF_INITIALIZER;
+    StrBuf    Name = STATIC_STRBUF_INITIALIZER;
+    SymEntry* Sym;
+    int       AddrSize;
+    int       NoScope;
+
+
+    /* Assume we don't know the size */
+    AddrSize = 0;
+
+    /* Check for a cheap local which needs special handling */
+    if (CurTok.Tok == TOK_LOCAL_IDENT) {
+
+        /* Cheap local symbol */
+        Sym = SymFindLocal(SymLast, &CurTok.SVal, SYM_FIND_EXISTING);
+        if (Sym == 0) {
+            Error("Unknown symbol or scope: `%m%p'", &CurTok.SVal);
+        }
+        else {
+            AddrSize = Sym->AddrSize;
+        }
+
+        /* Remember and skip SVal, terminate ScopeName so it is empty */
+        SB_Copy(&Name, &CurTok.SVal);
+        NextTok();
+        SB_Terminate(&ScopeName);
+
+    }
+    else {
+
+        /* Parse the scope and the name */
+        SymTable* ParentScope = ParseScopedIdent(&Name, &ScopeName);
+
+        /* Check if the parent scope is valid */
+        if (ParentScope == 0) {
+            /* No such scope */
+            SB_Done(&ScopeName);
+            SB_Done(&Name);
+            return GenLiteral0();
+        }
+
+        /* If ScopeName is empty, no explicit scope was specified. We have to
+        * search upper scope levels in this case.
+        */
+        NoScope = SB_IsEmpty(&ScopeName);
+
+        /* If we did find a scope with the name, read the symbol defining the
+        * size, otherwise search for a symbol entry with the name and scope.
+        */
+        if (NoScope) {
+            Sym = SymFindAny(ParentScope, &Name);
+        }
+        else {
+            Sym = SymFind(ParentScope, &Name, SYM_FIND_EXISTING);
+        }
+        /* If we found the symbol retrieve the size, otherwise complain */
+        if (Sym) {
+            AddrSize = Sym->AddrSize;
+        }
+        else {
+            Error("Unknown symbol or scope: `%m%p%m%p'",
+                &ScopeName, &Name);
+        }
+
+    }
+
+    /* Check if we have a size */
+    /* if we don't know, return it anyway, zero can mean unknown, or uncomment this code for an error
+    if (AddrSize == 0 ) {
+    Error ("Address size of `%m%p%m%p' is unknown", &ScopeName, &Name);
+    }
+    */
+
+    /* Free the string buffers */
+    SB_Done(&ScopeName);
+    SB_Done(&Name);
+
+    /* Return the size */
+    return GenLiteralExpr(AddrSize);
+}
+
+
+
 static ExprNode* FuncSizeOf (void)
 /* Handle the .SIZEOF function */
 {
@@ -963,6 +1049,10 @@ static ExprNode* Factor (void)
 
         case TOK_BANKBYTE:
             N = Function (FuncBankByte);
+            break;
+
+        case TOK_ADDRSIZE:
+            N = Function(FuncAddrSize);
             break;
 
         case TOK_BLANK:

--- a/src/ca65/expr.c
+++ b/src/ca65/expr.c
@@ -688,15 +688,13 @@ static ExprNode* FuncAddrSize (void)
         if (Sym) {
             AddrSize = Sym->AddrSize;
         } else {
-            Error ("Unknown symbol or scope: `%m%p%m%p'",
-                &ScopeName, &Name);
+            Error ("Unknown symbol or scope: `%m%p%m%p'", &ScopeName, &Name);
         }
 
     }
 
     if (AddrSize == 0) {
-        Warning(1, "Unknown address size: `%m%p%m%p'",
-            &ScopeName, &Name);
+        Warning (1, "Unknown address size: `%m%p%m%p'", &ScopeName, &Name);
     }
 
     /* Free the string buffers */

--- a/src/ca65/feature.c
+++ b/src/ca65/feature.c
@@ -63,6 +63,7 @@ static const char* FeatureKeys[FEAT_COUNT] = {
     "c_comments",
     "force_range",
     "underline_in_numbers",
+    "addrsize",
 };
 
 
@@ -119,6 +120,7 @@ feature_t SetFeature (const StrBuf* Key)
         case FEAT_C_COMMENTS:                 CComments         = 1;    break;
         case FEAT_FORCE_RANGE:                ForceRange        = 1;    break;
         case FEAT_UNDERLINE_IN_NUMBERS:       UnderlineInNumbers= 1;    break;
+        case FEAT_ADDRSIZE:                   AddrSize          = 1;    break;
         default:                         /* Keep gcc silent */          break;
     }
 

--- a/src/ca65/feature.h
+++ b/src/ca65/feature.h
@@ -65,6 +65,7 @@ typedef enum {
     FEAT_C_COMMENTS,
     FEAT_FORCE_RANGE,
     FEAT_UNDERLINE_IN_NUMBERS,
+    FEAT_ADDRSIZE,
 
     /* Special value: Number of features available */
     FEAT_COUNT

--- a/src/ca65/global.c
+++ b/src/ca65/global.c
@@ -82,3 +82,4 @@ unsigned char OrgPerSeg          = 0;   /* Make .org local to current seg */
 unsigned char CComments          = 0;   /* Allow C like comments */
 unsigned char ForceRange         = 0;   /* Force values into expected range */
 unsigned char UnderlineInNumbers = 0;   /* Allow underlines in numbers */
+unsigned char AddrSize           = 0;   /* Allow .ADDRSIZE function */

--- a/src/ca65/global.h
+++ b/src/ca65/global.h
@@ -84,6 +84,8 @@ extern unsigned char    OrgPerSeg;          /* Make .org local to current seg */
 extern unsigned char    CComments;          /* Allow C like comments */
 extern unsigned char    ForceRange;         /* Force values into expected range */
 extern unsigned char    UnderlineInNumbers; /* Allow underlines in numbers */
+extern unsigned char    AddrSize;           /* Allow .ADDRSIZE function */
+
 
 
 

--- a/src/ca65/pseudo.c
+++ b/src/ca65/pseudo.c
@@ -1964,6 +1964,7 @@ static CtrlDesc CtrlCmdTab [] = {
     { ccNone,           DoA16           },
     { ccNone,           DoA8            },
     { ccNone,           DoAddr          },      /* .ADDR */
+    { ccNone,           DoUnexpected    },      /* .ADDRSIZE */
     { ccNone,           DoAlign         },
     { ccNone,           DoASCIIZ        },
     { ccNone,           DoAssert        },

--- a/src/ca65/scanner.c
+++ b/src/ca65/scanner.c
@@ -739,9 +739,10 @@ static token_t FindDotKeyword (void)
             default:
                 break;
         }
+
         return R->Tok;
-    }
-    else {
+
+    } else {
         return TOK_NONE;
     }
 }

--- a/src/ca65/scanner.c
+++ b/src/ca65/scanner.c
@@ -135,6 +135,7 @@ struct DotKeyword {
     { ".A16",           TOK_A16         },
     { ".A8",            TOK_A8          },
     { ".ADDR",          TOK_ADDR        },
+    { ".ADDRSIZE",      TOK_ADDRSIZE    },
     { ".ALIGN",         TOK_ALIGN       },
     { ".AND",           TOK_BOOLAND     },
     { ".ASCIIZ",        TOK_ASCIIZ      },
@@ -723,8 +724,24 @@ static token_t FindDotKeyword (void)
     R = bsearch (&K, DotKeywords, sizeof (DotKeywords) / sizeof (DotKeywords [0]),
                  sizeof (DotKeywords [0]), CmpDotKeyword);
     if (R != 0) {
+
+        /* By default, disable any somewhat experiemental DotKeyword. */
+
+        switch (R->Tok) {
+
+            case TOK_ADDRSIZE:
+                /* Disallow .ADDRSIZE function by default */
+                if (AddrSize == 0) {
+                    return TOK_NONE;
+                }
+                break;
+
+            default:
+                break;
+        }
         return R->Tok;
-    } else {
+    }
+    else {
         return TOK_NONE;
     }
 }

--- a/src/ca65/token.h
+++ b/src/ca65/token.h
@@ -123,6 +123,7 @@ typedef enum token_t {
     TOK_A16             = TOK_FIRSTPSEUDO,
     TOK_A8,
     TOK_ADDR,
+    TOK_ADDRSIZE,
     TOK_ALIGN,
     TOK_ASCIIZ,
     TOK_ASSERT,


### PR DESCRIPTION
Hi!
I have a few ideas I want to add to ca65. This one was borne from the need to be able to check the address size of a symbol when creating custom instructions (that have different opcodes - like zeropage or absolute) with macros. This information is known by ca65 if the symbol is constant or imported. This function can give that information to a macro. 

See here for a practical example: http://forums.nesdev.com/viewtopic.php?p=121457#p121457

More to come, but one at a time I think is best.