### PR TITLE
Fix the CBM random-seed generators.

### DIFF
--- a/libsrc/c128/randomize.s
+++ b/libsrc/c128/randomize.s
@@ -1,5 +1,6 @@
 ;
-; Ullrich von Bassewitz, 05.11.2002
+; 2002-11-05, Ullrich von Bassewitz
+; 2015-09-11, Greg King
 ;
 ; void _randomize (void);
 ; /* Initialize the random number generator */
@@ -12,6 +13,6 @@
 
 __randomize:
         ldx     VIC_HLINE       ; Use VIC rasterline as high byte
-        lda     TIME            ; Use 60HZ clock as low byte
+        lda     TIME+2          ; Use 60HZ clock as low byte
         jmp     _srand          ; Initialize generator
 

--- a/libsrc/c16/randomize.s
+++ b/libsrc/c16/randomize.s
@@ -1,5 +1,6 @@
 ;
-; Ullrich von Bassewitz, 05.11.2002
+; 2002-11-05, Ullrich von Bassewitz
+; 2015-09-11, Greg King
 ;
 ; void _randomize (void);
 ; /* Initialize the random number generator */
@@ -12,6 +13,6 @@
 
 __randomize:
         ldx     TED_VLINELO     ; Use TED rasterline as high byte
-        lda     TIME            ; Use 60HZ clock as low byte
+        lda     TIME+2          ; Use 60HZ clock as low byte
         jmp     _srand          ; Initialize generator
 

--- a/libsrc/c64/randomize.s
+++ b/libsrc/c64/randomize.s
@@ -1,5 +1,6 @@
 ;
-; Ullrich von Bassewitz, 05.11.2002
+; 2002-11-05, Ullrich von Bassewitz
+; 2015-09-11, Greg King
 ;
 ; void _randomize (void);
 ; /* Initialize the random number generator */
@@ -12,6 +13,6 @@
 
 __randomize:              
         ldx     VIC_HLINE       ; Use VIC rasterline as high byte
-        lda     TIME            ; Use 60HZ clock as low byte
+        lda     TIME+2          ; Use 60HZ clock as low byte
         jmp     _srand          ; Initialize generator
 

--- a/libsrc/cbm510/randomize.s
+++ b/libsrc/cbm510/randomize.s
@@ -1,5 +1,6 @@
 ;
-; Ullrich von Bassewitz, 05.11.2002
+; 2002-11-05, Ullrich von Bassewitz
+; 2015-09-11, Greg King
 ;
 ; void _randomize (void);
 ; /* Initialize the random number generator */
@@ -10,7 +11,7 @@
         .importzp       time
 
 __randomize:
-        ldx     time            ; Use 50/60HZ clock
+        ldx     time+2          ; Use 50/60HZ clock
         lda     time+1
         jmp     _srand          ; Initialize generator
 

--- a/libsrc/cbm610/randomize.s
+++ b/libsrc/cbm610/randomize.s
@@ -1,5 +1,6 @@
 ;
-; Ullrich von Bassewitz, 05.11.2002
+; 2002-11-05, Ullrich von Bassewitz
+; 2015-09-11, Greg King
 ;
 ; void _randomize (void);
 ; /* Initialize the random number generator */
@@ -10,7 +11,7 @@
         .importzp       time
 
 __randomize:               
-        ldx     time            ; Use 50/60HZ clock
+        ldx     time+2          ; Use 50/60HZ clock
         lda     time+1
         jmp     _srand          ; Initialize generator
 

--- a/libsrc/pet/randomize.s
+++ b/libsrc/pet/randomize.s
@@ -1,5 +1,6 @@
 ;
-; Ullrich von Bassewitz, 05.11.2002
+; 2002-11-05, Ullrich von Bassewitz
+; 2015-09-11, Greg King
 ;
 ; void _randomize (void);
 ; /* Initialize the random number generator */
@@ -11,7 +12,7 @@
         .include        "pet.inc"
 
 __randomize:              
-        ldx     TIME
+        ldx     TIME+2
         lda     TIME+1          ; Use 60HZ clock
         jmp     _srand          ; Initialize generator
 

--- a/libsrc/plus4/randomize.s
+++ b/libsrc/plus4/randomize.s
@@ -1,5 +1,6 @@
 ;
-; Ullrich von Bassewitz, 05.11.2002
+; 2002-11-05, Ullrich von Bassewitz
+; 2015-09-11, Greg King
 ;
 ; void _randomize (void);
 ; /* Initialize the random number generator */
@@ -12,6 +13,6 @@
 
 __randomize:              
         ldx     TED_VLINELO     ; Use TED rasterline as high byte
-        lda     TIME            ; Use 60HZ clock as low byte
+        lda     TIME+2          ; Use 60HZ clock as low byte
         jmp     _srand          ; Initialize generator
 

--- a/libsrc/vic20/randomize.s
+++ b/libsrc/vic20/randomize.s
@@ -1,5 +1,6 @@
 ;
-; Ullrich von Bassewitz, 05.11.2002
+; 2002-11-05, Ullrich von Bassewitz
+; 2015-09-11, Greg King
 ;
 ; void _randomize (void);
 ; /* Initialize the random number generator */
@@ -16,6 +17,6 @@ __randomize:
         lda     VIC_HLINE       ; Get bit 1-8 of rasterline
         rol     a               ; Use bit 0-7
         tax                     ; Use VIC rasterline as high byte
-        lda     TIME            ; Use 60HZ clock as low byte
+        lda     TIME+2          ; Use 60HZ clock as low byte
         jmp     _srand          ; Initialize generator
 


### PR DESCRIPTION
Those functions had assumed that TIME is stored in little-endian order.  But, it's stored "backwards".

This fixes bug report #206.