### PR TITLE
pragma: bring pragma_t enum in line with Pragmas struct

### DIFF
--- a/src/cc65/pragma.c
+++ b/src/cc65/pragma.c
@@ -79,8 +79,8 @@ typedef enum {
     PRAGMA_INLINE_STDFUNCS,
     PRAGMA_LOCAL_STRINGS,
     PRAGMA_OPTIMIZE,
-    PRAGMA_REGVARADDR,
     PRAGMA_REGISTER_VARS,
+    PRAGMA_REGVARADDR,
     PRAGMA_REGVARS,                                     /* obsolete */
     PRAGMA_RODATA_NAME,
     PRAGMA_RODATASEG,                                   /* obsolete */


### PR DESCRIPTION
fixes an inconsequential inconsistency, might prevent some
confusion in the future.