### PR TITLE
Fix doesclrscrafterexit() function on atarixl target.

### DIFF
--- a/libsrc/atari/doesclrscr.s
+++ b/libsrc/atari/doesclrscr.s
@@ -7,13 +7,14 @@
 ;
 
         .export  _doesclrscrafterexit
-        .import  __dos_type
-        .include "atari.inc"
+        .import  __is_cmdline_dos
+        .import  return1
 
+.ifdef __ATARIXL__
+_doesclrscrafterexit = return1          ; the c65 runtime always clears the screen at program termination
+.else   
 _doesclrscrafterexit:
-        ldx     #0
-        lda     __dos_type
-        cmp     #MAX_DOS_WITH_CMDLINE + 1
-        txa
-        rol     a
+        jsr     __is_cmdline_dos        ; currently (unless a DOS behaving differently is popping up)
+        eor     #$01                    ; we can get by with the inverse of __is_cmdline_dos
         rts
+.endif

--- a/libsrc/atari/is_cmdline_dos.s
+++ b/libsrc/atari/is_cmdline_dos.s
@@ -7,9 +7,14 @@
 ;
 
         .export  __is_cmdline_dos
-        .import  _doesclrscrafterexit
+        .import  __dos_type
+        .include "atari.inc"
 
 __is_cmdline_dos:
-        jsr     _doesclrscrafterexit    ; currently (unless a DOS behaving differently is popping up)
-        eor     #$01                    ; we can get by with the inverse of _doesclrscrafterexit
+        ldx     #0
+        lda     __dos_type
+        cmp     #MAX_DOS_WITH_CMDLINE + 1
+        txa
+        rol     a
+        eor     #$01
         rts


### PR DESCRIPTION
On atarixl, the screen is always cleared, regardless of the running DOS.