### PR TITLE
Correct bits in gamate joystick detection

### DIFF
--- a/libsrc/gamate/joy/gamate-stdjoy.s
+++ b/libsrc/gamate/joy/gamate-stdjoy.s
@@ -79,7 +79,7 @@ COUNT:
 
 READJOY:
         lda     JOY_DATA
-        eor     #$ff
+        eor     #$FF
         ldx     #0
         rts
 

--- a/libsrc/gamate/joy/gamate-stdjoy.s
+++ b/libsrc/gamate/joy/gamate-stdjoy.s
@@ -79,7 +79,7 @@ COUNT:
 
 READJOY:
         lda     JOY_DATA
-	eor     #$ff
+        eor     #$ff
         ldx     #0
         rts
 

--- a/libsrc/gamate/joy/gamate-stdjoy.s
+++ b/libsrc/gamate/joy/gamate-stdjoy.s
@@ -79,6 +79,7 @@ COUNT:
 
 READJOY:
         lda     JOY_DATA
+	eor     #$ff
         ldx     #0
         rts
 


### PR DESCRIPTION
This fixes GAMATE joystick input: joy_read was producing inverted bits.
This fixes makes GAMATE fully compatible with the other targets.