### PR TITLE
Add support for weak symbols in assembly source files

### DIFF
--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -3080,8 +3080,8 @@ Here's a list of all control commands and a description, what they do:
         .import bar: zeropage
   </verb></tscreen>
 
-  See: <tt><ref id=".IMPORTZP" name=".IMPORTZP"></tt>
-
+  See: <tt><ref id=".IMPORTZP" name=".IMPORTZP"></tt>,
+       <tt><ref id=".WEAK" name=".WEAK"></tt>
 
 <sect1><tt>.IMPORTZP</tt><label id=".IMPORTZP"><p>
 
@@ -3845,6 +3845,30 @@ Here's a list of all control commands and a description, what they do:
   See also: <tt><ref id=".ERROR" name=".ERROR"></tt>,
             <tt><ref id=".FATAL" name=".FATAL"></tt>,
             <tt><ref id=".OUT" name=".OUT"></tt>
+
+
+<sect1><tt>.WEAK</tt><label id=".WEAK"><p>
+
+  Import a symbol from another module. The command is followed by a comma
+  separated list of symbols to import, with each one optionally followed by
+  an address specification.
+
+  <tt>.WEAK</tt> behaves like <tt>.IMPORT</tt>, except that if the
+  symbol isn't defined anywhere at the linking stage, the linker doesn't
+  throw an error, but resolves the symbol's value to zero instead. If the
+  symbol was used with the JSR opcode, the JSR is replaced by NOPs. Furthermore,
+  members of libraries aren't pulled in to satisfy a weak import.
+
+  Example:
+
+  <tscreen><verb>
+	.weak   foo
+	.weak   bar: zeropage
+  </verb></tscreen>
+
+  Weak imports of zeropage symbols are not useful in general.
+
+  See: <tt><ref id=".IMPORT" name=".IMPORT"></tt>
 
 
 <sect1><tt>.WORD</tt><label id=".WORD"><p>

--- a/src/ca65/listing.c
+++ b/src/ca65/listing.c
@@ -359,6 +359,7 @@ void CreateListing (void)
             switch (Frag->Type) {
 
                 case FRAG_LITERAL:
+                case FRAG_NOPABLE:
                     for (I = 0; I < Frag->Len; ++I) {
                         B = AddHex (B, Frag->V.Data[I]);
                     }

--- a/src/ca65/objcode.c
+++ b/src/ca65/objcode.c
@@ -59,6 +59,15 @@ void Emit0 (unsigned char OPC)
 
 
 
+void Emit0Nopable (unsigned char OPC)
+/* Emit an instruction with a zero sized operand, indicating that it's "NOPable" */
+{
+    Fragment* F = GenFragment (FRAG_NOPABLE, 1);
+    F->V.Data[0] = OPC;
+}
+
+
+
 void Emit1 (unsigned char OPC, ExprNode* Value)
 /* Emit an instruction with an one byte argument */
 {
@@ -91,7 +100,7 @@ void Emit1 (unsigned char OPC, ExprNode* Value)
 
 
 
-void Emit2 (unsigned char OPC, ExprNode* Value)
+void Emit2 (unsigned char OPC, ExprNode* Value, int Nopable)
 /* Emit an instruction with a two byte argument */
 {
     long V;
@@ -114,7 +123,11 @@ void Emit2 (unsigned char OPC, ExprNode* Value)
     } else {
 
         /* Emit the opcode */
-        Emit0 (OPC);
+        if (Nopable != 0) {
+            Emit0Nopable (OPC);
+        } else {
+            Emit0 (OPC);
+        }
 
         /* Emit the argument as an expression */
         F = GenFragment (FRAG_EXPR, 2);

--- a/src/ca65/objcode.h
+++ b/src/ca65/objcode.h
@@ -53,10 +53,13 @@
 void Emit0 (unsigned char OPC);
 /* Emit an instruction with a zero sized operand */
 
+void Emit0Nopable (unsigned char OPC);
+/* Emit an instruction with a zero sized operand, indicating that it's "NOPable" */
+
 void Emit1 (unsigned char OPC, ExprNode* Value);
 /* Emit an instruction with an one byte argument */
 
-void Emit2 (unsigned char OPC, ExprNode* Value);
+void Emit2 (unsigned char OPC, ExprNode* Value, int Nopable);
 /* Emit an instruction with a two byte argument */
 
 void Emit3 (unsigned char OPC, ExprNode* Expr);

--- a/src/ca65/pseudo.c
+++ b/src/ca65/pseudo.c
@@ -1197,6 +1197,14 @@ static void DoImportZP (void)
 
 
 
+static void DoWeak (void)
+/* Import a symbol */
+{
+    ExportImport (SymImport, ADDR_SIZE_DEFAULT, SF_WEAK);
+}
+
+
+
 static void DoIncBin (void)
 /* Include a binary file */
 {
@@ -2095,6 +2103,7 @@ static CtrlDesc CtrlCmdTab [] = {
     { ccNone,           DoUnion         },
     { ccNone,           DoUnexpected    },      /* .VERSION */
     { ccNone,           DoWarning       },
+    { ccNone,           DoWeak          },
     { ccNone,           DoWord          },
     { ccNone,           DoUnexpected    },      /* .XMATCH */
     { ccNone,           DoZeropage      },

--- a/src/ca65/scanner.c
+++ b/src/ca65/scanner.c
@@ -288,6 +288,7 @@ struct DotKeyword {
     { ".UNION",         TOK_UNION               },
     { ".VERSION",       TOK_VERSION             },
     { ".WARNING",       TOK_WARNING             },
+    { ".WEAK",          TOK_WEAK                },
     { ".WORD",          TOK_WORD                },
     { ".XMATCH",        TOK_XMATCH              },
     { ".XOR",           TOK_BOOLXOR             },

--- a/src/ca65/segment.c
+++ b/src/ca65/segment.c
@@ -446,7 +446,7 @@ void SegDump (void)
         printf ("New segment: %s", S->Def->Name);
         F = S->Root;
         while (F) {
-            if (F->Type == FRAG_LITERAL) {
+            if (F->Type == FRAG_LITERAL || F->Type == FRAG_NOPABLE) {
                 if (State != 0) {
                     printf ("\n  Literal:");
                     X = 15;
@@ -554,6 +554,12 @@ static void WriteOneSeg (Segment* Seg)
 
             case FRAG_LITERAL:
                 ObjWrite8 (FRAG_LITERAL);
+                ObjWriteVar (Frag->Len);
+                ObjWriteData (Frag->V.Data, Frag->Len);
+                break;
+
+            case FRAG_NOPABLE:
+                ObjWrite8 (FRAG_NOPABLE);
                 ObjWriteVar (Frag->Len);
                 ObjWriteData (Frag->V.Data, Frag->Len);
                 break;

--- a/src/ca65/symentry.c
+++ b/src/ca65/symentry.c
@@ -740,6 +740,9 @@ unsigned GetSymInfoFlags (const SymEntry* S, long* ConstVal)
     if (S->Flags & SF_IMPORT) {
         Flags |= SYM_IMPORT;
     }
+    if (S->Flags & SF_WEAK) {
+        Flags |= SYM_WEAK;
+    }
 
     /* Return the result */
     return Flags;

--- a/src/ca65/symentry.h
+++ b/src/ca65/symentry.h
@@ -74,6 +74,7 @@ struct HLLDbgSym;
 #define SF_MULTDEF      0x1000          /* Multiply defined symbol */
 #define SF_DEFINED      0x2000          /* Defined */
 #define SF_REFERENCED   0x4000          /* Referenced */
+#define SF_WEAK         0x8000          /* Weak import, SF_IMPORT also set */
 
 /* Combined values */
 #define SF_REFIMP       (SF_REFERENCED|SF_IMPORT)       /* A ref'd import */

--- a/src/ca65/symtab.c
+++ b/src/ca65/symtab.c
@@ -40,6 +40,7 @@
 #include "check.h"
 #include "hashfunc.h"
 #include "mmodel.h"
+#include "objdefs.h"
 #include "scopedefs.h"
 #include "symdefs.h"
 #include "xmalloc.h"
@@ -735,6 +736,11 @@ void WriteImports (void)
             (S->Flags & (SF_REFERENCED | SF_FORCED)) != 0) {
 
             ObjWrite8 (S->AddrSize);
+            if ((S->Flags & SF_WEAK) == SF_WEAK) {
+                ObjWrite8 (OBJ_FLAGS_IMPORT_WEAK);  /* Import flags */
+            } else {
+                ObjWrite8 (0);
+            }
             ObjWriteVar (S->Name);
             WriteLineInfo (&S->DefLines);
             WriteLineInfo (&S->RefLines);

--- a/src/ca65/token.h
+++ b/src/ca65/token.h
@@ -254,6 +254,7 @@ typedef enum token_t {
     TOK_UNION,
     TOK_VERSION,
     TOK_WARNING,
+    TOK_WEAK,
     TOK_WORD,
     TOK_XMATCH,
     TOK_ZEROPAGE,

--- a/src/common/exprdefs.c
+++ b/src/common/exprdefs.c
@@ -82,6 +82,10 @@ static void InternalDumpExpr (const ExprNode* Expr, const ExprNode* (*ResolveSym
             printf (" MEM");
             break;
 
+        case EXPR_WEAK:
+            printf (" WEA");
+            break;
+
         case EXPR_PLUS:
             printf (" +");
             break;

--- a/src/common/exprdefs.h
+++ b/src/common/exprdefs.h
@@ -60,6 +60,7 @@
 #define EXPR_SEGMENT            (EXPR_LEAFNODE | 0x04)  /* Linker only */
 #define EXPR_MEMAREA            (EXPR_LEAFNODE | 0x05)  /* Linker only */
 #define EXPR_ULABEL             (EXPR_LEAFNODE | 0x06)  /* Assembler only */
+#define EXPR_WEAK               (EXPR_LEAFNODE | 0x07)  /* Linker only */
 
 /* Binary operations, left and right hand sides are valid */
 #define EXPR_PLUS               (EXPR_BINARYNODE | 0x01)

--- a/src/common/fragdefs.h
+++ b/src/common/fragdefs.h
@@ -45,7 +45,7 @@
 
 
 /* Masks for the fragment type byte */
-#define FRAG_TYPEMASK   0x38            /* Mask the type of the fragment */
+#define FRAG_TYPEMASK   0x78            /* Mask the type of the fragment */
 #define FRAG_BYTEMASK   0x07            /* Mask for byte count */
 
 /* Fragment types */
@@ -65,7 +65,7 @@
 
 #define FRAG_FILL       0x20            /* Fill bytes */
 
-
+#define FRAG_NOPABLE    0x40            /* similar to FRAG_LITERAL, but indicates a "nopable" instruction */
 
 /* End of fragdefs.h */
 

--- a/src/common/objdefs.h
+++ b/src/common/objdefs.h
@@ -46,7 +46,7 @@
 
 /* Defines for magic and version */
 #define OBJ_MAGIC       0x616E7A55
-#define OBJ_VERSION     0x0011
+#define OBJ_VERSION     0x0012
 
 /* Size of an object file header */
 #define OBJ_HDR_SIZE    (24*4)
@@ -55,6 +55,9 @@
 #define OBJ_FLAGS_DBGINFO       0x0001  /* File has debug info */
 #define OBJ_HAS_DBGINFO(x)      (((x) & OBJ_FLAGS_DBGINFO) != 0)
 
+/* Flag bits for imports */
+#define OBJ_FLAGS_IMPORT_WEAK   0x0001  /* This import is "weak" */
+#define OBJ_IMPORT_IS_WEAK(x)   (((x) & OBJ_FLAGS_IMPORT_WEAK) != 0)
 
 
 /* Header structure */

--- a/src/common/symdefs.h
+++ b/src/common/symdefs.h
@@ -98,6 +98,12 @@
 
 #define SYM_IS_IMPORT(x)        (((x) & SYM_MASK_IMPORT) == SYM_IMPORT)
 
+/* Weak import */
+#define SYM_WEAK                0x0200U /* Import */
+#define SYM_MASK_WEAK           0x0200U /* Value mask */
+
+#define SYM_IS_WEAK(x)          (((x) & SYM_MASK_WEAK) == SYM_WEAK)
+
 
 
 /* End of symdefs.h */

--- a/src/ld65/exports.h
+++ b/src/ld65/exports.h
@@ -170,6 +170,9 @@ int IsUnresolved (unsigned Name);
 int IsUnresolvedExport (const Export* E);
 /* Return true if the given export is unresolved */
 
+int HasJustWeakImports(unsigned Name);
+/* Check if the imports of this symbol are all "weak" */
+
 int IsConstExport (const Export* E);
 /* Return true if the expression associated with this export is const */
 

--- a/src/ld65/expr.c
+++ b/src/ld65/expr.c
@@ -90,6 +90,12 @@ void FreeExpr (ExprNode* Root)
 }
 
 
+int IsWeakExpr (ExprNode *Node)
+/* Return true if the given expression is "weak". */
+{
+    return Node->Op == EXPR_WEAK;
+}
+
 
 int IsConstExpr (ExprNode* Root)
 /* Return true if the given expression is a constant expression, that is, one
@@ -105,6 +111,7 @@ int IsConstExpr (ExprNode* Root)
         switch (Root->Op) {
 
             case EXPR_LITERAL:
+            case EXPR_WEAK:
                 return 1;
 
             case EXPR_SYMBOL:
@@ -282,6 +289,7 @@ long GetExprVal (ExprNode* Expr)
     switch (Expr->Op) {
 
         case EXPR_LITERAL:
+        case EXPR_WEAK:
             return Expr->V.IVal;
 
         case EXPR_SYMBOL:
@@ -463,6 +471,7 @@ static void GetSegExprValInternal (ExprNode* Expr, SegExprDesc* D, int Sign)
     switch (Expr->Op) {
 
         case EXPR_LITERAL:
+        case EXPR_WEAK:
             D->Val += (Sign * Expr->V.IVal);
             break;
 
@@ -549,6 +558,16 @@ ExprNode* LiteralExpr (long Val, ObjData* O)
 /* Return an expression tree that encodes the given literal value */
 {
     ExprNode* Expr = NewExprNode (O, EXPR_LITERAL);
+    Expr->V.IVal = Val;
+    return Expr;
+}
+
+
+
+ExprNode* WeakExpr (long Val, ObjData* O)
+/* Return an expression tree that encodes the given literal value, indicating it's "weak" */
+{
+    ExprNode* Expr = NewExprNode (O, EXPR_WEAK);
     Expr->V.IVal = Val;
     return Expr;
 }

--- a/src/ld65/expr.h
+++ b/src/ld65/expr.h
@@ -76,6 +76,9 @@ ExprNode* NewExprNode (ObjData* O, unsigned char Op);
 void FreeExpr (ExprNode* Root);
 /* Free the expression tree, Root is pointing to. */
 
+int IsWeakExpr (ExprNode *Node);
+/* Return true if the given expression is "weak". */
+
 int IsConstExpr (ExprNode* Root);
 /* Return true if the given expression is a constant expression, that is, one
 ** with no references to external symbols.
@@ -101,6 +104,9 @@ void GetSegExprVal (ExprNode* Expr, SegExprDesc* D);
 
 ExprNode* LiteralExpr (long Val, ObjData* O);
 /* Return an expression tree that encodes the given literal value */
+
+ExprNode* WeakExpr (long Val, ObjData* O);
+/* Return an expression tree that encodes the given literal value, indicating it's "weak" */
 
 ExprNode* MemoryExpr (MemoryArea* Mem, long Offs, ObjData* O);
 /* Return an expression tree that encodes an offset into the memory area */

--- a/src/ld65/fragment.c
+++ b/src/ld65/fragment.c
@@ -60,7 +60,7 @@ Fragment* NewFragment (unsigned char Type, unsigned Size, Section* S)
     ** fragment contains literal data.
     */
     unsigned FragSize = sizeof (Fragment) - 1;
-    if (Type == FRAG_LITERAL) {
+    if (Type == FRAG_LITERAL || Type == FRAG_NOPABLE) {
         FragSize += Size;
     }
 
@@ -69,6 +69,7 @@ Fragment* NewFragment (unsigned char Type, unsigned Size, Section* S)
 
     /* Initialize the data */
     F->Next      = 0;
+    F->Prev      = 0;
     F->Obj       = 0;
     F->Sec       = S;
     F->Size      = Size;
@@ -79,8 +80,10 @@ Fragment* NewFragment (unsigned char Type, unsigned Size, Section* S)
     /* Insert the code fragment into the section */
     if (S->FragRoot == 0) {
         /* First fragment */
+        F->Prev     = 0;
         S->FragRoot = F;
     } else {
+        F->Prev           = S->FragLast;
         S->FragLast->Next = F;
     }
     S->FragLast = F;

--- a/src/ld65/fragment.h
+++ b/src/ld65/fragment.h
@@ -67,6 +67,7 @@ struct Section;
 typedef struct Fragment Fragment;
 struct Fragment {
     Fragment*           Next;           /* Next fragment in list */
+    Fragment*           Prev;
     struct ObjData*     Obj;            /* Source of fragment */
     struct Section*     Sec;            /* Section for this fragment */
     unsigned            Size;           /* Size of data/expression */

--- a/src/ld65/library.c
+++ b/src/ld65/library.c
@@ -300,7 +300,7 @@ static void LibCheckExports (ObjData* O)
     /* Check all exports */
     for (I = 0; I < CollCount (&O->Exports); ++I) {
         const Export* E = CollConstAt (&O->Exports, I);
-        if (IsUnresolved (E->Name)) {
+        if (IsUnresolved (E->Name) && HasJustWeakImports (E->Name) == 0) {
            /* We need this module, insert the imports and exports */
             O->Flags |= OBJ_REF;
             InsertObjGlobals (O);

--- a/src/od65/dump.c
+++ b/src/od65/dump.c
@@ -557,6 +557,7 @@ void DumpObjImports (FILE* F, unsigned long Offset)
 
         /* Read the data for one import */
         unsigned char AddrSize = Read8 (F);
+        unsigned char Flags    = Read8 (F);
         const char*   Name     = GetString (&StrPool, ReadVar (F));
         unsigned      Len      = strlen (Name);
 
@@ -571,6 +572,11 @@ void DumpObjImports (FILE* F, unsigned long Offset)
         printf ("      Address size:%14s0x%02X  (%s)\n", "", AddrSize,
                 AddrSizeToStr (AddrSize));
         printf ("      Name:%*s\"%s\"\n", (int)(24-Len), "", Name);
+        printf ("      Flags:%21s0x%02X", "", Flags);
+        if (OBJ_IMPORT_IS_WEAK(Flags)) {
+            printf("  (weak)");
+        }
+        printf("\n");
     }
 
     /* Destroy the string pool */
@@ -738,7 +744,11 @@ void DumpObjDbgSyms (FILE* F, unsigned long Offset)
             printf ("      Size:%20s0x%04lX  (%lu)\n", "", Size, Size);
         }
         if (SYM_IS_IMPORT (Type)) {
-            printf ("      Import:%24u\n", ImportId);
+            if (SYM_IS_WEAK (Type)) {
+                printf ("      Import:%24u  (weak)\n", ImportId);
+            } else {
+                printf ("      Import:%24u\n", ImportId);
+            }
         }
         if (SYM_IS_EXPORT (Type)) {
             printf ("      Export:%24u\n", ExportId);


### PR DESCRIPTION
These changes add support for weak symbols in assembly source files.

'.weak' behaves like '.import', except that if the symbol isn't defined at the linking stage, it's resolved to zero and not error is thrown.
A slightly different behaviour is implemented if the weak symbol was the argument of a JSR: In this case the JSR instruction is replaced by NOPs.

I had to change the object file format to implement this and increased the version field in the object file header.