### PR TITLE
Demonstration code for "register call" feature, as base for a discussion

### DIFF
--- a/include/callconv.h
+++ b/include/callconv.h
@@ -1,0 +1,91 @@
+/*****************************************************************************/
+/*                                                                           */
+/*                             callconv.h                                    */
+/*                                                                           */
+/*                 Calling convertor, register call to fastcall              */
+/*                                                                           */
+/*                                                                           */
+/*                                                                           */
+/* (c) Christian Krüger, latest change: 22-Jul-2013                          */
+/*                                                                           */
+/*                                                                           */
+/* This software is provided 'as-is', without any expressed or implied       */
+/* warranty.  In no event will the authors be held liable for any damages    */
+/* arising from the use of this software.                                    */
+/*                                                                           */
+/* Permission is granted to anyone to use this software for any purpose,     */
+/* including commercial applications, and to alter it and redistribute it    */
+/* freely, subject to the following restrictions:                            */
+/*                                                                           */
+/* 1. The origin of this software must not be misrepresented; you must not   */
+/*    claim that you wrote the original software. If you use this software   */
+/*    in a product, an acknowledgment in the product documentation would be  */
+/*    appreciated but is not required.                                       */
+/* 2. Altered source versions must be plainly marked as such, and must not   */
+/*    be misrepresented as being the original software.                      */
+/* 3. This notice may not be removed or altered from any source              */
+/*    distribution.                                                          */
+/*                                                                           */
+/*****************************************************************************/
+
+#ifndef _CALLCONV_H
+#define _CALLCONV_H
+
+#include <stddef.h>
+
+typedef void __fastcall__ (* RegCallFuncRetV)(void);
+typedef int __fastcall__ (* RegCallFuncRetN)(void);
+typedef size_t __fastcall__ (* RegCallFuncRetSt)(void);
+typedef void* __fastcall__ (* RegCallFuncRetPv)(void);
+typedef char* __fastcall__ (* RegCallFuncRetPc)(void);
+
+int __fastcall__
+RegCallPcPcRetN(RegCallFuncRetN func, char* param1, char* param2);
+
+size_t __fastcall__
+RegCallPcPcRetSt(RegCallFuncRetSt func, char* param1, char* param2);
+
+void __fastcall__
+RegCallPvPvRetV(RegCallFuncRetPv func, void* param1, void* param2);
+
+void __fastcall__
+RegCallPvStRetV(RegCallFuncRetV func, void* param1, size_t param2);
+
+void* __fastcall__
+RegCallPvPvRetPv(RegCallFuncRetPv func, void* param1, void* param2);
+
+void* __fastcall__
+RegCallPvStRetPv(RegCallFuncRetPv func, void* param1, size_t param2);
+
+char* __fastcall__
+RegCallPcPcRetPc(RegCallFuncRetPc func, char* param1, char* param2);
+
+char* __fastcall__
+RegCallPcNRetPc(RegCallFuncRetPc func, char* param1, int param2);
+
+void* __fastcall__
+RegCallPvNStRetPv(RegCallFuncRetPv func, void* param1, int param2, size_t param3);
+
+void* __fastcall__
+RegCallPvStNRetPv(RegCallFuncRetPv func, void* param1, size_t param2, int param3);
+
+int __fastcall__
+RegCallPvPvStRetN(RegCallFuncRetN func, void* param1, void* param2, size_t param3);
+
+void* __fastcall__
+RegCallPvPvStRetPv(RegCallFuncRetPv func, void* param1, void* param2, size_t param3);
+
+int __fastcall__
+RegCallPcPcStRetN(RegCallFuncRetN func, char* param1, char* param2, size_t param3);
+
+size_t __fastcall__
+RegCallPcPcStRetSt(RegCallFuncRetSt func, char* param1, char* param2, size_t param3);
+
+char* __fastcall__
+RegCallPcPcStRetPc(RegCallFuncRetPc func, char* param1, char* param2, size_t param3);
+
+/* End of callconv.h */
+#endif
+
+
+

--- a/include/regcall.h
+++ b/include/regcall.h
@@ -1,0 +1,66 @@
+/*****************************************************************************/
+/*                                                                           */
+/*                                regcall.h                                  */
+/*                                                                           */
+/*           Imports to tie C macros to 'registers' for calling              */
+/*                                                                           */
+/*                                                                           */
+/*                                                                           */
+/* (c) Christian Krüger, latest change: 03-Jul-2013                          */
+/*                                                                           */
+/* This software is provided 'as-is', without any expressed or implied       */
+/* warranty.  In no event will the authors be held liable for any damages    */
+/* arising from the use of this software.                                    */
+/*                                                                           */
+/* Permission is granted to anyone to use this software for any purpose,     */
+/* including commercial applications, and to alter it and redistribute it    */
+/* freely, subject to the following restrictions:                            */
+/*                                                                           */
+/* 1. The origin of this software must not be misrepresented; you must not   */
+/*    claim that you wrote the original software. If you use this software   */
+/*    in a product, an acknowledgment in the product documentation would be  */
+/*    appreciated but is not required.                                       */
+/* 2. Altered source versions must be plainly marked as such, and must not   */
+/*    be misrepresented as being the original software.                      */
+/* 3. This notice may not be removed or altered from any source              */
+/*    distribution.                                                          */
+/*                                                                           */
+/*****************************************************************************/
+
+#ifndef _REGCALL_H
+#define _REGCALL_H
+
+#include <stddef.h>
+
+typedef union
+{
+    void* pV;           // declare all possible data types here
+    char* pC;           // to keep compiler calm and ease use
+    int n;
+    size_t st;
+}
+Register;
+
+/* import of zeropage symbols */
+
+extern Register R0;
+#pragma zpsym ("R0");
+
+extern Register R1;
+#pragma zpsym ("R1");
+
+extern Register R2;
+#pragma zpsym ("R2");
+
+extern Register R3;
+#pragma zpsym ("R3");
+
+extern Register R4;
+#pragma zpsym ("R4");
+
+/* End of regcall.h */
+
+#endif
+
+
+

--- a/include/string.h
+++ b/include/string.h
@@ -39,7 +39,8 @@
 
 
 #include <stddef.h>
-
+#include <regcall.h>
+#include <callconv.h>
 
 
 char* __fastcall__ strcat (char* dest, const char* src);
@@ -59,8 +60,20 @@ char* __fastcall__ strstr (const char* str, const char* substr);
 char* __fastcall__ strtok (char* s1, const char* s2);
 size_t __fastcall__ strxfrm (char* s1, const char* s2, size_t count);
 void* __fastcall__ memchr (const void* mem, int c, size_t count);
+
+// -> CK: Regcall test
 int __fastcall__ memcmp (const void* p1, const void* p2, size_t count);
+int __fastcall__ rc_memcmp(void);
+#define MEMCMP(a,b,c) (R0.pV=(a), R1.pV=(b), R2.st=(c), rc_memcmp())
+//#define memcmp(a,b,c) (RegCallPvPvStRetN(rc_memcmp, (a), (b), (c)))		// calling converter variant
+
 void* __fastcall__ memcpy (void* dest, const void* src, size_t count);
+void* __fastcall__ rc_memcpy(void);
+#define MEMCPY(a,b,c) (R0.pV=(a), R1.pV=(b), R2.st=(c), rc_memcpy())
+//#define memcpy(a,b,c) (RegCallPvPvStRetPv(rc_memcpy, (a), (b), (c)))		// calling converter variant
+// <-
+
+
 void* __fastcall__ memmove (void* dest, const void* src, size_t count);
 void* __fastcall__ memset (void* s, int c, size_t count);
 

--- a/libsrc/common/memcpy.s
+++ b/libsrc/common/memcpy.s
@@ -1,80 +1,76 @@
 ;
 ; Ullrich von Bassewitz, 2003-08-20
-; Performance increase (about 20%) by
-; Christian Krueger, 2009-09-13
+; Christian Krueger: 2009-Sep-13, performance increase (about 20%)
+;                    2013-Jul-24, regcall parameter passing 
 ;
-; void* __fastcall__ memcpy (void* dest, const void* src, size_t n);
+; void* __fastcall__ memcpy (void* dest, const void* src, size_t count);
+; void* __fastcall__ _rc_memcpy(void);
+; ptr1 = void* dest
+; ptr2 = const void* src
+; ptr3 = size_t n
 ;
 ; NOTE: This function contains entry points for memmove, which will ressort
 ; to memcpy for an upwards copy. Don't change this module without looking
 ; at memmove!
 ;
 
-        .export         _memcpy, memcpy_upwards, memcpy_getparams
-        .import         popax
-        .importzp       sp, ptr1, ptr2, ptr3
+.export	    	_memcpy, _rc_memcpy, rc_memcpy_upwards
+.importzp      	sp, ptr1, ptr2, ptr3, ptr4
+.import 		popax
 
 ; ----------------------------------------------------------------------
+
 _memcpy:
-        jsr     memcpy_getparams
+    sta ptr3
+    stx ptr3+1
+    
+    jsr popax
+    sta ptr2
+    stx ptr2+1
 
-memcpy_upwards:                 ; assert Y = 0
-        ldx     ptr3+1          ; Get high byte of n
-        beq     L2              ; Jump if zero
+    jsr popax
+    sta ptr1
+    stx ptr1+1
 
-L1:     .repeat 2               ; Unroll this a bit to make it faster...
-        lda     (ptr1),Y        ; copy a byte
-        sta     (ptr2),Y
-        iny
-        .endrepeat
-        bne     L1
-        inc     ptr1+1
-        inc     ptr2+1
-        dex                     ; Next 256 byte block
-        bne     L1              ; Repeat if any
+_rc_memcpy:
+    lda ptr1+1      ; save destination
+    sta ptr4+1      ; for restore at end (ptr1 untouched!)
+rc_memcpy_upwards:  ; (entry point from memmove(), where dest is already saved
+    ldy #0          ; init offset
+	ldx	ptr3+1      ; Get high byte of n
+    beq L2          ; Jump if zero
 
-        ; the following section could be 10% faster if we were able to copy
-        ; back to front - unfortunately we are forced to copy strict from
-        ; low to high since this function is also used for
-        ; memmove and blocks could be overlapping!
-        ; {
-L2:                             ; assert Y = 0
-        ldx     ptr3            ; Get the low byte of n
-        beq     done            ; something to copy
+L1:
+  .repeat 2		    ; unroll this a bit to make it faster...
+	lda	(ptr2),Y	; copy a byte
+	sta	(ptr1),Y
+	iny
+  .endrepeat
+	bne	L1
+	inc	ptr2+1
+	inc	ptr1+1
+	dex			    ; next 256 byte block
+	bne	L1		    ; repeat if any
 
-L3:     lda     (ptr1),Y        ; copy a byte
-        sta     (ptr2),Y
-        iny
-        dex
-        bne     L3
+	; the following section could be 10% faster if we were able to copy
+	; back to front - unfortunately we are forced to copy strict from
+	; low to high since this function is also used for
+	; memmove and blocks could be overlapping!
+	; {
+L2:				    ; assert Y = 0
+	ldx	ptr3		; Get the low byte of n
+	beq	done		; something to copy
 
-        ; }
+L3:	lda	(ptr2),Y	; copy a byte
+	sta	(ptr1),Y
+	iny
+	dex
+	bne	L3
 
-done:   jmp     popax           ; Pop ptr and return as result
+	; }
 
-; ----------------------------------------------------------------------
-; Get the parameters from stack as follows:
-;
-;       size            --> ptr3
-;       src             --> ptr1
-;       dest            --> ptr2
-;       First argument (dest) will remain on stack and is returned in a/x!
+done:
+    lda ptr1        ; restore dest for return...
+    ldx ptr4+1      ; (touched high byte saved in ptr4)
+    rts
 
-memcpy_getparams:               ; IMPORTANT! Function has to leave with Y=0!
-        sta     ptr3
-        stx     ptr3+1          ; save n to ptr3
-
-        jsr     popax
-        sta     ptr1
-        stx     ptr1+1          ; save src to ptr1
-
-                                ; save dest to ptr2
-        ldy     #1              ; (direct stack access is three cycles faster
-                                ; (total cycle count with return))
-        lda     (sp),y
-        tax
-        stx     ptr2+1          ; save high byte of ptr2
-        dey                     ; Y = 0
-        lda     (sp),y          ; Get ptr2 low
-        sta     ptr2
-        rts

--- a/libsrc/runtime/callconv.s
+++ b/libsrc/runtime/callconv.s
@@ -1,0 +1,101 @@
+; callconv.s                                    
+; Calling convertor, fastcall to register call               
+;                                                                           
+; (c) Christian Krüger, latest change: 18-Jul-2013                          
+;
+
+.importzp ptr1,ptr2,ptr3,ptr4
+.import popax
+
+; int __fastcall__
+; RegCallPcPcRetN(RegCallFuncRetN func, char* param1, char* param2);
+.export _RegCallPcPcRetN
+
+; size_t __fastcall__
+; RegCallPcPcRetSt(RegCallFuncRetSt func, char* param1, char* param2);
+.export _RegCallPcPcRetSt
+
+; void __fastcall__
+; RegCallPvPvRetV(RegCallFuncRetPv func, void* param1, void* param2);
+.export _RegCallPvPvRetV
+
+; void __fastcall__
+; RegCallPvStRetV(RegCallFuncRetV func, void* param1, size_t param2);
+.export _RegCallPvStRetV
+
+; void* __fastcall__
+; RegCallPvPvRetPv(RegCallFuncRetPv func, void* param1, void* param2);
+.export _RegCallPvPvRetPv
+
+; void* __fastcall__
+; RegCallPvStRetpV(RegCallFuncRetPv func, void* param1, size_t param2);
+.export _RegCallPvStRetPv
+
+; char* __fastcall__
+; RegCallPcPcRetPc(RegCallFunc func, char* param1, char* param2);
+.export _RegCallPcPcRetPc
+
+; char* __fastcall__
+; RegCallPcNRetPc(RegCallFuncRetPc func, char* param1, int param2);
+.export _RegCallPcNRetPc
+
+; int __fastcall__
+; RegCallPvPvStRetN(RegCallFuncRetN func, void* param1, void* param2, size_t param3);
+.export _RegCallPvPvStRetN
+
+; void* __fastcall__
+; RegCallPvNStRetPv(RegCallFuncRetPv func, void* param1, int param2, size_t param3);
+.export _RegCallPvNStRetPv
+
+; void* __fastcall__
+; RegCallPvStNRetPv(RegCallFuncRetPv func, void* param1, size_t param2, int param3);
+.export _RegCallPvStNRetPv
+
+; void* __fastcall__
+; RegCallPvPvStRetPv(RegCallFuncRetPv func, void* param1, void* param2, size_t param3);
+.export _RegCallPvPvStRetPv
+
+; int __fastcall__
+; RegCallPcPcStRetN(RegCallFuncRetN func, char* param1, char* param2, size_t param3);
+.export _RegCallPcPcStRetN
+
+; size_t __fastcall__
+; RegCallPcPcStRetSt(RegCallFuncRetSt func, char* param1, char* param2, size_t param3);
+.export _RegCallPcPcStRetSt
+
+; char* __fastcall__
+; RegCallPcPcStRetPc(RegCallFuncRetPc func, char* param1, char* param2, size_t param3);
+.export _RegCallPcPcStRetPc
+
+
+_RegCallPvNStRetPv:
+_RegCallPvStNRetPv:
+_RegCallPvPvStRetN:
+_RegCallPvPvStRetPv:
+_RegCallPcPcStRetN:
+_RegCallPcPcStRetSt:
+_RegCallPcPcStRetPc:
+    sta ptr3
+    stx ptr3+1
+    jsr popax
+    
+_RegCallPcPcRetN:
+_RegCallPcPcRetSt:
+_RegCallPvPvRetV:
+_RegCallPvStRetV:
+_RegCallPvPvRetPv:
+_RegCallPvStRetPv:
+_RegCallPcPcRetPc:    
+_RegCallPcNRetPc:    
+    sta ptr2
+    stx ptr2+1
+    jsr popax
+    
+_RegCall1P:    
+    sta ptr1
+    stx ptr1+1
+    jsr popax
+    sta ptr4
+    stx ptr4+1    
+    jmp (ptr4)
+    

--- a/libsrc/runtime/regcall.s
+++ b/libsrc/runtime/regcall.s
@@ -1,0 +1,31 @@
+; regcall.s
+; Export of zero page locations for quick function calling via 'registers'
+;
+; (c) Christian Krüger, latest change: 17-Jul-2013
+;
+; This software is provided 'as-is', without any expressed or implied
+; warranty.  In no event will the authors be held liable for any damages
+; arising from the use of this software.
+;
+; Permission is granted to anyone to use this software for any purpose,
+; including commercial applications, and to alter it and redistribute it
+; freely, subject to the following restrictions:
+;
+; 1. The origin of this software must not be misrepresented; you must not
+;    claim that you wrote the original software. If you use this software
+;    in a product, an acknowledgment in the product documentation would be
+;    appreciated but is not required.
+; 2. Altered source versions must be plainly marked as such, and must not
+;    be misrepresented as being the original software.
+; 3. This notice may not be removed or altered from any source
+;    distribution.
+;
+
+.include "zeropage.inc"
+
+.EXPORTZP _R0 := ptr1
+.EXPORTZP _R1 := ptr2
+.EXPORTZP _R2 := ptr3
+.EXPORTZP _R3 := tmp1
+.EXPORTZP _R4 := tmp3
+

--- a/testcode/lib/regcalltest.c
+++ b/testcode/lib/regcalltest.c
@@ -1,0 +1,67 @@
+
+#pragma static-locals(1)
+
+
+// original code: 35.8 sec
+// 3578 bytes
+
+// regcall: 21.8 sec
+// 3584 bytes
+
+
+#include <peekpoke.h>
+#include <time.h>
+#include <conio.h>
+#include <string.h>
+
+#define REGCALL
+
+
+void waitKey()
+{
+	POKE(764,255);
+	while (PEEK(764)==255);
+}
+
+
+int
+main(void)
+{
+	static clock_t t;
+	static unsigned int count = 30000;
+	static unsigned char bufferOne[5];
+	static unsigned char bufferTwo[5];
+	static unsigned long sec;
+    static unsigned sec10;
+    static unsigned int length = sizeof(bufferOne);
+
+	clrscr ();
+
+	 t = clock ();
+
+	while (count != 0)
+	{
+
+#ifdef REGCALL
+		MEMCPY(bufferTwo, bufferOne, length);		
+		MEMCMP(bufferTwo, bufferOne, length);
+#else
+		memcpy(bufferTwo, bufferOne, length);		
+		memcmp(bufferTwo, bufferOne, length);
+#endif		
+		--count;
+	}
+
+	t = clock () - t;
+    
+    /* Calculate stats */
+    sec = (t * 10) / CLK_TCK;
+    sec10 = sec % 10;
+    sec /= 10;
+
+    /* Output stats */
+    cprintf ("Total runtime: %lu.%us\n\r", sec, sec10);
+	waitKey();
+
+	return 0;
+}


### PR DESCRIPTION
Most parts of the changes where lurking on my hard disks more than three years, where I proposed a new 'regcall' calling convention. (Unfortunately I'm unable to find the old proposal on the mailing list nor Uz reaction. (I wonder where wish #314 comes from - it goes in the same direction using the same vocabulary)).

Like Uz back then remarked: The problem when putting arguments into registers consists in subroutine calls taking arguments in the same registers.
I browsed through the compiler sources back then quite a lot and left with big respect for anybody who is able to service that beast.

So my solution targets the preprocessor, allowing the speed of registers calls without changing the compiler. The user is self responsible for applying the correct call. In the commits I've changed exemplary the memcpy() and memcmp() calls.

These are usable the standard (fastcall) way or using them in upper case letters "MEMCPY"/"MEMCMP" calls the register variant, where the user has to take care currently, that no argument is formed itself by a call destroying the registers.

The selection of this library function is sub-optimal, since register calls make the biggest sense when the runtime performance of the function itself is quite low compared to the performance of fulfilling the calling convention. (Like e.g. fixed point math functions.)

I did however a small test to show the potential: Thanks to the register calls, I've saved ~1/3 of the execution time (see code).
A drawback is that a regcall takes "numberOfParameters-1" more bytes to be executed ("lda var, ldx var+1, jsr pushax" vs. "lda var, sta zp, ldx var+1, sta zp+1")

Things I like to have discussed/answered:

Is there interest in supporting this kind of call or is it just me preferring lean parameter passing this way?

Currently every regcall function has two entry points, one for the fastcall and another one (inner) for the register call. I've created a calling converter which would allow to save these identical "stack to register" code for every individual function (they are currently commented). But here the overhead for the function pointer transfer to the stack (runtime/size) is quite high. A more lean variant could consist in supplying only the function pointer in a register running the same stack to register code and jumping to code of the pointer, but this would imply a (limited) change of the compiler (but also a 8 byte penalty per function call in the classic case (saved code for translation vs. costly calls). Any hints or remarks on this subject?

It would be very desirable if the compiler could detect on his own if a simple register call is possible (no sub calls for arguments) an could choose the correct calling variant. This would imply that the compiler must be able to detect that a function supports the register call (keyword?!).
Is there a chance for such support?

   

 


