### PR TITLE
Add functions that make it easier to write portable programs for OSI computers.

### DIFF
--- a/libsrc/osic1p/doesclrscr.s
+++ b/libsrc/osic1p/doesclrscr.s
@@ -1,0 +1,14 @@
+;
+; 2016-06, Christian Groessler
+; 2017-06-26, Greg King
+;
+; unsigned char doesclrscrafterexit (void);
+;
+; Returns 0/1 if, after program termination, the screen isn't/is cleared.
+;
+
+        .import         return1
+
+; cc65's OSI programs return to the monitor ROM which clears the screen.
+
+        .export         _doesclrscrafterexit := return1

--- a/libsrc/osic1p/revers.s
+++ b/libsrc/osic1p/revers.s
@@ -1,0 +1,9 @@
+;
+; 2017-06-26, Greg King
+;
+; unsigned char __fastcall__ revers (unsigned char onoff)
+;
+
+        .import         return0
+
+        .export         _revers := return0      ; no attribute


### PR DESCRIPTION
I learned that we need those functions, while testing the conio peek functions on the `osic1p` target.