### PR TITLE
Remove pointless rules from a regression test makefile.

### DIFF
--- a/test/err/Makefile
+++ b/test/err/Makefile
@@ -1,4 +1,3 @@
-
 # makefile for the tests that MUST NOT compile
 
 ifneq ($(shell echo),)
@@ -13,36 +12,18 @@ else
   DEL = $(RM) $1
 endif
 
-CC65FLAGS := -t sim6502
-
-CL65 := $(if $(wildcard ../../bin/cl65*),../../bin/cl65,cl65)
+CC65 := $(if $(wildcard ../../bin/cc65*),../../bin/cc65,cc65)
 
 WORKDIR := ../../testwrk
 
 .PHONY: all clean
 
-SOURCES := $(wildcard *.c)
-TESTS := $(foreach option,. .o. .os. .osi. .osir. .oi. .oir. .or.,$(SOURCES:%.c=$(WORKDIR)/%$(option)prg))
+TESTS := $(patsubst %.c,$(WORKDIR)/%.s,$(wildcard *.c))
 
 all: $(TESTS)
 
-$(WORKDIR)/%.prg: %.c
-	$(NOT) $(CL65) $(CC65FLAGS) $< -o $@
-$(WORKDIR)/%.o.prg: %.c
-	$(NOT) $(CL65) -O $(CC65FLAGS) $< -o $@
-$(WORKDIR)/%.os.prg: %.c
-	$(NOT) $(CL65) -Os $(CC65FLAGS) $< -o $@
-$(WORKDIR)/%.osi.prg: %.c
-	$(NOT) $(CL65) -Osi $(CC65FLAGS) $< -o $@
-$(WORKDIR)/%.osir.prg: %.c
-	$(NOT) $(CL65) -Osir $(CC65FLAGS) $< -o $@
-$(WORKDIR)/%.oi.prg: %.c
-	$(NOT) $(CL65) -Oi $(CC65FLAGS) $< -o $@
-$(WORKDIR)/%.oir.prg: %.c
-	$(NOT) $(CL65) -Oir $(CC65FLAGS) $< -o $@
-$(WORKDIR)/%.or.prg: %.c
-	$(NOT) $(CL65) -Or $(CC65FLAGS) $< -o $@
+$(WORKDIR)/%.s: %.c
+	$(NOT) $(CC65) -o $@ $<
 
 clean:
 	@$(call DEL,$(TESTS))
-	@$(call DEL,$(SOURCES:.c=.o))


### PR DESCRIPTION
The files in `test/err/` cannot be compiled.  It doesn't make sense to attempt to assemble and link them.  It doesn't make sense to try different amounts of optimization.

This patch also reduces the number of lines that are written into a Travis-CI build's listing.