### PR TITLE
Atari: add new function '_is_cmdline_dos()' and some other small changes

### DIFF
--- a/doc/atari.sgml
+++ b/doc/atari.sgml
@@ -275,6 +275,7 @@ See the <url url="funcref.html" name="function reference"> for declaration and u
 <item>_getcolor
 <item>_getdefdev
 <item>_graphics
+<item>_is_cmdline_dos
 <item>_rest_vecs
 <item>_save_vecs
 <item>_scroll

--- a/doc/funcref.sgml
+++ b/doc/funcref.sgml
@@ -98,6 +98,7 @@ function.
 <!-- <item><ref id="_getcolor" name="_getcolor"> -->
 <!-- <item><ref id="_getdefdev" name="_getdefdev"> -->
 <!-- <item><ref id="_graphics" name="_graphics"> -->
+<item><ref id="_is_cmdline_dos" name="_is_cmdline_dos">
 <!-- <item><ref id="_rest_vecs" name="_rest_vecs"> -->
 <!-- <item><ref id="_save_vecs" name="_save_vecs"> -->
 <!-- <item><ref id="_scroll" name="_scroll"> -->
@@ -935,6 +936,40 @@ id="malloc" name="malloc"> may still return <tt/NULL/.
 <ref id="malloc" name="malloc">,
 <ref id="realloc" name="realloc">
 <tag/Example/None.
+</descrip>
+</quote>
+
+
+<sect1>_is_cmdline_dos<label id="_is_cmdline_dos"><p>
+
+<quote>
+<descrip>
+<tag/Function/Determines whether the underlying DOS supports command line arguments.
+<tag/Header/<tt/<ref id="atari.h" name="atari.h">/
+<tag/Declaration/<tt/unsigned char _is_cmdline_dos (void);/
+<tag/Description/The function returns 0 if the DOS doesn't support command line arguments.
+It returns 1 if it does.
+<tag/Notes/<itemize>
+<item>Many Atari DOSes which don't support command line arguments immediately clear the screen
+and display their menu after a program exits. Therefore it might be difficult to read
+the last messages printed by the program prior to its exit. This function can be used
+to decide if a delay or wait for a key press should be executed when then program
+exits.
+</itemize>
+<tag/Availability/cc65 (<tt/atari/ and <tt/atarixl/ platforms)
+<tag/Example/<verb>
+/* Hello World for Atari */
+#include <stdio.h>
+#include <unistd.h>
+#include <atari.h>
+int main(void)
+{
+    printf("Hello World\n");
+    if (! _is_cmdline_dos())
+        sleep(5);
+    return 0;
+}
+</verb>
 </descrip>
 </quote>
 

--- a/include/atari.h
+++ b/include/atari.h
@@ -161,11 +161,12 @@ extern void __fastcall__ _scroll (signed char numlines);
                                           /* numlines < 0  scrolls down */
 
 /* misc. functions */
-extern unsigned char get_ostype(void);  /* get ROM version */
-extern unsigned char get_tv(void);      /* get TV system */
-extern void _save_vecs(void);           /* save system vectors */
-extern void _rest_vecs(void);           /* restore system vectors */
-extern char *_getdefdev(void);          /* get default floppy device */
+extern unsigned char get_ostype(void);       /* get ROM version */
+extern unsigned char get_tv(void);           /* get TV system */
+extern void _save_vecs(void);                /* save system vectors */
+extern void _rest_vecs(void);                /* restore system vectors */
+extern char *_getdefdev(void);               /* get default floppy device */
+extern unsigned char _is_cmdline_dos(void);  /* does DOS support command lines */
 
 /* global variables */
 extern unsigned char _dos_type;         /* the DOS flavour */

--- a/libsrc/atari/getdefdev.s
+++ b/libsrc/atari/getdefdev.s
@@ -27,10 +27,9 @@
 __getdefdev:
 
         lda     __dos_type      ; which DOS?
-        cmp     #ATARIDOS
-        beq     finish
-        cmp     #MYDOS
-        beq     finish
+        cmp     #OSADOS+1
+        bcs     finish          ; only supported on OS/A+ and SpartaDOS
+                                ; (TODO: add XDOS support)
 
         ldy     #BUFOFF
         lda     #0

--- a/libsrc/atari/is_cmdline_dos.s
+++ b/libsrc/atari/is_cmdline_dos.s
@@ -1,0 +1,20 @@
+;
+; Christian Groessler, May-2016
+;
+; unsigned char _is_cmdline_dos(void);
+;
+; returns 0 for non-commandline DOS, 1 for commandline DOS
+;
+
+        .export  __is_cmdline_dos
+        .import  __dos_type
+        .include "atari.inc"
+
+__is_cmdline_dos:
+        ldx     #0
+        lda     __dos_type
+        cmp     #MAX_DOS_WITH_CMDLINE + 1
+        txa
+        rol     a
+        eor     #$01
+        rts

--- a/libsrc/atari/sysrmdir.s
+++ b/libsrc/atari/sysrmdir.s
@@ -26,11 +26,12 @@
 
         pha
         lda     __dos_type
-        beq     not_impl                ; AtariDOS
         cmp     #OSADOS+1
         bcc     do_sparta               ; OS/A and SpartaDOS
+        cmp     #MYDOS
+        bne     not_impl                ; neither MyDOS, OS/A, nor SpartaDOS
         pla
-        jmp     __sysremove             ; MyDOS and others (TODO: check XDOS)
+        jmp     __sysremove             ; MyDOS
 
 not_impl:
         pla

--- a/libsrc/atari/targetutil/w2cas.c
+++ b/libsrc/atari/targetutil/w2cas.c
@@ -45,7 +45,7 @@ int main(int argc, char **argv)
 
     if (! iocb) {
         fprintf(stderr, "couldn't find a free iocb\n");
-        if (_dos_type != 1)
+        if (! _is_cmdline_dos())
             cgetc();
         return 1;
     }
@@ -57,10 +57,20 @@ int main(int argc, char **argv)
         printf("\nfilename: ");
         x = fgets(buf, 19, stdin);
         printf("\n");
-        if (! x)
+        if (! x) {
+            printf("empty filename, exiting...\n");
+            if (! _is_cmdline_dos())
+                cgetc();
             return 1;
+        }
         if (*x && *(x + strlen(x) - 1) == '\n')
             *(x + strlen(x) - 1) = 0;
+        if (! strlen(x)) {  /* empty filename */
+            printf("empty filename, exiting...\n");
+            if (! _is_cmdline_dos())
+                cgetc();
+            return 1;
+        }
         filename = x;
     }
     else {
@@ -74,7 +84,7 @@ int main(int argc, char **argv)
         buffer = malloc(buflen);
         if (! buffer) {
             fprintf(stderr, "cannot alloc %ld bytes -- aborting...\n", (long)buflen);
-            if (_dos_type != 1)
+            if (! _is_cmdline_dos())
                 cgetc();
             return 1;
         }
@@ -87,7 +97,7 @@ int main(int argc, char **argv)
     if (! file) {
         free(buffer);
         fprintf(stderr, "cannot open '%s': %s\n", filename, strerror(errno));
-        if (_dos_type != 1)
+        if (! _is_cmdline_dos())
             cgetc();
         return 1;
     }
@@ -101,7 +111,7 @@ int main(int argc, char **argv)
     file_err:
         fclose(file);
         free(buffer);
-        if (_dos_type != 1)
+        if (! _is_cmdline_dos())
             cgetc();
         return 1;
     }
@@ -133,7 +143,7 @@ int main(int argc, char **argv)
     if (regs.y != 1) {
         fprintf(stderr, "CIO call to open cassette returned %d\n", regs.y);
         free(buffer);
-        if (_dos_type != 1)
+        if (! _is_cmdline_dos())
             cgetc();
         return 1;
     }
@@ -157,7 +167,7 @@ int main(int argc, char **argv)
         regs.pc = 0xe456;   /* CIOV */
         _sys(&regs);
 
-        if (_dos_type != 1)
+        if (! _is_cmdline_dos())
             cgetc();
         return 1;
     }
@@ -173,14 +183,14 @@ int main(int argc, char **argv)
 
     if (regs.y != 1) {
         fprintf(stderr, "CIO call to close cassette returned %d\n", regs.y);
-        if (_dos_type != 1)
+        if (! _is_cmdline_dos())
             cgetc();
         return 1;
     }
 
     /* all is fine */
     printf("success\n");
-    if (_dos_type != 1)
+    if (! _is_cmdline_dos())
         cgetc();
     return 0;
 }

--- a/testcode/lib/atari/defdev.c
+++ b/testcode/lib/atari/defdev.c
@@ -13,6 +13,6 @@ extern char _defdev[];
 int main(void)
 {
         printf("default device: %s\n", _defdev);
-        if (_dos_type != SPARTADOS && _dos_type != OSADOS) cgetc();
+        if (! _is_cmdline_dos()) cgetc();
         return 0;
 }

--- a/testcode/lib/atari/mem.c
+++ b/testcode/lib/atari/mem.c
@@ -11,7 +11,6 @@
 
 extern int getsp(void);                         /* comes from ../getsp.s */
 
-extern char _dos_type;                          /* bss variable */
 unsigned char data = 0x12;                      /* data variable */
 
 unsigned int *APPMHI = (unsigned int *)14;      /* 14,15 */
@@ -42,6 +41,6 @@ int main(void)
   printf("  sp:              $%04X  (stack ptr)\n", getsp());
 
   if (allocmem) free(allocmem);
-  if (_dos_type != 1) cgetc();
+  if (! _is_cmdline_dos()) cgetc();
   return(0);
 }


### PR DESCRIPTION
- use this function instead of directly looking at _dos_type in the included
  targetutil and test programs
- fixes/improvements to the Atari runtime library regarding the recently
  changed _dos_type values
- libsrc/atari/targetutil/w2cas.c: exit if no filename was entered
- add documentation for the new function
