### PR TITLE
Make a small optimization to some library functions' inlined versions.

### DIFF
--- a/src/cc65/codegen.c
+++ b/src/cc65/codegen.c
@@ -55,6 +55,7 @@
 #include "global.h"
 #include "segments.h"
 #include "stackptr.h"
+#include "stdfunc.h"
 #include "textseg.h"
 #include "util.h"
 #include "codegen.h"
@@ -4241,7 +4242,7 @@ void g_initauto (unsigned Label, unsigned Size)
         AddCodeLine ("lda %s,y", GetLabelName (CF_STATIC, Label, 0));
         AddCodeLine ("sta (sp),y");
         AddCodeLine ("iny");
-        AddCodeLine ("cpy #$%02X", (unsigned char) Size);
+	AddCmpCodeIfSizeNot256 ("cpy #$%02X", Size);
         AddCodeLine ("bne %s", LocalLabelName (CodeLabel));
     }
 }
@@ -4266,10 +4267,10 @@ void g_initstatic (unsigned InitLabel, unsigned VarLabel, unsigned Size)
         AddCodeLine ("lda %s,y", GetLabelName (CF_STATIC, InitLabel, 0));
         AddCodeLine ("sta %s,y", GetLabelName (CF_STATIC, VarLabel, 0));
         AddCodeLine ("iny");
-        AddCodeLine ("cpy #$%02X", (unsigned char) Size);
+	AddCmpCodeIfSizeNot256 ("cpy #$%02X", Size);
         AddCodeLine ("bne %s", LocalLabelName (CodeLabel));
     } else {
-        /* Use the easy way here: memcpy */
+        /* Use the easy way here: memcpy() */
         g_getimmed (CF_STATIC, VarLabel, 0);
         AddCodeLine ("jsr pushax");
         g_getimmed (CF_STATIC, InitLabel, 0);

--- a/src/cc65/stdfunc.c
+++ b/src/cc65/stdfunc.c
@@ -185,6 +185,19 @@ static void ParseArg (ArgDesc* Arg, Type* Type)
 
 
 
+void AddCmpCodeIfSizeNot256 (const char* Code, long Size)
+/* Add a line of Assembly code that compares an index register
+** only if it isn't comparing to #<256.  (If the next line
+** is "bne", then this will avoid a redundant line.)
+*/
+{
+    if (Size != 256) {
+        AddCodeLine (Code, (unsigned int)Size);
+    }
+}
+
+
+
 /*****************************************************************************/
 /*                                  memcpy                                   */
 /*****************************************************************************/
@@ -272,7 +285,6 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
         if (Arg3.Expr.IVal <= 127) {
 
             AddCodeLine ("ldy #$%02X", (unsigned char) (Arg3.Expr.IVal-1));
-            AddCodeLine ("lda #$%02X", (unsigned char) Arg2.Expr.IVal);
             g_defcodelabel (Label);
             if (Reg2) {
                 AddCodeLine ("lda (%s),y", ED_GetLabelName (&Arg2.Expr, 0));
@@ -290,7 +302,6 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
         } else {
 
             AddCodeLine ("ldy #$00");
-            AddCodeLine ("lda #$%02X", (unsigned char) Arg2.Expr.IVal);
             g_defcodelabel (Label);
             if (Reg2) {
                 AddCodeLine ("lda (%s),y", ED_GetLabelName (&Arg2.Expr, 0));
@@ -303,7 +314,7 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
                 AddCodeLine ("sta %s,y", ED_GetLabelName (&Arg1.Expr, 0));
             }
             AddCodeLine ("iny");
-            AddCodeLine ("cpy #$%02X", (unsigned char) Arg3.Expr.IVal);
+            AddCmpCodeIfSizeNot256 ("cpy #$%02X", Arg3.Expr.IVal);
             AddCodeLine ("bne %s", LocalLabelName (Label));
 
         }
@@ -366,7 +377,7 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
                 AddCodeLine ("lda %s,y", ED_GetLabelName (&Arg2.Expr, -Offs));
                 AddCodeLine ("sta (sp),y");
                 AddCodeLine ("iny");
-                AddCodeLine ("cpy #$%02X", (unsigned char) (Offs + Arg3.Expr.IVal));
+                AddCmpCodeIfSizeNot256 ("cpy #$%02X", Offs + Arg3.Expr.IVal);
                 AddCodeLine ("bne %s", LocalLabelName (Label));
             } else {
                 AddCodeLine ("ldx #$00");
@@ -376,7 +387,7 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
                 AddCodeLine ("sta (sp),y");
                 AddCodeLine ("iny");
                 AddCodeLine ("inx");
-                AddCodeLine ("cpx #$%02X", (unsigned char) Arg3.Expr.IVal);
+                AddCmpCodeIfSizeNot256 ("cpx #$%02X", Arg3.Expr.IVal);
                 AddCodeLine ("bne %s", LocalLabelName (Label));
             }
 
@@ -440,7 +451,7 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
                 AddCodeLine ("lda (sp),y");
                 AddCodeLine ("sta %s,y", ED_GetLabelName (&Arg1.Expr, -Offs));
                 AddCodeLine ("iny");
-                AddCodeLine ("cpy #$%02X", (unsigned char) (Offs + Arg3.Expr.IVal));
+                AddCmpCodeIfSizeNot256 ("cpy #$%02X", Offs + Arg3.Expr.IVal);
                 AddCodeLine ("bne %s", LocalLabelName (Label));
             } else {
                 AddCodeLine ("ldx #$00");
@@ -450,7 +461,7 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
                 AddCodeLine ("sta %s,x", ED_GetLabelName (&Arg1.Expr, 0));
                 AddCodeLine ("iny");
                 AddCodeLine ("inx");
-                AddCodeLine ("cpx #$%02X", (unsigned char) Arg3.Expr.IVal);
+                AddCmpCodeIfSizeNot256 ("cpx #$%02X", Arg3.Expr.IVal);
                 AddCodeLine ("bne %s", LocalLabelName (Label));
             }
 
@@ -487,7 +498,7 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
             AddCodeLine ("lda (sp),y");
             AddCodeLine ("sta (ptr1),y");
             AddCodeLine ("iny");
-            AddCodeLine ("cpy #$%02X", (unsigned char) Arg3.Expr.IVal);
+            AddCmpCodeIfSizeNot256 ("cpy #$%02X", Arg3.Expr.IVal);
             AddCodeLine ("bne %s", LocalLabelName (Label));
         }
 
@@ -631,7 +642,7 @@ static void StdFunc_memset (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
                 AddCodeLine ("sta %s,y", ED_GetLabelName (&Arg1.Expr, 0));
             }
             AddCodeLine ("iny");
-            AddCodeLine ("cpy #$%02X", (unsigned char) Arg3.Expr.IVal);
+            AddCmpCodeIfSizeNot256 ("cpy #$%02X", Arg3.Expr.IVal);
             AddCodeLine ("bne %s", LocalLabelName (Label));
 
         }
@@ -661,7 +672,7 @@ static void StdFunc_memset (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
         g_defcodelabel (Label);
         AddCodeLine ("sta (sp),y");
         AddCodeLine ("iny");
-        AddCodeLine ("cpy #$%02X", (unsigned char) (Offs + Arg3.Expr.IVal));
+        AddCmpCodeIfSizeNot256 ("cpy #$%02X", Offs + Arg3.Expr.IVal);
         AddCodeLine ("bne %s", LocalLabelName (Label));
 
         /* memset returns the address, so the result is actually identical
@@ -697,7 +708,7 @@ static void StdFunc_memset (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
             g_defcodelabel (Label);
             AddCodeLine ("sta (ptr1),y");
             AddCodeLine ("iny");
-            AddCodeLine ("cpy #$%02X", (unsigned char) Arg3.Expr.IVal);
+            AddCmpCodeIfSizeNot256 ("cpy #$%02X", Arg3.Expr.IVal);
             AddCodeLine ("bne %s", LocalLabelName (Label));
         }
 

--- a/src/cc65/stdfunc.h
+++ b/src/cc65/stdfunc.h
@@ -50,6 +50,12 @@
 
 
 
+void AddCmpCodeIfSizeNot256 (const char* Code, long Size);
+/* Add a line of Assembly code that compares an index register
+** only if it isn't comparing to #<256.  (If the next line
+** is "bne", then this will avoid a redundant line.)
+*/
+
 int FindStdFunc (const char* Name);
 /* Determine if the given function is a known standard function that may be
 ** called in a special way. If so, return the index, otherwise return -1.
@@ -61,5 +67,4 @@ void HandleStdFunc (int Index, struct FuncDesc* F, ExprDesc* lval);
 
 
 /* End of stdfunc.h */
-
 #endif


### PR DESCRIPTION
Calls to memcpy() and memset() will compile to optimum code when the length argument is constant, and 256 or less.

(This patch was inspired by issue #288.)