### PR TITLE
Fix exec() for atarixl target.

### DIFF
--- a/libsrc/atari/exec.s
+++ b/libsrc/atari/exec.s
@@ -177,9 +177,9 @@ openok: lda     #>buf
 ; program file appears to be available and good
 ; here's the point of no return
 
-        lda     tmp4            ; get IOCB index
         ldx     SP_save
         txs                     ; reset stack pointer to what it was at program entry
+        lda     tmp4            ; get IOCB index
         pha                     ; and save it ('excexit' calls destructors and they might destroy tmp4)
         jsr     excexit         ; on atarixl this will enable the ROM again, making all high variables inaccessible
         pla

--- a/libsrc/atari/open.s
+++ b/libsrc/atari/open.s
@@ -8,6 +8,7 @@
         .include "fcntl.inc"
         .include "errno.inc"
         .include "fd.inc"
+        .include "zeropage.inc"
 
         .export _open
         .destructor     closeallfiles, 5
@@ -19,9 +20,7 @@
         .import incsp4
         .import ldaxysp,addysp
         .import __oserror
-        .importzp tmp4,tmp2
 .ifdef  UCASE_FILENAME
-        .importzp tmp3
         .import ucase_fn
 .endif
 


### PR DESCRIPTION
The final part of exec() called 'excexit' and only then restored the
stack pointer to its value at program entry.  'excexit' does all
cleanup (the same as '_exit()'), which means that on the atarixl
target the ROM is banked in again.  On big programs the 'SP_save'
variable might reside at a high memory address which is no longer
accessible after the ROM has been banked in.
The change just moves the restoration of the stack pointer before
the call to 'excexit'.

Another change lets exec.s compile if UCASE_FILENAME is not defined.
And some other small cleanups, also in open.s.