### PR TITLE
Atari: fix lookup of default device on XDOS.

### DIFF
--- a/asminc/atari.inc
+++ b/asminc/atari.inc
@@ -1024,9 +1024,16 @@ XFILE        = $087D    ; XDOS filename buffer
 XLINE        = $0880    ; XDOS DUP input line
 XGLIN        = $0871    ; get line
 XSKIP        = $0874    ; skip parameter
+.ifdef __ATARIXL__
+.ifndef SHRAM_HANDLERS
+.import XMOVE_handler
+.endif
+.define XMOVE XMOVE_handler
+XMOVE_org    = $0877    ; move filename
+.else
 XMOVE        = $0877    ; move filename
+.endif
 XGNUM        = $087A    ; get number
-XDEFDEV      = $0816    ; current drive * undocumented *
 
 ;-------------------------------------------------------------------------
 ; End of atari.inc

--- a/libsrc/atari/shadow_ram_handlers.s
+++ b/libsrc/atari/shadow_ram_handlers.s
@@ -22,6 +22,7 @@ SHRAM_HANDLERS  =       1
         .export         CIO_handler
         .export         SIO_handler
         .export         SETVBV_handler
+        .export         XMOVE_handler
 
 BUFSZ           =       128     ; bounce buffer size
 BUFSZ_SIO       =       256
@@ -1085,6 +1086,24 @@ SETVBV_handler:
         plp
         rts
 
+;---------------------------------------------------------
+
+XMOVE_handler:
+
+        pha
+        lda     PORTB
+        sta     cur_XMOVE_PORTB
+        enable_rom
+        pla
+        jsr     XMOVE_org
+        php
+        pha
+        disable_rom_val cur_XMOVE_PORTB
+        pla
+        plp
+        rts
+
+
 CIO_a:                  .res    1
 CIO_x:                  .res    1
 CIO_y:                  .res    1
@@ -1093,6 +1112,7 @@ cur_CIOV_PORTB:         .res    1
 cur_SIOV_PORTB:         .res    1
 cur_KEYBDV_PORTB:       .res    1
 cur_SETVBV_PORTB:       .res    1
+cur_XMOVE_PORTB:        .res    1
 orig_ptr:               .res    2
 orig_len:               .res    2
 req_len:                .res    2


### PR DESCRIPTION
Stefan Dorndorf, author of XDOS, pointed out that retrieving the
default device by looking at an undocumented memory location won't
work in future XDOS versions.
He also showed a way to get the default device in a compatible
manner.

This change implements his method and adds a version check (XDOS
versions below 2.4 don't support this -- for them the behaviour
will be the same as, for example, AtariDOS: no notion of a default
drive).