### PR TITLE
Adjust some new test programs.

### DIFF
--- a/test/misc/Makefile
+++ b/test/misc/Makefile
@@ -53,7 +53,7 @@ $(WORKDIR)/sitest%prg: sitest.c
 	-$(CL65) $(subst .,,$(*:.o%=-O%)) $(CC65FLAGS) $< -o $@
 #	-$(SIM65) $(SIM65FLAGS) $@
 $(WORKDIR)/cc65141011%prg: cc65141011.c
-	@echo "FIXME: " $@ "currently will fail."
+	@echo "FIXME: " $@ "currently can fail."
 	$(CL65) $(subst .,,$(*:.o%=-O%)) $(CC65FLAGS) $< -o $@
 	-$(SIM65) $(SIM65FLAGS) $@
 

--- a/test/misc/cc65141011.c
+++ b/test/misc/cc65141011.c
@@ -1,4 +1,3 @@
-
 /*
   !!DESCRIPTION!! equality problem
   !!ORIGIN!!      Testsuite
@@ -6,32 +5,37 @@
 */
 
 /*
-    different result depending on whether constant is on left or right side
+    Different results, depending on whether constant is on left or right side.
+
+    The optimizer sometimes makes code that executes the right-side expression
+    as eight bits; but then, tests it against the left-side zero as 16 bits.
+    The high-byte is garbage; therefore, that test might, or might not, work.
+    It depends on the platform and the amount of optimization.
 
     http://www.cc65.org/mailarchive/2014-10/11680.html
+    http://www.cc65.org/mailarchive/2014-10/11682.html
     http://www.cc65.org/mailarchive/2014-10/11683.html
 */
 
-#include <stdlib.h>
 #include <stdio.h>
 
 static unsigned char fails = 4;
 static unsigned char bad[3], good[3];
 
-int main(int n, char **args)
+int main(void)
 {
     unsigned char joy_state = 0x7e;
     unsigned a, b;
 
-    /* NOTE: somehow it only fails in the printf statement, the other stuff
+    /* NOTE: It fails in only the printf() statements, the other stuff
              below works! */
-    printf("bad: %u\n", 0 == (joy_state & 1) );
+    printf("bad: %u, ", 0 == (joy_state & 1) );
     printf("good: %u\n", (joy_state & 1) == 0 );
 
     sprintf(bad, "%u", 0 == (joy_state & 1) );
     sprintf(good, "%u", (joy_state & 1) == 0 );
 
-    printf("bad: %u\n", bad[0] - '0' );
+    printf("bad: %u, ", bad[0] - '0' );
     printf("good: %u\n", good[0] - '0' );
 
     fails -= bad[0] - '0';
@@ -40,12 +44,15 @@ int main(int n, char **args)
     if (0 == (joy_state & 1)) fails--;
     if ((joy_state & 1) == 0) fails--;
 
-    printf("fails: %u\n", fails );
+    printf("failures: %u\n", fails );
 
+    /* The above printf() returns a value with a zero high-byte.
+    ** Therefore, the next (broken) statement works (by accident).
+    */
     a = 0 == (joy_state & 1);
     b = (joy_state & 1) == 0;
 
-    printf("a: %u\n", a );
+    printf("a: %u, ", a );
     printf("b: %u\n", b );
 
     return fails;

--- a/test/val/cc65141022.c
+++ b/test/val/cc65141022.c
@@ -19,13 +19,13 @@ struct yywork
 struct yysvf
 {
         struct yywork *yystoff;
-};
+} yysvec[1];
 
 unsigned char fails = 0;
 
 int main(int n, char **args)
 {
-    struct yysvf *yystate;
+    struct yysvf *yystate = yysvec;
     struct yywork *yyt;
 
     yystate->yystoff = yycrank;


### PR DESCRIPTION
Two of the new regression-test programs give unstable results because they use "uncontrolled" data.

One of those programs is supposed to do that (it's a symptom of the cc65 bug that's being tested); therefore, I added some comments that tell people to expect it.

But, the other program used a garbage pointer.  I added a proper initiation.  The pointer pointedly points to where it should point. :smirk: