### PR TITLE
Update some overlooked fastcall pointer-to-function system declarations

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -107,12 +107,12 @@ int __fastcall__ atoi (const char* s);
 long __fastcall__ atol (const char* s);
 int __fastcall__ atexit (void (*exitfunc) (void));
 void* __fastcall__ bsearch (const void* key, const void* base, size_t n,
-                            size_t size, int (*cmp) (const void*, const void*));
+                            size_t size, int __fastcall__ (* cmp) (const void*, const void*));
 div_t __fastcall__ div (int numer, int denom);
 void __fastcall__ exit (int ret) __attribute__ ((noreturn));
 char* __fastcall__ getenv (const char* name);
 void __fastcall__ qsort (void* base, size_t count, size_t size,
-                         int (*compare) (const void*, const void*));
+                         int __fastcall__ (* compare) (const void*, const void*));
 long __fastcall__ strtol (const char* nptr, char** endptr, int base);
 unsigned long __fastcall__ strtoul (const char* nptr, char** endptr, int base);
 int __fastcall__ system (const char* s);

--- a/libsrc/common/_printf.h
+++ b/libsrc/common/_printf.h
@@ -16,7 +16,7 @@
 struct outdesc;
 
 /* Type of the function that is called to output data */
-typedef void (*outfunc) (struct outdesc* desc, const char* buf, unsigned count);
+typedef void __cdecl__ (* outfunc) (struct outdesc* desc, const char* buf, unsigned count);
 
 
 

--- a/libsrc/common/bsearch.c
+++ b/libsrc/common/bsearch.c
@@ -1,7 +1,8 @@
 /*
 ** bsearch.c
 **
-** Ullrich von Bassewitz, 17.06.1998
+** 1998-06-17, Ullrich von Bassewitz
+** 2015-06-21, Greg King
 */
 
 
@@ -11,7 +12,7 @@
 
 
 void* __fastcall__ bsearch (const void* key, const void* base, size_t n,
-                            size_t size, int (*cmp) (const void*, const void*))
+                            size_t size, int __fastcall__ (* cmp) (const void*, const void*))
 {
     int current;
     int result;

--- a/libsrc/common/qsort.c
+++ b/libsrc/common/qsort.c
@@ -1,7 +1,8 @@
 /*
 ** qsort.c
 **
-** Ullrich von Bassewitz, 09.12.1998
+** 1998.12.09, Ullrich von Bassewitz
+** 2015-06-21, Greg King
 */
 
 
@@ -12,7 +13,7 @@
 
 static void QuickSort (register unsigned char* Base, int Lo, int Hi,
                        register size_t Size,
-                       int (*Compare)(const void*, const void*))
+                       int __fastcall__ (* Compare) (const void*, const void*))
 /* Internal recursive function. Works with ints, but this shouldn't be
 ** a problem.
 */
@@ -52,7 +53,7 @@ static void QuickSort (register unsigned char* Base, int Lo, int Hi,
 
 
 void __fastcall__ qsort (void* base, size_t nmemb, size_t size,
-                         int (*compare)(const void*, const void*))
+                         int __fastcall__ (* compare) (const void*, const void*))
 /* Quicksort implementation */
 {
     if (nmemb > 1) {

--- a/libsrc/common/vfprintf.s
+++ b/libsrc/common/vfprintf.s
@@ -33,7 +33,7 @@ ptr:    .res    2               ; Points to output file
 ; can ignore the passed pointer d, and access the data directly. While this
 ; is not very clean, it gives better and shorter code.
 ;
-; static void out (struct outdesc* d, const char* buf, unsigned count)
+; static void cdecl out (struct outdesc* d, const char* buf, unsigned count)
 ; /* Routine used for writing */
 ; {
 ;     register size_t cnt;
@@ -56,7 +56,7 @@ out:    ldy     #5
         ldy     #7
         jsr     pushwysp        ; Push count
         lda     ptr
-        ldx     ptr+1   
+        ldx     ptr+1
         jsr     _fwrite
         sta     ptr1            ; Save function result
         stx     ptr1+1

--- a/libsrc/common/vsnprintf.s
+++ b/libsrc/common/vsnprintf.s
@@ -1,5 +1,5 @@
 ;
-; int vsnprintf (char* Buf, size_t size, const char* Format, va_list ap);
+; int __fastcall__ vsnprintf (char* Buf, size_t size, const char* Format, va_list ap);
 ;
 ; Ullrich von Bassewitz, 2009-09-26
 ;
@@ -130,7 +130,7 @@ L9:     pla
 ; ----------------------------------------------------------------------------
 ; Callback routine used for the actual output.
 ;
-; static void out (struct outdesc* d, const char* buf, unsigned count)
+; static void __cdecl__ out (struct outdesc* d, const char* buf, unsigned count)
 ; /* Routine used for writing */
 ;
 ; Since we know, we're called with a pointer to our static outdesc structure,


### PR DESCRIPTION
When I upgraded cc65, I explicitly declared the calling conventions for the functions in the system headers, so that they would be immune to the cc65 command-line option `--all-cdecl`.  But, I didn't notice that there are some pointers-to-functions, in some header files.  This pull request immunizes those pointers, too.