### PR TITLE
Add a missing -O configuration to some regression-test make-files.

### DIFF
--- a/test/misc/Makefile
+++ b/test/misc/Makefile
@@ -35,7 +35,7 @@ SIM65 := $(if $(wildcard ../../bin/sim65*),..$S..$Sbin$Ssim65,sim65)
 
 WORKDIR = ..$S..$Stestwrk$Smisc
 
-OPTIONS = g O Os Osi Osir Oi Oir Or
+OPTIONS = g O Os Osi Osir Osr Oi Oir Or
 
 DIFF = $(WORKDIR)$Sbdiff$(EXE)
 

--- a/test/ref/Makefile
+++ b/test/ref/Makefile
@@ -33,7 +33,7 @@ SIM65 := $(if $(wildcard ../../bin/sim65*),..$S..$Sbin$Ssim65,sim65)
 
 WORKDIR = ..$S..$Stestwrk$Sref
 
-OPTIONS = g O Os Osi Osir Oi Oir Or
+OPTIONS = g O Os Osi Osir Osr Oi Oir Or
 
 DIFF = $(WORKDIR)$Sbdiff$(EXE)
 

--- a/test/val/Makefile
+++ b/test/val/Makefile
@@ -31,7 +31,7 @@ SIM65 := $(if $(wildcard ../../bin/sim65*),..$S..$Sbin$Ssim65,sim65)
 
 WORKDIR = ../../testwrk/val
 
-OPTIONS = g O Os Osi Osir Oi Oir Or
+OPTIONS = g O Os Osi Osir Osr Oi Oir Or
 
 .PHONY: all clean
 


### PR DESCRIPTION
I created this PR completely in Github's web interface.  (That's why there are three commits for the three files -- one commit would have been enough if I had done it in my local computer's Git.)