### PR TITLE
Add missing tag and remove duplicate text

### DIFF
--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -3552,7 +3552,7 @@ Here's a list of all control commands and a description, what they do:
 
   See: <tt><ref id=".P02" name=".P02"></tt>, <tt><ref id=".PSC02"
   name=".PSC02"></tt>, <tt><ref id=".P816" name=".P816"></tt> and
-  <ref id=".P4510" name=".P4510">4510</tt>
+  <tt><ref id=".P4510" name=".P4510"></tt>
 
 
 <sect1><tt>.POPCPU</tt><label id=".POPCPU"><p>


### PR DESCRIPTION
The docbook toolchain as of Debian stretch seems to get more strict and no longer accepts the missing &lt;tt&gt; tag:

`onsgmls:<OSFD>0:3555:41:E: end tag for element "TT" which is not open`
