### PR TITLE
"static" forward declarations

### DIFF
--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -154,7 +154,7 @@ static void Parse (void)
                  (Decl.StorageClass & (SC_EXTERN|SC_STATIC)) == SC_STATIC)) {
 
                 /* We will allocate storage */
-                Decl.StorageClass |= SC_STORAGE | SC_DEF;
+                Decl.StorageClass |= SC_STORAGE;
             }
 
             /* If this is a function declarator that is not followed by a comma
@@ -186,6 +186,9 @@ static void Parse (void)
 
                 /* Allow initialization */
                 if (CurTok.Tok == TOK_ASSIGN) {
+
+                    /* This is a definition */
+                    Entry->Flags |= SC_DEF;
 
                     /* We cannot initialize types of unknown size, or
                     ** void types in ISO modes.
@@ -234,18 +237,14 @@ static void Parse (void)
                         Entry->Flags &= ~(SC_STORAGE | SC_DEF);
                     }
 
-                    /* Allocate storage if it is still needed */
-                    if (Entry->Flags & SC_STORAGE) {
-
-                        /* Switch to the BSS segment */
-                        g_usebss ();
-
-                        /* Define a label */
-                        g_defgloblabel (Entry->Name);
-
-                        /* Allocate space for uninitialized variable */
-                        g_res (Size);
-                    }
+                    /* A global (including static) uninitialized variable
+                    ** is only a tentative definition. For example, this is valid:
+                    ** int i;
+                    ** int i;
+                    ** static int j;
+                    ** static int j = 42;
+                    ** Code for these will be generated in FinishCompile.
+                    */
                 }
 
             }
@@ -300,7 +299,7 @@ void Compile (const char* FileName)
     struct tm*  TM;
 
     /* Since strftime is locale dependent, we need the abbreviated month names
-    ** in english.
+    ** in English.
     */
     static const char MonthNames[12][4] = {
         "Jan", "Feb", "Mar", "Apr", "May", "Jun",
@@ -397,20 +396,26 @@ void Compile (const char* FileName)
 void FinishCompile (void)
 /* Emit literals, externals, debug info, do cleanup and optimizations */
 {
-    SymTable* SymTab;
-    SymEntry* Func;
+    SymEntry* Entry;
 
-    /* Walk over all functions, doing cleanup, optimizations ... */
-    SymTab = GetGlobalSymTab ();
-    Func   = SymTab->SymHead;
-    while (Func) {
-        if (SymIsOutputFunc (Func)) {
+    /* Walk over all global symbols:
+    ** - for functions do cleanup, optimizations ...
+    ** - generate code for uninitialized global variables
+    */
+    for (Entry = GetGlobalSymTab ()->SymHead; Entry; Entry = Entry->NextSym) {
+        if (SymIsOutputFunc (Entry)) {
             /* Function which is defined and referenced or extern */
-            MoveLiteralPool (Func->V.F.LitPool);
-            CS_MergeLabels (Func->V.F.Seg->Code);
-            RunOpt (Func->V.F.Seg->Code);
+            MoveLiteralPool (Entry->V.F.LitPool);
+            CS_MergeLabels (Entry->V.F.Seg->Code);
+            RunOpt (Entry->V.F.Seg->Code);
+        } else if ((Entry->Flags & (SC_STORAGE | SC_DEF | SC_STATIC)) == (SC_STORAGE | SC_STATIC)) {
+            /* Tentative definition of uninitialized global variable */
+            g_usebss ();
+            g_defgloblabel (Entry->Name);
+            g_res (SizeOf (Entry->Type));
+            /* Mark as defined, so that it will be exported not imported */
+            Entry->Flags |= SC_DEF;
         }
-        Func = Func->NextSym;
     }
 
     /* Output the literal pool */

--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -144,14 +144,17 @@ static void Parse (void)
             **
             **   - if it is not a typedef or function,
             **   - if we don't had a storage class given ("int i")
-            **     or the storage class is explicitly specified as static.
+            **   - if the storage class is explicitly specified as static,
+            **   - or if there is an initialization.
             **
             ** This means that "extern int i;" will not get storage allocated.
             */
             if ((Decl.StorageClass & SC_FUNC) != SC_FUNC          &&
                 (Decl.StorageClass & SC_TYPEMASK) != SC_TYPEDEF    &&
                 ((Spec.Flags & DS_DEF_STORAGE) != 0         ||
-                 (Decl.StorageClass & (SC_EXTERN|SC_STATIC)) == SC_STATIC)) {
+                 (Decl.StorageClass & (SC_EXTERN|SC_STATIC)) == SC_STATIC ||
+                 ((Decl.StorageClass & SC_EXTERN) != 0 &&
+                  CurTok.Tok == TOK_ASSIGN))) {
 
                 /* We will allocate storage */
                 Decl.StorageClass |= SC_STORAGE;

--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -144,17 +144,14 @@ static void Parse (void)
             **
             **   - if it is not a typedef or function,
             **   - if we don't had a storage class given ("int i")
-            **   - if the storage class is explicitly specified as static,
-            **   - or if there is an initialization.
+            **     or the storage class is explicitly specified as static.
             **
             ** This means that "extern int i;" will not get storage allocated.
             */
             if ((Decl.StorageClass & SC_FUNC) != SC_FUNC          &&
                 (Decl.StorageClass & SC_TYPEMASK) != SC_TYPEDEF    &&
                 ((Spec.Flags & DS_DEF_STORAGE) != 0         ||
-                 (Decl.StorageClass & (SC_EXTERN|SC_STATIC)) == SC_STATIC ||
-                 ((Decl.StorageClass & SC_EXTERN) != 0 &&
-                  CurTok.Tok == TOK_ASSIGN))) {
+                 (Decl.StorageClass & (SC_EXTERN|SC_STATIC)) == SC_STATIC)) {
 
                 /* We will allocate storage */
                 Decl.StorageClass |= SC_STORAGE | SC_DEF;

--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -188,6 +188,10 @@ static void Parse (void)
                 if (CurTok.Tok == TOK_ASSIGN) {
 
                     /* This is a definition */
+                    if (SymIsDef (Entry)) {
+                        Error ("Global variable `%s' has already been defined",
+                               Entry->Name);
+                    }
                     Entry->Flags |= SC_DEF;
 
                     /* We cannot initialize types of unknown size, or

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -821,7 +821,7 @@ SymEntry* AddGlobalSym (const char* Name, const Type* T, unsigned Flags)
         }
 
         /* An extern declaration must not change the current linkage. */
-        if (IsFunc || (Flags & (SC_EXTERN | SC_DEF)) == SC_EXTERN) {
+        if (IsFunc || (Flags & (SC_EXTERN | SC_STORAGE)) == SC_EXTERN) {
             Flags &= ~SC_EXTERN;
         }
 

--- a/test/err/duplicate-global-static.c
+++ b/test/err/duplicate-global-static.c
@@ -1,0 +1,18 @@
+/*
+  !!DESCRIPTION!! global duplicated with static variable
+  !!ORIGIN!!      cc65 regression tests
+  !!LICENCE!!     Public Domain
+  !!AUTHOR!!      Piotr Fusik
+*/
+
+/*
+  see: https://github.com/cc65/cc65/issues/191
+*/
+
+int n = 0;
+static int n = 0;           /* should give an error */
+
+int main(void)
+{
+    return n;
+}

--- a/test/err/duplicate-global.c
+++ b/test/err/duplicate-global.c
@@ -1,0 +1,20 @@
+/*
+  !!DESCRIPTION!! duplicate globals
+  !!ORIGIN!!      cc65 regression tests
+  !!LICENCE!!     Public Domain
+  !!AUTHOR!!      Piotr Fusik
+*/
+
+/*
+  see: https://github.com/cc65/cc65/issues/191
+*/
+
+#pragma warn(error, on)
+
+int n = 0;
+int n = 0;           /* should give an error */
+
+int main(void)
+{
+    return n;
+}

--- a/test/err/duplicate-static-global.c
+++ b/test/err/duplicate-static-global.c
@@ -1,0 +1,18 @@
+/*
+  !!DESCRIPTION!! static duplicated with global variable
+  !!ORIGIN!!      cc65 regression tests
+  !!LICENCE!!     Public Domain
+  !!AUTHOR!!      Piotr Fusik
+*/
+
+/*
+  see: https://github.com/cc65/cc65/issues/191
+*/
+
+static int n = 0;
+int n = 0;           /* should give an error */
+
+int main(void)
+{
+    return n;
+}

--- a/test/err/duplicate-static.c
+++ b/test/err/duplicate-static.c
@@ -1,0 +1,20 @@
+/*
+  !!DESCRIPTION!! duplicate static variables
+  !!ORIGIN!!      cc65 regression tests
+  !!LICENCE!!     Public Domain
+  !!AUTHOR!!      Piotr Fusik
+*/
+
+/*
+  see: https://github.com/cc65/cc65/issues/191
+*/
+
+#pragma warn(error, on)
+
+static int n = 0;
+static int n = 0;           /* should give an error */
+
+int main(void)
+{
+    return n;
+}

--- a/test/val/static-fwd-decl.c
+++ b/test/val/static-fwd-decl.c
@@ -1,0 +1,35 @@
+/*
+  !!DESCRIPTION!! static forward declarations
+  !!ORIGIN!!      cc65 regression tests
+  !!LICENCE!!     Public Domain
+  !!AUTHOR!!      Bob Andrews
+*/
+
+/*
+  see: https://github.com/cc65/cc65/issues/204
+*/
+
+#pragma warn(error, on)
+
+typedef struct _DIRMENU
+{
+    const char *name;
+    struct _DIRMENU *dest;
+} DIRMENU; 
+
+static DIRMENU rmenu;
+
+static DIRMENU lmenu = {
+    "left",
+    &rmenu
+};
+
+static DIRMENU rmenu = {
+    "right",
+    &lmenu
+};
+
+int main(void)
+{
+    return lmenu.dest == &rmenu && rmenu.dest == &lmenu ? 0 : 1;
+}


### PR DESCRIPTION
The middle commit fixes #204. The sample code from this ticket now compiles as expected.

While working on it, I noticed and fixed two other problems (in the other commits):

* The compiler silently upgraded a declaration with an initializer to a definition, e.g. in `extern int i = 42;` the `extern` was ignored. I made it a syntax error.
* Duplicate global variables were only signaled by the assembler. I made them a compiler error.
