### PR TITLE
New ".feature" to use brackets instead of parens for 6502 indirect addressing.

### DIFF
--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -2701,13 +2701,15 @@ Here's a list of all control commands and a description, what they do:
 
   <tag><tt>bracket_as_indirect</tt><label id="bracket_as_indirect"></tag>
 
-    Use <tt>[]</tt> intead of <tt>()</tt> for the indirect addressing mode.
+    Use <tt>[]</tt> instead of <tt>()</tt> for the indirect addressing modes.
     Example:
 
     <tscreen><verb>
         lda     [$82]
         lda     [$82,x]
         lda     [$82],y
+        jmp     [$fffe]
+        jmp     [table,x]
     </verb></tscreen>
     <em/Note:/ This should not be used in 65186 mode because it conflicts with
     the 65816 instruction syntax for far addressing. See the section covering

--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -2699,6 +2699,20 @@ Here's a list of all control commands and a description, what they do:
     at character is not allowed to start an identifier, even with this
     feature enabled.
 
+  <tag><tt>bracket_as_indirect</tt><label id="bracket_as_indirect"></tag>
+
+    Use <tt>[]</tt> intead of <tt>()</tt> for the indirect addressing mode.
+    Example:
+
+    <tscreen><verb>
+        lda     [$82]
+        lda     [$82,x]
+        lda     [$82],y
+    </verb></tscreen>
+    <em/Note:/ This should not be used in 65186 mode because it conflicts with
+    the 65816 instruction syntax for far addressing. See the section covering
+    <tt/<ref id="address-sizes" name="address sizes">/ for more information.
+
   <tag><tt>c_comments</tt><label id="c_comments"></tag>
 
     Allow C like comments using <tt>/*</tt> and <tt>*/</tt> as left and right

--- a/src/ca65/ea65.c
+++ b/src/ca65/ea65.c
@@ -40,6 +40,7 @@
 #include "expr.h"
 #include "instr.h"
 #include "nexttok.h"
+#include "global.h"
 
 
 
@@ -53,6 +54,20 @@ void GetEA (EffAddr* A)
 /* Parse an effective address, return the result in A */
 {
     unsigned long Restrictions;
+    token_t IndirectEnter;
+    token_t IndirectLeave;
+    const char* IndirectExpect;
+
+    /* Choose syntax for indirection */
+    if (BracketAsIndirect) {
+        IndirectEnter = TOK_LBRACK;
+        IndirectLeave = TOK_RBRACK;
+        IndirectExpect = "']' expected";
+    } else {
+        IndirectEnter = TOK_LPAREN;
+        IndirectLeave = TOK_RPAREN;
+        IndirectExpect = "')' expected";
+    }
 
     /* Clear the output struct */
     A->AddrModeSet = 0;
@@ -97,23 +112,7 @@ void GetEA (EffAddr* A)
         NextTok ();
         A->AddrModeSet = AM65_ACCU;
 
-    } else if (CurTok.Tok == TOK_LBRACK) {
-
-        /* [dir] or [dir],y */
-        NextTok ();
-        A->Expr = Expression ();
-        Consume (TOK_RBRACK, "']' expected");
-        if (CurTok.Tok == TOK_COMMA) {
-            /* [dir],y */
-            NextTok ();
-            Consume (TOK_Y, "`Y' expected");
-            A->AddrModeSet = AM65_DIR_IND_LONG_Y;
-        } else {
-            /* [dir] */
-            A->AddrModeSet = AM65_DIR_IND_LONG | AM65_ABS_IND_LONG;
-        }
-
-    } else if (CurTok.Tok == TOK_LPAREN) {
+    } else if (CurTok.Tok == IndirectEnter) {
 
         /* One of the indirect modes */
         NextTok ();
@@ -127,12 +126,12 @@ void GetEA (EffAddr* A)
                 /* (adr,x) */
                 NextTok ();
                 A->AddrModeSet = AM65_ABS_X_IND | AM65_DIR_X_IND;
-                ConsumeRParen ();
+                Consume (IndirectLeave, IndirectExpect);
             } else if (CurTok.Tok == TOK_S) {
                 /* (rel,s),y */
                 NextTok ();
                 A->AddrModeSet = AM65_STACK_REL_IND_Y;
-                ConsumeRParen ();
+                Consume (IndirectLeave, IndirectExpect);
                 ConsumeComma ();
                 Consume (TOK_Y, "`Y' expected");
             } else {
@@ -142,7 +141,7 @@ void GetEA (EffAddr* A)
         } else {
 
             /* (adr) or (adr),y */
-            ConsumeRParen ();
+            Consume (IndirectLeave, IndirectExpect);
             if (CurTok.Tok == TOK_COMMA) {
                 /* (adr),y */
                 NextTok ();
@@ -152,6 +151,23 @@ void GetEA (EffAddr* A)
                 /* (adr) */
                 A->AddrModeSet = AM65_ABS_IND | AM65_ABS_IND_LONG | AM65_DIR_IND;
             }
+        }
+
+    } else if (CurTok.Tok == TOK_LBRACK) {
+
+        /* Never executed if BracketAsIndirect feature is enabled. */
+        /* [dir] or [dir],y */
+        NextTok ();
+        A->Expr = Expression ();
+        Consume (TOK_RBRACK, "']' expected");
+        if (CurTok.Tok == TOK_COMMA) {
+            /* [dir],y */
+            NextTok ();
+            Consume (TOK_Y, "`Y' expected");
+            A->AddrModeSet = AM65_DIR_IND_LONG_Y;
+        } else {
+            /* [dir] */
+            A->AddrModeSet = AM65_DIR_IND_LONG | AM65_ABS_IND_LONG;
         }
 
     } else {

--- a/src/ca65/feature.c
+++ b/src/ca65/feature.c
@@ -64,6 +64,7 @@ static const char* FeatureKeys[FEAT_COUNT] = {
     "force_range",
     "underline_in_numbers",
     "addrsize",
+    "bracket_as_indirect",
 };
 
 
@@ -121,6 +122,7 @@ feature_t SetFeature (const StrBuf* Key)
         case FEAT_FORCE_RANGE:                ForceRange        = 1;    break;
         case FEAT_UNDERLINE_IN_NUMBERS:       UnderlineInNumbers= 1;    break;
         case FEAT_ADDRSIZE:                   AddrSize          = 1;    break;
+        case FEAT_BRACKET_AS_INDIRECT:        BracketAsIndirect = 1;    break;
         default:                         /* Keep gcc silent */          break;
     }
 

--- a/src/ca65/feature.h
+++ b/src/ca65/feature.h
@@ -66,6 +66,7 @@ typedef enum {
     FEAT_FORCE_RANGE,
     FEAT_UNDERLINE_IN_NUMBERS,
     FEAT_ADDRSIZE,
+    FEAT_BRACKET_AS_INDIRECT,
 
     /* Special value: Number of features available */
     FEAT_COUNT

--- a/src/ca65/global.c
+++ b/src/ca65/global.c
@@ -83,4 +83,5 @@ unsigned char CComments          = 0;   /* Allow C like comments */
 unsigned char ForceRange         = 0;   /* Force values into expected range */
 unsigned char UnderlineInNumbers = 0;   /* Allow underlines in numbers */
 unsigned char AddrSize           = 0;   /* Allow .ADDRSIZE function */
+unsigned char BracketAsIndirect  = 0;   /* Use '[]' not '()' for indirection */
 

--- a/src/ca65/global.h
+++ b/src/ca65/global.h
@@ -85,6 +85,7 @@ extern unsigned char    CComments;          /* Allow C like comments */
 extern unsigned char    ForceRange;         /* Force values into expected range */
 extern unsigned char    UnderlineInNumbers; /* Allow underlines in numbers */
 extern unsigned char    AddrSize;           /* Allow .ADDRSIZE function */
+extern unsigned char    BracketAsIndirect;  /* Use '[]' not '()' for indirection */
 
 
 


### PR DESCRIPTION
Things to note ...

1) It's actually a pretty small change, but it seems bigger because I'm moving the code that checks for the 65816's "far" addressing mode to below the check for the 6502 indirect addressing mode. I've also added a comment to the "far" check to indicate that it isn't executed when the BracketAsIndirect option is activated.

2) It could all be done a tiny bit more efficiently with static variables, but that didn't seem to be as easy-to-read.
