### PR TITLE
Update exehdr.s for Lynx target

### DIFF
--- a/cfg/lynx-bll.cfg
+++ b/cfg/lynx-bll.cfg
@@ -1,7 +1,8 @@
 SYMBOLS {
     __STACKSIZE__:        type = weak, value = $0800; # 2k stack
     __STARTOFDIRECTORY__: type = weak, value = $00CB; # start just after loader
-    __BLOCKSIZE__:        type = weak, value = $0400; # cart block size
+    __BANK0BLOCKSIZE__:   type = weak, value = 1024; # bank 0 cart block size
+    __BANK1BLOCKSIZE__:   type = weak, value = 0; # bank 1 block size
     __BLLHDR__:           type = import;
 }
 MEMORY {

--- a/cfg/lynx-bll.cfg
+++ b/cfg/lynx-bll.cfg
@@ -1,8 +1,8 @@
 SYMBOLS {
     __STACKSIZE__:        type = weak, value = $0800; # 2k stack
     __STARTOFDIRECTORY__: type = weak, value = $00CB; # start just after loader
-    __BANK0BLOCKSIZE__:   type = weak, value = 1024; # bank 0 cart block size
-    __BANK1BLOCKSIZE__:   type = weak, value = 0; # bank 1 block size
+    __BANK0BLOCKSIZE__:   type = weak, value = $0400; # bank 0 cart block size
+    __BANK1BLOCKSIZE__:   type = weak, value = $0000; # bank 1 block size
     __BLLHDR__:           type = import;
 }
 MEMORY {

--- a/cfg/lynx-coll.cfg
+++ b/cfg/lynx-coll.cfg
@@ -1,7 +1,8 @@
 SYMBOLS {
     __STACKSIZE__:        type = weak, value = $0800; # 2k stack
     __STARTOFDIRECTORY__: type = weak, value = $00CB; # start just after loader
-    __BLOCKSIZE__:        type = weak, value = $0400; # cart block size
+    __BANK0BLOCKSIZE__:   type = weak, value = 1024; # bank 0 cart block size
+    __BANK1BLOCKSIZE__:   type = weak, value = 0; # bank 1 block size
     __EXEHDR__:           type = import;
     __BOOTLDR__:          type = import;
     __DEFDIR__:           type = import;

--- a/cfg/lynx-coll.cfg
+++ b/cfg/lynx-coll.cfg
@@ -1,8 +1,8 @@
 SYMBOLS {
     __STACKSIZE__:        type = weak, value = $0800; # 2k stack
     __STARTOFDIRECTORY__: type = weak, value = $00CB; # start just after loader
-    __BANK0BLOCKSIZE__:   type = weak, value = 1024; # bank 0 cart block size
-    __BANK1BLOCKSIZE__:   type = weak, value = 0; # bank 1 block size
+    __BANK0BLOCKSIZE__:   type = weak, value = $0400; # bank 0 cart block size
+    __BANK1BLOCKSIZE__:   type = weak, value = $0000; # bank 1 block size
     __EXEHDR__:           type = import;
     __BOOTLDR__:          type = import;
     __DEFDIR__:           type = import;

--- a/cfg/lynx-uploader.cfg
+++ b/cfg/lynx-uploader.cfg
@@ -1,7 +1,8 @@
 SYMBOLS {
     __STACKSIZE__:        type = weak, value = $0800; # 2k stack
     __STARTOFDIRECTORY__: type = weak, value = $00CB; # start just after loader
-    __BLOCKSIZE__:        type = weak, value = $0400; # cart block size
+    __BANK0BLOCKSIZE__:   type = weak, value = 1024; # bank 0 cart block size
+    __BANK1BLOCKSIZE__:   type = weak, value = 0; # bank 1 block size
     __EXEHDR__:           type = import;
     __BOOTLDR__:          type = import;
     __DEFDIR__:           type = import;

--- a/cfg/lynx-uploader.cfg
+++ b/cfg/lynx-uploader.cfg
@@ -1,8 +1,8 @@
 SYMBOLS {
     __STACKSIZE__:        type = weak, value = $0800; # 2k stack
     __STARTOFDIRECTORY__: type = weak, value = $00CB; # start just after loader
-    __BANK0BLOCKSIZE__:   type = weak, value = 1024; # bank 0 cart block size
-    __BANK1BLOCKSIZE__:   type = weak, value = 0; # bank 1 block size
+    __BANK0BLOCKSIZE__:   type = weak, value = $0400; # bank 0 cart block size
+    __BANK1BLOCKSIZE__:   type = weak, value = $0000; # bank 1 block size
     __EXEHDR__:           type = import;
     __BOOTLDR__:          type = import;
     __DEFDIR__:           type = import;

--- a/cfg/lynx.cfg
+++ b/cfg/lynx.cfg
@@ -1,8 +1,8 @@
 SYMBOLS {
     __STACKSIZE__:        type = weak, value = $0800; # 2k stack
     __STARTOFDIRECTORY__: type = weak, value = $00CB; # start just after loader
-    __BANK0BLOCKSIZE__:   type = weak, value = 512; # bank 0 cart block size
-    __BANK1BLOCKSIZE__:   type = weak, value = 0; # bank 1 block size
+    __BANK0BLOCKSIZE__:   type = weak, value = $0400; # bank 0 cart block size
+    __BANK1BLOCKSIZE__:   type = weak, value = $0000; # bank 1 block size
     __EXEHDR__:           type = import;
     __BOOTLDR__:          type = import;
     __DEFDIR__:           type = import;

--- a/cfg/lynx.cfg
+++ b/cfg/lynx.cfg
@@ -1,7 +1,8 @@
 SYMBOLS {
     __STACKSIZE__:        type = weak, value = $0800; # 2k stack
     __STARTOFDIRECTORY__: type = weak, value = $00CB; # start just after loader
-    __BLOCKSIZE__:        type = weak, value = 1024; # cart block size
+    __BANK0BLOCKSIZE__:   type = weak, value = 512; # bank 0 cart block size
+    __BANK1BLOCKSIZE__:   type = weak, value = 0; # bank 1 block size
     __EXEHDR__:           type = import;
     __BOOTLDR__:          type = import;
     __DEFDIR__:           type = import;

--- a/libsrc/lynx/bootldr.s
+++ b/libsrc/lynx/bootldr.s
@@ -5,7 +5,7 @@
 ;
         .include "lynx.inc"
         .include "extzp.inc"
-        .import         __BLOCKSIZE__
+        .import         __BANK0BLOCKSIZE__
         .export         __BOOTLDR__: absolute = 1
 
 
@@ -167,7 +167,7 @@ seclynxblock:
         lda __iodat
         sta IODAT
         stz _FileBlockByte
-        lda #<($100-(>__BLOCKSIZE__))
+        lda #<($100-(>__BANK0BLOCKSIZE__))
         sta _FileBlockByte+1
         ply
         plx

--- a/libsrc/lynx/defdir.s
+++ b/libsrc/lynx/defdir.s
@@ -8,7 +8,7 @@
         .import         __MAIN_START__
         .import         __CODE_SIZE__, __DATA_SIZE__, __RODATA_SIZE__
         .import         __STARTUP_SIZE__, __ONCE_SIZE__, __LOWCODE_SIZE__
-        .import         __BLOCKSIZE__
+        .import         __BANK0BLOCKSIZE__
         .export         __DEFDIR__: absolute = 1
 
 
@@ -18,12 +18,12 @@
 
 __DIRECTORY_START__:
 off0 = __STARTOFDIRECTORY__ + (__DIRECTORY_END__ - __DIRECTORY_START__)
-blocka = off0 / __BLOCKSIZE__
+blocka = off0 / __BANK0BLOCKSIZE__
 ; Entry 0 - first executable
-block0 = off0 / __BLOCKSIZE__
+block0 = off0 / __BANK0BLOCKSIZE__
 len0 = __STARTUP_SIZE__ + __ONCE_SIZE__ + __CODE_SIZE__ + __DATA_SIZE__ + __RODATA_SIZE__ + __LOWCODE_SIZE__
         .byte   <block0
-        .word   off0 & (__BLOCKSIZE__ - 1)
+        .word   off0 & (__BANK0BLOCKSIZE__ - 1)
         .byte   $88
         .word   __MAIN_START__
         .word   len0

--- a/libsrc/lynx/exehdr.s
+++ b/libsrc/lynx/exehdr.s
@@ -3,7 +3,8 @@
 ;
 ; This header contains data for emulators like Handy and Mednafen
 ;
-        .import         __BLOCKSIZE__
+        .import         __BANK0BLOCKSIZE__
+        .import         __BANK1BLOCKSIZE__
         .export         __EXEHDR__: absolute = 1
 
 
@@ -11,8 +12,8 @@
 ; EXE header
         .segment "EXEHDR"
         .byte   'L','Y','N','X'                         ; magic
-        .word   __BLOCKSIZE__                           ; bank 0 page size
-        .word   0                                       ; bank 1 page size
+        .word   __BANK0BLOCKSIZE__                      ; bank 0 page size
+        .word   __BANK1BLOCKSIZE__                      ; bank 1 page size
         .word   1                                       ; version number
         .asciiz "Cart name                      "       ; 32 bytes cart name
         .asciiz "Manufacturer   "                       ; 16 bytes manufacturer

--- a/libsrc/lynx/exehdr.s
+++ b/libsrc/lynx/exehdr.s
@@ -12,7 +12,7 @@
         .segment "EXEHDR"
         .byte   'L','Y','N','X'                         ; magic
         .word   __BLOCKSIZE__                           ; bank 0 page size
-        .word   __BLOCKSIZE__                           ; bank 1 page size
+        .word   0                                       ; bank 1 page size
         .word   1                                       ; version number
         .asciiz "Cart name                      "       ; 32 bytes cart name
         .asciiz "Manufacturer   "                       ; 16 bytes manufacturer


### PR DESCRIPTION
Fix for memory bank 1 which should be zero in almost all cartridges for emulators to work correctly.