### PR TITLE
Update the <nes.h> include file.

### DIFF
--- a/include/nes.h
+++ b/include/nes.h
@@ -100,6 +100,63 @@
 #define KEY_LEFT        0x40
 #define KEY_RIGHT       0x80
 
+/* Define hardware */
+
+/* Picture Processing Unit */
+struct __ppu {
+    unsigned char control;
+    unsigned char mask;                 /* color; show sprites, background */
+      signed char volatile const status;
+    struct {
+        unsigned char address;
+        unsigned char data;
+    } sprite;
+    unsigned char scroll;
+    struct {
+        unsigned char address;
+        unsigned char data;
+    } vram;
+};
+#define PPU             (*(struct __ppu*)0x2000)
+#define SPRITE_DMA      (APU.sprite.dma)
+
+/* Audio Processing Unit */
+struct __apu {
+    struct {
+        unsigned char control;          /* duty, counter halt, volume/envelope */
+        unsigned char ramp;
+        unsigned char period_low;       /* timing */
+        unsigned char len_period_high;  /* length, timing */
+    } pulse[2];
+    struct {
+        unsigned char counter;          /* counter halt, linear counter */
+        unsigned char unused;
+        unsigned char period_low;       /* timing */
+        unsigned char len_period_high;  /* length, timing */
+    } triangle;
+    struct {
+        unsigned char control;          /* counter halt, volume/envelope */
+        unsigned char unused;
+        unsigned char period;           /* loop, timing */
+        unsigned char len;              /* length */
+    } noise;
+    struct {
+        unsigned char control;          /* IRQ, loop, rate */
+        unsigned char output;           /* output value */
+        unsigned char address;
+        unsigned char length;
+    } delta_mod;                        /* delta pulse-code modulation */
+    struct {
+        unsigned char dma;
+    } sprite;
+      signed char volatile status;
+    unsigned char unused;
+    unsigned char fcontrol;
+};
+#define APU             (*(struct __apu*)0x4000)
+
+#define JOYPAD          ((unsigned char volatile const[2])0x4016)
+
 /* The addresses of the static drivers */
 extern void nes_stdjoy_joy[];       /* Referred to by joy_static_stddrv[] */
 extern void nes_64_56_2_tgi[];      /* Referred to by tgi_static_stddrv[] */


### PR DESCRIPTION
As I mentioned in issue #218, `<nes.h>` now has the chip declarations.  Therefore, people like @clbr should have much less trouble using direct NES I/O in a C program.