### PR TITLE
Add support for HuC6280 zero-page at $2000 instead of $0000

### DIFF
--- a/src/ca65/instr.c
+++ b/src/ca65/instr.c
@@ -1054,7 +1054,11 @@ static void EmitCode (EffAddr* A)
             break;
 
         case 1:
-            Emit1 (A->Opcode, A->Expr);
+            if (A->AddrModeBit & (AM65_ALL_ZP | AM65_DIR_IND_Y | AM65_DIR_IND_LONG | AM65_DIR_IND_LONG_Y)) {
+                EmitZP (A->Opcode, A->Expr);
+            } else {
+                Emit1 (A->Opcode, A->Expr);
+            }
             break;
 
         case 2:

--- a/src/ca65/objcode.h
+++ b/src/ca65/objcode.h
@@ -62,6 +62,9 @@ void Emit2 (unsigned char OPC, ExprNode* Value);
 void Emit3 (unsigned char OPC, ExprNode* Expr);
 /* Emit an instruction with a three byte argument */
 
+void EmitZP (unsigned char OPC, ExprNode* Value);
+/* Emit an instruction with an one byte direct-page argument */
+
 void EmitSigned (ExprNode* Expr, unsigned Size);
 /* Emit a signed expression with the given size */
 

--- a/src/ca65/studyexpr.c
+++ b/src/ca65/studyexpr.c
@@ -40,6 +40,7 @@
 #include "debugflag.h"
 #include "shift.h"
 #include "xmalloc.h"
+#include "cpu.h"
 
 /* ca65 */
 #include "error.h"
@@ -445,7 +446,8 @@ static void StudyExprInternal (ExprNode* Expr, ExprDesc* D);
 static unsigned char GetConstAddrSize (long Val)
 /* Get the address size of a constant */
 {
-    if ((Val & ~0xFFL) == 0) {
+    if ((CPU != CPU_HUC6280 && (Val & ~0xFFL) == 0x0000) ||
+        (CPU == CPU_HUC6280 && (Val & ~0xFFL) == 0x2000)) {
         return ADDR_SIZE_ZP;
     } else if ((Val & ~0xFFFFL) == 0) {
         return ADDR_SIZE_ABS;


### PR DESCRIPTION
CA65 currently assumes that zero-page/direct-page references resolve to absolute address $0000-$00FF.

This isn't correct on the HuC6280 where zero-page/direct-page references resolve to absolute addresses $2000-$20FF.

This leads CA65 to generate inefficient/wrong code for instructions referencing addresses $0000-$00FF and $2000-$20FF on the HuC6280.

This patch fixes this by allowing CA65 to differentiate between instructions with one-byte immediate operands that are always $0000-$00FF (handled by the existing old Emit1() function), and instructions that have one-byte direct-page/zero-page references where the top-byte of the address is different on different processors (handled by the new EmitZP() function).

EmitZP() is just a copy of the existing Emit1() function but with the check for the top-byte changing depending upon the currently-selected processor.
