### PR TITLE
Fix a signed char right-shift compiler optimization.

### DIFF
--- a/src/cc65/coptshift.c
+++ b/src/cc65/coptshift.c
@@ -341,7 +341,7 @@ unsigned OptShift2 (CodeSeg* S)
         L[0] = CS_GetEntry (S, I);
 
         /* Check for the sequence */
-        if (L[0]->OPC == OP65_BPL                                       &&
+        if ((L[0]->OPC == OP65_BPL || L[0]->OPC == OP65_BCC)            &&
             L[0]->JumpTo != 0                                           &&
             CS_GetEntries (S, L+1, I+1, 3)                              &&
             L[1]->OPC == OP65_DEX                                       &&

--- a/src/cc65/coptshift.h
+++ b/src/cc65/coptshift.h
@@ -60,12 +60,19 @@ unsigned OptShift1 (CodeSeg* S);
 **  L1:
 */
 
-unsigned OptShift2(CodeSeg* S);
-/* A call to the asrax1 routines may get replaced by something simpler, if
-** X is not used later:
+unsigned OptShift2 (CodeSeg* S);
+/* The sequence
+**
+**      bpl     L
+**      dex
+** L:   jsr     asraxN
+**
+** might be replaced by N copies of
 **
 **      cmp     #$80
 **      ror     a
+**
+** if X is not used later (X is assumed to be zero on entry).
 */
 
 unsigned OptShift3 (CodeSeg* S);

--- a/test/val/rotate8.c
+++ b/test/val/rotate8.c
@@ -1,0 +1,156 @@
+/*
+  !!DESCRIPTION!! Optimized-shift signed ints right by a constant; and, assign to chars.
+  !!ORIGIN!!      cc65 regression tests
+  !!LICENCE!!     Public Domain
+  !!AUTHOR!!      Greg King
+*/
+
+#include <stdio.h>
+
+static unsigned char failures = 0;
+static unsigned char n = 0;
+
+/* This number must be read from a variable because
+** we want this program, not cc65, to do the shift.
+*/
+static const signed int aint0 = 0xAAC0;
+
+static signed char achar0, achar1;
+
+static void check(void)
+{
+    if ((unsigned char)achar0 != (unsigned char)achar1)
+        ++failures;
+}
+
+static void shift_right_0(void)
+{
+    achar0 = aint0 >> 0;
+    check();
+}
+
+static void shift_right_1(void)
+{
+    achar0 = aint0 >> 1;
+    check();
+}
+
+static void shift_right_2(void)
+{
+    achar0 = aint0 >> 2;
+    check();
+}
+
+static void shift_right_3(void)
+{
+    achar0 = aint0 >> 3;
+    check();
+}
+
+static void shift_right_4(void)
+{
+    achar0 = aint0 >> 4;
+    check();
+}
+
+static void shift_right_5(void)
+{
+    achar0 = aint0 >> 5;
+    check();
+}
+
+static void shift_right_6(void)
+{
+    achar0 = aint0 >> 6;
+    check();
+}
+
+static void shift_right_7(void)
+{
+    achar0 = aint0 >> 7;
+    check();
+}
+
+static void shift_right_8(void)
+{
+    achar0 = aint0 >> 8;
+    check();
+}
+
+static void shift_right_9(void)
+{
+    achar0 = aint0 >> 9;
+    check();
+}
+
+static void shift_right_10(void)
+{
+    achar0 = aint0 >> 10;
+    check();
+}
+
+static void shift_right_11(void)
+{
+    achar0 = aint0 >> 11;
+    check();
+}
+
+static void shift_right_12(void)
+{
+    achar0 = aint0 >> 12;
+    check();
+}
+
+static void shift_right_13(void)
+{
+    achar0 = aint0 >> 13;
+    check();
+}
+
+static void shift_right_14(void)
+{
+    achar0 = aint0 >> 14;
+    check();
+}
+
+static void shift_right_15(void)
+{
+    achar0 = aint0 >> 15;
+    check();
+}
+
+const struct {
+    signed char achar;
+    void (*func)(void);
+} tests[] = {
+    {0xC0, shift_right_0},
+    {0x60, shift_right_1},
+    {0xB0, shift_right_2},
+    {0x58, shift_right_3},
+    {0xAC, shift_right_4},
+    {0x56, shift_right_5},
+    {0xAB, shift_right_6},
+    {0x55, shift_right_7},
+    {0xAA, shift_right_8},
+    {0xD5, shift_right_9},
+    {0xEA, shift_right_10},
+    {0xF5, shift_right_11},
+    {0xFA, shift_right_12},
+    {0xFD, shift_right_13},
+    {0xFE, shift_right_14},
+    {0xFF, shift_right_15}
+};
+
+int main(void)
+{
+    do {
+        achar1 = tests[n].achar;
+        tests[n].func();
+    } while (++n < sizeof tests / sizeof tests[0]);
+
+    if (failures) {
+        printf("rotate8: failures: %u (of %u).\n",
+               failures, sizeof tests / sizeof tests[0]);
+    }
+    return failures;
+}


### PR DESCRIPTION
This PR fixes bug report #244.

A compiler shift optimization that is intended for signed character expressions and the high byte of signed integer expressions (when the right-shift is greater than eight bits) wasn't limited enough.  Sometimes, it was used on only the low byte of integers (when a high byte wasn't going to be used after the shift); but, that would fail to shift some bits from the high byte into the low byte.

This patch makes sure that cc65 won't optimize the wrong integer shifts.