### PR TITLE
Fixed test negation.

### DIFF
--- a/src/cc65/typeconv.c
+++ b/src/cc65/typeconv.c
@@ -237,7 +237,7 @@ void TypeConversion (ExprDesc* Expr, Type* NewType)
                 switch (TypeCmp (NewType, Expr->Type)) {
 
                     case TC_INCOMPATIBLE:
-                        Error ("Incompatible pointer types at '%s'", (!Expr->Sym? Expr->Sym->Name : "Unknown"));
+                        Error ("Incompatible pointer types at '%s'", (Expr->Sym? Expr->Sym->Name : "Unknown"));
                         break;
 
                     case TC_QUAL_DIFF:


### PR DESCRIPTION
My previous PR contained an error with the test. Given the previous PR and the following input:

```
cat ../tmp/incompat.c
void func(char* a, int* b, char* c) {
	*a= 'a';
	*b = 1;
	*c = 'c';
}

void main() {
	char *a, *c;
	int *b;
	// should work
	func(a, b, c);

	// error
	func(a, c, b);
}
```

The negation in the test causes the following:

```
./bin/cc65 ../tmp/incompat.c
../tmp/incompat.c(14): Error: Incompatible pointer types at 'Unknown'
../tmp/incompat.c(14): Error: Incompatible pointer types at 'Unknown'
```

Now with the negation removed:

```
./bin/cc65 ../tmp/incompat.c
../tmp/incompat.c(14): Error: Incompatible pointer types at 'c'
../tmp/incompat.c(14): Error: Incompatible pointer types at 'b'
```