### PR TITLE
Remove a pointless cc65 command-line option from "samples/Makefile".

### DIFF
--- a/samples/Makefile
+++ b/samples/Makefile
@@ -90,7 +90,7 @@ LDFLAGS_tgidemo_atarixl    = --start-addr 0x4000
 %: %.s
 
 .c.o:
-	$(CC) $(CFLAGS) -Oirs --codesize 500 -T -g -t $(SYS) $<
+	$(CC) $(CFLAGS) -Ors --codesize 500 -T -g -t $(SYS) $<
 	$(AS) $(<:.c=.s)
 
 .s.o:


### PR DESCRIPTION
See [this PR comment](https://github.com/cc65/cc65/pull/389#issuecomment-284243168).