### PR TITLE
Escaping of spaces in ca65 dependency files

### DIFF
--- a/src/ca65/filetab.c
+++ b/src/ca65/filetab.c
@@ -262,6 +262,21 @@ void WriteFiles (void)
 
 
 
+static void WriteEscaped (FILE* F, const char* Name)
+/* Write a file name to a dependency file escaping spaces */
+{
+    while (*Name) {
+        if (*Name == ' ') {
+            /* Escape spaces */
+            fputc ('\\', F);
+        }
+        fputc (*Name, F);
+        ++Name;
+    }
+}
+
+
+
 static void WriteDep (FILE* F, FileType Types)
 /* Helper function. Writes all file names that match Types to the output */
 {
@@ -285,9 +300,9 @@ static void WriteDep (FILE* F, FileType Types)
             fputc (' ', F);
         }
 
-        /* Print the dependency */
+        /* Print the dependency escaping spaces */
         Filename = GetStrBuf (E->Name);
-        fprintf (F, "%*s", SB_GetLen (Filename), SB_GetConstBuf (Filename));
+        WriteEscaped (F, SB_GetConstBuf (Filename));
     }
 }
 
@@ -305,7 +320,8 @@ static void CreateDepFile (const char* Name, FileType Types)
     }
 
     /* Print the output file followed by a tab char */
-    fprintf (F, "%s:\t", OutFile);
+    WriteEscaped (F, OutFile);
+    fputs (":\t", F);
 
     /* Write out the dependencies for the output file */
     WriteDep (F, Types);


### PR DESCRIPTION
WRT #230

WriteEscaped() was copied from cc65's input.c, I didn't attempt to DRY because there seemed to be a fair amount of copy&paste going on between the two files (cc65 input.c and ca65 filetab.c) as it is.