### PR TITLE
Make an ar65 warning show both object files' names.

### DIFF
--- a/src/ar65/exports.c
+++ b/src/ar65/exports.c
@@ -113,9 +113,9 @@ void ExpInsert (const char* Name, const ObjData* Module)
     while (1) {
         if (strcmp (L->Name, Name) == 0) {
             /* Duplicate entry */
-            Warning ("External symbol `%s' in module `%s', library `%s' "
+            Warning ("External symbol `%s' in module `%s', library `%s', "
                      "is duplicated in module `%s'",
-                     Name, L->Name, LibName, Module->Name);
+                     Name, L->Module->Name, LibName, Module->Name);
         }
         if (L->Next == 0) {
             break;


### PR DESCRIPTION
When an object file is added to an archive, ar65 adds the symbols that are exported.  If any one of those symbols already exists in that archive, then ar65 shows a warning.  That message gives the name of the newly added object file.  But, instead of giving the name of the already existing file, it shows the symbol twice.

This fix makes the message say, "`External symbol '<symbol-name>' in module '<existing file.o>', library '<archive-name>', is duplicated in module '<new file.o>'`".