### PR TITLE
make changes

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,8 +6,8 @@ endif
 
 .SUFFIXES:
 
-htmldir = $(prefix)/share/doc/cc65$(DESTPACKAGE_SUFFIX)/html
-infodir = $(prefix)/share/info
+htmldir = $(PREFIX)/share/doc/cc65$(DESTPACKAGE_SUFFIX)/html
+infodir = $(PREFIX)/share/info
 
 ifdef CMD_EXE
 
@@ -46,7 +46,7 @@ clean:
 	$(RM) -r ../html ../info
 
 install:
-	$(if $(prefix),,$(error variable `prefix' must be set))
+	$(if $(PREFIX),,$(error variable `PREFIX' must be set))
 ifeq ($(wildcard ../html),../html)
 	$(INSTALL) -d $(DESTDIR)$(htmldir)
 	$(INSTALL) -m0644 ../html/*.* $(DESTDIR)$(htmldir)

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -72,7 +72,7 @@ endif
 
 ifndef TARGET
 
-datadir = $(prefix)/share/cc65
+datadir = $(PREFIX)/share/cc65
 
 all lib: $(TARGETS)
 
@@ -92,7 +92,7 @@ INSTALL = install
 
 define INSTALL_recipe
 
-$(if $(prefix),,$(error variable `prefix' must be set))
+$(if $(PREFIX),,$(error variable `PREFIX' must be set))
 $(INSTALL) -d $(DESTDIR)$(datadir)/$(dir)
 $(INSTALL) -m0644 ../$(dir)/*.* $(DESTDIR)$(datadir)/$(dir)
 

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -237,10 +237,10 @@ samples.atr: samples
 # Installation rules
 
 INSTALL = install
-samplesdir = $(prefix)/share/cc65/samples
+samplesdir = $(PREFIX)/share/cc65/samples
 
 install:
-	$(if $(prefix),,$(error variable `prefix' must be set))
+	$(if $(PREFIX),,$(error variable `PREFIX' must be set))
 	$(INSTALL) -d $(DESTDIR)$(samplesdir)
 	$(INSTALL) -d $(DESTDIR)$(samplesdir)/geos
 	$(INSTALL) -d $(DESTDIR)$(samplesdir)/tutorial

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -237,7 +237,7 @@ samples.atr: samples
 # Installation rules
 
 INSTALL = install
-samplesdir = $(prefix)/share/cc65
+samplesdir = $(prefix)/share/cc65/samples
 
 install:
 	$(if $(prefix),,$(error variable `prefix' must be set))

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,8 +19,8 @@ PROGS = ar65     \
 
 .SUFFIXES:
 
-bindir  := $(prefix)/bin
-datadir := $(if $(prefix),$(prefix)/share/cc65,$(abspath ..))
+bindir  := $(PREFIX)/bin
+datadir := $(if $(PREFIX),$(PREFIX)/share/cc65,$(abspath ..))
 
 CA65_INC = $(datadir)/asminc
 CC65_INC = $(datadir)/include
@@ -107,7 +107,7 @@ $(RM) /usr/local/bin/$(prog)
 endef # UNAVAIL_recipe
 
 install:
-	$(if $(prefix),,$(error variable `prefix' must be set))
+	$(if $(PREFIX),,$(error variable `PREFIX' must be set))
 	$(INSTALL) -d $(DESTDIR)$(bindir)
 	$(INSTALL) ../bin/* $(DESTDIR)$(bindir)
 


### PR DESCRIPTION
This branch does two things:
1. it installs the samples to their own subdirectory, which makes the installation result a bit more tidy.
2. it changes the prefix env var, to uppercase, since this seems to be in more common use, as this confused me while creating the Debian packaging as well.