### PR TITLE
Fix regression of #pragma bss-name

### DIFF
--- a/cfg/sim6502.cfg
+++ b/cfg/sim6502.cfg
@@ -3,7 +3,7 @@ SYMBOLS {
     __STACKSIZE__: type = weak, value = $0800; # 2k stack
 }
 MEMORY {
-    ZP:     file = "",               start = $0000, size = $001A;
+    ZP:     file = "",               start = $0000, size = $001B;
     HEADER: file = %O,               start = $0000, size = $0001;
     MAIN:   file = %O, define = yes, start = $0200, size = $FDF0 - __STACKSIZE__;
 }

--- a/cfg/sim65c02.cfg
+++ b/cfg/sim65c02.cfg
@@ -3,7 +3,7 @@ SYMBOLS {
     __STACKSIZE__: type = weak, value = $0800; # 2k stack
 }
 MEMORY {
-    ZP:     file = "",               start = $0000, size = $001A;
+    ZP:     file = "",               start = $0000, size = $001B;
     HEADER: file = %O,               start = $0000, size = $0001;
     MAIN:   file = %O, define = yes, start = $0200, size = $FDF0 - __STACKSIZE__;
 }

--- a/src/cc65/symentry.c
+++ b/src/cc65/symentry.c
@@ -71,6 +71,7 @@ SymEntry* NewSymEntry (const char* Name, unsigned Flags)
     E->Type     = 0;
     E->Attr     = 0;
     E->AsmName  = 0;
+    E->V.BssName = 0;
     memcpy (E->Name, Name, Len+1);
 
     /* Return the new entry */

--- a/src/cc65/symentry.h
+++ b/src/cc65/symentry.h
@@ -153,6 +153,8 @@ struct SymEntry {
             struct LiteralPool* LitPool;  /* Literal pool for this function */
         } F;
 
+        /* Segment name for tentantive global definitions */
+        const char*             BssName;
     } V;
     char                       Name[1]; /* Name, dynamically allocated */
 };

--- a/test/err/bss-name-conflict.c
+++ b/test/err/bss-name-conflict.c
@@ -1,0 +1,20 @@
+/*
+  !!DESCRIPTION!! conflicting bss-name pragmas
+  !!ORIGIN!!      cc65 regression tests
+  !!LICENCE!!     Public Domain
+  !!AUTHOR!!      Piotr Fusik
+*/
+
+/*
+  see: https://github.com/cc65/cc65/issues/409
+*/
+
+char oam_off;
+#pragma bss-name (push,"ZEROPAGE")
+char oam_off;
+#pragma bss-name (pop)
+
+int main(void)
+{
+    return 0;
+}

--- a/test/val/bss-name-decl.c
+++ b/test/val/bss-name-decl.c
@@ -1,0 +1,22 @@
+/*
+  !!DESCRIPTION!! bss-name pragma not affecting declarations
+  !!ORIGIN!!      cc65 regression tests
+  !!LICENCE!!     Public Domain
+  !!AUTHOR!!      Piotr Fusik
+*/
+
+/*
+  see: https://github.com/cc65/cc65/issues/409
+*/
+
+#pragma bss-name (push,"ZEROPAGE")
+
+char n; /* only a declaration because followed by definition */
+char n = 1; /* not BSS */
+
+#pragma bss-name (pop)
+
+int main(void)
+{
+    return (unsigned) &n >= 0x100 ? 0 : 1;
+}

--- a/test/val/bss-name.c
+++ b/test/val/bss-name.c
@@ -1,0 +1,21 @@
+/*
+  !!DESCRIPTION!! bss-name pragma
+  !!ORIGIN!!      cc65 regression tests
+  !!LICENCE!!     Public Domain
+  !!AUTHOR!!      Piotr Fusik
+*/
+
+/*
+  see: https://github.com/cc65/cc65/issues/409
+*/
+
+#pragma bss-name (push,"ZEROPAGE")
+
+char zp_var;
+
+#pragma bss-name (pop)
+
+int main(void)
+{
+    return (unsigned) &zp_var < 0x100 ? 0 : 1;
+}


### PR DESCRIPTION
Closes #409 

Added tests, also for the two corner cases I mentioned in #409.
The sim6502 linker scripts are modified because of the `bss-name.c` test. I'm not sure if it's ok.