### PR TITLE
Fix bugs in the Tiny Graphics Interface's document.

### DIFF
--- a/doc/tgi.sgml
+++ b/doc/tgi.sgml
@@ -2,21 +2,21 @@
 
 <article>
 <title>Tiny Graphics Interface
-<author><url url="mailto:uz@cc65.org" name="Ullrich von Bassewitz">
-<date>2017-11-23
+<author><url url="mailto:uz@cc65.org" name="Ullrich von Bassewitz">,<newline>
+<url url="mailto:polluks@sdf.lonestar.org" name="Stefan A. Haubenthal">,<newline>
+<url url="mailto:greg.king5@verizon.net" name="Greg King">
+<date>2017-11-26
 
 <abstract>
 The cc65 library provides functions for platform independent graphics.
 Include the tgi.h header file to get the necessary definitions.
 </abstract>
 
-<!-- Table of contents -->
-<tt/tgi.h/<label id="tgi.h"><p>
-<toc>
-
 <!-- Begin the document -->
 
-<sect>tgi_arc<label id="tgi_arc"><p>
+<sect>tgi.h<label id="tgi.h">
+
+<sect1>tgi_arc<label id="tgi_arc"><p>
 
 <quote>
 <descrip>
@@ -50,7 +50,7 @@ tgi_arc (50, 50, 40, 20, 0, 180);
 </quote>
 
 
-<sect>tgi_bar<label id="tgi_bar"><p>
+<sect1>tgi_bar<label id="tgi_bar"><p>
 
 <quote>
 <descrip>
@@ -74,7 +74,7 @@ tgi_bar(10, 10, 100, 60);
 </quote>
 
 
-<sect>tgi_circle<label id="tgi_circle"><p>
+<sect1>tgi_circle<label id="tgi_circle"><p>
 
 <quote>
 <descrip>
@@ -101,7 +101,7 @@ tgi_circle(50, 40, 40);
 </quote>
 
 
-<sect>tgi_clear<label id="tgi_clear"><p>
+<sect1>tgi_clear<label id="tgi_clear"><p>
 
 <quote>
 <descrip>
@@ -116,7 +116,7 @@ tgi_circle(50, 40, 40);
 </quote>
 
 
-<sect>tgi_done<label id="tgi_done"><p>
+<sect1>tgi_done<label id="tgi_done"><p>
 
 <quote>
 <descrip>
@@ -133,7 +133,7 @@ Will NOT uninstall or unload the driver!
 </quote>
 
 
-<sect>tgi_ellipse<label id="tgi_ellipse"><p>
+<sect1>tgi_ellipse<label id="tgi_ellipse"><p>
 
 <quote>
 <descrip>
@@ -161,7 +161,7 @@ tgi_ellipse (50, 40, 40, 20);
 </quote>
 
 
-<sect>tgi_free_vectorfont<label id="tgi_free_vectorfont"><p>
+<sect1>tgi_free_vectorfont<label id="tgi_free_vectorfont"><p>
 
 <quote>
 <descrip>
@@ -182,7 +182,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_getaspectratio<label id="tgi_getaspectratio"><p>
+<sect1>tgi_getaspectratio<label id="tgi_getaspectratio"><p>
 
 <quote> <descrip> <tag/Function/Return the pixel aspect ratio.
 <tag/Header/<tt/<ref id="tgi.h" name="tgi.h">/
@@ -212,7 +212,7 @@ original aspect ratio.
 </quote>
 
 
-<sect>tgi_getcolor<label id="tgi_getcolor"><p>
+<sect1>tgi_getcolor<label id="tgi_getcolor"><p>
 
 <quote>
 <descrip>
@@ -234,7 +234,7 @@ color = tgi_getcolor();
 </quote>
 
 
-<sect>tgi_getcolorcount<label id="tgi_getcolorcount"><p>
+<sect1>tgi_getcolorcount<label id="tgi_getcolorcount"><p>
 
 <quote>
 <descrip>
@@ -254,7 +254,7 @@ if (tgi_getcolorcount() == 2) {
 </quote>
 
 
-<sect>tgi_getdefpalette<label id="tgi_getdefpalette"><p>
+<sect1>tgi_getdefpalette<label id="tgi_getdefpalette"><p>
 
 <quote>
 <descrip>
@@ -271,7 +271,7 @@ palette to work correctly.
 </quote>
 
 
-<sect>tgi_geterror<label id="tgi_geterror"><p>
+<sect1>tgi_geterror<label id="tgi_geterror"><p>
 
 <quote>
 <descrip>
@@ -288,7 +288,7 @@ This will also clear the error.
 </quote>
 
 
-<sect>tgi_geterrormsg<label id="tgi_geterrormsg"><p>
+<sect1>tgi_geterrormsg<label id="tgi_geterrormsg"><p>
 
 <quote>
 <descrip>
@@ -307,7 +307,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_getmaxcolor<label id="tgi_getmaxcolor"><p>
+<sect1>tgi_getmaxcolor<label id="tgi_getmaxcolor"><p>
 
 <quote>
 <descrip>
@@ -322,7 +322,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_getmaxx<label id="tgi_getmaxx"><p>
+<sect1>tgi_getmaxx<label id="tgi_getmaxx"><p>
 
 <quote>
 <descrip>
@@ -337,7 +337,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_getmaxy<label id="tgi_getmaxy"><p>
+<sect1>tgi_getmaxy<label id="tgi_getmaxy"><p>
 
 <quote>
 <descrip>
@@ -352,7 +352,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_getpagecount<label id="tgi_getpagecount"><p>
+<sect1>tgi_getpagecount<label id="tgi_getpagecount"><p>
 
 <quote>
 <descrip>
@@ -369,7 +369,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_getpalette<label id="tgi_getpalette"><p>
+<sect1>tgi_getpalette<label id="tgi_getpalette"><p>
 
 <quote>
 <descrip>
@@ -384,7 +384,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_getpixel<label id="tgi_getpixel"><p>
+<sect1>tgi_getpixel<label id="tgi_getpixel"><p>
 
 <quote>
 <descrip>
@@ -403,7 +403,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_getxres<label id="tgi_getxres"><p>
+<sect1>tgi_getxres<label id="tgi_getxres"><p>
 
 <quote>
 <descrip>
@@ -419,7 +419,7 @@ This is same as tgi_maxx()+1.
 </quote>
 
 
-<sect>tgi_getyres<label id="tgi_getyres"><p>
+<sect1>tgi_getyres<label id="tgi_getyres"><p>
 
 <quote>
 <descrip>
@@ -435,7 +435,7 @@ This is same as tgi_maxy()+1.
 </quote>
 
 
-<sect>tgi_gotoxy<label id="tgi_gotoxy"><p>
+<sect1>tgi_gotoxy<label id="tgi_gotoxy"><p>
 
 <quote>
 <descrip>
@@ -454,7 +454,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_init<label id="tgi_init"><p>
+<sect1>tgi_init<label id="tgi_init"><p>
 
 <quote>
 <descrip>
@@ -479,7 +479,7 @@ tgi_init(); //Set up the default palette and clear the screen.
 </quote>
 
 
-<sect>tgi_install<label id="tgi_install"><p>
+<sect1>tgi_install<label id="tgi_install"><p>
 
 <quote>
 <descrip>
@@ -506,7 +506,7 @@ tgi_init(); //Set up the default palette and clear the screen.
 </quote>
 
 
-<sect>tgi_install_vectorfont<label id="tgi_install_vectorfont"><p>
+<sect1>tgi_install_vectorfont<label id="tgi_install_vectorfont"><p>
 
 <quote>
 <descrip>
@@ -530,7 +530,7 @@ used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_ioctl<label id="tgi_ioctl"><p>
+<sect1>tgi_ioctl<label id="tgi_ioctl"><p>
 
 <quote>
 <descrip>
@@ -565,7 +565,7 @@ if (!tgi_busy()) {
 </quote>
 
 
-<sect>tgi_line<label id="tgi_line"><p>
+<sect1>tgi_line<label id="tgi_line"><p>
 
 <quote>
 <descrip>
@@ -586,7 +586,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_lineto<label id="tgi_lineto"><p>
+<sect1>tgi_lineto<label id="tgi_lineto"><p>
 
 <quote>
 <descrip>
@@ -607,7 +607,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_load_driver<label id="tgi_load_driver"><p>
+<sect1>tgi_load_driver<label id="tgi_load_driver"><p>
 
 <quote>
 <descrip>
@@ -628,7 +628,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_load_vectorfont<label id="tgi_load_vectorfont"><p>
+<sect1>tgi_load_vectorfont<label id="tgi_load_vectorfont"><p>
 
 <quote>
 <descrip>
@@ -652,7 +652,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_outtext<label id="tgi_outtext"><p>
+<sect1>tgi_outtext<label id="tgi_outtext"><p>
 
 <quote>
 <descrip>
@@ -673,7 +673,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_outtextxy<label id="tgi_outtextxy"><p>
+<sect1>tgi_outtextxy<label id="tgi_outtextxy"><p>
 
 <quote>
 <descrip>
@@ -694,7 +694,7 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect>tgi_pieslice<label id="tgi_pieslice"><p>
+<sect1>tgi_pieslice<label id="tgi_pieslice"><p>
 
 <quote>
 <descrip>
@@ -728,7 +728,7 @@ tgi_pieslice (50, 50, 40, 20, 0, 180);
 </quote>
 
 
-<sect>tgi_setaspectratio<label id="tgi_setaspectratio"><p>
+<sect1>tgi_setaspectratio<label id="tgi_setaspectratio"><p>
 
 <quote> <descrip> <tag/Function/Set the pixel aspect ratio.
 <tag/Header/<tt/<ref id="tgi.h" name="tgi.h">/
@@ -760,7 +760,7 @@ only in the presence of a prototype.
 </quote>
 
 
-<sect>tgi_setcolor<label id="tgi_setcolor"><p>
+<sect1>tgi_setcolor<label id="tgi_setcolor"><p>
 
 <quote>
 <descrip>
@@ -783,7 +783,8 @@ tgi_bar(10,10,20,20);
 </descrip>
 </quote>
 
-<sect>tgi_setdrawpage<label id="tgi_setdrawpage"><p>
+
+<sect1>tgi_setdrawpage<label id="tgi_setdrawpage"><p>
 
 <quote>
 <descrip>
@@ -812,7 +813,8 @@ tgi_setviewpage(0); // Show page 0
 </descrip>
 </quote>
 
-<sect>tgi_setpalette<label id="tgi_setpalette"><p>
+
+<sect1>tgi_setpalette<label id="tgi_setpalette"><p>
 
 <quote>
 <descrip>
@@ -832,7 +834,8 @@ be used in presence of a prototype.
 </descrip>
 </quote>
 
-<sect>tgi_setpixel<label id="tgi_setpixel"><p>
+
+<sect1>tgi_setpixel<label id="tgi_setpixel"><p>
 
 <quote>
 <descrip>
@@ -850,7 +853,8 @@ be used in presence of a prototype.
 </descrip>
 </quote>
 
-<sect>tgi_setviewpage<label id="tgi_setviewpage"><p>
+
+<sect1>tgi_setviewpage<label id="tgi_setviewpage"><p>
 
 <quote>
 <descrip>
@@ -879,7 +883,8 @@ tgi_setviewpage(0); // Show page 0
 </descrip>
 </quote>
 
-<sect>tgi_gettextheight<label id="tgi_gettextheight"><p>
+
+<sect1>tgi_gettextheight<label id="tgi_gettextheight"><p>
 
 <quote>
 <descrip>
@@ -899,7 +904,8 @@ be used in presence of a prototype.
 </descrip>
 </quote>
 
-<sect>tgi_settextscale<label id="tgi_settextscale"><p>
+
+<sect1>tgi_settextscale<label id="tgi_settextscale"><p>
 
 <quote>
 <descrip>
@@ -920,7 +926,8 @@ be used in presence of a prototype.
 </descrip>
 </quote>
 
-<sect>tgi_settextstyle<label id="tgi_settextstyle"><p>
+
+<sect1>tgi_settextstyle<label id="tgi_settextstyle"><p>
 
 <quote>
 <descrip>
@@ -939,7 +946,8 @@ be used in presence of a prototype.
 </descrip>
 </quote>
 
-<sect>tgi_gettextwidth<label id="tgi_gettextwidth"><p>
+
+<sect1>tgi_gettextwidth<label id="tgi_gettextwidth"><p>
 
 <quote>
 <descrip>
@@ -957,7 +965,8 @@ be used in presence of a prototype.
 </descrip>
 </quote>
 
-<sect>tgi_uninstall<label id="tgi_uninstall"><p>
+
+<sect1>tgi_uninstall<label id="tgi_uninstall"><p>
 
 <quote>
 <descrip>
@@ -973,7 +982,8 @@ Will call tgi_done if necessary.
 </descrip>
 </quote>
 
-<sect>tgi_unload<label id="tgi_unload"><p>
+
+<sect1>tgi_unload<label id="tgi_unload"><p>
 
 <quote>
 <descrip>

--- a/doc/tgi.sgml
+++ b/doc/tgi.sgml
@@ -5,7 +5,7 @@
 <author><url url="mailto:uz@cc65.org" name="Ullrich von Bassewitz">,<newline>
 <url url="mailto:polluks@sdf.lonestar.org" name="Stefan A. Haubenthal">,<newline>
 <url url="mailto:greg.king5@verizon.net" name="Greg King">
-<date>2017-11-26
+<date>2017-11-30
 
 <abstract>
 The cc65 library provides functions for platform independent graphics.
@@ -392,6 +392,46 @@ be used in presence of a prototype.
 <tag/Header/<tt/<ref id="tgi.h" name="tgi.h">/
 <tag/Declaration/<tt/unsigned char __fastcall__ tgi_getpixel (int x, int y);/
 <tag/Description/Get the color of a pixel from the viewpage.
+<tag/Notes/<itemize>
+<item>The function is only available as fastcall function, so it may only
+be used in presence of a prototype.
+</itemize>
+<tag/Availability/cc65
+<tag/See also/Other tgi functions.
+<tag/Example/None.
+</descrip>
+</quote>
+
+
+<sect1>tgi_gettextheight<label id="tgi_gettextheight"><p>
+
+<quote>
+<descrip>
+<tag/Function/Calculate the height of the text in pixels according to
+the current text style.
+<tag/Header/<tt/<ref id="tgi.h" name="tgi.h">/
+<tag/Declaration/<tt/unsigned __fastcall__ tgi_gettextheight (const char* s);/
+<tag/Description/Calculate the height of the text in pixels according to
+the current text style.
+<tag/Notes/<itemize>
+<item>The function is only available as fastcall function, so it may only
+be used in presence of a prototype.
+</itemize>
+<tag/Availability/cc65
+<tag/See also/Other tgi functions.
+<tag/Example/None.
+</descrip>
+</quote>
+
+
+<sect1>tgi_gettextwidth<label id="tgi_gettextwidth"><p>
+
+<quote>
+<descrip>
+<tag/Function/Calculate the width of the text in pixels according to the current text style.
+<tag/Header/<tt/<ref id="tgi.h" name="tgi.h">/
+<tag/Declaration/<tt/unsigned __fastcall__ tgi_gettextwidth (const char* s);/
+<tag/Description/Calculate the width of the text in pixels according to the current text style.
 <tag/Notes/<itemize>
 <item>The function is only available as fastcall function, so it may only
 be used in presence of a prototype.
@@ -854,57 +894,6 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect1>tgi_setviewpage<label id="tgi_setviewpage"><p>
-
-<quote>
-<descrip>
-<tag/Function/Set page to be visible on screen.
-<tag/Header/<tt/<ref id="tgi.h" name="tgi.h">/
-<tag/Declaration/<tt/void __fastcall__ tgi_setviewpage (unsigned char page);/
-<tag/Description/If the drawpage and the viewpage are the same then all drawing
-is seen immediately as it is drawn. For double buffered games you can set the
-drawpage to a different page than the viewpage. This lets you draw the next
-screen in the background and when the screen is ready you display it.
-<tag/Notes/<itemize>
-<item>The function is only available as fastcall function, so it may only
-be used in presence of a prototype.
-</itemize>
-<tag/Availability/cc65
-<tag/See also/Other tgi functions.
-<tag/Example/<verb>
-tgi_setdrawpage(1);
-tgi_outtextxy(10, 10, "Hello World");
-tgi_setviewpage(1); // Show page 1
-tgi_setdrawpage(0);
-tgi_outtextxy(10, 10, "Creating next frame");
-...
-tgi_setviewpage(0); // Show page 0
-</verb>
-</descrip>
-</quote>
-
-
-<sect1>tgi_gettextheight<label id="tgi_gettextheight"><p>
-
-<quote>
-<descrip>
-<tag/Function/Calculate the height of the text in pixels according to
-the current text style.
-<tag/Header/<tt/<ref id="tgi.h" name="tgi.h">/
-<tag/Declaration/<tt/unsigned __fastcall__ tgi_gettextheight (const char* s);/
-<tag/Description/Calculate the height of the text in pixels according to
-the current text style.
-<tag/Notes/<itemize>
-<item>The function is only available as fastcall function, so it may only
-be used in presence of a prototype.
-</itemize>
-<tag/Availability/cc65
-<tag/See also/Other tgi functions.
-<tag/Example/None.
-</descrip>
-</quote>
-
-
 <sect1>tgi_settextscale<label id="tgi_settextscale"><p>
 
 <quote>
@@ -947,21 +936,32 @@ be used in presence of a prototype.
 </quote>
 
 
-<sect1>tgi_gettextwidth<label id="tgi_gettextwidth"><p>
+<sect1>tgi_setviewpage<label id="tgi_setviewpage"><p>
 
 <quote>
 <descrip>
-<tag/Function/Calculate the width of the text in pixels according to the current text style.
+<tag/Function/Set page to be visible on screen.
 <tag/Header/<tt/<ref id="tgi.h" name="tgi.h">/
-<tag/Declaration/<tt/unsigned __fastcall__ tgi_gettextwidth (const char* s);/
-<tag/Description/Calculate the width of the text in pixels according to the current text style.
+<tag/Declaration/<tt/void __fastcall__ tgi_setviewpage (unsigned char page);/
+<tag/Description/If the drawpage and the viewpage are the same then all drawing
+is seen immediately as it is drawn. For double buffered games you can set the
+drawpage to a different page than the viewpage. This lets you draw the next
+screen in the background and when the screen is ready you display it.
 <tag/Notes/<itemize>
 <item>The function is only available as fastcall function, so it may only
 be used in presence of a prototype.
 </itemize>
 <tag/Availability/cc65
 <tag/See also/Other tgi functions.
-<tag/Example/None.
+<tag/Example/<verb>
+tgi_setdrawpage(1);
+tgi_outtextxy(10, 10, "Hello World");
+tgi_setviewpage(1); // Show page 1
+tgi_setdrawpage(0);
+tgi_outtextxy(10, 10, "Creating next frame");
+...
+tgi_setviewpage(0); // Show page 0
+</verb>
 </descrip>
 </quote>
 


### PR DESCRIPTION
This Pull Request fixes a bug that causes warning messages from LinuxDoc Tools.

And, it puts some descriptions into proper order, sorted by function name.