### PR TITLE
pce/memcpy.s: remove superfluous comma in comment

### DIFF
--- a/libsrc/pce/memcpy.s
+++ b/libsrc/pce/memcpy.s
@@ -97,7 +97,7 @@ memcpy_getparams:
 
 ; ----------------------------------------------------------------------
 ; The transfer instructions use inline arguments.
-; Therefore, we must build the instruction, in the DATA segment.
+; Therefore, we must build the instruction in the DATA segment.
 
 .data
 


### PR DESCRIPTION
I'm not a native English speaker but I think this comma is wrong...