### PR TITLE
Fix the Plus/4 (and C16) joystick driver.

### DIFF
--- a/libsrc/plus4/joy/plus4-stdjoy.s
+++ b/libsrc/plus4/joy/plus4-stdjoy.s
@@ -1,17 +1,15 @@
 ;
-; Standard joystick driver for the Plus/4. May be used multiple times when linked
-; to the statically application.
+; Standard joystick driver for the Plus/4 and C16.
+; May be used multiple times when linked statically to an application.
 ;
-; Ullrich von Bassewitz, 2002-12-21
+; 2002-12-21, Ullrich von Bassewitz
+; 2016-06-18, Greg King
 ;
-
-        .include        "zeropage.inc"
 
         .include        "joy-kernel.inc"
         .include        "joy-error.inc"
         .include        "plus4.inc"
 
-        .macpack        generic
         .macpack        module
 
 
@@ -26,7 +24,7 @@
 
 ; Driver signature
 
-        .byte   $6A, $6F, $79           ; "joy"
+        .byte   $6A, $6F, $79           ; ASCII "joy"
         .byte   JOY_API_VERSION         ; Driver API version number
 
 ; Library reference
@@ -39,7 +37,7 @@
         .byte   $02                     ; JOY_DOWN
         .byte   $04                     ; JOY_LEFT
         .byte   $08                     ; JOY_RIGHT
-        .byte   $10                     ; JOY_FIRE
+        .byte   $80                     ; JOY_FIRE
         .byte   $00                     ; JOY_FIRE2 unavailable
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
@@ -98,16 +96,20 @@ COUNT:
 ; READ: Read a particular joystick passed in A.
 ;
 
-READ:   ldy     #$FA            ; Load index for joystick #1
+READ:   ldy     #%11111011      ; Load index for joystick #1
         tax                     ; Test joystick number
         beq     @L1
-        ldy     #$FB            ; Load index for joystick #2
+        ldy     #%11111101      ; Load index for joystick #2
+        ldx     #>$0000         ; (Return unsigned int)
 @L1:    sei
-        sty     TED_KBD
-        lda     TED_KBD
+        sty     TED_KBD         ; Read a joystick ...
+        lda     TED_KBD         ; ... and some keys -- it's unavoidable
         cli
-        ldx     #$00            ; Clear high byte
-        and     #$1F
-        eor     #$1F
-        rts
+        eor     #%11111111
 
+; The fire buttons are in bits 6 and 7.  Both of them cannot be %1 together.
+; Therefore, bit 6 can be merged with bit 7.
+
+        clc
+        adc     #%01000000
+        rts


### PR DESCRIPTION
It now chooses a stick correctly.  And, it now reads the stick's fire button.

This fixes https://sourceforge.net/p/cc65/mailman/cc65-devel/thread/f2f66618-7a40-3d72-6c41-1b43216a0ed0%40suomi24.fi/#msg35162158 -- the parts that can be fixed.