### PR TITLE
Add a pragma for finer control of forced inlining of some C functions.

### DIFF
--- a/doc/cc65.sgml
+++ b/doc/cc65.sgml
@@ -4,7 +4,7 @@
 <title>cc65 Users Guide
 <author><url url="mailto:uz@cc65.org" name="Ullrich von Bassewitz">,<newline>
 <url url="mailto:gregdk@users.sf.net" name="Greg King">
-<date>2016-06-11
+<date>2017-03-08
 
 <abstract>
 cc65 is a C compiler for 6502 targets. It supports several 6502 based home
@@ -58,7 +58,7 @@ Short options:
   -O                            Optimize code
   -Oi                           Optimize code, inline more code
   -Or                           Enable register variables
-  -Os                           Inline some known functions
+  -Os                           Force inlining of some known functions
   -T                            Include source as comment
   -V                            Print the compiler version number
   -W warning[,...]              Suppress warnings
@@ -89,6 +89,7 @@ Long options:
   --dep-target target           Use this dependency target
   --disable-opt name            Disable an optimization step
   --enable-opt name             Enable an optimization step
+  --force-inline-funcs          Force inlining of some known functions
   --help                        Help (this text)
   --include-dir dir             Set an include directory search path
   --list-opt-steps              List all optimizer steps and exit
@@ -217,6 +218,41 @@ Here is a description of all the command line options:
   This will cause the compiler to insert a <tt/.DEBUGINFO/ command into the
   generated assembler code. This will cause the assembler to include all
   symbols in a special section in the object file.
+
+
+  <label id="option-force-inline">
+  <tag><tt>--force-inline-funcs</tt></tag>
+
+  Force the compiler to inline these functions from the C library:
+  <itemize>
+  <item><tt/memcpy()/
+  <item><tt/memset()/
+  <item><tt/strcmp()/
+  <item><tt/strcpy()/
+  <item><tt/strlen()/
+  <item>most of the functions declared in <tt/&lt;ctype.h&gt;/
+  </itemize>
+
+  Note: that has two consequences:
+  <itemize>
+  <item>You may not use names of standard C functions for your own functions.
+        If you do that, your program is not standard-compliant anyway; but,
+        using <tt/--force-inline-funcs/ actually will break things.
+        <p>
+  <item>The inlined string and memory functions will not handle strings or
+        memory areas larger than 255 bytes.  Similarly, the inlined <tt/is..()/
+        functions will not work with values outside the char. range (such as
+        <tt/EOF/).
+  </itemize>
+
+  You can combine this setting with other optimizer settings by using the
+  <tt/<ref id="option-O" name="-O">/ switch.  For example, <tt/-Ois/ will
+  enable the optimizer, convert internal calls to run-time functions into
+  faster inline code, and convert calls to those C functions even if cc65
+  isn't sure that it's safe to do so.
+
+  The compiler setting also can be changed within a source file by using
+  <tt/<ref id="pragma-force-inline" name="#pragma&nbsp;force-inline">/.
 
 
   <tag><tt>-h, --help</tt></tag>
@@ -445,20 +481,9 @@ Here is a description of all the command line options:
   id="register-vars" name="discussion of register variables"> below.
 
   Using <tt/-Os/ will force the compiler to inline some known functions from
-  the C library like strlen. Note: This has two consequences:
-  <p>
-  <itemize>
-  <item>You may not use names of standard C functions in your own code. If you
-     	do that, your program is not standard compliant anyway, but using
-     	<tt/-Os/ will actually break things.
-     	<p>
-  <item>The inlined string and memory functions will not handle strings or
-	memory areas larger than 255 bytes. Similarly, the inlined <tt/is..()/
-	functions will not work with values outside the char. range (such as
-	<tt/EOF/).
-     	<p>
-  </itemize>
-  <p>
+  the C library.  See the <tt/<ref id="option-force-inline"
+  name="--force-inline-funcs">/ switch for the details.
+
   It is possible to concatenate the modifiers for <tt/-O/. For example, to
   enable register variables and inlining of known functions, you may use
   <tt/-Ors/.
@@ -1030,6 +1055,23 @@ parameter with the <tt/#pragma/.
   <tscreen><verb>
        	#pragma data-name ("MyDATA")
   </verb></tscreen>
+
+
+<sect1><tt>#pragma force-inline ([push,] on|off)</tt><label id="pragma-force-inline"><p>
+
+  cc65 can substitute faster inline code for calls to some C library array
+  functions.  That inline code can handle only arrays that are smaller than
+  256 bytes.  Therefore, cc65 normally won't substitute if it cannot be sure
+  that the array is small enough.  This pragma can make cc65 ignore that
+  caution.
+
+  The default is "off", but may be changed with the <tt/<ref name="-Os"
+  id="option-O">/ compiler command-line option.  If the command-line switch
+  has changed the default to "on", then a programmer can use the pragma to
+  avoid substitution where it is risky, while allowing it everywhere else.
+
+  The <tt/#pragma/ understands the <tt/push/ and <tt/pop/ parameters, as
+  explained above.
 
 
 <sect1><tt>#pragma local-strings ([push,] on|off)</tt><label id="pragma-local-strings"><p>

--- a/src/cc65/main.c
+++ b/src/cc65/main.c
@@ -88,7 +88,7 @@ static void Usage (void)
             "  -O\t\t\t\tOptimize code\n"
             "  -Oi\t\t\t\tOptimize code, inline more code\n"
             "  -Or\t\t\t\tEnable register variables\n"
-            "  -Os\t\t\t\tInline some known functions\n"
+            "  -Os\t\t\t\tForce inlining of some known functions\n"
             "  -T\t\t\t\tInclude source as comment\n"
             "  -V\t\t\t\tPrint the compiler version number\n"
             "  -W warning[,...]\t\tSuppress warnings\n"
@@ -119,6 +119,7 @@ static void Usage (void)
             "  --dep-target target\t\tUse this dependency target\n"
             "  --disable-opt name\t\tDisable an optimization step\n"
             "  --enable-opt name\t\tEnable an optimization step\n"
+            "  --force-inline-funcs\t\tForce inlining of some known functions\n"
             "  --help\t\t\tHelp (this text)\n"
             "  --include-dir dir\t\tSet an include directory search path\n"
             "  --list-opt-steps\t\tList all optimizer steps and exit\n"
@@ -254,7 +255,7 @@ static void SetSys (const char* Sys)
         case TGT_TELESTRAT:
             DefineNumericMacro ("__TELESTRAT__", 1);
             break;
-                                
+
         case TGT_NES:
             DefineNumericMacro ("__NES__", 1);
             break;
@@ -556,7 +557,7 @@ static void OptDebugOpt (const char* Opt attribute ((unused)), const char* Arg)
 
 
 
-static void OptDebugOptOutput (const char* Opt attribute ((unused)), 
+static void OptDebugOptOutput (const char* Opt attribute ((unused)),
                                const char* Arg attribute ((unused)))
 /* Output optimization steps */
 {
@@ -585,6 +586,15 @@ static void OptEnableOpt (const char* Opt attribute ((unused)), const char* Arg)
 /* Enable an optimization step */
 {
     EnableOpt (Arg);
+}
+
+
+
+static void OptForceFuncs (const char* Opt attribute ((unused)),
+                           const char* Arg attribute ((unused)))
+/* Handle the --force-inline-funcs option */
+{
+    IS_Set (&InlineStdFuncs, 1);
 }
 
 
@@ -819,39 +829,40 @@ int main (int argc, char* argv[])
 {
     /* Program long options */
     static const LongOpt OptTab[] = {
-        { "--add-source",       0,      OptAddSource            },
-        { "--all-cdecl",        0,      OptAllCDecl             },
-        { "--bss-name",         1,      OptBssName              },
-        { "--check-stack",      0,      OptCheckStack           },
-        { "--code-name",        1,      OptCodeName             },
-        { "--codesize",         1,      OptCodeSize             },
-        { "--cpu",              1,      OptCPU                  },
-        { "--create-dep",       1,      OptCreateDep            },
-        { "--create-full-dep",  1,      OptCreateFullDep        },
-        { "--data-name",        1,      OptDataName             },
-        { "--debug",            0,      OptDebug                },
-        { "--debug-info",       0,      OptDebugInfo            },
-        { "--debug-opt",        1,      OptDebugOpt             },
-        { "--debug-opt-output", 0,      OptDebugOptOutput       },
-        { "--dep-target",       1,      OptDepTarget            },
-        { "--disable-opt",      1,      OptDisableOpt           },
-        { "--enable-opt",       1,      OptEnableOpt            },
-        { "--help",             0,      OptHelp                 },
-        { "--include-dir",      1,      OptIncludeDir           },
-        { "--list-opt-steps",   0,      OptListOptSteps         },
-        { "--list-warnings",    0,      OptListWarnings         },
-        { "--local-strings",    0,      OptLocalStrings         },
-        { "--memory-model",     1,      OptMemoryModel          },
-        { "--register-space",   1,      OptRegisterSpace        },
-        { "--register-vars",    0,      OptRegisterVars         },
-        { "--rodata-name",      1,      OptRodataName           },
-        { "--signed-chars",     0,      OptSignedChars          },
-        { "--standard",         1,      OptStandard             },
-        { "--static-locals",    0,      OptStaticLocals         },
-        { "--target",           1,      OptTarget               },
-        { "--verbose",          0,      OptVerbose              },
-        { "--version",          0,      OptVersion              },
-        { "--writable-strings", 0,      OptWritableStrings      },
+        { "--add-source",               0,      OptAddSource            },
+        { "--all-cdecl",                0,      OptAllCDecl             },
+        { "--bss-name",                 1,      OptBssName              },
+        { "--check-stack",              0,      OptCheckStack           },
+        { "--code-name",                1,      OptCodeName             },
+        { "--codesize",                 1,      OptCodeSize             },
+        { "--cpu",                      1,      OptCPU                  },
+        { "--create-dep",               1,      OptCreateDep            },
+        { "--create-full-dep",          1,      OptCreateFullDep        },
+        { "--data-name",                1,      OptDataName             },
+        { "--debug",                    0,      OptDebug                },
+        { "--debug-info",               0,      OptDebugInfo            },
+        { "--debug-opt",                1,      OptDebugOpt             },
+        { "--debug-opt-output",         0,      OptDebugOptOutput       },
+        { "--dep-target",               1,      OptDepTarget            },
+        { "--disable-opt",              1,      OptDisableOpt           },
+        { "--enable-opt",               1,      OptEnableOpt            },
+        { "--force-inline-funcs",       0,      OptForceFuncs           },
+        { "--help",                     0,      OptHelp                 },
+        { "--include-dir",              1,      OptIncludeDir           },
+        { "--list-opt-steps",           0,      OptListOptSteps         },
+        { "--list-warnings",            0,      OptListWarnings         },
+        { "--local-strings",            0,      OptLocalStrings         },
+        { "--memory-model",             1,      OptMemoryModel          },
+        { "--register-space",           1,      OptRegisterSpace        },
+        { "--register-vars",            0,      OptRegisterVars         },
+        { "--rodata-name",              1,      OptRodataName           },
+        { "--signed-chars",             0,      OptSignedChars          },
+        { "--standard",                 1,      OptStandard             },
+        { "--static-locals",            0,      OptStaticLocals         },
+        { "--target",                   1,      OptTarget               },
+        { "--verbose",                  0,      OptVerbose              },
+        { "--version",                  0,      OptVersion              },
+        { "--writable-strings",         0,      OptWritableStrings      },
     };
 
     unsigned I;

--- a/src/cc65/pragma.c
+++ b/src/cc65/pragma.c
@@ -74,6 +74,7 @@ typedef enum {
     PRAGMA_CODESIZE,
     PRAGMA_DATA_NAME,
     PRAGMA_DATASEG,                                     /* obsolete */
+    PRAGMA_FORCE_INLINE,
     PRAGMA_LOCAL_STRINGS,
     PRAGMA_OPTIMIZE,
     PRAGMA_REGVARADDR,
@@ -91,7 +92,7 @@ typedef enum {
     PRAGMA_COUNT
 } pragma_t;
 
-/* Pragma table */
+/* Sorted pragma table */
 static const struct Pragma {
     const char* Key;            /* Keyword */
     pragma_t    Tok;            /* Token */
@@ -107,6 +108,7 @@ static const struct Pragma {
     { "codesize",               PRAGMA_CODESIZE         },
     { "data-name",              PRAGMA_DATA_NAME        },
     { "dataseg",                PRAGMA_DATASEG          },      /* obsolete */
+    { "force-inline",           PRAGMA_FORCE_INLINE     },
     { "local-strings",          PRAGMA_LOCAL_STRINGS    },
     { "optimize",               PRAGMA_OPTIMIZE         },
     { "register-vars",          PRAGMA_REGISTER_VARS    },
@@ -737,6 +739,10 @@ static void ParsePragma (void)
             /* FALLTHROUGH */
         case PRAGMA_DATA_NAME:
             SegNamePragma (&B, SEG_DATA);
+            break;
+
+        case PRAGMA_FORCE_INLINE:
+            FlagPragma (&B, &InlineStdFuncs);
             break;
 
         case PRAGMA_LOCAL_STRINGS:


### PR DESCRIPTION
`#pragma force-inline(on | off)` can be used to control where cc65 will inline calls to certain array and string functions.  Inlining can be controlled on an expression-by-expression basis.  (The pragma doesn't affect what `<ctype.h>` does.  But, you can use `#undef` to disable that header's inlining.)

I added a command-line switch that lets us enable the forcing independently of the `-O` switch.  But, `-O` will disable `--force-inline-funcs` if `-O` follows that long switch.

This Pull Request will allow C library string function tests to be added to the automated regression test suite, without needing to alter the makefile.  See the comments at PRs #389 and #395.