### PR TITLE
c64: add dummy waitvblank();

### DIFF
--- a/include/c64.h
+++ b/include/c64.h
@@ -158,6 +158,9 @@ extern void c64_hi_tgi[];               /* Referred to by tgi_static_stddrv[] */
 
 
 
+void waitvblank (void);
+/* Wait for the vertical blanking */
+
 unsigned char get_ostype (void);
 /* Get the ROM version. Returns one of the C64_OS_xxx codes. */
 

--- a/libsrc/c64/waitvblank.s
+++ b/libsrc/c64/waitvblank.s
@@ -1,0 +1,14 @@
+;
+; Written by Groepaz/Hitmen <groepaz@gmx.net>
+; Cleanup by Ullrich von Bassewitz <uz@cc65.org>
+;
+; void waitvblank(void);
+;
+
+        .export _waitvblank
+
+.proc   _waitvblank
+
+        rts
+
+.endproc


### PR DESCRIPTION
having to #ifdef waitvblank makes for ugly code, having a dummy
waitvblank for systems lacking it seems like a lesser evil.