### PR TITLE
joy: expand/standardize JOY_ consts on NES

### DIFF
--- a/include/joystick.h
+++ b/include/joystick.h
@@ -60,8 +60,10 @@
 #define JOY_DOWN        1
 #define JOY_LEFT        2
 #define JOY_RIGHT       3
-#define JOY_FIRE        4
-#define JOY_FIRE2       5               /* Second fire button if available */
+#define JOY_A           4
+#define JOY_B           5               /* Second fire button if available */
+#define JOY_SELECT      6               /* Select or third button if available */
+#define JOY_START       7               /* Start or fourth button if avaiable */
 
 /* Array of masks used to check the return value of joy_read for a state */
 extern const unsigned char joy_masks[8];
@@ -71,8 +73,11 @@ extern const unsigned char joy_masks[8];
 #define JOY_BTN_DOWN(v)         ((v) & joy_masks[JOY_DOWN])
 #define JOY_BTN_LEFT(v)         ((v) & joy_masks[JOY_LEFT])
 #define JOY_BTN_RIGHT(v)        ((v) & joy_masks[JOY_RIGHT])
-#define JOY_BTN_FIRE(v)         ((v) & joy_masks[JOY_FIRE])
-#define JOY_BTN_FIRE2(v)        ((v) & joy_masks[JOY_FIRE2])
+#define JOY_BTN_A(v)            ((v) & joy_masks[JOY_A])
+#define JOY_BTN_B(v)            ((v) & joy_masks[JOY_B])
+#define JOY_BTN_SELECT(v)       ((v) & joy_masks[JOY_SELECT])
+#define JOY_BTN_START(v)        ((v) & joy_masks[JOY_START])
+
 
 /* The name of the standard joystick driver for a platform */
 extern const char joy_stddrv[];

--- a/include/nes.h
+++ b/include/nes.h
@@ -90,16 +90,6 @@
 /* No support for dynamically loadable drivers */
 #define DYN_DRV         0
 
-/* The joystick keys - all keys are supported */
-#define KEY_A           0x01
-#define KEY_B           0x02
-#define KEY_SELECT      0x04
-#define KEY_START       0x08
-#define KEY_UP          0x10
-#define KEY_DOWN        0x20
-#define KEY_LEFT        0x40
-#define KEY_RIGHT       0x80
-
 /* Define hardware */
 
 /* Picture Processing Unit */

--- a/libsrc/atari/joy/atrmj8.s
+++ b/libsrc/atari/joy/atrmj8.s
@@ -41,8 +41,8 @@
         .byte   $04                     ; JOY_DOWN
         .byte   $08                     ; JOY_LEFT
         .byte   $10                     ; JOY_RIGHT
-        .byte   $01                     ; JOY_FIRE
-        .byte   $00                     ; JOY_FIRE2 not available
+        .byte   $01                     ; JOY_A
+        .byte   $00                     ; JOY_B not available
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
 

--- a/libsrc/atari/joy/atrstd.s
+++ b/libsrc/atari/joy/atrstd.s
@@ -40,8 +40,8 @@
         .byte   $02                     ; JOY_DOWN
         .byte   $04                     ; JOY_LEFT
         .byte   $08                     ; JOY_RIGHT
-        .byte   $10                     ; JOY_FIRE
-        .byte   $00                     ; JOY_FIRE2 not available
+        .byte   $10                     ; JOY_A
+        .byte   $00                     ; JOY_B not available
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
 

--- a/libsrc/atari5200/joy/atr5200std.s
+++ b/libsrc/atari5200/joy/atr5200std.s
@@ -33,8 +33,8 @@
         .byte   $02             ; JOY_DOWN
         .byte   $04             ; JOY_LEFT
         .byte   $08             ; JOY_RIGHT
-        .byte   $10             ; JOY_FIRE
-        .byte   $20             ; JOY_FIRE2
+        .byte   $10             ; JOY_A
+        .byte   $20             ; JOY_B
         .byte   $00             ; Future expansion
         .byte   $00             ; Future expansion
 
@@ -99,7 +99,7 @@ READJOY:
         lda     #0              ; Initialize return value
         cmp     TRIG0,y
         bne     @notrg
-        lda     #$10            ; JOY_FIRE
+        lda     #$10            ; JOY_A
 
 ; Read joystick
 

--- a/libsrc/atmos/joy/atmos-pase.s
+++ b/libsrc/atmos/joy/atmos-pase.s
@@ -34,7 +34,7 @@
         .byte   $08                     ; JOY_DOWN
         .byte   $01                     ; JOY_LEFT
         .byte   $02                     ; JOY_RIGHT
-        .byte   $20                     ; JOY_FIRE
+        .byte   $20                     ; JOY_A
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion

--- a/libsrc/c128/joy/c128-ptvjoy.s
+++ b/libsrc/c128/joy/c128-ptvjoy.s
@@ -36,8 +36,8 @@
         .byte   $02                     ; JOY_DOWN
         .byte   $04                     ; JOY_LEFT
         .byte   $08                     ; JOY_RIGHT
-        .byte   $10                     ; JOY_FIRE
-        .byte   $00                     ; JOY_FIRE2 unavailable
+        .byte   $10                     ; JOY_A
+        .byte   $00                     ; JOY_B unavailable
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
 

--- a/libsrc/c128/joy/c128-stdjoy.s
+++ b/libsrc/c128/joy/c128-stdjoy.s
@@ -36,8 +36,8 @@
         .byte   $02                     ; JOY_DOWN
         .byte   $04                     ; JOY_LEFT
         .byte   $08                     ; JOY_RIGHT
-        .byte   $10                     ; JOY_FIRE
-        .byte   $00                     ; JOY_FIRE2 unavailable
+        .byte   $10                     ; JOY_A
+        .byte   $00                     ; JOY_B unavailable
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
 

--- a/libsrc/c64/joy/c64-hitjoy.s
+++ b/libsrc/c64/joy/c64-hitjoy.s
@@ -35,8 +35,8 @@
         .byte   $02                     ; JOY_DOWN
         .byte   $04                     ; JOY_LEFT
         .byte   $08                     ; JOY_RIGHT
-        .byte   $10                     ; JOY_FIRE
-        .byte   $00                     ; JOY_FIRE2 unavailable
+        .byte   $10                     ; JOY_A
+        .byte   $00                     ; JOY_B unavailable
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
 

--- a/libsrc/c64/joy/c64-numpad.s
+++ b/libsrc/c64/joy/c64-numpad.s
@@ -36,8 +36,8 @@
         .byte   $10                     ; JOY_DOWN      "2"
         .byte   $20                     ; JOY_LEFT      "4"
         .byte   $08                     ; JOY_RIGHT     "6"
-        .byte   $04                     ; JOY_FIRE      "5" ENTER
-        .byte   $00                     ; JOY_FIRE2 unavailable
+        .byte   $04                     ; JOY_A      "5" ENTER
+        .byte   $00                     ; JOY_B unavailable
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
 

--- a/libsrc/c64/joy/c64-ptvjoy.s
+++ b/libsrc/c64/joy/c64-ptvjoy.s
@@ -35,8 +35,8 @@
         .byte   $02                     ; JOY_DOWN
         .byte   $04                     ; JOY_LEFT
         .byte   $08                     ; JOY_RIGHT
-        .byte   $10                     ; JOY_FIRE
-        .byte   $00                     ; JOY_FIRE2 unavailable
+        .byte   $10                     ; JOY_A
+        .byte   $00                     ; JOY_B unavailable
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
 

--- a/libsrc/c64/joy/c64-stdjoy.s
+++ b/libsrc/c64/joy/c64-stdjoy.s
@@ -35,8 +35,8 @@
         .byte   $02                     ; JOY_DOWN
         .byte   $04                     ; JOY_LEFT
         .byte   $08                     ; JOY_RIGHT
-        .byte   $10                     ; JOY_FIRE
-        .byte   $00                     ; JOY_FIRE2 unavailable
+        .byte   $10                     ; JOY_A
+        .byte   $00                     ; JOY_B unavailable
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
 

--- a/libsrc/cbm510/joy/cbm510-std.s
+++ b/libsrc/cbm510/joy/cbm510-std.s
@@ -36,8 +36,8 @@
         .byte   $02                     ; JOY_DOWN
         .byte   $04                     ; JOY_LEFT
         .byte   $08                     ; JOY_RIGHT
-        .byte   $10                     ; JOY_FIRE
-        .byte   $00                     ; JOY_FIRE2 unavailable
+        .byte   $10                     ; JOY_A
+        .byte   $00                     ; JOY_B unavailable
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
 

--- a/libsrc/creativision/joy/creativision-stdjoy.s
+++ b/libsrc/creativision/joy/creativision-stdjoy.s
@@ -33,8 +33,8 @@ JOY_UP          =       $10
 JOY_DOWN        =       $04
 JOY_LEFT        =       $20
 JOY_RIGHT       =       $08
-JOY_FIRE        =       $01
-JOY_FIRE2       =       $02
+JOY_A        =       $01
+JOY_B       =       $02
 
 ; Joystick state masks (8 values)
 
@@ -42,8 +42,8 @@ JOY_FIRE2       =       $02
                 .byte   JOY_DOWN
                 .byte   JOY_LEFT
                 .byte   JOY_RIGHT
-                .byte   JOY_FIRE
-                .byte   JOY_FIRE2
+                .byte   JOY_A
+                .byte   JOY_B
                 .byte   $00                     ; Future expansion
                 .byte   $00                     ; Future expansion
 

--- a/libsrc/gamate/joy/gamate-stdjoy.s
+++ b/libsrc/gamate/joy/gamate-stdjoy.s
@@ -30,8 +30,8 @@
         .byte   $02                     ; JOY_DOWN
         .byte   $04                     ; JOY_LEFT
         .byte   $08                     ; JOY_RIGHT
-        .byte   $10                     ; JOY_FIRE_A
-        .byte   $20                     ; JOY_FIRE_B
+        .byte   $10                     ; JOY_A_A
+        .byte   $20                     ; JOY_A_B
         .byte   $80                     ; JOY_SELECT
         .byte   $40                     ; JOY_START
 

--- a/libsrc/geos-cbm/joy/geos-stdjoy.s
+++ b/libsrc/geos-cbm/joy/geos-stdjoy.s
@@ -34,7 +34,7 @@
         .byte $02               ; JOY_DOWN
         .byte $04               ; JOY_LEFT
         .byte $08               ; JOY_RIGHT
-        .byte $10               ; JOY_FIRE
+        .byte $10               ; JOY_A
         .byte $00               ; Future expansion
         .byte $00               ; Future expansion
         .byte $00               ; Future expansion

--- a/libsrc/lynx/joy/lynx-stdjoy.s
+++ b/libsrc/lynx/joy/lynx-stdjoy.s
@@ -38,8 +38,8 @@ joy_mask:
         .byte   $40                     ; JOY_DOWN
         .byte   $20                     ; JOY_LEFT
         .byte   $10                     ; JOY_RIGHT
-        .byte   $01                     ; JOY_FIRE
-        .byte   $02                     ; JOY_FIRE1
+        .byte   $01                     ; JOY_A
+        .byte   $02                     ; JOY_A1
         .byte   $00                     ;
         .byte   $00                     ;
 

--- a/libsrc/nes/joy/nes-stdjoy.s
+++ b/libsrc/nes/joy/nes-stdjoy.s
@@ -35,10 +35,10 @@
         .byte   $20                     ; JOY_DOWN
         .byte   $40                     ; JOY_LEFT
         .byte   $80                     ; JOY_RIGHT
-        .byte   $01                     ; JOY_FIRE      (A)
-        .byte   $02                     ; JOY_FIRE2     (B)
-        .byte   $04                     ;               (Select)
-        .byte   $08                     ;               (Start)
+        .byte   $01                     ; JOY_A         (A)
+        .byte   $02                     ; JOY_B         (B)
+        .byte   $04                     ; JOY_SELECT    (Select)
+        .byte   $08                     ; JOY_START     (Start)
 
 ; Jump table.
 

--- a/libsrc/pce/joy/pce-stdjoy.s
+++ b/libsrc/pce/joy/pce-stdjoy.s
@@ -30,8 +30,8 @@
         .byte   $40                     ; JOY_DOWN
         .byte   $80                     ; JOY_LEFT
         .byte   $20                     ; JOY_RIGHT
-        .byte   $01                     ; JOY_FIRE_A
-        .byte   $02                     ; JOY_FIRE_B
+        .byte   $01                     ; JOY_A_A
+        .byte   $02                     ; JOY_A_B
         .byte   $04                     ; JOY_SELECT
         .byte   $08                     ; JOY_RUN
 

--- a/libsrc/pet/joy/pet-ptvjoy.s
+++ b/libsrc/pet/joy/pet-ptvjoy.s
@@ -34,8 +34,8 @@
         .byte   $02                     ; JOY_DOWN
         .byte   $04                     ; JOY_LEFT
         .byte   $08                     ; JOY_RIGHT
-        .byte   $10                     ; JOY_FIRE
-        .byte   $00                     ; JOY_FIRE2 unavailable
+        .byte   $10                     ; JOY_A
+        .byte   $00                     ; JOY_B unavailable
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
 

--- a/libsrc/pet/joy/pet-stdjoy.s
+++ b/libsrc/pet/joy/pet-stdjoy.s
@@ -33,8 +33,8 @@
         .byte   $02             ; JOY_DOWN
         .byte   $04             ; JOY_LEFT
         .byte   $08             ; JOY_RIGHT
-        .byte   $10             ; JOY_FIRE
-        .byte   $00             ; JOY_FIRE2 unavailable
+        .byte   $10             ; JOY_A
+        .byte   $00             ; JOY_B unavailable
         .byte   $00             ; Future expansion
         .byte   $00             ; Future expansion
 

--- a/libsrc/plus4/joy/plus4-stdjoy.s
+++ b/libsrc/plus4/joy/plus4-stdjoy.s
@@ -37,8 +37,8 @@
         .byte   $02                     ; JOY_DOWN
         .byte   $04                     ; JOY_LEFT
         .byte   $08                     ; JOY_RIGHT
-        .byte   $80                     ; JOY_FIRE
-        .byte   $00                     ; JOY_FIRE2 unavailable
+        .byte   $80                     ; JOY_A
+        .byte   $00                     ; JOY_B unavailable
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
 

--- a/libsrc/vic20/joy/vic20-ptvjoy.s
+++ b/libsrc/vic20/joy/vic20-ptvjoy.s
@@ -36,8 +36,8 @@
         .byte   $02                     ; JOY_DOWN
         .byte   $04                     ; JOY_LEFT
         .byte   $08                     ; JOY_RIGHT
-        .byte   $10                     ; JOY_FIRE
-        .byte   $00                     ; JOY_FIRE2 unavailable
+        .byte   $10                     ; JOY_A
+        .byte   $00                     ; JOY_B unavailable
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
 

--- a/libsrc/vic20/joy/vic20-stdjoy.s
+++ b/libsrc/vic20/joy/vic20-stdjoy.s
@@ -36,8 +36,8 @@
         .byte   $04                     ; JOY_DOWN
         .byte   $08                     ; JOY_LEFT
         .byte   $80                     ; JOY_RIGHT
-        .byte   $10                     ; JOY_FIRE
-        .byte   $00                     ; JOY_FIRE2 unavailable
+        .byte   $10                     ; JOY_A
+        .byte   $00                     ; JOY_B unavailable
         .byte   $00                     ; Future expansion
         .byte   $00                     ; Future expansion
 


### PR DESCRIPTION
Standardize on A/B as opposed to FIRE/FIRE2 as per NES.

expand to include SELECT/START for the NES

PC Engine seems to be similar to the NES.

Most older platforms seems to be effectively single action button.