### PR TITLE
Save space by using the apple2 target's INIT overlay scheme on the c64 target.

### DIFF
--- a/asminc/c64.inc
+++ b/asminc/c64.inc
@@ -24,6 +24,7 @@ SCREEN_PTR      := $D1          ; Pointer to current char in text screen
 CURS_X          := $D3          ; Cursor column
 CURS_Y          := $D6          ; Cursor row
 CRAM_PTR        := $F3          ; Pointer to current char in color RAM
+FREKZP          := $FB          ; Five unused bytes
 
 BASIC_BUF       := $200         ; Location of command-line
 BASIC_BUF_LEN   = 89            ; Maximum length of command-line
@@ -212,4 +213,3 @@ CASSMOT         = $20           ; Cassette motor on
 TP_FAST         = $80           ; Switch Rossmoeller TurboProcess to fast mode
 
 RAMONLY         = $F8           ; (~(LORAM | HIRAM | IOEN)) & $FF
-

--- a/cfg/c64-overlay.cfg
+++ b/cfg/c64-overlay.cfg
@@ -1,64 +1,70 @@
+FEATURES {
+    STARTADDRESS:    default = $0801;
+}
 SYMBOLS {
     __LOADADDR__:    type = import;
     __EXEHDR__:      type = import;
     __OVERLAYADDR__: type = import;
-    __STACKSIZE__:   type = weak, value = $0800; # 2k stack
-    __OVERLAYSIZE__: type = weak, value = $1000; # 4k overlay
+    __STACKSIZE__:   type = weak,   value = $0800; # 2k stack
+    __OVERLAYSIZE__: type = weak,   value = $1000; # 4k overlay
+    __HIMEM__:       type = weak,   value = $D000;
+    __HIMEM2__:      type = export, value = __HIMEM__ - 2;
 }
 MEMORY {
-    ZP:       file = "", define = yes, start = $0002,                   size = $001A;
-    LOADADDR: file = %O,               start = $07FF,                   size = $0002;
-    HEADER:   file = %O,               start = $0801,                   size = $000C;
-    RAM:      file = %O, define = yes, start = $080D,                   size = $C7F3 - __OVERLAYSIZE__ - __STACKSIZE__;
-    OVL1ADDR: file = "%O.1",           start = $CFFE - __OVERLAYSIZE__, size = $0002;
-    OVL1:     file = "%O.1",           start = $D000 - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL2ADDR: file = "%O.2",           start = $CFFE - __OVERLAYSIZE__, size = $0002;
-    OVL2:     file = "%O.2",           start = $D000 - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL3ADDR: file = "%O.3",           start = $CFFE - __OVERLAYSIZE__, size = $0002;
-    OVL3:     file = "%O.3",           start = $D000 - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL4ADDR: file = "%O.4",           start = $CFFE - __OVERLAYSIZE__, size = $0002;
-    OVL4:     file = "%O.4",           start = $D000 - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL5ADDR: file = "%O.5",           start = $CFFE - __OVERLAYSIZE__, size = $0002;
-    OVL5:     file = "%O.5",           start = $D000 - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL6ADDR: file = "%O.6",           start = $CFFE - __OVERLAYSIZE__, size = $0002;
-    OVL6:     file = "%O.6",           start = $D000 - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL7ADDR: file = "%O.7",           start = $CFFE - __OVERLAYSIZE__, size = $0002;
-    OVL7:     file = "%O.7",           start = $D000 - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL8ADDR: file = "%O.8",           start = $CFFE - __OVERLAYSIZE__, size = $0002;
-    OVL8:     file = "%O.8",           start = $D000 - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL9ADDR: file = "%O.9",           start = $CFFE - __OVERLAYSIZE__, size = $0002;
-    OVL9:     file = "%O.9",           start = $D000 - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
+    ZP:       file = "", define = yes, start = $0002,                        size = $001A;
+    LOADADDR: file = %O,               start = %S - 2,                       size = $0002;
+    HEADER:   file = %O, define = yes, start = %S,                           size = $000D;
+    RAM:      file = %O,               start = __HEADER_LAST__,              size = __HIMEM__ - __OVERLAYSIZE__ - __STACKSIZE__ - __HEADER_LAST__;
+    MOVE:     file = %O,               start = __ZPSAVE_LOAD__,              size = __HIMEM__ - __INIT_RUN__;
+    OVL1ADDR: file = "%O.1",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
+    OVL1:     file = "%O.1",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
+    OVL2ADDR: file = "%O.2",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
+    OVL2:     file = "%O.2",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
+    OVL3ADDR: file = "%O.3",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
+    OVL3:     file = "%O.3",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
+    OVL4ADDR: file = "%O.4",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
+    OVL4:     file = "%O.4",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
+    OVL5ADDR: file = "%O.5",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
+    OVL5:     file = "%O.5",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
+    OVL6ADDR: file = "%O.6",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
+    OVL6:     file = "%O.6",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
+    OVL7ADDR: file = "%O.7",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
+    OVL7:     file = "%O.7",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
+    OVL8ADDR: file = "%O.8",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
+    OVL8:     file = "%O.8",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
+    OVL9ADDR: file = "%O.9",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
+    OVL9:     file = "%O.9",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
 }
 SEGMENTS {
-    LOADADDR: load = LOADADDR, type = ro;
-    EXEHDR:   load = HEADER,   type = ro;
-    STARTUP:  load = RAM,      type = ro;
-    LOWCODE:  load = RAM,      type = ro,                optional = yes;
-    INIT:     load = RAM,      type = ro,  define = yes, optional = yes;
-    CODE:     load = RAM,      type = ro;
-    RODATA:   load = RAM,      type = ro;
-    DATA:     load = RAM,      type = rw;
-    ZPSAVE:   load = RAM,      type = bss;
-    BSS:      load = RAM,      type = bss, define = yes;
-    ZEROPAGE: load = ZP,       type = zp;
-    OVL1ADDR: load = OVL1ADDR, type = ro;
-    OVERLAY1: load = OVL1,     type = ro,  define = yes, optional = yes;
-    OVL2ADDR: load = OVL2ADDR, type = ro;
-    OVERLAY2: load = OVL2,     type = ro,  define = yes, optional = yes;
-    OVL3ADDR: load = OVL3ADDR, type = ro;
-    OVERLAY3: load = OVL3,     type = ro,  define = yes, optional = yes;
-    OVL4ADDR: load = OVL4ADDR, type = ro;
-    OVERLAY4: load = OVL4,     type = ro,  define = yes, optional = yes;
-    OVL5ADDR: load = OVL5ADDR, type = ro;
-    OVERLAY5: load = OVL5,     type = ro,  define = yes, optional = yes;
-    OVL6ADDR: load = OVL6ADDR, type = ro;
-    OVERLAY6: load = OVL6,     type = ro,  define = yes, optional = yes;
-    OVL7ADDR: load = OVL7ADDR, type = ro;
-    OVERLAY7: load = OVL7,     type = ro,  define = yes, optional = yes;
-    OVL8ADDR: load = OVL8ADDR, type = ro;
-    OVERLAY8: load = OVL8,     type = ro,  define = yes, optional = yes;
-    OVL9ADDR: load = OVL9ADDR, type = ro;
-    OVERLAY9: load = OVL9,     type = ro,  define = yes, optional = yes;
+    ZEROPAGE: load = ZP,              type = zp;
+    LOADADDR: load = LOADADDR,        type = ro;
+    EXEHDR:   load = HEADER,          type = ro;
+    STARTUP:  load = RAM,             type = ro;
+    LOWCODE:  load = RAM,             type = ro,                optional = yes;
+    CODE:     load = RAM,             type = ro;
+    RODATA:   load = RAM,             type = ro;
+    DATA:     load = RAM,             type = rw;
+    ZPSAVE:   load = RAM,             type = bss, define = yes;
+    BSS:      load = RAM,             type = bss, define = yes;
+    INIT:     load = MOVE, run = RAM, type = ro,  define = yes, optional = yes;
+    OVL1ADDR: load = OVL1ADDR,        type = ro;
+    OVERLAY1: load = OVL1,            type = ro,  define = yes, optional = yes;
+    OVL2ADDR: load = OVL2ADDR,        type = ro;
+    OVERLAY2: load = OVL2,            type = ro,  define = yes, optional = yes;
+    OVL3ADDR: load = OVL3ADDR,        type = ro;
+    OVERLAY3: load = OVL3,            type = ro,  define = yes, optional = yes;
+    OVL4ADDR: load = OVL4ADDR,        type = ro;
+    OVERLAY4: load = OVL4,            type = ro,  define = yes, optional = yes;
+    OVL5ADDR: load = OVL5ADDR,        type = ro;
+    OVERLAY5: load = OVL5,            type = ro,  define = yes, optional = yes;
+    OVL6ADDR: load = OVL6ADDR,        type = ro;
+    OVERLAY6: load = OVL6,            type = ro,  define = yes, optional = yes;
+    OVL7ADDR: load = OVL7ADDR,        type = ro;
+    OVERLAY7: load = OVL7,            type = ro,  define = yes, optional = yes;
+    OVL8ADDR: load = OVL8ADDR,        type = ro;
+    OVERLAY8: load = OVL8,            type = ro,  define = yes, optional = yes;
+    OVL9ADDR: load = OVL9ADDR,        type = ro;
+    OVERLAY9: load = OVL9,            type = ro,  define = yes, optional = yes;
 }
 FEATURES {
     CONDES: type    = constructor,

--- a/cfg/c64-overlay.cfg
+++ b/cfg/c64-overlay.cfg
@@ -1,39 +1,39 @@
 FEATURES {
-    STARTADDRESS:    default = $0801;
+    STARTADDRESS:     default = $0801;
 }
 SYMBOLS {
-    __LOADADDR__:    type = import;
-    __EXEHDR__:      type = import;
-    __OVERLAYADDR__: type = import;
-    __STACKSIZE__:   type = weak,   value = $0800; # 2k stack
-    __OVERLAYSIZE__: type = weak,   value = $1000; # 4k overlay
-    __HIMEM__:       type = weak,   value = $D000;
-    __HIMEM2__:      type = export, value = __HIMEM__ - 2;
+    __LOADADDR__:     type = import;
+    __EXEHDR__:       type = import;
+    __OVERLAYADDR__:  type = import;
+    __STACKSIZE__:    type = weak,   value = $0800; # 2k stack
+    __OVERLAYSIZE__:  type = weak,   value = $1000; # 4k overlay
+    __HIMEM__:        type = weak,   value = $D000;
+    __OVERLAYSTART__: type = export, value = __HIMEM__ - __OVERLAYSIZE__;
 }
 MEMORY {
-    ZP:       file = "", define = yes, start = $0002,                        size = $001A;
-    LOADADDR: file = %O,               start = %S - 2,                       size = $0002;
-    HEADER:   file = %O, define = yes, start = %S,                           size = $000D;
-    RAM:      file = %O, define = yes, start = __HEADER_LAST__,              size = __HIMEM__ - __OVERLAYSIZE__ - __STACKSIZE__ - __HEADER_LAST__;
-    MOVE:     file = %O,               start = __ZPSAVE_LOAD__,              size = __HIMEM__ - __INIT_RUN__;
-    OVL1ADDR: file = "%O.1",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
-    OVL1:     file = "%O.1",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL2ADDR: file = "%O.2",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
-    OVL2:     file = "%O.2",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL3ADDR: file = "%O.3",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
-    OVL3:     file = "%O.3",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL4ADDR: file = "%O.4",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
-    OVL4:     file = "%O.4",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL5ADDR: file = "%O.5",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
-    OVL5:     file = "%O.5",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL6ADDR: file = "%O.6",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
-    OVL6:     file = "%O.6",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL7ADDR: file = "%O.7",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
-    OVL7:     file = "%O.7",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL8ADDR: file = "%O.8",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
-    OVL8:     file = "%O.8",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
-    OVL9ADDR: file = "%O.9",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
-    OVL9:     file = "%O.9",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;
+    ZP:       file = "", define = yes, start = $0002,                size = $001A;
+    LOADADDR: file = %O,               start = %S - 2,               size = $0002;
+    HEADER:   file = %O, define = yes, start = %S,                   size = $000D;
+    RAM:      file = %O, define = yes, start = __HEADER_LAST__,      size = __OVERLAYSTART__ - __STACKSIZE__ - __HEADER_LAST__;
+    MOVE:     file = %O,               start = __ZPSAVE_LOAD__,      size = __HIMEM__ - __INIT_RUN__;
+    OVL1ADDR: file = "%O.1",           start = __OVERLAYSTART__ - 2, size = $0002;
+    OVL1:     file = "%O.1",           start = __OVERLAYSTART__,     size = __OVERLAYSIZE__;
+    OVL2ADDR: file = "%O.2",           start = __OVERLAYSTART__ - 2, size = $0002;
+    OVL2:     file = "%O.2",           start = __OVERLAYSTART__,     size = __OVERLAYSIZE__;
+    OVL3ADDR: file = "%O.3",           start = __OVERLAYSTART__ - 2, size = $0002;
+    OVL3:     file = "%O.3",           start = __OVERLAYSTART__,     size = __OVERLAYSIZE__;
+    OVL4ADDR: file = "%O.4",           start = __OVERLAYSTART__ - 2, size = $0002;
+    OVL4:     file = "%O.4",           start = __OVERLAYSTART__,     size = __OVERLAYSIZE__;
+    OVL5ADDR: file = "%O.5",           start = __OVERLAYSTART__ - 2, size = $0002;
+    OVL5:     file = "%O.5",           start = __OVERLAYSTART__,     size = __OVERLAYSIZE__;
+    OVL6ADDR: file = "%O.6",           start = __OVERLAYSTART__ - 2, size = $0002;
+    OVL6:     file = "%O.6",           start = __OVERLAYSTART__,     size = __OVERLAYSIZE__;
+    OVL7ADDR: file = "%O.7",           start = __OVERLAYSTART__ - 2, size = $0002;
+    OVL7:     file = "%O.7",           start = __OVERLAYSTART__,     size = __OVERLAYSIZE__;
+    OVL8ADDR: file = "%O.8",           start = __OVERLAYSTART__ - 2, size = $0002;
+    OVL8:     file = "%O.8",           start = __OVERLAYSTART__,     size = __OVERLAYSIZE__;
+    OVL9ADDR: file = "%O.9",           start = __OVERLAYSTART__ - 2, size = $0002;
+    OVL9:     file = "%O.9",           start = __OVERLAYSTART__,     size = __OVERLAYSIZE__;
 }
 SEGMENTS {
     ZEROPAGE: load = ZP,              type = zp;

--- a/cfg/c64-overlay.cfg
+++ b/cfg/c64-overlay.cfg
@@ -14,7 +14,7 @@ MEMORY {
     ZP:       file = "", define = yes, start = $0002,                        size = $001A;
     LOADADDR: file = %O,               start = %S - 2,                       size = $0002;
     HEADER:   file = %O, define = yes, start = %S,                           size = $000D;
-    RAM:      file = %O,               start = __HEADER_LAST__,              size = __HIMEM__ - __OVERLAYSIZE__ - __STACKSIZE__ - __HEADER_LAST__;
+    RAM:      file = %O, define = yes, start = __HEADER_LAST__,              size = __HIMEM__ - __OVERLAYSIZE__ - __STACKSIZE__ - __HEADER_LAST__;
     MOVE:     file = %O,               start = __ZPSAVE_LOAD__,              size = __HIMEM__ - __INIT_RUN__;
     OVL1ADDR: file = "%O.1",           start = __HIMEM2__ - __OVERLAYSIZE__, size = $0002;
     OVL1:     file = "%O.1",           start = __HIMEM__  - __OVERLAYSIZE__, size = __OVERLAYSIZE__;

--- a/cfg/c64-overlay.cfg
+++ b/cfg/c64-overlay.cfg
@@ -46,7 +46,7 @@ SEGMENTS {
     DATA:     load = RAM,             type = rw;
     ZPSAVE:   load = RAM,             type = bss, define = yes;
     BSS:      load = RAM,             type = bss, define = yes;
-    INIT:     load = MOVE, run = RAM, type = ro,  define = yes, optional = yes;
+    INIT:     load = MOVE, run = RAM, type = ro,  define = yes;
     OVL1ADDR: load = OVL1ADDR,        type = ro;
     OVERLAY1: load = OVL1,            type = ro,  define = yes, optional = yes;
     OVL2ADDR: load = OVL2ADDR,        type = ro;

--- a/cfg/c64.cfg
+++ b/cfg/c64.cfg
@@ -1,26 +1,31 @@
+FEATURES {
+    STARTADDRESS:  default = $0801;
+}
 SYMBOLS {
     __LOADADDR__:  type = import;
     __EXEHDR__:    type = import;
     __STACKSIZE__: type = weak, value = $0800; # 2k stack
+    __HIMEM__:     type = weak, value = $D000;
 }
 MEMORY {
-    ZP:       file = "", define = yes, start = $0002, size = $001A;
-    LOADADDR: file = %O,               start = $07FF, size = $0002;
-    HEADER:   file = %O,               start = $0801, size = $000C;
-    RAM:      file = %O, define = yes, start = $080D, size = $C7F3 - __STACKSIZE__;
+    ZP:       file = "", define = yes, start = $0002,           size = $001A;
+    LOADADDR: file = %O,               start = %S - 2,          size = $0002;
+    HEADER:   file = %O, define = yes, start = %S,              size = $000D;
+    RAM:      file = %O,               start = __HEADER_LAST__, size = __HIMEM__ - __STACKSIZE__ - __HEADER_LAST__;
+    MOVE:     file = %O,               start = __ZPSAVE_LOAD__, size = __HIMEM__ - __INIT_RUN__;
 }
 SEGMENTS {
-    LOADADDR: load = LOADADDR, type = ro;
-    EXEHDR:   load = HEADER,   type = ro;
-    STARTUP:  load = RAM,      type = ro;
-    LOWCODE:  load = RAM,      type = ro,                optional = yes;
-    INIT:     load = RAM,      type = ro,  define = yes, optional = yes;
-    CODE:     load = RAM,      type = ro;
-    RODATA:   load = RAM,      type = ro;
-    DATA:     load = RAM,      type = rw;
-    ZPSAVE:   load = RAM,      type = bss;
-    BSS:      load = RAM,      type = bss, define = yes;
-    ZEROPAGE: load = ZP,       type = zp;
+    ZEROPAGE: load = ZP,              type = zp;
+    LOADADDR: load = LOADADDR,        type = ro;
+    EXEHDR:   load = HEADER,          type = ro;
+    STARTUP:  load = RAM,             type = ro;
+    LOWCODE:  load = RAM,             type = ro,                optional = yes;
+    CODE:     load = RAM,             type = ro;
+    RODATA:   load = RAM,             type = ro;
+    DATA:     load = RAM,             type = rw;
+    ZPSAVE:   load = RAM,             type = bss, define = yes;
+    BSS:      load = RAM,             type = bss, define = yes;
+    INIT:     load = MOVE, run = RAM, type = ro,  define = yes, optional = yes;
 }
 FEATURES {
     CONDES: type    = constructor,

--- a/cfg/c64.cfg
+++ b/cfg/c64.cfg
@@ -11,7 +11,7 @@ MEMORY {
     ZP:       file = "", define = yes, start = $0002,           size = $001A;
     LOADADDR: file = %O,               start = %S - 2,          size = $0002;
     HEADER:   file = %O, define = yes, start = %S,              size = $000D;
-    RAM:      file = %O,               start = __HEADER_LAST__, size = __HIMEM__ - __STACKSIZE__ - __HEADER_LAST__;
+    RAM:      file = %O, define = yes, start = __HEADER_LAST__, size = __HIMEM__ - __STACKSIZE__ - __HEADER_LAST__;
     MOVE:     file = %O,               start = __ZPSAVE_LOAD__, size = __HIMEM__ - __INIT_RUN__;
 }
 SEGMENTS {

--- a/cfg/c64.cfg
+++ b/cfg/c64.cfg
@@ -25,7 +25,7 @@ SEGMENTS {
     DATA:     load = RAM,             type = rw;
     ZPSAVE:   load = RAM,             type = bss, define = yes;
     BSS:      load = RAM,             type = bss, define = yes;
-    INIT:     load = MOVE, run = RAM, type = ro,  define = yes, optional = yes;
+    INIT:     load = MOVE, run = RAM, type = ro,  define = yes;
 }
 FEATURES {
     CONDES: type    = constructor,

--- a/libsrc/c64/crt0.s
+++ b/libsrc/c64/crt0.s
@@ -8,7 +8,8 @@
         .import         initlib, donelib
         .import         moveinit, zerobss, callmain
         .import         BSOUT
-        .import         __HIMEM__                       ; from configure file
+        .import         __RAM_START__, __RAM_SIZE__     ; Linker generated
+        .import         __STACKSIZE__                   ; from configure file
         .importzp       ST
 
         .include        "zeropage.inc"
@@ -105,8 +106,8 @@ L1:     lda     sp,x
 
 ; Set up the stack.
 
-        lda     #<__HIMEM__
-        ldx     #>__HIMEM__
+        lda     #<(__RAM_START__ + __RAM_SIZE__ + __STACKSIZE__)
+        ldx     #>(__RAM_START__ + __RAM_SIZE__ + __STACKSIZE__)
         sta     sp
         stx     sp+1            ; Set argument stack ptr
 

--- a/libsrc/c64/crt0.s
+++ b/libsrc/c64/crt0.s
@@ -40,7 +40,7 @@ Start:
         stx     spsave          ; Save the system stack ptr
 
 ; Allow some re-entrancy by skipping the next task if it already was done.
-; This often can let us rerun the program without reloading it.
+; This sometimes can let us rerun the program without reloading it.
 
         ldx     move_init
         beq     L0
@@ -125,8 +125,12 @@ L1:     lda     sp,x
 
 .data
 
+; These two variables were moved out of the BSS segment, and into DATA, because
+; we need to use them before INIT is moved off of BSS, and before BSS is zeroed.
+
 mmusave:.res    1
 spsave: .res    1
+
 move_init:
         .byte   1
 

--- a/libsrc/common/moveinit.s
+++ b/libsrc/common/moveinit.s
@@ -1,0 +1,54 @@
+;
+; 2015-10-04, Greg King
+;
+
+        .export         move_init
+
+        .import         __INIT_LOAD__, __INIT_RUN__, __INIT_SIZE__ ; Linker-generated
+        .importzp       init_load_, init_run_
+
+        .macpack        cpu
+        .macpack        generic
+
+
+; Move the INIT segment from where it was loaded (over the bss segments)
+; into where it must be run (in the heap).  The two areas might overlap; and,
+; the segment is moved upwards.  Therefore, this code starts at the highest
+; address, and decrements to the lowest address.  The low bytes of the starting
+; pointers are not sums.  The high bytes are sums; but, they do not include the
+; carry.  Both the low-byte sums and the carries will be done when the pointers
+; are indexed by the .Y register.
+
+move_init:
+        lda     #<__INIT_LOAD__
+        ldx     #>__INIT_LOAD__ + >__INIT_SIZE__
+        sta     init_load_
+        stx     init_load_+1
+        lda     #<__INIT_RUN__
+        ldx     #>__INIT_RUN__ + >__INIT_SIZE__
+        sta     init_run_
+        stx     init_run_+1
+
+; First, move the last, partial page.
+; Then, move all of the full pages.
+
+        ldx     #>__INIT_SIZE__ + 1     ; number of pages, including partial
+        ldy     #<__INIT_SIZE__         ; size of partial page
+.if     .cpu & CPU_ISET_65SC02
+        bra     L3
+.else
+        jmp     L3
+.endif
+
+L1:     dec     init_load_+1
+        dec     init_run_+1
+
+L2:     dey
+        lda     (init_load_),y
+        sta     (init_run_),y
+        tya
+L3:     bnz     L2                      ; page not finished
+
+        dex
+        bnz     L1                      ; move next page
+        rts

--- a/libsrc/common/moveinit.s
+++ b/libsrc/common/moveinit.s
@@ -1,15 +1,18 @@
 ;
-; 2015-10-04, Greg King
+; 2015-10-07, Greg King
 ;
 
-        .export         move_init
+        .export         moveinit
 
         .import         __INIT_LOAD__, __INIT_RUN__, __INIT_SIZE__ ; Linker-generated
-        .importzp       init_load_, init_run_
 
         .macpack        cpu
         .macpack        generic
 
+
+; Put this in the DATA segment because it is self-modifying code.
+
+.data
 
 ; Move the INIT segment from where it was loaded (over the bss segments)
 ; into where it must be run (in the heap).  The two areas might overlap; and,
@@ -19,36 +22,24 @@
 ; carry.  Both the low-byte sums and the carries will be done when the pointers
 ; are indexed by the .Y register.
 
-move_init:
-        lda     #<__INIT_LOAD__
-        ldx     #>__INIT_LOAD__ + >__INIT_SIZE__
-        sta     init_load_
-        stx     init_load_+1
-        lda     #<__INIT_RUN__
-        ldx     #>__INIT_RUN__ + >__INIT_SIZE__
-        sta     init_run_
-        stx     init_run_+1
+moveinit:
 
 ; First, move the last, partial page.
 ; Then, move all of the full pages.
 
-        ldx     #>__INIT_SIZE__ + 1     ; number of pages, including partial
         ldy     #<__INIT_SIZE__         ; size of partial page
-.if     .cpu & CPU_ISET_65SC02
-        bra     L3
-.else
-        jmp     L3
-.endif
+        ldx     #>__INIT_SIZE__ + (<__INIT_SIZE__ <> 0)  ; number of pages, including partial
 
-L1:     dec     init_load_+1
-        dec     init_run_+1
-
-L2:     dey
-        lda     (init_load_),y
-        sta     (init_run_),y
+L1:     dey
+init_load:
+        lda     __INIT_LOAD__ + (__INIT_SIZE__ & $FF00) - $0100 * (<__INIT_SIZE__ = 0),y
+init_run:
+        sta     __INIT_RUN__  + (__INIT_SIZE__ & $FF00) - $0100 * (<__INIT_SIZE__ = 0),y
         tya
-L3:     bnz     L2                      ; page not finished
+        bnz     L1                      ; page not finished
 
+        dec     init_load+2
+        dec     init_run+2
         dex
         bnz     L1                      ; move next page
         rts


### PR DESCRIPTION
This Pull Request implements the INIT segment scheme that Oliver urged us (in PR #213 comments) to use.

The c64 configuration files have other changes that come from my project to make the configure files more versatile and more consistent with each other.  I put them in this PR because they work well with the INIT changes.

I plan to do the INIT scheme on most of the other targets.  I publish these c64 changes so that Soft80 and Contiki can take advantage of them now.