### PR TITLE
make BSS segment optional in atari-cassette.cfg

### DIFF
--- a/cfg/atari-cassette.cfg
+++ b/cfg/atari-cassette.cfg
@@ -21,7 +21,7 @@ SEGMENTS {
     CODE:     load = MAIN, type = ro,  define = yes;
     RODATA:   load = MAIN, type = ro,                optional = yes;
     DATA:     load = MAIN, type = rw,                optional = yes;
-    BSS:      load = MAIN, type = bss, define = yes;
+    BSS:      load = MAIN, type = bss, define = yes, optional = yes;
     INIT:     load = MAIN, type = bss,               optional = yes;
 }
 FEATURES {


### PR DESCRIPTION
Don't know why it wasn't optional.

Documentation says that this config file can be used for both C and Assembler programs. Assembler programs typically don't have  a BSS segment.