### PR TITLE
Fix a yaccdbg pointer test again.

### DIFF
--- a/test/ref/yacc.c
+++ b/test/ref/yacc.c
@@ -562,13 +562,13 @@ yylook()
 		}
 
 # ifdef LEXDEBUG
-		if (*(lsp-1) < yysvec + 1)
+		if (lsp == yylstate)
 		{
 			fprintf(yyout,"yylook:  stopped (end)\n");
 		}
 		else
 		{
-			fprintf(yyout,"yylook:  stopped at %d with\n",*(lsp-1)-yysvec-1);
+			fprintf(yyout,"yylook:  stopped at %d with:\n",*(lsp-1)-(yysvec+1));
 		}
 # endif
 		while (lsp-- > yylstate)
@@ -594,7 +594,7 @@ yylook()
 				yyleng = yylastch-yytext+1;
 				yytext[yyleng] = 0;
 # ifdef LEXDEBUG
-				fprintf(yyout,"\nyylook:  match action %d\n",*yyfnd);
+				fprintf(yyout,"yylook:  match action %d\n",*yyfnd);
 				fprintf(yyout,"yylook:  done loops: %d\n",testbreak);
 # endif
 				return(*yyfnd++);


### PR DESCRIPTION
It seems that I didn't go far enough in pull request #391.  Hopefully, this version will fix the yaccdbg regression test for both gcc and cc65.