### PR TITLE
More POSIX.2, staying compatible

### DIFF
--- a/src/ar65/main.c
+++ b/src/ar65/main.c
@@ -62,7 +62,7 @@ static void Usage (void)
 {
     fprintf (stderr, "Usage: %s <operation ...> lib file|module ...\n"
             "Operations are some of:\n"
-            "\ta\tAdd modules\n"
+            "\tr\tAdd modules\n"
             "\td\tDelete modules\n"
             "\tt\tList library table\n"
             "\tv\tIncrease verbosity (put before other operation)\n"
@@ -96,7 +96,8 @@ int main (int argc, char* argv [])
 
         switch (Arg [0]) {
 
-            case 'a':
+            case 'r': /* POSIX.2 */
+            case 'a': /* staying compatible */
                 AddObjFiles (ArgCount - I - 1, &ArgVec[I+1]);
                 break;
 

--- a/src/ar65/main.c
+++ b/src/ar65/main.c
@@ -65,7 +65,7 @@ static void Usage (void)
             "\ta\tAdd modules\n"
             "\td\tDelete modules\n"
             "\tt\tList library table\n"
-            "\tv\tIncrease verbosity (put after other operation)\n"
+            "\tv\tIncrease verbosity (put before other operation)\n"
             "\tx\tExtract modules\n"
             "\tV\tPrint the archiver version\n",
             ProgName);

--- a/src/ar65/main.c
+++ b/src/ar65/main.c
@@ -64,8 +64,8 @@ static void Usage (void)
             "Operations are some of:\n"
             "\ta\tAdd modules\n"
             "\td\tDelete modules\n"
-            "\tl\tList library contents\n"
-            "\tv\tIncrease verbosity (put before other operation)\n"
+            "\tt\tList library table\n"
+            "\tv\tIncrease verbosity (put after other operation)\n"
             "\tx\tExtract modules\n"
             "\tV\tPrint the archiver version\n",
             ProgName);
@@ -94,10 +94,6 @@ int main (int argc, char* argv [])
         /* Get the argument */
         const char* Arg = ArgVec [I];
 
-        /* Check for an option */
-        if (strlen (Arg) != 1) {
-            Usage ();
-        }
         switch (Arg [0]) {
 
             case 'a':
@@ -108,7 +104,11 @@ int main (int argc, char* argv [])
                 DelObjFiles (ArgCount - I - 1, &ArgVec [I+1]);
                 break;
 
-            case 'l':
+            case 't': /* POSIX.2 */
+            case 'l': /* staying compatible */
+                if (Arg [1] == 'v') {
+                    ++Verbosity;
+                }
                 ListObjFiles (ArgCount - I - 1, &ArgVec [I+1]);
                 break;
 


### PR DESCRIPTION
The old syntax was "ar65 v l foo.lib", now "ar65 tv foo.lib" also works (maybe ar's syntax was always a bit crude because of its age).