### PR TITLE
moved output of target utils and drivers to separate directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,8 @@
 /bin/
-/emd/
 /html/
 /info/
-/joy/
 /lib/
 /libwrk/
-/mou/
-/ser/
-/targetutil/
+/target/
 /testwrk/
-/tgi/
 /wrk/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /target/
 /testwrk/
 /wrk/
+cc65.zip

--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,22 @@
 .SUFFIXES:
 
 all mostlyclean clean install zip:
-	@$(MAKE) -C src    --no-print-directory $@
-	@$(MAKE) -C libsrc --no-print-directory $@
-	@$(MAKE) -C doc    --no-print-directory $@
+	@$(MAKE) -C src     --no-print-directory $@
+	@$(MAKE) -C libsrc  --no-print-directory $@
+	@$(MAKE) -C doc     --no-print-directory $@
+	@$(MAKE) -C samples --no-print-directory $@
 
 avail unavail bin:
-	@$(MAKE) -C src    --no-print-directory $@
+	@$(MAKE) -C src     --no-print-directory $@
 
 lib:
-	@$(MAKE) -C libsrc --no-print-directory $@
+	@$(MAKE) -C libsrc  --no-print-directory $@
 
 doc:
-	@$(MAKE) -C doc    --no-print-directory $@
+	@$(MAKE) -C doc     --no-print-directory $@
 
 %65:
-	@$(MAKE) -C src    --no-print-directory $@
+	@$(MAKE) -C src     --no-print-directory $@
 
 %:
-	@$(MAKE) -C libsrc --no-print-directory $@
+	@$(MAKE) -C libsrc  --no-print-directory $@

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -41,7 +41,9 @@ ifeq ($(wildcard ../info),../info)
 endif
 
 zip:
+ifneq "$(wildcard ../html)" ""
 	@cd .. && zip cc65 html/*.*
+endif
 
 doc: html info
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -33,11 +33,11 @@ install:
 	$(if $(prefix),,$(error variable `prefix' must be set))
 ifeq ($(wildcard ../html),../html)
 	$(INSTALL) -d $(DESTDIR)$(htmldir)
-	$(INSTALL) -m644 ../html/*.* $(DESTDIR)$(htmldir)
+	$(INSTALL) -m0644 ../html/*.* $(DESTDIR)$(htmldir)
 endif
 ifeq ($(wildcard ../info),../info)
 	$(INSTALL) -d $(DESTDIR)$(infodir)
-	$(INSTALL) -m644 ../info/*.* $(DESTDIR)$(infodir)
+	$(INSTALL) -m0644 ../info/*.* $(DESTDIR)$(infodir)
 endif
 
 zip:

--- a/doc/apple2.sgml
+++ b/doc/apple2.sgml
@@ -241,7 +241,7 @@ The easiest (and for really large programs in fact the only) way to have a cc65
 program use the memory from &dollar;800 to &dollar;2000 is to link it as binary
 (as opposed to system) program using the default linker configuration
 <ref id="apple-def-cfg" name="apple2.cfg"> with <tt/__HIMEM__/ set to &dollar;BF00
-and load it with the targetutil LOADER.SYSTEM. The program then works like a system
+and load it with the LOADER.SYSTEM utility. The program then works like a system
 program (i.e. quits to the ProDOS dispatcher).
 
 Using LOADER.SYSTEM is as simple as copying it to the ProDOS 8 directory of the

--- a/doc/apple2enh.sgml
+++ b/doc/apple2enh.sgml
@@ -241,7 +241,7 @@ The easiest (and for really large programs in fact the only) way to have a cc65
 program use the memory from &dollar;800 to &dollar;2000 is to link it as binary
 (as opposed to system) program using the default linker configuration
 <ref id="apple-def-cfg" name="apple2enh.cfg"> with <tt/__HIMEM__/set to &dollar;BF00
-and load it with the targetutil LOADER.SYSTEM. The program then works like a system
+and load it with the LOADER.SYSTEM utility. The program then works like a system
 program (i.e. quits to the ProDOS dispatcher).
 
 Using LOADER.SYSTEM is as simple as copying it to the ProDOS 8 directory of the
@@ -277,7 +277,7 @@ default I/O buffer allocation basically yields the same placement of I/O buffers
 in memory the primary benefit of <tt/apple2enh-iobuf-0800.o/ is a reduction in code
 size - and thus program file size - of more than 1400 bytes.
 
-Using <tt/apple2enh-iobuf-0800.o/ is as simple as placing it on the linker command 
+Using <tt/apple2enh-iobuf-0800.o/ is as simple as placing it on the linker command
 line like this:
 
 <tscreen><verb>

--- a/doc/atari.sgml
+++ b/doc/atari.sgml
@@ -229,8 +229,8 @@ for C and assembly language programs.
 The size of a cassette boot file is restricted to 32K. Larger programs
 would need to be split in more parts and the parts to be loaded manually.
 
-To write the generated file to a cassette, a utility to run
-on an Atari is provided in the <tt/targetutil/ directory (<tt/w2cas.com/).
+To write the generated file to a cassette, a utility (<tt/w2cas.com/) to run
+on an Atari is provided in the <tt/util/ directory of <tt/atari/ target dir.
 
 <sect1><tt/atarixl/ config files<p>
 

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -39,12 +39,13 @@ DRVTYPES = emd \
            tgi
 
 OUTPUTDIRS := lib                 \
-              target              \
               asminc              \
               cfg                 \
               include             \
               samples             \
-              $(subst ../,,$(filter-out $(wildcard ../include/*.*),$(wildcard ../include/*)))
+              $(subst ../,,$(filter-out $(wildcard ../include/*.*),$(wildcard ../include/*)))\
+              $(subst ../,,$(wildcard ../target/*/drv/*))\
+              $(subst ../,,$(wildcard ../target/*/util))\
 
 .PHONY: all mostlyclean clean install zip lib $(TARGETS)
 
@@ -80,8 +81,8 @@ mostlyclean:
 # Transitional line active. Final line commented out below in order to
 # allow some time for transition between the directory structures
 clean:
-	$(call RMDIR,../libwrk ../lib ../targetutil ../target $(addprefix ../,$(DRVTYPES)))
-# 	$(call RMDIR,../libwrk ../lib ../target)
+	$(call RMDIR,../libwrk ../lib ../targetutil ../$(TARGETDIR) $(addprefix ../,$(DRVTYPES)))
+# 	$(call RMDIR,../libwrk ../lib ../$(TARGETDIR))
 
 ifdef CMD_EXE
 
@@ -95,12 +96,13 @@ define INSTALL_recipe
 
 $(if $(prefix),,$(error variable `prefix' must be set))
 $(INSTALL) -d $(DESTDIR)$(datadir)/$(dir)
-$(INSTALL) -m644 ../$(dir)/*.* $(DESTDIR)$(datadir)/$(dir)
+$(INSTALL) -m0644 ../$(dir)/*.* $(DESTDIR)$(datadir)/$(dir)
 
 endef # INSTALL_recipe
 
 install:
 	$(foreach dir,$(OUTPUTDIRS),$(INSTALL_recipe))
+
 
 endif # CMD_EXE
 

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -37,12 +37,15 @@ DRVTYPES = emd \
            ser \
            tgi
 
-OUTPUTDIRS := lib         \
-              $(DRVTYPES) \
-              targetutil  \
-              asminc      \
-              cfg         \
-              include     \
+DRVOUTPUTDIRS := $(foreach drvtype,$(DRVTYPES),goodies/drivers/$(drvtype))
+
+OUTPUTDIRS := lib                 \
+              $(DRVOUTPUTDIRS)    \
+              goodies/targetutil  \
+              asminc              \
+              cfg                 \
+              include             \
+              samples             \
               $(subst ../,,$(filter-out $(wildcard ../include/*.*),$(wildcard ../include/*)))
 
 .PHONY: all mostlyclean clean install zip lib $(TARGETS)
@@ -76,8 +79,11 @@ all lib: $(TARGETS)
 mostlyclean:
 	$(call RMDIR,../libwrk)
 
+# Transitional line active. Final line commented out below in order to
+# allow some time for transition between the directory structures
 clean:
-	$(call RMDIR,../libwrk ../lib ../targetutil $(addprefix ../,$(DRVTYPES)))
+	$(call RMDIR,../libwrk ../lib ../targetutil ../goodies $(addprefix ../,$(DRVTYPES)))
+# 	$(call RMDIR,../libwrk ../lib ../goodies)
 
 ifdef CMD_EXE
 
@@ -212,7 +218,7 @@ define DRVTYPE_template
 $1_SRCDIR = $$(SRCDIR)/$1
 $1_STCDIR = ../libwrk/$$(TARGET)
 $1_DYNDIR = ../libwrk/$$(TARGET)/$1
-$1_DRVDIR = ../$1
+$1_DRVDIR = ../goodies/drivers/$1
 
 $1_SRCPAT = $$($1_SRCDIR)/$$(OBJPFX)%.s
 $1_STCPAT = $$($1_STCDIR)/$$(OBJPFX)%-$1.o
@@ -283,7 +289,7 @@ $(EXTRA_OBJPAT): $(EXTRA_SRCPAT) | ../lib
 ../lib/$(TARGET).lib: $(OBJS) | ../lib
 	$(AR65) a $@ $?
 
-../libwrk/$(TARGET) ../lib ../targetutil:
+../libwrk/$(TARGET) ../lib ../goodies/targetutil:
 	@$(call MKDIR,$@)
 
 $(TARGET): $(EXTRA_OBJS) ../lib/$(TARGET).lib

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -78,11 +78,8 @@ all lib: $(TARGETS)
 mostlyclean:
 	$(call RMDIR,../libwrk)
 
-# Transitional line active. Final line commented out below in order to
-# allow some time for transition between the directory structures
 clean:
-	$(call RMDIR,../libwrk ../lib ../targetutil ../target $(addprefix ../,$(DRVTYPES)))
-# 	$(call RMDIR,../libwrk ../lib ../target)
+	$(call RMDIR,../libwrk ../lib ../target)
 
 ifdef CMD_EXE
 
@@ -102,7 +99,6 @@ endef # INSTALL_recipe
 
 install:
 	$(foreach dir,$(OUTPUTDIRS),$(INSTALL_recipe))
-
 
 endif # CMD_EXE
 

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -1,3 +1,4 @@
+
 ifneq ($(shell echo),)
   CMD_EXE = 1
 endif
@@ -37,11 +38,8 @@ DRVTYPES = emd \
            ser \
            tgi
 
-DRVOUTPUTDIRS := $(foreach drvtype,$(DRVTYPES),goodies/drivers/$(drvtype))
-
 OUTPUTDIRS := lib                 \
-              $(DRVOUTPUTDIRS)    \
-              goodies/targetutil  \
+              target              \
               asminc              \
               cfg                 \
               include             \
@@ -82,8 +80,8 @@ mostlyclean:
 # Transitional line active. Final line commented out below in order to
 # allow some time for transition between the directory structures
 clean:
-	$(call RMDIR,../libwrk ../lib ../targetutil ../goodies $(addprefix ../,$(DRVTYPES)))
-# 	$(call RMDIR,../libwrk ../lib ../goodies)
+	$(call RMDIR,../libwrk ../lib ../targetutil ../target $(addprefix ../,$(DRVTYPES)))
+# 	$(call RMDIR,../libwrk ../lib ../target)
 
 ifdef CMD_EXE
 
@@ -218,7 +216,7 @@ define DRVTYPE_template
 $1_SRCDIR = $$(SRCDIR)/$1
 $1_STCDIR = ../libwrk/$$(TARGET)
 $1_DYNDIR = ../libwrk/$$(TARGET)/$1
-$1_DRVDIR = ../goodies/drivers/$1
+$1_DRVDIR = ../target/$$(TARGET)/drv/$1
 
 $1_SRCPAT = $$($1_SRCDIR)/$$(OBJPFX)%.s
 $1_STCPAT = $$($1_STCDIR)/$$(OBJPFX)%-$1.o
@@ -289,7 +287,7 @@ $(EXTRA_OBJPAT): $(EXTRA_SRCPAT) | ../lib
 ../lib/$(TARGET).lib: $(OBJS) | ../lib
 	$(AR65) a $@ $?
 
-../libwrk/$(TARGET) ../lib ../goodies/targetutil:
+../libwrk/$(TARGET) ../lib ../target/$(TARGET)/util:
 	@$(call MKDIR,$@)
 
 $(TARGET): $(EXTRA_OBJS) ../lib/$(TARGET).lib

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -42,7 +42,6 @@ OUTPUTDIRS := lib                 \
               asminc              \
               cfg                 \
               include             \
-              samples             \
               $(subst ../,,$(filter-out $(wildcard ../include/*.*),$(wildcard ../include/*)))\
               $(subst ../,,$(wildcard ../target/*/drv/*))\
               $(subst ../,,$(wildcard ../target/*/util))\

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -81,8 +81,8 @@ mostlyclean:
 # Transitional line active. Final line commented out below in order to
 # allow some time for transition between the directory structures
 clean:
-	$(call RMDIR,../libwrk ../lib ../targetutil ../$(TARGETDIR) $(addprefix ../,$(DRVTYPES)))
-# 	$(call RMDIR,../libwrk ../lib ../$(TARGETDIR))
+	$(call RMDIR,../libwrk ../lib ../targetutil ../target $(addprefix ../,$(DRVTYPES)))
+# 	$(call RMDIR,../libwrk ../lib ../target)
 
 ifdef CMD_EXE
 

--- a/libsrc/apple2/targetutil/Makefile.inc
+++ b/libsrc/apple2/targetutil/Makefile.inc
@@ -3,7 +3,7 @@ DEPS += ../libwrk/$(TARGET)/loader.d
 ../libwrk/$(TARGET)/loader.o: $(SRCDIR)/targetutil/loader.s | ../libwrk/$(TARGET)
 	$(ASSEMBLE_recipe)
 
-../goodies/targetutil/loader.system: ../libwrk/$(TARGET)/loader.o $(SRCDIR)/targetutil/loader.cfg | ../goodies/targetutil
+../target/$(TARGET)/util/loader.system: ../libwrk/$(TARGET)/loader.o $(SRCDIR)/targetutil/loader.cfg | ../target/$(TARGET)/util
 	$(LD65) -o $@ -C $(filter %.cfg,$^) $(filter-out %.cfg,$^)
 
-$(TARGET): ../goodies/targetutil/loader.system
+$(TARGET): ../target/$(TARGET)/util/loader.system

--- a/libsrc/apple2/targetutil/Makefile.inc
+++ b/libsrc/apple2/targetutil/Makefile.inc
@@ -3,7 +3,7 @@ DEPS += ../libwrk/$(TARGET)/loader.d
 ../libwrk/$(TARGET)/loader.o: $(SRCDIR)/targetutil/loader.s | ../libwrk/$(TARGET)
 	$(ASSEMBLE_recipe)
 
-../targetutil/loader.system: ../libwrk/$(TARGET)/loader.o $(SRCDIR)/targetutil/loader.cfg | ../targetutil
+../goodies/targetutil/loader.system: ../libwrk/$(TARGET)/loader.o $(SRCDIR)/targetutil/loader.cfg | ../goodies/targetutil
 	$(LD65) -o $@ -C $(filter %.cfg,$^) $(filter-out %.cfg,$^)
 
-$(TARGET): ../targetutil/loader.system
+$(TARGET): ../goodies/targetutil/loader.system

--- a/libsrc/atari/targetutil/Makefile.inc
+++ b/libsrc/atari/targetutil/Makefile.inc
@@ -3,7 +3,7 @@ DEPS += ../libwrk/$(TARGET)/w2cas.d
 ../libwrk/$(TARGET)/w2cas.o: $(SRCDIR)/targetutil/w2cas.c | ../libwrk/$(TARGET)
 	$(COMPILE_recipe)
 
-../targetutil/w2cas.com: ../libwrk/$(TARGET)/w2cas.o ../lib/$(TARGET).lib | ../targetutil
+../goodies/targetutil/w2cas.com: ../libwrk/$(TARGET)/w2cas.o ../lib/$(TARGET).lib | ../goodies/targetutil
 	$(LD65) -o $@ -t $(TARGET) $^
 
-$(TARGET): ../targetutil/w2cas.com
+$(TARGET): ../goodies/targetutil/w2cas.com

--- a/libsrc/atari/targetutil/Makefile.inc
+++ b/libsrc/atari/targetutil/Makefile.inc
@@ -3,7 +3,7 @@ DEPS += ../libwrk/$(TARGET)/w2cas.d
 ../libwrk/$(TARGET)/w2cas.o: $(SRCDIR)/targetutil/w2cas.c | ../libwrk/$(TARGET)
 	$(COMPILE_recipe)
 
-../goodies/targetutil/w2cas.com: ../libwrk/$(TARGET)/w2cas.o ../lib/$(TARGET).lib | ../goodies/targetutil
+../target/$(TARGET)/util/w2cas.com: ../libwrk/$(TARGET)/w2cas.o ../lib/$(TARGET).lib | ../target/$(TARGET)/util
 	$(LD65) -o $@ -t $(TARGET) $^
 
-$(TARGET): ../goodies/targetutil/w2cas.com
+$(TARGET): ../target/$(TARGET)/util/w2cas.com

--- a/libsrc/geos-apple/targetutil/Makefile.inc
+++ b/libsrc/geos-apple/targetutil/Makefile.inc
@@ -8,7 +8,7 @@ DEPS += ../libwrk/$(TARGET)/convert.d
 ../lib/apple2enh.lib:
 	@$(MAKE) --no-print-directory apple2enh
 
-../targetutil/convert.system: ../libwrk/$(TARGET)/convert.o ../lib/apple2enh.lib | ../targetutil
+../goodies/targetutil/convert.system: ../libwrk/$(TARGET)/convert.o ../lib/apple2enh.lib | ../goodies/targetutil
 	$(LD65) -o $@ -C apple2enh-system.cfg $^
 
-$(TARGET): ../targetutil/convert.system
+$(TARGET): ../goodies/targetutil/convert.system

--- a/libsrc/geos-apple/targetutil/Makefile.inc
+++ b/libsrc/geos-apple/targetutil/Makefile.inc
@@ -8,7 +8,7 @@ DEPS += ../libwrk/$(TARGET)/convert.d
 ../lib/apple2enh.lib:
 	@$(MAKE) --no-print-directory apple2enh
 
-../goodies/targetutil/convert.system: ../libwrk/$(TARGET)/convert.o ../lib/apple2enh.lib | ../goodies/targetutil
+../target/$(TARGET)/util/convert.system: ../libwrk/$(TARGET)/convert.o ../lib/apple2enh.lib | ../target/$(TARGET)/util
 	$(LD65) -o $@ -C apple2enh-system.cfg $^
 
-$(TARGET): ../goodies/targetutil/convert.system
+$(TARGET): ../target/$(TARGET)/util/convert.system

--- a/libsrc/nes/Makefile.inc
+++ b/libsrc/nes/Makefile.inc
@@ -1,8 +1,8 @@
-../goodies/drivers/tgi/nes-64-56-2.tgi: ../libwrk/nes/clrscr.o \
-                                               ../libwrk/nes/cputc.o  \
-                                               ../libwrk/nes/get_tv.o \
-                                               ../libwrk/nes/gotoxy.o \
-                                               ../libwrk/nes/popa.o   \
-                                               ../libwrk/nes/ppu.o    \
-                                               ../libwrk/nes/ppubuf.o \
-                                               ../libwrk/nes/setcursor.o
+../target/nes/drv/tgi/nes-64-56-2.tgi: ../libwrk/nes/clrscr.o \
+                                   ../libwrk/nes/cputc.o  \
+                                   ../libwrk/nes/get_tv.o \
+                                   ../libwrk/nes/gotoxy.o \
+                                   ../libwrk/nes/popa.o   \
+                                   ../libwrk/nes/ppu.o    \
+                                   ../libwrk/nes/ppubuf.o \
+                                   ../libwrk/nes/setcursor.o

--- a/libsrc/nes/Makefile.inc
+++ b/libsrc/nes/Makefile.inc
@@ -1,8 +1,9 @@
-../target/nes/drv/tgi/nes-64-56-2.tgi: ../libwrk/nes/clrscr.o \
-                                       ../libwrk/nes/cputc.o  \
-                                       ../libwrk/nes/get_tv.o \
-                                       ../libwrk/nes/gotoxy.o \
-                                       ../libwrk/nes/popa.o   \
-                                       ../libwrk/nes/ppu.o    \
-                                       ../libwrk/nes/ppubuf.o \
-                                       ../libwrk/nes/setcursor.o
+../target/nes/drv/tgi/nes-64-56-2.tgi:  \
+                ../libwrk/nes/clrscr.o  \
+                ../libwrk/nes/cputc.o   \
+                ../libwrk/nes/get_tv.o  \
+                ../libwrk/nes/gotoxy.o  \
+                ../libwrk/nes/popa.o    \
+                ../libwrk/nes/ppu.o     \
+                ../libwrk/nes/ppubuf.o  \
+                ../libwrk/nes/setcursor.o

--- a/libsrc/nes/Makefile.inc
+++ b/libsrc/nes/Makefile.inc
@@ -1,8 +1,8 @@
 ../target/nes/drv/tgi/nes-64-56-2.tgi: ../libwrk/nes/clrscr.o \
-                                   ../libwrk/nes/cputc.o  \
-                                   ../libwrk/nes/get_tv.o \
-                                   ../libwrk/nes/gotoxy.o \
-                                   ../libwrk/nes/popa.o   \
-                                   ../libwrk/nes/ppu.o    \
-                                   ../libwrk/nes/ppubuf.o \
-                                   ../libwrk/nes/setcursor.o
+                                       ../libwrk/nes/cputc.o  \
+                                       ../libwrk/nes/get_tv.o \
+                                       ../libwrk/nes/gotoxy.o \
+                                       ../libwrk/nes/popa.o   \
+                                       ../libwrk/nes/ppu.o    \
+                                       ../libwrk/nes/ppubuf.o \
+                                       ../libwrk/nes/setcursor.o

--- a/libsrc/nes/Makefile.inc
+++ b/libsrc/nes/Makefile.inc
@@ -1,8 +1,8 @@
-../tgi/nes-64-56-2.tgi: ../libwrk/nes/clrscr.o \
-                        ../libwrk/nes/cputc.o  \
-                        ../libwrk/nes/get_tv.o \
-                        ../libwrk/nes/gotoxy.o \
-                        ../libwrk/nes/popa.o   \
-                        ../libwrk/nes/ppu.o    \
-                        ../libwrk/nes/ppubuf.o \
-                        ../libwrk/nes/setcursor.o
+../goodies/drivers/tgi/nes-64-56-2.tgi: ../libwrk/nes/clrscr.o \
+                                               ../libwrk/nes/cputc.o  \
+                                               ../libwrk/nes/get_tv.o \
+                                               ../libwrk/nes/gotoxy.o \
+                                               ../libwrk/nes/popa.o   \
+                                               ../libwrk/nes/ppu.o    \
+                                               ../libwrk/nes/ppubuf.o \
+                                               ../libwrk/nes/setcursor.o

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -12,20 +12,19 @@ SYS	= c64
 # source tree; otherwise, use the "install" directories.
 ifeq "$(wildcard ../src)" ""
 # No source tree
-MOUS = /usr/lib/cc65/target/$(SYS)/drv/mou/$(SYS)*.mou
-TGI  = /usr/lib/cc65/target/$(SYS)/drv/tgi/$(SYS)*.tgi
+installdir = /usr/lib/cc65
 ifneq "$(wildcard /usr/local/lib/cc65)" ""
-MOUS = /usr/local/lib/cc65/target/$(SYS)/drv/mou/$(SYS)*.mou
-TGI  = /usr/local/lib/cc65/target/$(SYS)/drv/tgi/$(SYS)*.tgi
+installdir = /usr/local/lib/cc65
 endif
 ifneq "$(wildcard /opt/local/share/cc65)" ""
-MOUS = /opt/local/share/cc65/target/$(SYS)/drv/mou/$(SYS)*.mou
-TGI  = /opt/local/share/cc65/target/$(SYS)/drv/tgi/$(SYS)*.tgi
+installdir = /opt/local/share/cc65
 endif
 ifdef CC65_HOME
-MOUS = $(CC65_HOME)/target/$(SYS)/drv/mou/$(SYS)*.mou
-TGI  = $(CC65_HOME)/target/$(SYS)/drv/tgi/$(SYS)*.tgi
+installdir = $(CC65_HOME)
 endif
+
+MOUS = $(installdir)/target/$(SYS)/drv/mou/$(SYS)*.mou
+TGI  = $(installdir)/target/$(SYS)/drv/tgi/$(SYS)*.tgi
 CLIB = --lib $(SYS).lib
 CL   = cl65
 CC   = cc65
@@ -109,8 +108,11 @@ EXELIST	=	ascii		\
 # --------------------------------------------------------------------------
 # Rules to make the binaries
 
-.PHONY:	all
-all:	$(EXELIST)
+.PHONY: all samples
+all:
+
+samples:
+	$(EXELIST)
 
 # --------------------------------------------------------------------------
 # Overlay rules. Overlays need special ld65 configuration files.  Also, the
@@ -139,7 +141,34 @@ samples.d64:	all
 	done
 
 # --------------------------------------------------------------------------
+# Installation rules
+
+INSTALL = install
+samplesdir = $(prefix)/share/cc65
+.PHONY:	install
+install:
+	$(if $(prefix),,$(error variable `prefix' must be set))
+	$(INSTALL) -d $(DESTDIR)$(samplesdir)
+	$(INSTALL) -d $(DESTDIR)$(samplesdir)/geos
+	$(INSTALL) -d $$(DESTDIR)$(samplesdir)/tutorial
+	$(INSTALL) -m0644 *.* $(DESTDIR)$(samplesdir)
+	$(INSTALL) -m0644 README $(DESTDIR)$(samplesdir)
+	$(INSTALL) -m0644 Makefile $(DESTDIR)$(samplesdir)
+	$(INSTALL) -m0644 geos/*.* $(DESTDIR)$(samplesdir)/geos
+	$(INSTALL) -m0644 tutorial/*.* $(DESTDIR)$(samplesdir)/tutorial
+
+# --------------------------------------------------------------------------
+# Packaging rules
+
+.PHONY:	zip
+zip:
+	@cd .. && zip -r cc65 samples/
+
+# --------------------------------------------------------------------------
 # Clean-up rules
+
+.PHONY:	mostlyclean
+mostlyclean:
 
 .PHONY:	clean
 clean:

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -12,15 +12,19 @@ SYS	= c64
 # source tree; otherwise, use the "install" directories.
 ifeq "$(wildcard ../src)" ""
 # No source tree
-MOUS = /usr/lib/cc65/mou/$(SYS)*.mou
-TGI  = /usr/lib/cc65/tgi/$(SYS)*.tgi
+MOUS = /usr/lib/cc65/target/$(SYS)/drv/mou/$(SYS)*.mou
+TGI  = /usr/lib/cc65/target/$(SYS)/drv/tgi/$(SYS)*.tgi
 ifneq "$(wildcard /usr/local/lib/cc65)" ""
-MOUS = /usr/local/lib/cc65/mou/$(SYS)*.mou
-TGI  = /usr/local/lib/cc65/tgi/$(SYS)*.tgi
+MOUS = /usr/local/lib/cc65/target/$(SYS)/drv/mou/$(SYS)*.mou
+TGI  = /usr/local/lib/cc65/target/$(SYS)/drv/tgi/$(SYS)*.tgi
+endif
+ifneq "$(wildcard /opt/local/share/cc65)" ""
+MOUS = /opt/local/share/cc65/target/$(SYS)/drv/mou/$(SYS)*.mou
+TGI  = /opt/local/share/cc65/target/$(SYS)/drv/tgi/$(SYS)*.tgi
 endif
 ifdef CC65_HOME
-MOUS = $(CC65_HOME)/mou/$(SYS)*.mou
-TGI  = $(CC65_HOME)/tgi/$(SYS)*.tgi
+MOUS = $(CC65_HOME)/target/$(SYS)/drv/mou/$(SYS)*.mou
+TGI  = $(CC65_HOME)/target/$(SYS)/drv/tgi/$(SYS)*.tgi
 endif
 CLIB = --lib $(SYS).lib
 CL   = cl65
@@ -31,8 +35,8 @@ LD   = ld65
 else
 # "samples/" is a part of a complete source tree.
 export CC65_HOME := $(abspath ..)
-MOUS = ../mou/$(SYS)*.mou
-TGI  = ../tgi/$(SYS)*.tgi
+MOUS = ../target/$(SYS)/drv/mou/$(SYS)*.mou
+TGI  = ../target/$(SYS)/drv/tgi/$(SYS)*.tgi
 CLIB = ../lib/$(SYS).lib
 CL   = ../bin/cl65
 CC   = ../bin/cc65


### PR DESCRIPTION
Drivers moved to goodies/drivers, targetutil moved to goodies/targetutil, zip target now zips samples in addition to previously supported directories and doesn't break when html directory is missing (like not created due to lack of linuxdoc-tools)