### PR TITLE
Fix the "yaccdbg.c" compiler regression test.

### DIFF
--- a/test/ref/Makefile
+++ b/test/ref/Makefile
@@ -1,4 +1,3 @@
-
 # makefile for the regression tests that generate output which has to be
 # compared with reference output
 
@@ -24,7 +23,7 @@ WORKDIR := ..$S..$Stestwrk
 DIFF := $(WORKDIR)/bdiff
 
 CC := gcc
-CFLAGS := -O2 -Wall -W -Wextra -fwrapv -fno-strict-overflow
+CFLAGS := -O2 -Wall -W -Wextra -funsigned-char -fwrapv -fno-strict-overflow
 
 .PHONY: all clean
 
@@ -33,6 +32,11 @@ REFS := $(SOURCES:%.c=$(WORKDIR)/%.ref)
 TESTS := $(foreach option,. .o. .os. .osi. .osir. .oi. .oir. .or.,$(SOURCES:%.c=$(WORKDIR)/%$(option)prg))
 
 all: $(REFS) $(TESTS)
+
+# "yaccdbg.c" includes "yacc.c".
+# yaccdbg's built files must depend on both of them.
+
+$(WORKDIR)/yaccdbg.ref: yacc.c
 
 $(WORKDIR)/%.ref: %.c
 	$(CC) $(CFLAGS) $< -o $(WORKDIR)/$*.host
@@ -47,6 +51,8 @@ $(WORKDIR)/init%prg: CC65FLAGS += -Wc --all-cdecl
 $(WORKDIR)/switch.%rg: CC65FLAGS += -Wc --all-cdecl
 $(WORKDIR)/yacc.%rg: CC65FLAGS += -Wc --all-cdecl
 $(WORKDIR)/yaccdbg%prg: CC65FLAGS += -Wc --all-cdecl
+
+$(WORKDIR)/yaccdbg%prg: yacc.c
 
 $(WORKDIR)/%.prg: %.c $(WORKDIR)/%.ref
 	$(CL65) $(CC65FLAGS) $< -o $@

--- a/test/ref/yacc.c
+++ b/test/ref/yacc.c
@@ -562,7 +562,7 @@ yylook()
 		}
 
 # ifdef LEXDEBUG
-		if((*(lsp-1)-yysvec-1)<0)
+		if (*(lsp-1) < yysvec + 1)
 		{
 			fprintf(yyout,"yylook:  stopped (end)\n");
 		}


### PR DESCRIPTION
On my system, gcc uses unsigned division when it down-scales pointers that point to objects that are wider than `char`.  If a higher pointer is subtracted from a lower pointer, then the result is positive (it should be negative).

The regression test "`yaccdbg.c`" tests the sign of such a pointer difference expresion.  That test affects the program's output.  Therefore, the gcc-compiled program creates a flawed reference file.  cc65 works properly; its compiled program makes a good test file.  That means that the two files never matched; the yaccdbg test _always_ failed!

This pull request changes that expression; it will be a direct comparison between the two pointers (then, scaling won't be needed).  The yaccdbg test should be stable.