### PR TITLE
Make ca65's CONDES-type pseudo-instructions save line numbers correctly.

### DIFF
--- a/src/ca65/symentry.c
+++ b/src/ca65/symentry.c
@@ -570,8 +570,8 @@ void SymConDes (SymEntry* S, unsigned char AddrSize, unsigned Type, unsigned Pri
         }
     }
 
-    /* If the symbol was already declared as a condes, check if the new
-    ** priority value is the same as the old one.
+    /* If the symbol already was declared as a condes of this type,
+    ** check if the new priority value is the same as the old one.
     */
     if (S->ConDesPrio[Type] != CD_PRIO_NONE) {
         if (S->ConDesPrio[Type] != Prio) {
@@ -583,10 +583,8 @@ void SymConDes (SymEntry* S, unsigned char AddrSize, unsigned Type, unsigned Pri
     /* Set the symbol data */
     S->Flags |= (SF_EXPORT | SF_REFERENCED);
 
-    /* In case we have no line info for the definition, record it now */
-    if (CollCount (&S->DefLines) == 0) {
-        GetFullLineInfo (&S->DefLines);
-    }
+    /* Remember the line info for this reference */
+    CollAppend (&S->RefLines, GetAsmLineInfo ());
 }
 
 


### PR DESCRIPTION
Fixes #212.

ca65 memorizes the line numbers where symbol names are defined, and where they are used -- in two separate collections for each name.  Those line numbers are displayed in diagnostic messages.

The `.constructor`, `.destructor`, `.interruptor`, and `.condes` instructions saved those numbers in the "defined here" collection, instead of the "used here" collection (i.e., they acted like `.import`, instead of like `.export`).  Therefore, if ca65 needed to show error messages about those instructions, it did not have any "used here" line numbers to put in the messages.  ca65 failed a PRECONDITION (which tests the integrity of collections of objects); and, stopped.