### PR TITLE
Change the way that ld65 handles bad offset/start segment-attributes.

### DIFF
--- a/src/ld65/main.c
+++ b/src/ld65/main.c
@@ -819,8 +819,8 @@ int main (int argc, char* argv [])
         if (MapFileName) {
             CreateMapFile (SHORT_MAPFILE);
         }
-        Error ("Cannot generate output due to memory area overflow%s",
-               (MemoryAreaOverflows > 1)? "s" : "");
+        Error ("Cannot generate most of the files due to memory area overflow%c",
+               (MemoryAreaOverflows > 1) ? 's' : ' ');
     }
 
     /* Create the output file */


### PR DESCRIPTION
This Pull Request fixes a bug that was reported by Brad Smith on [the old cc65 mailing list](http://www.cc65.org/mailarchive/2015-10/11761.html).