### PR TITLE
Change multi-line C comments in files that were missed by a previous pull request.

### DIFF
--- a/src/cl65/spawn-amiga.inc
+++ b/src/cl65/spawn-amiga.inc
@@ -38,8 +38,8 @@
 
 
 /* Mode argument for spawn. This value is ignored by the function and only
- * provided for DOS/Windows compatibility.
- */
+** provided for DOS/Windows compatibility.
+*/
 #ifndef P_WAIT
 #define P_WAIT  0
 #endif
@@ -56,10 +56,10 @@ int spawnvp (int Mode attribute ((unused)),
              const char* File attribute ((unused)),
              char* const argv [])
 /* Execute the given program searching and wait til it terminates. The Mode
- * argument is ignored (compatibility only). The result of the function is
- * the return code of the program. The function will terminate the program
- * on errors.
- */
+** argument is ignored (compatibility only). The result of the function is
+** the return code of the program. The function will terminate the program
+** on errors.
+*/
 {
     int Status;
     StrBuf Command = AUTO_STRBUF_INITIALIZER;

--- a/src/cl65/spawn-unix.inc
+++ b/src/cl65/spawn-unix.inc
@@ -48,8 +48,8 @@
 
 
 /* Mode argument for spawn. This value is ignored by the function and only
- * provided for DOS/Windows compatibility.
- */
+** provided for DOS/Windows compatibility.
+*/
 #ifndef P_WAIT
 #define P_WAIT  0
 #endif
@@ -64,10 +64,10 @@
 
 int spawnvp (int Mode attribute ((unused)), const char* File, char* const argv [])
 /* Execute the given program searching and wait til it terminates. The Mode
- * argument is ignored (compatibility only). The result of the function is
- * the return code of the program. The function will terminate the program
- * on errors.
- */
+** argument is ignored (compatibility only). The result of the function is
+** the return code of the program. The function will terminate the program
+** on errors.
+*/
 {
     int Status = 0;
 
@@ -99,7 +99,7 @@ int spawnvp (int Mode attribute ((unused)), const char* File, char* const argv [
     }
 
     /* Only the father goes here, we place a return here regardless of that
-     * to avoid compiler warnings.
-     */
+    ** to avoid compiler warnings.
+    */
     return WEXITSTATUS (Status);
 }


### PR DESCRIPTION
In PR #128, I claimed that I changed _all_ of the comments.  I was too confident.  I changed the `.c` and `.h` files; but, I had forgotten that Uz had put C code into some `.inc` files.