### PR TITLE
Atari: add command line support for XDOS

### DIFF
--- a/asminc/atari.inc
+++ b/asminc/atari.inc
@@ -997,12 +997,15 @@ diopp_size   = 5        ; size of structure
 ; VALUES for dos_type
 ;-------------------------------------------------------------------------
 
-ATARIDOS     = 0
-SPARTADOS    = 1
-OSADOS       = 2        ; OS/A+
-MYDOS        = 3
-XDOS         = 4
+SPARTADOS    = 0
+OSADOS       = 1        ; OS/A+
+XDOS         = 2
+ATARIDOS     = 3
+MYDOS        = 4
 NODOS        = 255
+; The DOSes with dos_type below or equal MAX_DOS_WITH_CMDLINE do support
+; command line arguments.
+MAX_DOS_WITH_CMDLINE = XDOS
 
 ;-------------------------------------------------------------------------
 ; XDOS defines (version 2.4, taken from xdos24.pdf)

--- a/asminc/atari.inc
+++ b/asminc/atari.inc
@@ -1011,16 +1011,16 @@ MAX_DOS_WITH_CMDLINE = XDOS
 ; XDOS defines (version 2.4, taken from xdos24.pdf)
 ;-------------------------------------------------------------------------
 
-XOPT         = $70B     ; XDOS options
-XCAR         = $70C     ; XDOS cartridge address (+ $70D)
-XPAT         = $86F     ; XDOS bugfix and patch number
-XVER         = $870     ; XDOS version number
-XFILE        = $87D     ; XDOS filename buffer
-XLINE        = $880     ; XDOS DUP input line
-XGLIN        = $871     ; get line
-XSKIP        = $874     ; skip parameter
-XMOVE        = $877     ; move filename
-XGNUM        = $87A     ; get number
+XOPT         = $070B    ; XDOS options
+XCAR         = $070C    ; XDOS cartridge address (+ $70D)
+XPAT         = $086F    ; XDOS bugfix and patch number
+XVER         = $0870    ; XDOS version number
+XFILE        = $087D    ; XDOS filename buffer
+XLINE        = $0880    ; XDOS DUP input line
+XGLIN        = $0871    ; get line
+XSKIP        = $0874    ; skip parameter
+XMOVE        = $0877    ; move filename
+XGNUM        = $087A    ; get number
 
 ;-------------------------------------------------------------------------
 ; End of atari.inc

--- a/asminc/atari.inc
+++ b/asminc/atari.inc
@@ -106,7 +106,7 @@ SIO_WRPERCOM = $4F      ;write PERCOM block (XF551)
 SIO_WRITE    = $50      ;write sector
 SIO_READ     = $52      ;read sector
 SIO_STAT     = $53      ;get status information
-SIO_VERIFY   = $56      ;verify sector 
+SIO_VERIFY   = $56      ;verify sector
 SIO_WRITEV   = $57      ;write sector with verify
 SIO_WRITETRK = $60      ;write track (Speedy)
 SIO_READTRK  = $62      ;read track (Speedy)
@@ -689,7 +689,7 @@ CASFLG  = $030F         ;CASSETTE MODE WHEN SET
 TIMER2  = $0310         ;2-byte final baud rate timer value
 TEMP1   = $0312         ;TEMPORARY STORAGE REGISTER
 ;TEMP2  = $0314         ;##old## TEMPORARY STORAGE REGISTER
-TEMP2   = $0313         ;##1200xl## 1-byte temporary 
+TEMP2   = $0313         ;##1200xl## 1-byte temporary
 PTIMOT  = $0314         ;##1200xl## 1-byte printer timeout
 TEMP3   = $0315         ;TEMPORARY STORAGE REGISTER
 SAVIO   = $0316         ;SAVE SERIAL IN DATA PORT
@@ -765,7 +765,7 @@ CART    = $BFFC         ;##rev2## 1-byte cartridge present indicator
                         ;0=Cart Exists
 CARTFG  = $BFFD         ;##rev2## 1-byte cartridge flags
                         ;D7  0=Not a Diagnostic Cart
-                        ;    1=Is a Diagnostic cart and control is 
+                        ;    1=Is a Diagnostic cart and control is
                         ;      given to cart before any OS is init.
                         ;D2  0=Init but Do not Start Cart
                         ;    1=Init and Start Cart
@@ -925,7 +925,7 @@ RADON   = 0             ;INDICATES RADIANS
 DEGON   = 6             ;INDICATES DEGREES
 
 ASCZER  = '0'           ;ASCII ZERO
-COLON   = $3A           ;ASCII COLON 
+COLON   = $3A           ;ASCII COLON
 CR      = $9B           ;SYSTEM EOL (CARRIAGE RETURN)
 
 ;-------------------------------------------------------------------------
@@ -1003,6 +1003,21 @@ OSADOS       = 2        ; OS/A+
 MYDOS        = 3
 XDOS         = 4
 NODOS        = 255
+
+;-------------------------------------------------------------------------
+; XDOS defines (version 2.4, taken from xdos24.pdf)
+;-------------------------------------------------------------------------
+
+XOPT         = $70B     ; XDOS options
+XCAR         = $70C     ; XDOS cartridge address (+ $70D)
+XPAT         = $86F     ; XDOS bugfix and patch number
+XVER         = $870     ; XDOS version number
+XFILE        = $87D     ; XDOS filename buffer
+XLINE        = $880     ; XDOS DUP input line
+XGLIN        = $871     ; get line
+XSKIP        = $874     ; skip parameter
+XMOVE        = $877     ; move filename
+XGNUM        = $87A     ; get number
 
 ;-------------------------------------------------------------------------
 ; End of atari.inc

--- a/include/atari.h
+++ b/include/atari.h
@@ -261,11 +261,11 @@ extern void atrx15p2_tgi[];
 #define AT_PAL      1
 
 /* valid _dos_type values */
-#define ATARIDOS    0
-#define SPARTADOS   1
-#define OSADOS      2
-#define MYDOS       3
-#define XDOS        4
+#define SPARTADOS   0
+#define OSADOS      1
+#define XDOS        2
+#define ATARIDOS    3
+#define MYDOS       4
 #define NODOS       255
 
 /* Define hardware */

--- a/libsrc/atari/dosdetect.s
+++ b/libsrc/atari/dosdetect.s
@@ -50,4 +50,4 @@ done:   rts
 
         .data
 
-__dos_type:     .byte   0       ; default to ATARIDOS
+__dos_type:     .byte   ATARIDOS; default to ATARIDOS

--- a/libsrc/atari/getargs.s
+++ b/libsrc/atari/getargs.s
@@ -7,6 +7,8 @@
 ; startup code but is nevertheless included in the compiled program when
 ; needed.
 
+; XDOS support added 05/2016 by Christian Groessler
+
 MAXARGS = 16            ; max. amount of arguments in arg. table
 CL_SIZE = 64            ; command line buffer size
 SPACE   = 32            ; SPACE char.
@@ -22,22 +24,30 @@ SPACE   = 32            ; SPACE char.
 
 .segment        "ONCE"
 
+nargdos:rts
+
 initmainargs:
         lda     __dos_type      ; which DOS?
-        cmp     #ATARIDOS
-        beq     nargdos         ; DOS does not support arguments
-        cmp     #MYDOS
-        bne     argdos          ; DOS supports arguments
-nargdos:rts
+        cmp     #MAX_DOS_WITH_CMDLINE + 1
+        bcs     nargdos
 
 ; Initialize ourcl buffer
 
-argdos: lda     #ATEOL
-        sta     ourcl+CL_SIZE
+argdos: ldy     #ATEOL
+        sty     ourcl+CL_SIZE
 
-; Move SpartaDOS command line to our own buffer
+; Move SpartaDOS/XDOS command line to our own buffer
 
-        lda     DOSVEC
+        cmp     #XDOS
+        bne     sparta
+
+        lda     #<XLINE
+        sta     ptr1
+        lda     #>XLINE
+        sta     ptr1+1
+        bne     cpcl0
+
+sparta: lda     DOSVEC
         clc
         adc     #<LBUF
         sta     ptr1
@@ -45,7 +55,7 @@ argdos: lda     #ATEOL
         adc     #>LBUF
         sta     ptr1+1
 
-        ldy     #0
+cpcl0:  ldy     #0
 cpcl:   lda     (ptr1),y
         sta     ourcl,y
         iny


### PR DESCRIPTION
With this change the runtime library parses the command line arguments correctly on XDOS. Tested with XDOS 2.4.