### PR TITLE
Update the missing entries in the kernel jump table for the Vic20 wit…

### DIFF
--- a/libsrc/vic20/kernal.s
+++ b/libsrc/vic20/kernal.s
@@ -47,9 +47,9 @@
 ;-----------------------------------------------------------------------------
 ; All functions are available in the kernal jump table
 
-CINT            = $E518         ; No entries are in the kernal jump table for these functions.
-IOINIT          = $FDF9         ; The entries point directly to the function.
-RAMTAS          = $FD8D         ;
+CINT            = $E518         ; No entries are in the kernal jump table of the Vic20 for these three (3) functions.
+IOINIT          = $FDF9         ; The entries for these functions have been set to point directly to the functions 
+RAMTAS          = $FD8D         ; in the kernal to maintain compatibility with the other Commodore platforms.
 RESTOR          = $FF8A
 VECTOR          = $FF8D
 SETMSG          = $FF90

--- a/libsrc/vic20/kernal.s
+++ b/libsrc/vic20/kernal.s
@@ -47,9 +47,9 @@
 ;-----------------------------------------------------------------------------
 ; All functions are available in the kernal jump table
 
-CINT            = $FF81
-IOINIT          = $FF84
-RAMTAS          = $FF87
+CINT            = $E518         ; No entries are in the kernal jump table for these functions.
+IOINIT          = $FDF9         ; The entries point directly to the function.
+RAMTAS          = $FD8D         ;
 RESTOR          = $FF8A
 VECTOR          = $FF8D
 SETMSG          = $FF90


### PR DESCRIPTION
…h the actual function addresses.

The Vic20 does not have kernal table entries for the following functions.

;-----------------------------------------------------------------------------
; Functions which are not in the kernal jump table for VIC-20 but are for C64

CINT        := $E518
IOINIT      := $FDF9
RAMTAS      := $FD8D

All other kernal entries are the same as the C64, however, without this change, the startup code fails.

Without this change the vic20.lib builds incorrectly.