### PR TITLE
Show a warning message about misaligned segments, for all badly-aligned segments.

### DIFF
--- a/src/ld65/bin.c
+++ b/src/ld65/bin.c
@@ -169,18 +169,6 @@ static void BinWriteMem (BinDesc* D, MemoryArea* M)
         PrintNumVal  ("Address", Addr);
         PrintNumVal  ("FileOffs", (unsigned long) ftell (D->F));
 
-        /* Check if the alignment for the segment from the linker config is
-        ** a multiple for that of the segment.
-        */
-        if ((S->RunAlignment % S->Seg->Alignment) != 0) {
-            /* Segment requires another alignment than configured
-            ** in the linker.
-            */
-            Warning ("Segment `%s' is not aligned properly. Resulting "
-                     "executable may not be functional.",
-                     GetString (S->Name));
-        }
-
         /* If this is the run memory area, we must apply run alignment. If
         ** this is not the run memory area but the load memory area (which
         ** means that both are different), we must apply load alignment.

--- a/src/ld65/config.c
+++ b/src/ld65/config.c
@@ -1855,6 +1855,20 @@ unsigned CfgProcess (void)
                 /* This is the run (and maybe load) memory area. Handle
                 ** alignment and explict start address and offset.
                 */
+
+                /* Check if the alignment for the segment from the linker
+                ** config. is a multiple for that of the segment.
+                */
+                if ((S->RunAlignment % S->Seg->Alignment) != 0) {
+                    /* Segment requires another alignment than configured
+                    ** in the linker.
+                    */
+                    CfgWarning (GetSourcePos (S->LI),
+                                "Segment `%s' isn't aligned properly; the"
+                                " resulting executable might not be functional.",
+                                GetString (S->Name));
+                }
+
                 if (S->Flags & SF_ALIGN) {
                     /* Align the address */
                     unsigned long NewAddr = AlignAddr (Addr, S->RunAlignment);
@@ -1865,8 +1879,8 @@ unsigned CfgProcess (void)
                     */
                     if (M->FillLevel == 0 && NewAddr > Addr) {
                         CfgWarning (GetSourcePos (S->LI),
-                                    "First segment in memory area `%s' does "
-                                    "already need fill bytes for alignment",
+                                    "The first segment in memory area `%s' "
+                                    "needs fill bytes for alignment.",
                                     GetString (M->Name));
                     }
 


### PR DESCRIPTION
This PR fixes #278.

When a `.align` directive is used in Assembly code, an `align=` attribute must be used in the relevant segment definition in the ld65 configure file.  That attribute must be a multiple of the alignments that are in the Assembly code.  If it isn't, then ld65 should show a warning message.

It used to be shown only if the segment was put into a binary file.  It wasn't shown if the segment was put into an o65-format file; or, if it wasn't put into any file.  Now, it's shown for those segments also.