### PR TITLE
Add support for HuC6280 zero-page at $2000 instead of $0000

### DIFF
--- a/asminc/pce.inc
+++ b/asminc/pce.inc
@@ -34,11 +34,11 @@ VDC_LENR        = 18            ; (DMA) Length Register
 VDC_SATB        = 19            ; Sprite Attribute Table
 
 ; VDC port
-; Note: absolute addressing mode must be used when writing to this port
+; Note: use mirror location to avoid CA65 zero-page logic
 
-VDC_CTRL        = $0000
-VDC_DATA_LO     = $0002
-VDC_DATA_HI     = $0003
+VDC_CTRL        = $0100
+VDC_DATA_LO     = $0102
+VDC_DATA_HI     = $0103
 
 ; huc6260 - Video Color Encoder (vce)
 

--- a/libsrc/pce/crt0.s
+++ b/libsrc/pce/crt0.s
@@ -74,7 +74,7 @@ start:
         ;tam     #%10000000      ; e000-fFFF  hucard/syscard bank 0
 
         ; Clear work RAM (2000-3FFF)
-        stz     <$00
+        stz     $2000
         tii     $2000, $2001, $1FFF
 
         ; Initialize hardware

--- a/libsrc/pce/vdc.s
+++ b/libsrc/pce/vdc.s
@@ -7,7 +7,7 @@ HIRES   = 1
         .export         vdc_init
 
 vdc_init:
-        lda     a:VDC_CTRL
+        lda     VDC_CTRL
 
         VREG    $00, $0000      ; MAWR
         VREG    $01, $0000      ; MARR
@@ -37,5 +37,5 @@ vdc_init:
 
 .endif
 
-        lda     a:VDC_CTRL
+        lda     VDC_CTRL
         rts

--- a/src/ca65/instr.c
+++ b/src/ca65/instr.c
@@ -1054,7 +1054,11 @@ static void EmitCode (EffAddr* A)
             break;
 
         case 1:
-            Emit1 (A->Opcode, A->Expr);
+            if (A->AddrModeBit & (AM65_ALL_ZP | AM65_DIR_IND_Y | AM65_DIR_IND_LONG | AM65_DIR_IND_LONG_Y)) {
+                EmitZP (A->Opcode, A->Expr);
+            } else {
+                Emit1 (A->Opcode, A->Expr);
+            }
             break;
 
         case 2:

--- a/src/ca65/instr.c
+++ b/src/ca65/instr.c
@@ -1054,7 +1054,7 @@ static void EmitCode (EffAddr* A)
             break;
 
         case 1:
-            if (A->AddrModeBit & (AM65_ALL_ZP | AM65_DIR_IND_Y | AM65_DIR_IND_LONG | AM65_DIR_IND_LONG_Y)) {
+            if (A->AddrModeBit & AM65_ALL_ZP) {
                 EmitZP (A->Opcode, A->Expr);
             } else {
                 Emit1 (A->Opcode, A->Expr);

--- a/src/ca65/instr.h
+++ b/src/ca65/instr.h
@@ -93,7 +93,7 @@
 #define AM65_SET_ABS    (AM65_ABS | AM65_ABS_X)
 
 /* Bitmask for all ZP operations */
-#define AM65_ALL_ZP     (AM65_DIR | AM65_DIR_X | AM65_DIR_Y | AM65_DIR_IND | AM65_DIR_X_IND)
+#define AM65_ALL_ZP     (AM65_DIR | AM65_DIR_X | AM65_DIR_Y | AM65_DIR_IND | AM65_DIR_X_IND | AM65_DIR_IND_Y | AM65_DIR_IND_LONG | AM65_DIR_IND_LONG_Y)
 
 /* Bitmask for all ABS operations */
 #define AM65_ALL_ABS    (AM65_ABS | AM65_ABS_X | AM65_ABS_Y | AM65_ABS_IND | AM65_ABS_X_IND)

--- a/src/ca65/objcode.c
+++ b/src/ca65/objcode.c
@@ -137,15 +137,15 @@ void Emit3 (unsigned char OPC, ExprNode* Expr)
 
 
 void EmitZP (unsigned char OPC, ExprNode* Value)
-/* Emit an instruction with an one byte direct-page argument */
+/* Emit an instruction with an one byte zero-page argument */
 {
     long V;
     Fragment* F;
 
     if (IsEasyConst (Value, &V)) {
         /* Must be in byte range */
-        if ((CPU != CPU_HUC6280 && (V & ~0xFFL) != 0x0000) ||
-            (CPU == CPU_HUC6280 && (V & ~0xFFL) != 0x2000)) {
+        if (((V & ~0xFFL) != 0x0000L) &&
+            (CPU != CPU_HUC6280 || (V & ~0xFFL) != 0x2000L)) {
             Error ("Range error (0x%lx not in zero-page)", V);
         }
 

--- a/src/ca65/objcode.h
+++ b/src/ca65/objcode.h
@@ -62,6 +62,9 @@ void Emit2 (unsigned char OPC, ExprNode* Value);
 void Emit3 (unsigned char OPC, ExprNode* Expr);
 /* Emit an instruction with a three byte argument */
 
+void EmitZP (unsigned char OPC, ExprNode* Value);
+/* Emit an instruction with an one byte direct-page argument */
+
 void EmitSigned (ExprNode* Expr, unsigned Size);
 /* Emit a signed expression with the given size */
 

--- a/src/ca65/studyexpr.c
+++ b/src/ca65/studyexpr.c
@@ -443,11 +443,13 @@ static void StudyExprInternal (ExprNode* Expr, ExprDesc* D);
 
 
 
-static unsigned char GetConstAddrSize (long Val)
+// static unsigned char GetConstAddrSize (long Val)
+unsigned char GetConstAddrSize (long Val)
 /* Get the address size of a constant */
 {
-    if ((CPU != CPU_HUC6280 && (Val & ~0xFFL) == 0x0000) ||
-        (CPU == CPU_HUC6280 && (Val & ~0xFFL) == 0x2000)) {
+    if ((Val & ~0xFFL) == 0) {
+        return ADDR_SIZE_ZP;
+    } else if (CPU == CPU_HUC6280 && (Val & ~0xFFL) == 0x2000L) {
         return ADDR_SIZE_ZP;
     } else if ((Val & ~0xFFFFL) == 0) {
         return ADDR_SIZE_ABS;

--- a/src/ca65/studyexpr.c
+++ b/src/ca65/studyexpr.c
@@ -40,6 +40,7 @@
 #include "debugflag.h"
 #include "shift.h"
 #include "xmalloc.h"
+#include "cpu.h"
 
 /* ca65 */
 #include "error.h"
@@ -445,7 +446,8 @@ static void StudyExprInternal (ExprNode* Expr, ExprDesc* D);
 static unsigned char GetConstAddrSize (long Val)
 /* Get the address size of a constant */
 {
-    if ((Val & ~0xFFL) == 0) {
+    if ((CPU != CPU_HUC6280 && (Val & ~0xFFL) == 0x0000) ||
+        (CPU == CPU_HUC6280 && (Val & ~0xFFL) == 0x2000)) {
         return ADDR_SIZE_ZP;
     } else if ((Val & ~0xFFFFL) == 0) {
         return ADDR_SIZE_ABS;

--- a/src/ca65/studyexpr.c
+++ b/src/ca65/studyexpr.c
@@ -443,8 +443,7 @@ static void StudyExprInternal (ExprNode* Expr, ExprDesc* D);
 
 
 
-// static unsigned char GetConstAddrSize (long Val)
-unsigned char GetConstAddrSize (long Val)
+static unsigned char GetConstAddrSize (long Val)
 /* Get the address size of a constant */
 {
     if ((Val & ~0xFFL) == 0) {


### PR DESCRIPTION
CA65 currently assumes that zero-page references resolve to absolute address $0000-$00FF.

This isn't correct on the HuC6280 where zero-page references resolve to absolute addresses $2000-$20FF.

This leads CA65 to generate inefficient/wrong code for instructions referencing addresses $0000-$00FF and $2000-$20FF on the HuC6280.

This patch fixes this by allowing CA65 to differentiate between instructions with one-byte immediate operands that are always $0000-$00FF (handled by the existing old Emit1() function), and instructions that have one-byte zero-page references where the top-byte of the address is different on different processors (handled by the new EmitZP() function).

EmitZP() is just a copy of the existing Emit1() function but with the check for the top-byte changing depending upon the currently-selected processor.

This is a "fixed" version of my previous Pull Request #318.

CA65 has way too much code/logic in the flow that requires zero-page to be at $0000, that I've been unable to tell it that the HuC6280 zero-page is at $2000 and NOT at $0000.

Without a major rewrite of some core internal CA65 logic, the best that I've been able to do is to tell CA65 that the HuC6280 ALSO has zero-page at $2000.

The only accesses to $0000-$00FF in a normal PC Engine are to the VDC hardware. This hardware is mirrored throughout the $0000-$03FF region, so I've just chosen to change the equates that are used in PCE.INC to one of the mirrored locations in order to avoid confusing CA65 with instructions that access $0000-$00FF.

While not perfect, this solves the main issue of the the HuC6280 using $2000-$20FF to access zero-page, and it does so without making any major changes in CA65 that could break other platforms.
