### PR TITLE
scanner: Correct handling of \0101

### DIFF
--- a/src/cc65/scanner.c
+++ b/src/cc65/scanner.c
@@ -267,6 +267,7 @@ static int ParseChar (void)
 {
     int C;
     int HadError;
+    int Count;
 
     /* Check for escape chars */
     if (CurC == '\\') {
@@ -337,8 +338,9 @@ static int ParseChar (void)
             case '7':
                 /* Octal constant */
                 HadError = 0;
+                Count = 1;
                 C = HexVal (CurC);
-                while (IsODigit (NextC)) {
+                while (IsODigit (NextC) && Count++ < 3) {
                     if ((C << 3) >= 256) {
                         if (!HadError) {
                             Error ("Octal character constant out of range");


### PR DESCRIPTION
The C language has this oddity that octal constants are 3 bytes so the sequence
"\0101" is two bytes and well defined by the langage. cc65 currently misparses
this as a 1 byte octal code. Add a count to fix this.

Signed-off-by: Alan Cox <etchedpixels@gmail.com>