### PR TITLE
Switch error fix

### DIFF
--- a/src/cc65/swstmt.c
+++ b/src/cc65/swstmt.c
@@ -194,7 +194,7 @@ void SwitchStatement (void)
     /* Free the case value tree */
     FreeCaseNodeColl (SwitchData.Nodes);
 
-    /* If the case statement was (correctly) terminated by a closing curly
+    /* If the case statement was terminated by a closing curly
     ** brace, skip it now.
     */
     if (RCurlyBrace) {

--- a/src/cc65/swstmt.c
+++ b/src/cc65/swstmt.c
@@ -144,8 +144,8 @@ void SwitchStatement (void)
     /* Create a loop so we may use break. */
     AddLoop (ExitLabel, 0);
 
-    /* Parse the following statement, which will actually be a compound
-    ** statement because of the curly brace at the current input position
+    /* Parse the following statement, which may actually be a compound
+    ** statement if there is a curly brace at the current input position
     */
     HaveBreak = Statement (&RCurlyBrace);
 

--- a/src/cc65/swstmt.c
+++ b/src/cc65/swstmt.c
@@ -144,11 +144,6 @@ void SwitchStatement (void)
     /* Create a loop so we may use break. */
     AddLoop (ExitLabel, 0);
 
-    /* Make sure a curly brace follows */
-    if (CurTok.Tok != TOK_LCURLY) {
-        Error ("`{' expected");
-    }
-
     /* Parse the following statement, which will actually be a compound
     ** statement because of the curly brace at the current input position
     */

--- a/test/val/duffs-device.c
+++ b/test/val/duffs-device.c
@@ -1,0 +1,76 @@
+/*
+  !!DESCRIPTION!! Implementation of Duff's device (loop unrolling).
+  !!ORIGIN!!      
+  !!LICENCE!!     GPL, read COPYING.GPL
+*/
+
+#include <stdio.h>
+#include <limits.h>
+
+#define ASIZE (100)
+
+unsigned char success=0;
+unsigned char failures=0;
+unsigned char dummy=0;
+
+#ifdef SUPPORT_BIT_TYPES
+bit bit0 = 0;
+#endif
+
+void done()
+{
+  dummy++;
+}
+
+int acmp(char* a, char* b, int count)
+{
+  int i;
+
+  for(i = 0; i < count; i++) {
+    if(a[i] != b[i]) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+void duffit (char* to, char* from, int count) 
+{
+  int n = (count + 7) / 8;
+
+  switch(count % 8) {
+    case 0: do {    *to++ = *from++;
+    case 7:         *to++ = *from++;
+    case 6:         *to++ = *from++;
+    case 5:         *to++ = *from++;
+    case 4:         *to++ = *from++;
+    case 3:         *to++ = *from++;
+    case 2:         *to++ = *from++;
+    case 1:         *to++ = *from++;
+    } while(--n > 0);
+  }
+}
+
+int main(void)
+{
+  char a[ASIZE] = {1};
+  char b[ASIZE] = {2};
+  
+  /* a and b should be different */
+  if(!acmp(a, b, ASIZE)) {
+    failures++;
+  }
+  
+  duffit(a, b, ASIZE);
+  
+  /* a and b should be the same */
+  if(acmp(a, b, ASIZE)) {
+    failures++;
+  }
+
+  success=failures;
+  done();
+  printf("failures: %d\n",failures);
+
+  return failures;
+}

--- a/test/val/switch2.c
+++ b/test/val/switch2.c
@@ -1,0 +1,39 @@
+/*
+  !!DESCRIPTION!! Testing empty bodied switch statements.
+  !!ORIGIN!!      
+  !!LICENCE!!     GPL, read COPYING.GPL
+*/
+
+#include <stdio.h>
+
+unsigned char success=0;
+unsigned char failures=0;
+unsigned char dummy=0;
+
+void done()
+{
+  dummy++;
+}
+
+void switch_no_body(void)
+{
+  switch(0);
+}
+
+void switch_empty_body(void)
+{
+  switch(0) {};
+}
+
+/* only worried about this file compiling successfully */
+int main(void)
+{
+  switch_no_body();
+  switch_empty_body();
+
+  success=failures;
+  done();
+  printf("failures: %d\n",failures);
+
+  return failures;
+}

--- a/test/val/switch2.c
+++ b/test/val/switch2.c
@@ -22,7 +22,7 @@ void switch_no_body(void)
 
 void switch_empty_body(void)
 {
-  switch(0) {};
+  switch(0) {}
 }
 
 /* only worried about this file compiling successfully */


### PR DESCRIPTION
Removed the test for LCURLY inside the switch statement.

PR to address https://github.com/cc65/cc65/issues/330

Notes:

* The test for LCURLY was introduced at https://github.com/cc65/cc65/commit/64ec376140353367ed03cb7f294529f7536a1b9d. This commit mentions that those changes were made to support arbitrary code in switch statements such as Duff's Device. Accordingly, I added a test for Duff's Device.

* Also added tests for empty switch bodies. This test just needs to compile successfully to pass; although, I placed it inside the val dir since there doesn't appear to be an opposite of err dir (where these files *must* compile, rather than not compile).

* Unlike with gcc or clang an empty switch will still generate code in cc65 https://github.com/cc65/cc65/blob/master/src/cc65/swstmt.c#L116