### PR TITLE
Fix base 10 bug (ca65 allows 'a' or 'A' in base10 value)

### DIFF
--- a/src/ca65/scanner.c
+++ b/src/ca65/scanner.c
@@ -1012,7 +1012,7 @@ Again:
                 break;
             }
             DVal = DigitVal (Buf[I]);
-            if (DVal > Base) {
+            if (DVal >= Base) {
                 Error ("Invalid digits in number");
                 CurTok.IVal = 0;
                 break;


### PR DESCRIPTION
Fix for bug as mentioned: https://github.com/cc65/cc65/issues/175