### PR TITLE
Add a missing label to some conio cursor movement functions.

### DIFF
--- a/libsrc/atmos/gotoxy.s
+++ b/libsrc/atmos/gotoxy.s
@@ -1,13 +1,17 @@
 ;
-; Ullrich von Bassewitz, 2003-04-13
+; 2003-04-13, Ullrich von Bassewitz
+; 2017-06-15, Greg King
 ;
 ; void gotoxy (unsigned char x, unsigned char y);
 ;
 
-        .export         _gotoxy
+        .export         gotoxy, _gotoxy
+
         .import         popa
 
         .include        "atmos.inc"
+
+gotoxy: jsr     popa            ; Get Y
 
 .proc   _gotoxy
 
@@ -17,5 +21,3 @@
         rts
 
 .endproc
-
-

--- a/libsrc/creativision/gotoxy.s
+++ b/libsrc/creativision/gotoxy.s
@@ -1,14 +1,18 @@
 ;
-; Ullrich von Bassewitz, 06.08.1998
+; 1998-08-06, Ullrich von Bassewitz
+; 2017-06-15, Greg King
 ;
 ; void gotoxy (unsigned char x, unsigned char y);
 ;
 
-        .export         _gotoxy
+        .export         gotoxy, _gotoxy
+
         .import         setcursor
         .import         popa
 
         .include        "creativision.inc"
+
+gotoxy: jsr     popa            ; Get Y
 
 .proc   _gotoxy
 

--- a/libsrc/gamate/gotoxy.s
+++ b/libsrc/gamate/gotoxy.s
@@ -9,7 +9,7 @@
         .include        "extzp.inc"
 
 gotoxy:
-        jsr     popa            ; Get X
+        jsr     popa            ; Get Y
 
 _gotoxy:
         sta     CURS_Y          ; Set Y
@@ -20,6 +20,4 @@ _gotoxy:
 ;-------------------------------------------------------------------------------
 ; force the init constructor to be imported
 
-        .import initconio
-conio_init      = initconio
-
+        .forceimport    initconio

--- a/libsrc/telestrat/gotoxy.s
+++ b/libsrc/telestrat/gotoxy.s
@@ -1,19 +1,26 @@
 ;
-; jede jede@oric.org 2017-02-25
+; 2017-02-25, jede <jede@oric.org>
+; 2017-06-15, Greg King
 ;
-    .export    _gotoxy
-	
-    .import    popa
-	
-    .importzp  sp
+; void gotoxy (unsigned char x, unsigned char y);
+;
 
-    .include   "telestrat.inc"
+        .export         gotoxy, _gotoxy
+
+        .import         popa
+        .importzp       sp
+
+        .include        "telestrat.inc"
+
+gotoxy: jsr     popa            ; Get Y
 
 .proc _gotoxy
-   ; This function move only cursor for display, it does not move the prompt position
-   ; in telemon, there is position for prompt, and another for the cursor
-   sta    SCRY
-   jsr    popa
-   sta    SCRX
-   rts
-.endproc	
+
+; This function moves only the display cursor; it does not move the prompt position.
+; In telemon, there is a position for the prompt, and another for the cursor.
+
+        sta     SCRY
+        jsr     popa
+        sta     SCRX
+        rts
+.endproc


### PR DESCRIPTION
I noticed that @Fabrizio-Caruso had seen the linking problem while he was developing his https://github.com/Fabrizio-Caruso/ASCII-CHASE/commit/e5e35191ccfb547f4e97ecac94935bd5b5c96362 game.