### PR TITLE
added -E switch to cl65 for >>stop after the preprocessing stage<<.

### DIFF
--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -180,8 +180,8 @@ static void DisableLinking (void)
 
 static void DisableAssemblingAndLinking (void)
 {
-    DisableAssembling();
-    DisableLinking();
+    DisableAssembling ();
+    DisableLinking ();
 }
 
 
@@ -1427,7 +1427,7 @@ int main (int argc, char* argv [])
 
                 case 'S':
                     /* Dont assemble and link the created files */
-                    DisableAssemblingAndLinking();
+                    DisableAssemblingAndLinking ();
                     break;
 
                 case 'T':
@@ -1443,7 +1443,7 @@ int main (int argc, char* argv [])
                 case 'E':
                     /* Forward -E to compiler */
                     CmdAddArg (&CC65, Arg);  
-                    DisableAssemblingAndLinking();
+                    DisableAssemblingAndLinking ();
                     break;
                     
                 case 'W':
@@ -1465,9 +1465,10 @@ int main (int argc, char* argv [])
                             OptLdArgs (Arg, GetArg (&I, 3));
                             break;
                         default:
+                            UnknownOption (Arg);
                             break;
                        }
-                    }else {
+                    } else {
                         /* Anything else: Suppress warnings (compiler) */
                         CmdAddArg2 (&CC65, "-W", GetArg (&I, 2));
                     }
@@ -1475,7 +1476,7 @@ int main (int argc, char* argv [])
 
                 case 'c':
                     /* Don't link the resulting files */
-                    DisableLinking();
+                    DisableLinking ();
                     break;
 
                 case 'd':

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -734,7 +734,7 @@ static void Usage (void)
             "  -C name\t\t\tUse linker config file\n"
             "  -Cl\t\t\t\tMake local variables static\n"
             "  -D sym[=defn]\t\t\tDefine a preprocessor symbol\n"
-            "  -E Stop after the preprocessing stage\n"
+            "  -E\t\t\t\tStop after the preprocessing stage\n"
             "  -I dir\t\t\tSet a compiler include directory path\n"
             "  -L path\t\t\tSpecify a library search path\n"
             "  -Ln name\t\t\tCreate a VICE label file\n"

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -156,7 +156,21 @@ static char* TargetLib  = 0;
 #  endif
 #endif
 
+/*****************************************************************************/
+/*                        Credential functions		                         */
+/*****************************************************************************/
+void DisableAssembling(void){
+	DoAssemble = 0;
+}
 
+void DisableLinking(void){
+	DoLink = 0;
+}
+
+void DisableAssemblingAndLinking(void){
+	DisableAssembling();
+	DisableLinking();
+}
 
 /*****************************************************************************/
 /*                        Command structure handling                         */
@@ -1399,8 +1413,7 @@ int main (int argc, char* argv [])
 
                 case 'S':
                     /* Dont assemble and link the created files */
-                    DoAssemble = 0;
-                    DoLink     = 0;
+                    DisableAssemblingAndLinking();
                     break;
 
                 case 'T':
@@ -1416,37 +1429,16 @@ int main (int argc, char* argv [])
                 case 'E':
                     /*Forward -E to compiler*/
                     CmdAddArg (&CC65, Arg);  
-                    DoAssemble = 0;
-                    DoLink     = 0;
+                    DisableAssemblingAndLinking();
                     break;
                 case 'W':
                     if (Arg[2] == 'a' && Arg[3] == '\0') {
                         /* -Wa: Pass options to assembler */
                         OptAsmArgs (Arg, GetArg (&I, 3));
-                    }   
-                    else if (Arg[2] == 'c' && Arg[3] == '\0') {
+                    } else if (Arg[2] == 'c' && Arg[3] == '\0') {
                         /* -Wc: Pass options to compiler */
-                        
-                        /* Get argument succeeding -Wc switch */
-                        const char* WcSubArgs = GetArg (&I, 3); 
-                        
                         /* Remember -Wc sub arguments in cc65 arg struct */ 
-                        OptCCArgs (Arg, WcSubArgs);
-                        /* Check for isolated -E switch given after -Wc*/
-                        if (!strcmp("-E", WcSubArgs)){
-                            /*If both -Wc and -E given, then prevent assembling 
-                              and linking */
-                            DoAssemble = 0;
-                            DoLink     = 0;
-                        }else{
-                            /* Check for -E beeing part of comma separated arg 
-                            list given after -Wc*/
-                            if ( (NULL!=strstr(WcSubArgs, "-E,")) || 
-                                 (NULL!=strstr(WcSubArgs, ",-E"))){
-                                DoAssemble = 0;
-                                DoLink     = 0;
-                            }
-                        }
+                        OptCCArgs (Arg, GetArg (&I, 3));
                     } else if (Arg[2] == 'l' && Arg[3] == '\0') {
                         /* -Wl: Pass options to linker */
                         OptLdArgs (Arg, GetArg (&I, 3));
@@ -1458,7 +1450,7 @@ int main (int argc, char* argv [])
 
                 case 'c':
                     /* Don't link the resulting files */
-                    DoLink = 0;
+                    DisableLinking();
                     break;
 
                 case 'd':

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -157,19 +157,19 @@ static char* TargetLib  = 0;
 #endif
 
 /*****************************************************************************/
-/*                        Credential functions		                         */
+/*                        Credential functions                               */
 /*****************************************************************************/
 void DisableAssembling(void){
-	DoAssemble = 0;
+    DoAssemble = 0;
 }
 
 void DisableLinking(void){
-	DoLink = 0;
+    DoLink = 0;
 }
 
 void DisableAssemblingAndLinking(void){
-	DisableAssembling();
-	DisableLinking();
+    DisableAssembling();
+    DisableLinking();
 }
 
 /*****************************************************************************/

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -156,21 +156,35 @@ static char* TargetLib  = 0;
 #  endif
 #endif
 
+
+
 /*****************************************************************************/
 /*                        Credential functions                               */
 /*****************************************************************************/
-void DisableAssembling(void){
+
+
+
+static void DisableAssembling (void)
+{
     DoAssemble = 0;
 }
 
-void DisableLinking(void){
+
+
+static void DisableLinking (void)
+{
     DoLink = 0;
 }
 
-void DisableAssemblingAndLinking(void){
+
+
+static void DisableAssemblingAndLinking (void)
+{
     DisableAssembling();
     DisableLinking();
 }
+
+
 
 /*****************************************************************************/
 /*                        Command structure handling                         */
@@ -1427,22 +1441,33 @@ int main (int argc, char* argv [])
                     break;
                 
                 case 'E':
-                    /*Forward -E to compiler*/
+                    /* Forward -E to compiler */
                     CmdAddArg (&CC65, Arg);  
                     DisableAssemblingAndLinking();
                     break;
+                    
                 case 'W':
-                    if (Arg[2] == 'a' && Arg[3] == '\0') {
-                        /* -Wa: Pass options to assembler */
-                        OptAsmArgs (Arg, GetArg (&I, 3));
-                    } else if (Arg[2] == 'c' && Arg[3] == '\0') {
-                        /* -Wc: Pass options to compiler */
-                        /* Remember -Wc sub arguments in cc65 arg struct */ 
-                        OptCCArgs (Arg, GetArg (&I, 3));
-                    } else if (Arg[2] == 'l' && Arg[3] == '\0') {
-                        /* -Wl: Pass options to linker */
-                        OptLdArgs (Arg, GetArg (&I, 3));
-                    } else {
+                    /* avoid && with'\0' in if clauses */
+                    if (Arg[3] == '\0') {
+                        switch (Arg[2]) {
+                        case 'a':
+                            /* -Wa: Pass options to assembler */
+                            OptAsmArgs (Arg, GetArg (&I, 3));
+                            break;
+                        case 'c':
+                            /* -Wc: Pass options to compiler 
+                            ** Remember -Wc sub arguments in cc65 arg struct 
+                            */
+                            OptCCArgs (Arg, GetArg (&I, 3));
+                            break;
+                        case 'l':
+                            /* -Wl: Pass options to linker */
+                            OptLdArgs (Arg, GetArg (&I, 3));
+                            break;
+                        default:
+                            break;
+                       }
+                    }else {
                         /* Anything else: Suppress warnings (compiler) */
                         CmdAddArg2 (&CC65, "-W", GetArg (&I, 2));
                     }


### PR DESCRIPTION
Added compilation- and assemblation-disable after `-Wc -E`, also with `-E` being part of a comma-separated list of arguments. `Printf()` statements needed for testing have already been removed. 

Simple tests successful:
```
mc78@mc78-TP300LA:~$ ls Pre*
PreprocessOnlyTest.c
mc78@mc78-TP300LA:~$ cl65 -Wc -E PreprocessOnlyTest.c
-Wc given
Args: -E
mc78@mc78-TP300LA:~$ ls Pre*
PreprocessOnlyTest.c  PreprocessOnlyTest.i
mc78@mc78-TP300LA:~$ cl65 -Wc -tc64 PreprocessOnlyTest.c
-Wc given
Args: -tc64
mc78@mc78-TP300LA:~$ ls Pre*
PreprocessOnlyTest  PreprocessOnlyTest.c  PreprocessOnlyTest.i  
PreprocessOnlyTest.o
```
Erroneous input is still caught correctly:
```
mc78@mc78-TP300LA:~$ cl65 -Wc -c PreprocessOnlyTest.c
-Wc given
Args: -c
cc65: Unknown option: -c
mc78@mc78-TP300LA:~$ cl65 -Wc -t c64 PreprocessOnlyTest.c
-Wc given
Args: -t
cl65: Don't know what to do with `c64'

mc78@mc78-TP300LA:~$ rm PreprocessOnlyTest.i
mc78@mc78-TP300LA:~$ cl65 -Wc -tc64,-E PreprocessOnlyTest.c

-Wc given
Args: -tc64,-E
mc78@mc78-TP300LA:~$ ls Pre*
PreprocessOnlyTest.c  PreprocessOnlyTest.i

mc78@mc78-TP300LA:~$ rm PreprocessOnlyTest.i
mc78@mc78-TP300LA:~$ cl65 -Wc -E,-tc64 PreprocessOnlyTest.c

-Wc given
Args: -E,-tc64
mc78@mc78-TP300LA:~$ ls Pre*
PreprocessOnlyTest.c  PreprocessOnlyTest.i
```