### PR TITLE
Convert the Atmos configuration to the new constructor segment model.

### DIFF
--- a/cfg/atmos.cfg
+++ b/cfg/atmos.cfg
@@ -11,22 +11,22 @@ MEMORY {
     ZP:      file = "", define = yes, start = $00E2,            size = $001A;
     TAPEHDR: file = %O, type   = ro,  start = $0000,            size = $001F;
     BASHEAD: file = %O, define = yes, start = $0501,            size = $000D;
-    MAIN:    file = %O, define = yes, start = __BASHEAD_LAST__, size = __RAMEND__ - __MAIN_START__ - __STACKSIZE__;
+    MAIN:    file = %O, define = yes, start = __BASHEAD_LAST__, size = __RAMEND__ - __MAIN_START__;
+    BSS:     file = "",               start = __ONCE_RUN__,     size = __RAMEND__ - __STACKSIZE__ - __ONCE_RUN__;
 }
 SEGMENTS {
     ZEROPAGE: load = ZP,      type = zp;
     TAPEHDR:  load = TAPEHDR, type = ro;
-    BASHDR:   load = BASHEAD, type = ro,  define = yes, optional = yes;
+    BASHDR:   load = BASHEAD, type = ro,  optional = yes;
     STARTUP:  load = MAIN,    type = ro;
-    LOWCODE:  load = MAIN,    type = ro,                optional = yes;
+    LOWCODE:  load = MAIN,    type = ro,  optional = yes;
     CODE:     load = MAIN,    type = ro;
     RODATA:   load = MAIN,    type = ro;
-    ONCE:     load = MAIN,    type = ro,                optional = yes;
     DATA:     load = MAIN,    type = rw;
-    INIT:     load = MAIN,    type = rw,                optional = yes;
-    ZPSAVE1:  load = MAIN,    type = rw,  define = yes; # ZPSAVE1, ZPSAVE2 must be together
-    ZPSAVE2:  load = MAIN,    type = bss;               # see "libsrc/atmos/crt0.s"
-    BSS:      load = MAIN,    type = bss, define = yes;
+    INIT:     load = MAIN,    type = rw;
+    ONCE:     load = MAIN,    type = ro,  define   = yes;
+    BASTAIL:  load = MAIN,    type = ro,  optional = yes;
+    BSS:      load = BSS,     type = bss, define   = yes;
 }
 FEATURES {
     CONDES: type    = constructor,

--- a/libsrc/atmos/bashdr.s
+++ b/libsrc/atmos/bashdr.s
@@ -1,6 +1,6 @@
 ;
 ; 2010-11-14, Ullrich von Bassewitz
-; 2014-09-06, Greg King
+; 2016-03-17, Greg King
 ;
 ; This module supplies a small BASIC stub program that uses CALL
 ; to jump to the machine-language code that follows it.
@@ -22,3 +22,13 @@
         .byte   $00             ; End of BASIC line
 Next:   .addr   $0000           ; BASIC program end marker
 Start:
+
+; ------------------------------------------------------------------------
+
+; This padding is needed by a bug in the ROM.
+; (The CLOAD command starts BASIC's variables table on top of the last byte
+; that was loaded [instead of at the next address].)
+
+.segment        "BASTAIL"
+
+        .byte   0

--- a/libsrc/atmos/capslock.s
+++ b/libsrc/atmos/capslock.s
@@ -15,7 +15,8 @@
 
 
 ;--------------------------------------------------------------------------
-; Put this constructor into a segment that can be re-used by programs.
+; Put this constructor into a segment whose space
+; will be re-used by BSS, the heap, and the C stack.
 ;
 .segment        "ONCE"
 

--- a/libsrc/atmos/cgetc.s
+++ b/libsrc/atmos/cgetc.s
@@ -55,8 +55,8 @@
 .endproc
 
 ; ------------------------------------------------------------------------
-; Switch the cursor off. Code goes into the ONCE segment
-; which may be reused after it is run.
+; Switch the cursor off. Code goes into the ONCE segment,
+; which will be reused after it is run.
 
 .segment        "ONCE"
 

--- a/libsrc/atmos/crt0.s
+++ b/libsrc/atmos/crt0.s
@@ -2,14 +2,15 @@
 ; Startup code for cc65 (Oric version)
 ;
 ; By Debrune Jérôme <jede@oric.org> and Ullrich von Bassewitz <uz@cc65.org>
-; 2015-01-09, Greg King
+; 2016-03-18, Greg King
 ;
 
         .export         _exit
         .export         __STARTUP__ : absolute = 1      ; Mark as startup
+
         .import         initlib, donelib
         .import         callmain, zerobss
-        .import         __MAIN_START__, __MAIN_SIZE__, __STACKSIZE__
+        .import         __MAIN_START__, __MAIN_SIZE__
 
         .include        "zeropage.inc"
         .include        "atmos.inc"
@@ -19,39 +20,17 @@
 
 .segment        "STARTUP"
 
-; Save the zero-page area that we're about to use.
-
-        ldx     #zpspace-1
-L1:     lda     sp,x
-        sta     zpsave,x
-        dex
-        bpl     L1
-
-; Clear the BSS data.
-
-        jsr     zerobss
-
-; Currently, color isn't supported on the text screen.
-; Unprotect screen columns 0 and 1 (where each line's color codes would sit).
-
-        lda     STATUS
-        sta     stsave
-        and     #%11011111
-        sta     STATUS
-
-; Save some system stuff; and, set up the stack.
-
         tsx
         stx     spsave          ; Save system stk ptr
 
-        lda     #<(__MAIN_START__ + __MAIN_SIZE__ + __STACKSIZE__)
-        ldx     #>(__MAIN_START__ + __MAIN_SIZE__ + __STACKSIZE__)
-        sta     sp
-        stx     sp+1            ; Set argument stack ptr
+; Save space by putting some of the start-up code in a segment
+; that will be re-used.
 
-; Call the module constructors.
+        jsr     init
 
-        jsr     initlib
+; Clear the BSS variables (after the constructors have been run).
+
+        jsr     zerobss
 
 ; Push the command-line arguments; and, call main().
 
@@ -70,7 +49,7 @@ _exit:  jsr     donelib
 
 ; Copy back the zero-page stuff.
 
-        ldx     #zpspace-1
+        ldx     #zpspace - 1
 L2:     lda     zpsave,x
         sta     sp,x
         dex
@@ -81,28 +60,42 @@ L2:     lda     zpsave,x
         rts
 
 ; ------------------------------------------------------------------------
+; Put this code in a place that will be re-used by BSS, the heap,
+; and the C stack.
 
-.segment        "ZPSAVE1"
+.segment        "ONCE"
 
-zpsave:
+; Save the zero-page area that we're about to use.
 
-; This padding is needed by a bug in the ROM.
-; (The CLOAD command starts BASIC's variables table on top of the last byte
-; that was loaded [instead of at the next address].)
-; This is overlaid on a buffer, so that it doesn't use extra space in RAM.
+init:   ldx     #zpspace - 1
+L1:     lda     sp,x
+        sta     zpsave,x
+        dex
+        bpl     L1
 
-        .byte   0
+; Currently, color isn't supported on the text screen.
+; Unprotect screen columns 0 and 1 (where each line's color codes would sit).
 
-; The segments "ZPSAVE1" and "ZPSAVE2" always must be together.
-; They create a single object (the zpsave buffer).
+        lda     STATUS
+        sta     stsave
+        and     #%11011111
+        sta     STATUS
 
-.segment        "ZPSAVE2"
+; Set up the C stack.
 
-        .res    zpspace - 1
+        lda     #<(__MAIN_START__ + __MAIN_SIZE__)
+        ldx     #>(__MAIN_START__ + __MAIN_SIZE__)
+        sta     sp
+        stx     sp+1            ; Set argument stack ptr
+
+; Call the module constructors.
+
+        jmp     initlib
 
 ; ------------------------------------------------------------------------
 
-.bss
+.segment        "INIT"
 
 spsave: .res    1
 stsave: .res    1
+zpsave: .res    zpspace

--- a/libsrc/atmos/mainargs.s
+++ b/libsrc/atmos/mainargs.s
@@ -18,7 +18,7 @@ REM      = $9D                  ; BASIC token-code
 
 ;---------------------------------------------------------------------------
 ; Get possible command-line arguments. Goes into the special ONCE segment,
-; which may be reused after the startup code is run
+; which will be reused after the startup code is run.
 
 .segment        "ONCE"
 
@@ -119,8 +119,6 @@ done:   lda     #<argv
 
 .endproc
 
-; These arrays are zeroed before initmainargs is called.
-
 .segment        "INIT"
 
 term:   .res    1
@@ -129,6 +127,7 @@ args:   .res    SCREEN_XSIZE * 2 - 1
 
 .data
 
+; This array has zeroes when initmainargs starts.
 ; char* argv[MAXARGS+1]={name};
 
 argv:   .addr   name

--- a/libsrc/atmos/tapehdr.s
+++ b/libsrc/atmos/tapehdr.s
@@ -1,6 +1,6 @@
 ;
 ; Based on code by Debrune Jérôme <jede@oric.org>
-; 2015-01-08, Greg King
+; 2016-03-17, Greg King
 ;
 
         ; The following symbol is used by the linker config. file
@@ -8,7 +8,8 @@
         .export __TAPEHDR__:abs = 1
 
         ; These symbols, also, come from the configuration file.
-        .import __BASHDR_LOAD__, __ZPSAVE1_LOAD__, __AUTORUN__, __PROGFLAG__
+        .import __AUTORUN__, __PROGFLAG__
+        .import __BASHEAD_START__, __MAIN_LAST__
 
 
 ; ------------------------------------------------------------------------
@@ -16,16 +17,16 @@
 
 .segment        "TAPEHDR"
 
-        .byte   $16, $16, $16   ; Sync bytes
-        .byte   $24             ; Beginning-of-header marker
+        .byte   $16, $16, $16           ; Sync bytes
+        .byte   $24                     ; Beginning-of-header marker
 
-        .byte   $00             ; $2B0
-        .byte   $00             ; $2AF
-        .byte   <__PROGFLAG__   ; $2AE Language flag ($00=BASIC, $80=machine code)
-        .byte   <__AUTORUN__    ; $2AD Auto-run flag ($C7=run, $00=only load)
-        .dbyt   __ZPSAVE1_LOAD__ ;$2AB Address of end of file
-        .dbyt   __BASHDR_LOAD__ ; $2A9 Address of start of file
-        .byte   $00             ; $2A8
+        .byte   $00                     ; $2B0
+        .byte   $00                     ; $2AF
+        .byte   <__PROGFLAG__           ; $2AE Language flag ($00=BASIC, $80=machine code)
+        .byte   <__AUTORUN__            ; $2AD Auto-run flag ($C7=run, $00=only load)
+        .dbyt   __MAIN_LAST__ - 1       ; $2AB Address of end of file
+        .dbyt   __BASHEAD_START__       ; $2A9 Address of start of file
+        .byte   $00                     ; $2A8
 
         ; File name (a maximum of 17 characters), zero-terminated
         .asciiz .sprintf("%u", .time)


### PR DESCRIPTION
This PR brings the Atmos library into sync with the C64 and Apple II libraries.  (`INIT` and `ONCE` are at the end of the program file; and, `BSS` is in a separate memory area.)

A nice consequence is that the work-around, for the firmware bug, is simpler, now.