### PR TITLE
Make the sprintf() family of functions handle special argument conditions.

### DIFF
--- a/libsrc/common/vsnprintf.s
+++ b/libsrc/common/vsnprintf.s
@@ -86,9 +86,16 @@ L1:     dex
         sta     bufptr+0
         stx     bufptr+1
 
+; There must be a buffer if its size is non-zero.
+
+        bit     bufsize+1
+        bmi     L5
+        ora     bufptr+1
+        bze     L0              ; The pointer shouldn't be NULL
+
 ; Restore ap and call _printf
 
-        pla
+L5:     pla
         tax
         pla
         jsr     __printf
@@ -125,6 +132,11 @@ L4:     lda     ccount+0
 ; Bail out if size is too high.
 
 L9:     lda     #ERANGE
+        .byte   $2C             ;(bit $xxxx)
+
+; NULL buffer pointers usually are invalid.
+
+L0:     lda     #EINVAL
         jsr     __directerrno   ; Return -1
         jmp     incsp6          ; Drop parameters
 

--- a/libsrc/common/vsnprintf.s
+++ b/libsrc/common/vsnprintf.s
@@ -2,7 +2,7 @@
 ; int __fastcall__ vsnprintf (char* Buf, size_t size, const char* Format, va_list ap);
 ;
 ; 2009-09-26, Ullrich von Bassewitz
-; 2015-07-09, Greg King
+; 2015-07-17, Greg King
 ;
 
         .export         _vsnprintf, vsnprintf
@@ -131,12 +131,15 @@ L4:     lda     ccount+0
 
 ; Bail out if size is too high.
 
-L9:     lda     #ERANGE
+L9:     ldy     #ERANGE
         .byte   $2C             ;(bit $xxxx)
 
 ; NULL buffer pointers usually are invalid.
 
-L0:     lda     #EINVAL
+L0:     ldy     #EINVAL
+        pla                     ; Drop ap
+        pla
+        tya
         jsr     __directerrno   ; Return -1
         jmp     incsp6          ; Drop parameters
 

--- a/libsrc/sim6502/errno.s
+++ b/libsrc/sim6502/errno.s
@@ -1,11 +1,29 @@
 ;
-; Oliver Schmidt, 2013-05-16
+; 2013-05-16, Oliver Schmidt
+; 2015-07-18, Greg King
 ;
-; extern int errno;
+; Helper functions for several high-level functions.
 ;
 
         .include        "errno.inc"
 
+; ----------------------------------------------------------------------------
+; int __fastcall__ _directerrno (unsigned char code);
+; /* Set errno to a specific error code; and, return -1. Used
+; ** by the library.
+; */
+
+__directerrno:
+        jsr     __seterrno              ; Save in errno
+fail:   lda     #$FF                    ; Return -1
+        tax
+ok:     rts
+
+
+; ----------------------------------------------------------------------------
+;
+; extern int _errno;
+;
         .bss
 
 __errno:

--- a/testcode/lib/snprintf-test.c
+++ b/testcode/lib/snprintf-test.c
@@ -1,0 +1,144 @@
+/*
+** Test a function that formats and writes characters into a string buffer.
+** This program does not test formatting.  It tests some behaviors that are
+** specific to the buffer.  It tests that certain conditions are handled
+** properly.
+**
+** 2015-07-17, Greg King
+*/
+
+#include <conio.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+static const char format[] = "1234567890\nabcdefghijklmnopqrstuvwxyz\n%u\n%s\n\n";
+#define FORMAT_SIZE (sizeof format - 2u - 2u - 1u)
+
+#define arg1 12345u
+#define ARG1_SIZE (5u)
+
+static const char arg2[] = "!@#$%^&*()-+";
+#define ARG2_SIZE (sizeof arg2 - 1u)
+
+#define STRING_SIZE (FORMAT_SIZE + ARG1_SIZE + ARG2_SIZE)
+
+static char buf[256];
+static int size;
+
+
+static void fillbuf(void)
+{
+    memset(buf, 0xFF, sizeof buf - 1u);
+    buf[sizeof buf - 1u] = '\0';
+}
+
+
+unsigned char main(void)
+{
+    static unsigned char failures = 0;
+
+    /* Show what sprintf() should create. */
+
+    if ((size = printf(format, arg1, arg2)) != STRING_SIZE) {
+        ++failures;
+        printf("printf() gave the wrong size: %d.\n", size);
+    }
+
+    /* Test the normal behavior of sprintf(). */
+
+    fillbuf();
+    size = sprintf(buf, format, arg1, arg2);
+    fputs(buf, stdout);
+    if (size != STRING_SIZE) {
+        ++failures;
+        printf("sprintf() gave the wrong size: %d.\n", size);
+    }
+
+    /* Test the normal behavior of snprintf(). */
+
+    fillbuf();
+    size = snprintf(buf, sizeof buf, format, arg1, arg2);
+    fputs(buf, stdout);
+    if (size != STRING_SIZE) {
+        ++failures;
+        printf("snprintf(sizeof buf) gave the wrong size:\n %d.\n", size);
+    }
+
+    /* Does snprintf() return the full-formatted size even when the buffer
+    ** is short?  Does it write beyond the end of that buffer?
+    */
+
+    fillbuf();
+    size = snprintf(buf, STRING_SIZE - 5u, format, arg1, arg2);
+    if (size != STRING_SIZE) {
+        ++failures;
+        printf("snprintf(STRING_SIZE-5) gave the wrong size:\n %d.\n", size);
+    }
+    if (buf[STRING_SIZE - 5u - 1u] != '\0' || buf[STRING_SIZE - 5u] != 0xFF) {
+        ++failures;
+        printf("snprintf(STRING_SIZE-5) wrote beyond\n the end of the buffer.\n");
+    }
+
+    /* Does snprintf() detect a buffer size that is too big? */
+
+    fillbuf();
+    errno = 0;
+    size = snprintf(buf, 0x8000, format, arg1, arg2);
+    if (size >= 0) {
+        ++failures;
+        printf("snprintf(0x8000) didn't give an error:\n %d; errno=%d.\n", size, errno);
+    } else {
+        printf("snprintf(0x8000) did give an error:\n errno=%d.\n", errno);
+    }
+    if (buf[0] != 0xFF) {
+        ++failures;
+        printf("snprintf(0x8000) wrote into the buffer.\n");
+    }
+
+    /* snprintf() must measure the length of the formatted output even when the
+    ** buffer size is zero.  But, it must not touch the buffer.
+    */
+
+    fillbuf();
+    size = snprintf(buf, 0, format, arg1, arg2);
+    if (size != STRING_SIZE) {
+        ++failures;
+        printf("snprintf(0) gave the wrong size:\n %d.\n", size);
+    }
+    if (buf[0] != 0xFF) {
+        ++failures;
+        printf("snprintf(0) wrote into the buffer.\n");
+    }
+
+    /* Does sprintf() detect a zero buffer-pointer? */
+
+    errno = 0;
+    size = sprintf(NULL, format, arg1, arg2);
+    if (size >= 0) {
+        ++failures;
+        printf("sprintf(NULL) didn't give an error:\n %d; errno=%d.\n", size, errno);
+    } else {
+        printf("sprintf(NULL) did give an error:\n errno=%d.\n", errno);
+    }
+
+    /* snprintf() must measure the length of the formatted output even when the
+    ** buffer size is zero.  A zero pointer is not an error, in that case.
+    */
+
+    size = snprintf(NULL, 0, format, arg1, arg2);
+    if (size != STRING_SIZE) {
+        ++failures;
+        printf("snprintf(NULL,0) gave the wrong size:\n %d.\n", size);
+    }
+
+    if (failures != 0) {
+        printf("There were %u", failures);
+    } else {
+        printf("There were no");
+    }
+    printf(" failures.\nTap a key. ");
+    cgetc();
+
+    return failures;
+}


### PR DESCRIPTION
The functions properly will handle NULL buffer pointers and the zero buffer-length condition.

Fixes issue #172.