### PR TITLE
Handle almost-duplicate C declarations that have different linkages.

### DIFF
--- a/src/cc65/symentry.c
+++ b/src/cc65/symentry.c
@@ -126,19 +126,19 @@ void DumpSymEntry (FILE* F, const SymEntry* E)
     /* Print the assembler name if we have one */
     if (E->AsmName) {
         fprintf (F, "    AsmName: %s\n", E->AsmName);
-    }                                             
+    }
 
     /* Print the flags */
     SymFlags = E->Flags;
-    fprintf (F, "    Flags: ");
+    fprintf (F, "    Flags:");
     for (I = 0; I < sizeof (Flags) / sizeof (Flags[0]) && SymFlags != 0; ++I) {
         if ((SymFlags & Flags[I].Val) == Flags[I].Val) {
             SymFlags &= ~Flags[I].Val;
-            fprintf (F, "%s ", Flags[I].Name);
+            fprintf (F, " %s", Flags[I].Name);
         }
     }
     if (SymFlags != 0) {
-        fprintf (F, "%04X", SymFlags);
+        fprintf (F, " 0x%05X", SymFlags);
     }
     fprintf (F, "\n");
 

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -813,9 +813,23 @@ SymEntry* AddGlobalSym (const char* Name, const Type* T, unsigned Flags)
             }
         }
 
+        /* If a static declaration follows a non-static declaration, then
+        ** warn about the conflict.  (It will compile a public declaration.)
+        */
+        if ((Flags & SC_EXTERN) == 0 && (Entry->Flags & SC_EXTERN) != 0) {
+            Warning ("static declaration follows non-static declaration of `%s'.", Name);
+        }
+
         /* An extern declaration must not change the current linkage. */
         if (IsFunc || (Flags & (SC_EXTERN | SC_DEF)) == SC_EXTERN) {
             Flags &= ~SC_EXTERN;
+        }
+
+        /* If a public declaration follows a static declaration, then
+        ** warn about the conflict.  (It will compile a public declaration.)
+        */
+        if ((Flags & SC_EXTERN) != 0 && (Entry->Flags & SC_EXTERN) == 0) {
+            Warning ("public declaration follows static declaration of `%s'.", Name);
         }
 
         /* Add the new flags */

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -813,6 +813,11 @@ SymEntry* AddGlobalSym (const char* Name, const Type* T, unsigned Flags)
             }
         }
 
+        /* An extern declaration must not change the current linkage. */
+        if (IsFunc || (Flags & (SC_EXTERN | SC_DEF)) == SC_EXTERN) {
+            Flags &= ~SC_EXTERN;
+        }
+
         /* Add the new flags */
         Entry->Flags |= Flags;
 

--- a/test/err/static-2.c
+++ b/test/err/static-2.c
@@ -1,0 +1,20 @@
+/*
+  !!DESCRIPTION!! global non-static and static conflicts
+  !!ORIGIN!!      cc65 regression tests
+  !!LICENCE!!     Public Domain
+  !!AUTHOR!!      Greg King
+*/
+
+/*
+  see: https://github.com/cc65/cc65/issues/191
+*/
+
+#pragma warn(error, on)
+
+int n;
+static int n;           /* should give an error */
+
+int main(void)
+{
+    return n;
+}

--- a/test/err/static-3.c
+++ b/test/err/static-3.c
@@ -1,0 +1,20 @@
+/*
+  !!DESCRIPTION!! global non-static and static conflicts
+  !!ORIGIN!!      cc65 regression tests
+  !!LICENCE!!     Public Domain
+  !!AUTHOR!!      Greg King
+*/
+
+/*
+  see: https://github.com/cc65/cc65/issues/191
+*/
+
+#pragma warn(error, on)
+
+extern int n;
+static int n;           /* should give an error */
+
+int main(void)
+{
+    return n;
+}

--- a/test/err/static-4.c
+++ b/test/err/static-4.c
@@ -1,0 +1,20 @@
+/*
+  !!DESCRIPTION!! global non-static and static conflicts
+  !!ORIGIN!!      cc65 regression tests
+  !!LICENCE!!     Public Domain
+  !!AUTHOR!!      Greg King
+*/
+
+/*
+  see: https://github.com/cc65/cc65/issues/191
+*/
+
+#pragma warn(error, on)
+
+static int n;
+int n;                  /* should give an error */
+
+int main(void)
+{
+    return n;
+}

--- a/test/val/static-1.c
+++ b/test/val/static-1.c
@@ -1,0 +1,20 @@
+/*
+  !!DESCRIPTION!! global non-static and static conflicts
+  !!ORIGIN!!      cc65 regression tests
+  !!LICENCE!!     Public Domain
+  !!AUTHOR!!      Greg King
+*/
+
+/*
+  see: https://github.com/cc65/cc65/issues/191
+*/
+
+#pragma warn(error, on)
+
+static int n = 0;
+extern int n;           /* should not give an error */
+
+int main(void)
+{
+    return n;
+}


### PR DESCRIPTION
("Linkages" come from the `extern` and `static` qualifiers that can be put on global declarations/definitions.)

This Pull Request fixes the bug that was described by me in issue #191.  It adds some warning messages, as requested in that issue.  And, it adds some compiler regression tests for that issue.