### PR TITLE
NES memory map amend (16k prg, 8k chr default)

### DIFF
--- a/cfg/nes.cfg
+++ b/cfg/nes.cfg
@@ -12,10 +12,10 @@ MEMORY {
     # - code
     # - rodata
     # - data (load)
-    ROM0:   file = %O, start = $8000, size = $7FF4, fill = yes, define = yes;
+    ROM0:   file = %O, start = $8000, size = $7FFA, fill = yes, define = yes;
 
     # Hardware Vectors at End of 2nd 8K ROM
-    ROMV:   file = %O, start = $FFF6, size = $000C, fill = yes;
+    ROMV:   file = %O, start = $FFFA, size = $0006, fill = yes;
 
     # 1 8k CHR Bank
     ROM2:   file = %O, start = $0000, size = $2000, fill = yes;

--- a/libsrc/nes/crt0.s
+++ b/libsrc/nes/crt0.s
@@ -159,9 +159,6 @@ nmi:    pha
 
 ; Interrupt exit
 
-irq2:
-irq1:
-timerirq:
 irq:
         rti
 
@@ -171,9 +168,6 @@ irq:
 
 .segment "VECTORS"
 
-        .word   irq2        ; $fff4 ?
-        .word   irq1        ; $fff6 ?
-        .word   timerirq    ; $fff8 ?
         .word   nmi         ; $fffa vblank nmi
         .word   start       ; $fffc reset
         .word   irq         ; $fffe irq / brk


### PR DESCRIPTION
The configuration file and runtime (crt0.s) provided for the default NES
ROM layout (2x16k PRG, 8k CHR) incorrectly added interrupts (IRQ1, IRQ2,
TIMERIRQ) which are not supported by the NES hardware.  For example, see
the NESdev wiki, which makes no reference to these interrupts.

    https://wiki.nesdev.com/w/index.php/CPU_memory_map

The VECTORS region was also incorrectly set to 0xFFF6, which would have
left the 0xFFF4 normally unspecified.  This did not result in any error,
however, since cc65 simply placed ROMV directly after ROM0 regardless of
start address.

(This layout may be due to a copy-and-paste from the PC-Engine
configuration, whose interrupt registers start at 0xFFF6, begins with
the three interrupts listed above, followed by NMI and START, and does
not end with a final IRQ interrupt.)

Despite the absence of any actual error, since START is still placed at
0xFFFC, this patch removes the nonexistent interrupts and also correctly
aligns the ROM0 and ROMV regions.  It also has the (admittedly very
minor) benefit of freeing up 3 additional bytes for ROM0.