### PR TITLE
Fixed CPU definition of Lynx.

### DIFF
--- a/asminc/lynx.inc
+++ b/asminc/lynx.inc
@@ -4,7 +4,7 @@
 ;
 ; Reference:
 ;  Bastian Schick's Lynx Documentation
-;  http://www.geocities.com/SiliconValley/Byte/4242/lynx/
+;  http://www.geocities.ws/SiliconValley/Byte/4242/lynx/
 ;
 
 ; ***

--- a/asminc/supervision.inc
+++ b/asminc/supervision.inc
@@ -1,8 +1,7 @@
 ; supervision symbols
 
-;  supervision 65c02s
-; in cc65 up to 2.9.1 65c02 means 65c02s
-.pc02
+; supervision 65c02s
+; in cc65 up to 2.9.1 65c02 means 65sc02
 
 lcd_addr = $4000
 LCD_LINESIZE = $30

--- a/src/common/target.c
+++ b/src/common/target.c
@@ -139,7 +139,7 @@ struct TargetEntry {
 };
 
 /* Table that maps target names to ids. Sorted alphabetically for bsearch.
-** Allows mupltiple entries for one target id (target name aliases).
+** Allows multiple entries for one target id (target name aliases).
 */
 static const TargetEntry TargetMap[] = {
     {   "apple2",       TGT_APPLE2      },
@@ -168,7 +168,6 @@ static const TargetEntry TargetMap[] = {
     {   "sim6502",      TGT_SIM6502     },
     {   "sim65c02",     TGT_SIM65C02    },
     {   "supervision",  TGT_SUPERVISION },
-    {   "vc20",         TGT_VIC20       },
     {   "vic20",        TGT_VIC20       },
 };
 #define MAP_ENTRY_COUNT         (sizeof (TargetMap) / sizeof (TargetMap[0]))
@@ -199,7 +198,7 @@ static const TargetProperties PropertyTable[TGT_COUNT] = {
     { "atmos",          CPU_6502,       BINFMT_BINARY,      CTNone  },
     { "nes",            CPU_6502,       BINFMT_BINARY,      CTNone  },
     { "supervision",    CPU_65SC02,     BINFMT_BINARY,      CTNone  },
-    { "lynx",           CPU_65C02,      BINFMT_BINARY,      CTNone  },
+    { "lynx",           CPU_65SC02,     BINFMT_BINARY,      CTNone  },
     { "sim6502",        CPU_6502,       BINFMT_BINARY,      CTNone  },
     { "sim65c02",       CPU_65C02,      BINFMT_BINARY,      CTNone  },
 };


### PR DESCRIPTION
Greg wrote: The target platforms automatically choose a default CPU instruction-set. Therefore, CPU directives shouldn't be in the include files. Commit 55d6556 must be changed. It should remove the directive in "supervision.inc".

Currently, the Lynx target chooses the 65C02. If it should choose the 65SC02, then "src/common/target.c" should be patched.