### PR TITLE
Test-suite work-arounds for the new compiler

### DIFF
--- a/test/ref/Makefile
+++ b/test/ref/Makefile
@@ -36,6 +36,20 @@ $(WORKDIR)/%.ref: %.c
 	$(CC) $(CFLAGS) $< -o $(WORKDIR)/$*.host
 	$(WORKDIR)/$*.host > $@
 
+# Some files have "K & R"-style syntax.  Therefore, some forward
+# function-declarations don't match the later function definitions.
+# Those programs fail when fastcall is used; but, the cdecl calling convention
+# tolerates those conflicts.  Therefore, make their functions default to cdecl.
+#
+$(WORKDIR)/init%prg: CC65FLAGS += -Wc --all-cdecl
+$(WORKDIR)/switch.%rg: CC65FLAGS += -Wc --all-cdecl
+
+# Also, yacc.c does some things that fail when stack operations are optimized.
+# Therefore, don't optimize them.
+#
+$(WORKDIR)/yacc.%rg: CC65FLAGS += -Wc --all-cdecl,--disable-opt,OptStackOps
+$(WORKDIR)/yaccdbg%prg: CC65FLAGS += -Wc --all-cdecl,--disable-opt,OptStackOps
+
 $(WORKDIR)/%.prg: %.c $(WORKDIR)/%.ref
 	$(CL65) $(CC65FLAGS) $< -o $@
 	$(SIM65) $(SIM65FLAGS) $@ > $(WORKDIR)/$*.out

--- a/test/val/Makefile
+++ b/test/val/Makefile
@@ -26,12 +26,12 @@ TESTS := $(foreach option,. .o. .os. .osi. .osir. .oi. .oir. .or.,$(SOURCES:%.c=
 
 all: $(TESTS)
 
-# cq71.c and cq84.c have "K & R"-style syntax.  And, some local forward
-# function-declarations don't match the later global function definitions.
+# Some files have "K & R"-style syntax.  Therefore, some forward
+# function-declarations don't match the later function definitions.
 # Those programs fail when fastcall is used; but, the cdecl calling convention
 # tolerates those conflicts.  Therefore, make their functions default to cdecl.
 #
-$(WORKDIR)/cq71%prg $(WORKDIR)/cq84%prg: CC65FLAGS += -Wc --all-cdecl
+$(WORKDIR)/cq4%prg $(WORKDIR)/cq71.%rg $(WORKDIR)/cq81%prg $(WORKDIR)/cq84%prg: CC65FLAGS += -Wc --all-cdecl
 
 $(WORKDIR)/%.prg: %.c
 	$(CL65) $(CC65FLAGS) $< -o $@

--- a/test/val/ptrfunc.c
+++ b/test/val/ptrfunc.c
@@ -5,7 +5,8 @@
 */
 
 #include <stdio.h>
-#include <limits.h>
+
+#define NO_IMPLICIT_FUNCPTR_CONV
 
 unsigned char success=0;
 unsigned char failures=0;


### PR DESCRIPTION
I forgot to run the test-suite after I added some more error traps to cc65.  So, I didn't notice that a few of its programs couldn't be compiled.  This PR works around the "Kernighan & Ritchie" incompatibility, in the usual way.