### PR TITLE
Add constructors to make the C64 and the VIC-20 repeat all keys.

### DIFF
--- a/asminc/c64.inc
+++ b/asminc/c64.inc
@@ -31,11 +31,10 @@ BASIC_BUF_LEN   = 89            ; Maximum length of command-line
 
 CHARCOLOR       := $286
 CURS_COLOR      := $287         ; Color under the cursor
+KBDREPEAT       := $28A         ; $00 = cursor, $40 = none, $80 = all
+KBDREPEATRATE   := $28B
+KBDREPEATDELAY  := $28C
 PALFLAG         := $2A6         ; $01 = PAL, $00 = NTSC
-
-KBDREPEAT       := $28a
-KBDREPEATRATE   := $28b
-KBDREPEATDELAY  := $28c
 
 ; ---------------------------------------------------------------------------
 ; Kernal routines

--- a/asminc/vic20.inc
+++ b/asminc/vic20.inc
@@ -30,10 +30,9 @@ BASIC_BUF_LEN   = 89            ; Maximum length of command-line
 
 CHARCOLOR       := $286
 CURS_COLOR      := $287         ; Color under the cursor
-
-KBDREPEAT       := $28a
-KBDREPEATRATE   := $28b
-KBDREPEATDELAY  := $28c
+KBDREPEAT       := $28A         ; $00 = cursor, $40 = none, $80 = all
+KBDREPEATRATE   := $28B
+KBDREPEATDELAY  := $28C
 
 ; ---------------------------------------------------------------------------
 ; Screen size

--- a/libsrc/c64/cgetc.s
+++ b/libsrc/c64/cgetc.s
@@ -5,7 +5,9 @@
 ;
 
         .export         _cgetc
+
         .import         cursor
+        .forceimport    keys_repeat
 
         .include        "c64.inc"
 

--- a/libsrc/c64/keyrepeat.s
+++ b/libsrc/c64/keyrepeat.s
@@ -1,0 +1,52 @@
+;
+; Normally, the keyboards on some Commodore models repeat only their "editor"
+; keys (cursor movers, delete, insert, and space).  The keyboards on other CBM
+; models, and many other platforms, repeat all keys, normally.  This constructor
+; makes Commodore keyboards repeat, so that portable programs can assume that
+; all platforms with keyboards repeat all keys.
+;
+; This module is linked by the conio and POSIX input functions.
+;
+; 2017-08-20, Greg King
+;
+
+        .constructor    keys_repeat
+        .destructor     keys_normal
+
+        .include        "c64.inc"
+
+
+;--------------------------------------------------------------------------
+; Put this constructor into a segment whose space
+; will be re-used by BSS, the heap, and the C stack.
+;
+.segment        "ONCE"
+
+; Make all keys repeat.
+
+keys_repeat:
+        lda     KBDREPEAT
+        sta     rptsave
+        lda     #%10000000
+        sta     KBDREPEAT
+        rts
+
+
+;--------------------------------------------------------------------------
+
+.code
+
+; Restore the old keyboard-repeat state.
+
+keys_normal:
+        lda     rptsave
+        sta     KBDREPEAT
+        rts
+
+
+;--------------------------------------------------------------------------
+
+.segment        "INIT"
+
+rptsave:
+        .res    1

--- a/libsrc/c64/soft80_cgetc.s
+++ b/libsrc/c64/soft80_cgetc.s
@@ -7,9 +7,11 @@
 ;
 
         .export         soft80_cgetc
+
         .import         soft80_internal_cellcolor, soft80_internal_cursorxlsb
         .import         cursor
         .importzp       tmp1
+        .forceimport    keys_repeat
 
         .include        "c64.inc"
         .include        "soft80.inc"

--- a/libsrc/c64/soft80mono_cgetc.s
+++ b/libsrc/c64/soft80mono_cgetc.s
@@ -7,10 +7,12 @@
 ;
 
         .export         soft80mono_cgetc
+
         .import         soft80mono_internal_cellcolor, soft80mono_internal_cursorxlsb
         .import         soft80mono_internal_nibble
         .import         cursor
         .importzp       tmp1
+        .forceimport    keys_repeat
 
         .include        "c64.inc"
         .include        "soft80.inc"

--- a/libsrc/cbm/read.s
+++ b/libsrc/cbm/read.s
@@ -1,6 +1,6 @@
 ;
 ; 2002-11-16, Ullrich von Bassewitz
-; 2013-12-23, Greg King
+; 2017-08-07, Greg King
 ;
 ; int read (int fd, void* buf, unsigned count);
 ;
@@ -12,6 +12,10 @@
         .import         rwcommon
         .import         popax
         .importzp       ptr1, ptr2, ptr3, tmp1, tmp2, tmp3
+
+.if     .def(__C64__) || .def(__VIC20__)
+        .forceimport    keys_repeat
+.endif
 
         .include        "cbm.inc"
         .include        "errno.inc"

--- a/libsrc/vic20/cgetc.s
+++ b/libsrc/vic20/cgetc.s
@@ -5,7 +5,9 @@
 ;
 
         .export         _cgetc
+
         .import         cursor
+        .forceimport    keys_repeat
 
         .include        "vic20.inc"
 

--- a/libsrc/vic20/keyrepeat.s
+++ b/libsrc/vic20/keyrepeat.s
@@ -1,0 +1,52 @@
+;
+; Normally, the keyboards on some Commodore models repeat only their "editor"
+; keys (cursor movers, delete, insert, and space).  The keyboards on other CBM
+; models, and many other platforms, repeat all keys, normally.  This constructor
+; makes Commodore keyboards repeat, so that portable programs can assume that
+; all platforms with keyboards repeat all keys.
+;
+; This module is linked by the conio and POSIX input functions.
+;
+; 2017-08-20, Greg King
+;
+
+        .constructor    keys_repeat
+        .destructor     keys_normal
+
+        .include        "vic20.inc"
+
+
+;--------------------------------------------------------------------------
+; Put this constructor into a segment whose space
+; will be re-used by BSS, the heap, and the C stack.
+;
+.segment        "ONCE"
+
+; Make all keys repeat.
+
+keys_repeat:
+        lda     KBDREPEAT
+        sta     rptsave
+        lda     #%10000000
+        sta     KBDREPEAT
+        rts
+
+
+;--------------------------------------------------------------------------
+
+.code
+
+; Restore the old keyboard-repeat state.
+
+keys_normal:
+        lda     rptsave
+        sta     KBDREPEAT
+        rts
+
+
+;--------------------------------------------------------------------------
+
+.segment        "INIT"
+
+rptsave:
+        .res    1


### PR DESCRIPTION
This PR makes the Commodore 64 and VIC-20 keyboards repeat all of their keys when those machines execute cc65-compiled programs.  That makes them consistent with cc65's other platforms.  Portable programs can assume that if a machine has a keyboard, then _all_ of its keys probably will repeat.

I couldn't do it for the "pet" platform.  The models with "graphics" keyboards cannot repeat, at all.  The models with "business" keyboards have a REPEAT-key that actively controls the `KBREPEAT_ALL` flag (by means of the firmware).  That flag bit is set to zero while the key isn't pressed.