### PR TITLE
Add none.lib

### DIFF
--- a/cfg/none.cfg
+++ b/cfg/none.cfg
@@ -7,6 +7,7 @@ MEMORY {
 }
 SEGMENTS {
     ZEROPAGE: load = ZP,   type = zp;
+    STARTUP:  load = MAIN, type = ro,  optional = yes;
     LOWCODE:  load = MAIN, type = ro,  optional = yes;
     ONCE:     load = MAIN, type = ro,  optional = yes;
     CODE:     load = MAIN, type = rw;

--- a/cfg/none.cfg
+++ b/cfg/none.cfg
@@ -8,7 +8,7 @@ SYMBOLS {
 }
 MEMORY {
     ZP:   file = "", define = yes, start = __ZPSTART__, size = $001F;
-    MAIN: file = %O, define = yes, start = %S,          size = __STACKSTART__ - __STACKSIZE__;
+    MAIN: file = %O,               start = %S,          size = __STACKSTART__ - __STACKSIZE__ - %S;
 }
 SEGMENTS {
     ZEROPAGE: load = ZP,   type = zp;

--- a/cfg/none.cfg
+++ b/cfg/none.cfg
@@ -1,9 +1,14 @@
+FEATURES {
+    STARTADDRESS: default = $1000;
+}
 SYMBOLS {
-    __STACKSIZE__: type = weak, value = $0800; # 2k stack
+    __STACKSIZE__:  type = weak, value = $0800; # 2k stack
+    __STACKSTART__: type = weak, value = $8000;
+    __ZPSTART__:    type = weak, value = $0080;
 }
 MEMORY {
-    ZP:   file = "", define = yes, start = $0000, size = $0001F;
-    MAIN: file = %O, define = yes, start = %S,    size = $10000 - __STACKSIZE__;
+    ZP:   file = "", define = yes, start = __ZPSTART__, size = $001F;
+    MAIN: file = %O, define = yes, start = %S,          size = __STACKSTART__ - __STACKSIZE__;
 }
 SEGMENTS {
     ZEROPAGE: load = ZP,   type = zp;

--- a/cfg/none.cfg
+++ b/cfg/none.cfg
@@ -3,7 +3,7 @@ SYMBOLS {
 }
 MEMORY {
     ZP:   file = "", define = yes, start = $0000, size = $0001F;
-    MAIN: file = %O,               start = %S,    size = $10000 - __STACKSIZE__;
+    MAIN: file = %O,               start = %S,    size = $10000 - __STACKSIZE__, define = yes;
 }
 SEGMENTS {
     ZEROPAGE: load = ZP,   type = zp;

--- a/cfg/none.cfg
+++ b/cfg/none.cfg
@@ -3,7 +3,7 @@ SYMBOLS {
 }
 MEMORY {
     ZP:   file = "", define = yes, start = $0000, size = $0001F;
-    MAIN: file = %O,               start = %S,    size = $10000 - __STACKSIZE__, define = yes;
+    MAIN: file = %O, define = yes, start = %S,    size = $10000 - __STACKSIZE__;
 }
 SEGMENTS {
     ZEROPAGE: load = ZP,   type = zp;

--- a/doc/customizing.sgml
+++ b/doc/customizing.sgml
@@ -81,6 +81,7 @@ SEGMENTS {
     ZEROPAGE: load = ZP,  type = zp,  define   = yes;
     DATA:     load = ROM, type = rw,  define   = yes, run = RAM;
     BSS:      load = RAM, type = bss, define   = yes;
+    HEAP:     load = RAM, type = bss, optional = yes;
     STARTUP:  load = ROM, type = ro;
     ONCE:     load = ROM, type = ro,  optional = yes;
     CODE:     load = ROM, type = ro;
@@ -94,6 +95,7 @@ The meaning of each of these segments is as follows.
 <p><tt>       ZEROPAGE:  </tt>Data in page 0, defined by ZP as starting at $0 with length $100
 <p><tt>       DATA:      </tt>Initialized data that can be modified by the program, stored in RAM
 <p><tt>       BSS:       </tt>Uninitialized data stored in RAM (used for variable storage)
+<p><tt>       HEAP:      </tt>Uninitialized C-level heap storage in RAM, optional
 <p><tt>       STARTUP:   </tt>The program initialization code, stored in ROM
 <p><tt>       ONCE:      </tt>The code run once to initialize the system, stored in ROM
 <p><tt>       CODE:      </tt>The program code, stored in ROM
@@ -300,20 +302,23 @@ also forcing a BRK instruction into the CPU.
 <sect>Custom Run-Time Library Creation<p>
 
 The next step in customizing the cc65 toolset is creating a run-time
-library for the targeted hardware.  The recommended way to do this is to
-modify the platform-independent standard library of the cc65 distribution.
-It is named &quot;none.lib&quot; in the lib directory of the distribution.
+library for the targeted hardware.  The easiest way to do this is to
+modify a standard library from the cc65 distribution.  In this example,
+there is no console I/O, mouse, joystick, etc. in the system, so it is
+most appropriate to use the simplest library as the base, which is for
+the Watara Supervision and is named &quot;supervision.lib&quot; in the
+lib directory of the distribution.
 
-When using &quot;none.lib&quot; we need to supply our own <tt>crt0</tt>
-module with custom startup code.  This is simply done by first copying the
-the library and giving it a new name, compiling the startup code with ca65,
-and finally using the ar65 archiver to add the module to the new library.
-The steps are shown below:
+The only modification required is to replace the <tt>crt0</tt> module in
+the supervision.lib library with custom startup code.  This is simply
+done by first copying the library and giving it a new name, compiling
+the startup code with ca65, and finally using the ar65 archiver to
+replace the module in the new library.  The steps are shown below:
 
 <tscreen><verb>
-        cp /usr/local/share/cc65/lib/none.lib sbc.lib
-        ca65 crt0.s
-        ar65 a sbc.lib crt0.o
+$ copy &quot;C:\Program Files\cc65\lib\supervision.lib&quot; sbc.lib
+$ ca65 crt0.s
+$ ar65 a sbc.lib crt0.o
 </verb></tscreen>
 
 <sect>Interrupt Service Routine Definition<p>
@@ -701,14 +706,14 @@ that can be used as the initialization data for the Xilinx Block RAM
 used for code storage:
 
 <tscreen><verb>
-        cc65 -t none -O --cpu 65sc02 main.c
-        ca65 --cpu 65sc02 main.s
-        ca65 --cpu 65sc02 rs232_tx.s
-        ca65 --cpu 65sc02 interrupt.s
-        ca65 --cpu 65sc02 vectors.s
-        ca65 --cpu 65sc02 wait.s
-        ld65 -C sbc.cfg -m main.map interrupt.o vectors.o wait.o
-                  rs232_tx.o main.o sbc.lib
+$ cc65 -t none -O --cpu 65sc02 main.c
+$ ca65 --cpu 65sc02 main.s
+$ ca65 --cpu 65sc02 rs232_tx.s
+$ ca65 --cpu 65sc02 interrupt.s
+$ ca65 --cpu 65sc02 vectors.s
+$ ca65 --cpu 65sc02 wait.s
+$ ld65 -C sbc.cfg -m main.map interrupt.o vectors.o wait.o rs232_tx.o
+          main.o sbc.lib
 </verb></tscreen>
 
 During the C-level code compilation phase (<tt>cc65</tt>), assumptions

--- a/doc/customizing.sgml
+++ b/doc/customizing.sgml
@@ -302,17 +302,16 @@ also forcing a BRK instruction into the CPU.
 The next step in customizing the cc65 toolset is creating a run-time
 library for the targeted hardware.  The recommended way to do this is to
 modify the platform-independent standard library of the cc65 distribution.
-It is named &quot;no-platform.lib&quot; in the lib directory of the
-cc65 distribution.
+It is named &quot;none.lib&quot; in the lib directory of the distribution.
 
-When using &quot;no-platform.lib&quot; we need to supply our own <tt>crt0</tt>
+When using &quot;none.lib&quot; we need to supply our own <tt>crt0</tt>
 module with custom startup code.  This is simply done by first copying the
 the library and giving it a new name, compiling the startup code with ca65,
 and finally using the ar65 archiver to add the module to the new library.
 The steps are shown below:
 
 <tscreen><verb>
-        cp /usr/local/share/cc65/lib/no-platform.lib sbc.lib
+        cp /usr/local/share/cc65/lib/none.lib sbc.lib
         ca65 crt0.s
         ar65 a sbc.lib crt0.o
 </verb></tscreen>

--- a/doc/customizing.sgml
+++ b/doc/customizing.sgml
@@ -302,23 +302,20 @@ also forcing a BRK instruction into the CPU.
 <sect>Custom Run-Time Library Creation<p>
 
 The next step in customizing the cc65 toolset is creating a run-time
-library for the targeted hardware.  The easiest way to do this is to
-modify a standard library from the cc65 distribution.  In this example,
-there is no console I/O, mouse, joystick, etc. in the system, so it is
-most appropriate to use the simplest library as the base, which is for
-the Watara Supervision and is named &quot;supervision.lib&quot; in the
-lib directory of the distribution.
+library for the targeted hardware.  The recommended way to do this is to
+modify the platform-independent standard library of the cc65 distribution.
+It is named &quot;none.lib&quot; in the lib directory of the distribution.
 
-The only modification required is to replace the <tt>crt0</tt> module in
-the supervision.lib library with custom startup code.  This is simply
-done by first copying the library and giving it a new name, compiling
-the startup code with ca65, and finally using the ar65 archiver to
-replace the module in the new library.  The steps are shown below:
+When using &quot;none.lib&quot; we need to supply our own <tt>crt0<tt>
+module with custom startup code.  This is simply done by first copying the
+the library and giving it a new name, compiling the startup code with ca65,
+and finally using the ar65 archiver to add the module to the new library.
+The steps are shown below:
 
 <tscreen><verb>
-$ copy &quot;C:\Program Files\cc65\lib\supervision.lib&quot; sbc.lib
-$ ca65 crt0.s
-$ ar65 a sbc.lib crt0.o
+        cp /usr/local/share/cc65/lib/none.lib sbc.lib
+        ca65 crt0.s
+        ar65 a sbc.lib crt0.o
 </verb></tscreen>
 
 <sect>Interrupt Service Routine Definition<p>
@@ -706,14 +703,14 @@ that can be used as the initialization data for the Xilinx Block RAM
 used for code storage:
 
 <tscreen><verb>
-$ cc65 -t none -O --cpu 65sc02 main.c
-$ ca65 --cpu 65sc02 main.s
-$ ca65 --cpu 65sc02 rs232_tx.s
-$ ca65 --cpu 65sc02 interrupt.s
-$ ca65 --cpu 65sc02 vectors.s
-$ ca65 --cpu 65sc02 wait.s
-$ ld65 -C sbc.cfg -m main.map interrupt.o vectors.o wait.o rs232_tx.o
-          main.o sbc.lib
+        cc65 -t none -O --cpu 65sc02 main.c
+        ca65 --cpu 65sc02 main.s
+        ca65 --cpu 65sc02 rs232_tx.s
+        ca65 --cpu 65sc02 interrupt.s
+        ca65 --cpu 65sc02 vectors.s
+        ca65 --cpu 65sc02 wait.s
+        ld65 -C sbc.cfg -m main.map interrupt.o vectors.o wait.o
+                  rs232_tx.o main.o sbc.lib
 </verb></tscreen>
 
 During the C-level code compilation phase (<tt>cc65</tt>), assumptions

--- a/doc/customizing.sgml
+++ b/doc/customizing.sgml
@@ -306,7 +306,7 @@ library for the targeted hardware.  The recommended way to do this is to
 modify the platform-independent standard library of the cc65 distribution.
 It is named &quot;none.lib&quot; in the lib directory of the distribution.
 
-When using &quot;none.lib&quot; we need to supply our own <tt>crt0<tt>
+When using &quot;none.lib&quot; we need to supply our own <tt>crt0</tt>
 module with custom startup code.  This is simply done by first copying the
 the library and giving it a new name, compiling the startup code with ca65,
 and finally using the ar65 archiver to add the module to the new library.

--- a/doc/customizing.sgml
+++ b/doc/customizing.sgml
@@ -81,7 +81,6 @@ SEGMENTS {
     ZEROPAGE: load = ZP,  type = zp,  define   = yes;
     DATA:     load = ROM, type = rw,  define   = yes, run = RAM;
     BSS:      load = RAM, type = bss, define   = yes;
-    HEAP:     load = RAM, type = bss, optional = yes;
     STARTUP:  load = ROM, type = ro;
     ONCE:     load = ROM, type = ro,  optional = yes;
     CODE:     load = ROM, type = ro;
@@ -95,7 +94,6 @@ The meaning of each of these segments is as follows.
 <p><tt>       ZEROPAGE:  </tt>Data in page 0, defined by ZP as starting at $0 with length $100
 <p><tt>       DATA:      </tt>Initialized data that can be modified by the program, stored in RAM
 <p><tt>       BSS:       </tt>Uninitialized data stored in RAM (used for variable storage)
-<p><tt>       HEAP:      </tt>Uninitialized C-level heap storage in RAM, optional
 <p><tt>       STARTUP:   </tt>The program initialization code, stored in ROM
 <p><tt>       ONCE:      </tt>The code run once to initialize the system, stored in ROM
 <p><tt>       CODE:      </tt>The program code, stored in ROM
@@ -304,16 +302,17 @@ also forcing a BRK instruction into the CPU.
 The next step in customizing the cc65 toolset is creating a run-time
 library for the targeted hardware.  The recommended way to do this is to
 modify the platform-independent standard library of the cc65 distribution.
-It is named &quot;none.lib&quot; in the lib directory of the distribution.
+It is named &quot;no-platform.lib&quot; in the lib directory of the
+cc65 distribution.
 
-When using &quot;none.lib&quot; we need to supply our own <tt>crt0</tt>
+When using &quot;no-platform.lib&quot; we need to supply our own <tt>crt0</tt>
 module with custom startup code.  This is simply done by first copying the
 the library and giving it a new name, compiling the startup code with ca65,
 and finally using the ar65 archiver to add the module to the new library.
 The steps are shown below:
 
 <tscreen><verb>
-        cp /usr/local/share/cc65/lib/none.lib sbc.lib
+        cp /usr/local/share/cc65/lib/no-platform.lib sbc.lib
         ca65 crt0.s
         ar65 a sbc.lib crt0.o
 </verb></tscreen>

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -27,13 +27,13 @@ TARGETS = apple2       \
           gamate       \
           lynx         \
           nes          \
+          none         \
           osic1p       \
           pce          \
           sim6502      \
           sim65c02     \
           supervision  \
-          telestrat    \
-          none
+          telestrat
 
 DRVTYPES = emd \
            joy \

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -33,7 +33,7 @@ TARGETS = apple2       \
           sim65c02     \
           supervision  \
           telestrat    \
-          none
+          no-platform
 
 DRVTYPES = emd \
            joy \

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -33,7 +33,7 @@ TARGETS = apple2       \
           sim65c02     \
           supervision  \
           telestrat    \
-          no-platform
+          none
 
 DRVTYPES = emd \
            joy \

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -32,7 +32,8 @@ TARGETS = apple2       \
           sim6502      \
           sim65c02     \
           supervision  \
-          telestrat
+          telestrat    \
+          none
 
 DRVTYPES = emd \
            joy \

--- a/libsrc/none/crt0.s
+++ b/libsrc/none/crt0.s
@@ -1,0 +1,25 @@
+       .export         _exit
+       .export         __STARTUP__ : absolute = 1      ; Mark as startup
+       .import         zerobss, _main
+       .import         initlib, donelib
+       .import         __MAIN_START__, __MAIN_SIZE__   ; Linker generated
+       .import         __STACKSIZE__                   ; Linker generated
+
+       .include "zeropage.inc"
+
+       .segment "STARTUP"
+
+       cld
+       ldx #$FF
+       txs
+       lda #<(__MAIN_START__ + __MAIN_SIZE__ + __STACKSIZE__)
+       ldx #<(__MAIN_START__ + __MAIN_SIZE__ + __STACKSIZE__)
+       sta sp
+       stx sp+1
+       jsr zerobss
+       jsr initlib
+       jsr _main
+_exit: pha
+       jsr donelib
+       pla
+       brk

--- a/libsrc/none/crt0.s
+++ b/libsrc/none/crt0.s
@@ -2,7 +2,7 @@
        .export         __STARTUP__ : absolute = 1      ; Mark as startup
        .import         zerobss, _main
        .import         initlib, donelib
-       .import         __STACKSTART__, __STACKSIZE__   ; Linker generated
+       .import         __STACKSTART__                  ; Linker generated
 
        .include "zeropage.inc"
 

--- a/libsrc/none/crt0.s
+++ b/libsrc/none/crt0.s
@@ -9,9 +9,6 @@
 
        .segment "STARTUP"
 
-       cld
-       ldx #$FF
-       txs
        lda #<(__MAIN_START__ + __MAIN_SIZE__ + __STACKSIZE__)
        ldx #<(__MAIN_START__ + __MAIN_SIZE__ + __STACKSIZE__)
        sta sp
@@ -22,4 +19,4 @@
 _exit: pha
        jsr donelib
        pla
-       brk
+       rts

--- a/libsrc/none/crt0.s
+++ b/libsrc/none/crt0.s
@@ -2,15 +2,14 @@
        .export         __STARTUP__ : absolute = 1      ; Mark as startup
        .import         zerobss, _main
        .import         initlib, donelib
-       .import         __MAIN_START__, __MAIN_SIZE__   ; Linker generated
-       .import         __STACKSIZE__                   ; Linker generated
+       .import         __STACKSTART__, __STACKSIZE__   ; Linker generated
 
        .include "zeropage.inc"
 
        .segment "STARTUP"
 
-       lda #<(__MAIN_START__ + __MAIN_SIZE__ + __STACKSIZE__)
-       ldx #<(__MAIN_START__ + __MAIN_SIZE__ + __STACKSIZE__)
+       lda #<__STACKSTART__
+       lda #>__STACKSTART__
        sta sp
        stx sp+1
        jsr zerobss

--- a/libsrc/none/ctype.s
+++ b/libsrc/none/ctype.s
@@ -1,0 +1,159 @@
+;
+; Ullrich von Bassewitz, 2003-10-10
+;
+; Character specification table.
+;
+
+        .include        "ctype.inc"
+
+; The tables are readonly, put them into the rodata segment
+
+.rodata
+
+; The following 256 byte wide table specifies attributes for the isxxx type
+; of functions. Doing it by a table means some overhead in space, but it
+; has major advantages:
+;
+;   * It is fast. If it weren't for the slow parameter passing of cc65, one
+;     could even define macros for the isxxx functions (this is usually
+;     done on other platforms).
+;
+;   * It is highly portable. The only unportable part is the table itself,
+;     all real code goes into the common library.
+;
+;   * We save some code in the isxxx functions.
+
+
+__ctype:
+        .byte   CT_CTRL                 ;   0/00 ___ctrl_@___
+        .byte   CT_CTRL                 ;   1/01 ___ctrl_A___
+        .byte   CT_CTRL                 ;   2/02 ___ctrl_B___
+        .byte   CT_CTRL                 ;   3/03 ___ctrl_C___
+        .byte   CT_CTRL                 ;   4/04 ___ctrl_D___
+        .byte   CT_CTRL                 ;   5/05 ___ctrl_E___
+        .byte   CT_CTRL                 ;   6/06 ___ctrl_F___
+        .byte   CT_CTRL                 ;   7/07 ___ctrl_G___
+        .byte   CT_CTRL                 ;   8/08 ___ctrl_H___
+        .byte   CT_CTRL | CT_OTHER_WS | CT_SPACE_TAB
+                                        ;   9/09 ___ctrl_I___
+        .byte   CT_CTRL | CT_OTHER_WS   ;  10/0a ___ctrl_J___
+        .byte   CT_CTRL | CT_OTHER_WS   ;  11/0b ___ctrl_K___
+        .byte   CT_CTRL | CT_OTHER_WS   ;  12/0c ___ctrl_L___
+        .byte   CT_CTRL | CT_OTHER_WS   ;  13/0d ___ctrl_M___
+        .byte   CT_CTRL                 ;  14/0e ___ctrl_N___
+        .byte   CT_CTRL                 ;  15/0f ___ctrl_O___
+        .byte   CT_CTRL                 ;  16/10 ___ctrl_P___
+        .byte   CT_CTRL                 ;  17/11 ___ctrl_Q___
+        .byte   CT_CTRL                 ;  18/12 ___ctrl_R___
+        .byte   CT_CTRL                 ;  19/13 ___ctrl_S___
+        .byte   CT_CTRL                 ;  20/14 ___ctrl_T___
+        .byte   CT_CTRL                 ;  21/15 ___ctrl_U___
+        .byte   CT_CTRL                 ;  22/16 ___ctrl_V___
+        .byte   CT_CTRL                 ;  23/17 ___ctrl_W___
+        .byte   CT_CTRL                 ;  24/18 ___ctrl_X___
+        .byte   CT_CTRL                 ;  25/19 ___ctrl_Y___
+        .byte   CT_CTRL                 ;  26/1a ___ctrl_Z___
+        .byte   CT_CTRL                 ;  27/1b ___ctrl_[___
+        .byte   CT_CTRL                 ;  28/1c ___ctrl_\___
+        .byte   CT_CTRL                 ;  29/1d ___ctrl_]___
+        .byte   CT_CTRL                 ;  30/1e ___ctrl_^___
+        .byte   CT_CTRL                 ;  31/1f ___ctrl_____
+        .byte   CT_SPACE | CT_SPACE_TAB ;  32/20 ___SPACE___
+        .byte   CT_NONE                 ;  33/21 _____!_____
+        .byte   CT_NONE                 ;  34/22 _____"_____
+        .byte   CT_NONE                 ;  35/23 _____#_____
+        .byte   CT_NONE                 ;  36/24 _____$_____
+        .byte   CT_NONE                 ;  37/25 _____%_____
+        .byte   CT_NONE                 ;  38/26 _____&_____
+        .byte   CT_NONE                 ;  39/27 _____'_____
+        .byte   CT_NONE                 ;  40/28 _____(_____
+        .byte   CT_NONE                 ;  41/29 _____)_____
+        .byte   CT_NONE                 ;  42/2a _____*_____
+        .byte   CT_NONE                 ;  43/2b _____+_____
+        .byte   CT_NONE                 ;  44/2c _____,_____
+        .byte   CT_NONE                 ;  45/2d _____-_____
+        .byte   CT_NONE                 ;  46/2e _____._____
+        .byte   CT_NONE                 ;  47/2f _____/_____
+        .byte   CT_DIGIT | CT_XDIGIT    ;  48/30 _____0_____
+        .byte   CT_DIGIT | CT_XDIGIT    ;  49/31 _____1_____
+        .byte   CT_DIGIT | CT_XDIGIT    ;  50/32 _____2_____
+        .byte   CT_DIGIT | CT_XDIGIT    ;  51/33 _____3_____
+        .byte   CT_DIGIT | CT_XDIGIT    ;  52/34 _____4_____
+        .byte   CT_DIGIT | CT_XDIGIT    ;  53/35 _____5_____
+        .byte   CT_DIGIT | CT_XDIGIT    ;  54/36 _____6_____
+        .byte   CT_DIGIT | CT_XDIGIT    ;  55/37 _____7_____
+        .byte   CT_DIGIT | CT_XDIGIT    ;  56/38 _____8_____
+        .byte   CT_DIGIT | CT_XDIGIT    ;  57/39 _____9_____
+        .byte   CT_NONE                 ;  58/3a _____:_____
+        .byte   CT_NONE                 ;  59/3b _____;_____
+        .byte   CT_NONE                 ;  60/3c _____<_____
+        .byte   CT_NONE                 ;  61/3d _____=_____
+        .byte   CT_NONE                 ;  62/3e _____>_____
+        .byte   CT_NONE                 ;  63/3f _____?_____
+
+        .byte   CT_NONE                 ;  64/40 _____@_____
+        .byte   CT_UPPER | CT_XDIGIT    ;  65/41 _____A_____
+        .byte   CT_UPPER | CT_XDIGIT    ;  66/42 _____B_____
+        .byte   CT_UPPER | CT_XDIGIT    ;  67/43 _____C_____
+        .byte   CT_UPPER | CT_XDIGIT    ;  68/44 _____D_____
+        .byte   CT_UPPER | CT_XDIGIT    ;  69/45 _____E_____
+        .byte   CT_UPPER | CT_XDIGIT    ;  70/46 _____F_____
+        .byte   CT_UPPER                ;  71/47 _____G_____
+        .byte   CT_UPPER                ;  72/48 _____H_____
+        .byte   CT_UPPER                ;  73/49 _____I_____
+        .byte   CT_UPPER                ;  74/4a _____J_____
+        .byte   CT_UPPER                ;  75/4b _____K_____
+        .byte   CT_UPPER                ;  76/4c _____L_____
+        .byte   CT_UPPER                ;  77/4d _____M_____
+        .byte   CT_UPPER                ;  78/4e _____N_____
+        .byte   CT_UPPER                ;  79/4f _____O_____
+        .byte   CT_UPPER                ;  80/50 _____P_____
+        .byte   CT_UPPER                ;  81/51 _____Q_____
+        .byte   CT_UPPER                ;  82/52 _____R_____
+        .byte   CT_UPPER                ;  83/53 _____S_____
+        .byte   CT_UPPER                ;  84/54 _____T_____
+        .byte   CT_UPPER                ;  85/55 _____U_____
+        .byte   CT_UPPER                ;  86/56 _____V_____
+        .byte   CT_UPPER                ;  87/57 _____W_____
+        .byte   CT_UPPER                ;  88/58 _____X_____
+        .byte   CT_UPPER                ;  89/59 _____Y_____
+        .byte   CT_UPPER                ;  90/5a _____Z_____
+        .byte   CT_NONE                 ;  91/5b _____[_____
+        .byte   CT_NONE                 ;  92/5c _____\_____
+        .byte   CT_NONE                 ;  93/5d _____]_____
+        .byte   CT_NONE                 ;  94/5e _____^_____
+        .byte   CT_NONE                 ;  95/5f _UNDERLINE_
+        .byte   CT_NONE                 ;  96/60 ___grave___
+        .byte   CT_LOWER | CT_XDIGIT    ;  97/61 _____a_____
+        .byte   CT_LOWER | CT_XDIGIT    ;  98/62 _____b_____
+        .byte   CT_LOWER | CT_XDIGIT    ;  99/63 _____c_____
+        .byte   CT_LOWER | CT_XDIGIT    ; 100/64 _____d_____
+        .byte   CT_LOWER | CT_XDIGIT    ; 101/65 _____e_____
+        .byte   CT_LOWER | CT_XDIGIT    ; 102/66 _____f_____
+        .byte   CT_LOWER                ; 103/67 _____g_____
+        .byte   CT_LOWER                ; 104/68 _____h_____
+        .byte   CT_LOWER                ; 105/69 _____i_____
+        .byte   CT_LOWER                ; 106/6a _____j_____
+        .byte   CT_LOWER                ; 107/6b _____k_____
+        .byte   CT_LOWER                ; 108/6c _____l_____
+        .byte   CT_LOWER                ; 109/6d _____m_____
+        .byte   CT_LOWER                ; 110/6e _____n_____
+        .byte   CT_LOWER                ; 111/6f _____o_____
+        .byte   CT_LOWER                ; 112/70 _____p_____
+        .byte   CT_LOWER                ; 113/71 _____q_____
+        .byte   CT_LOWER                ; 114/72 _____r_____
+        .byte   CT_LOWER                ; 115/73 _____s_____
+        .byte   CT_LOWER                ; 116/74 _____t_____
+        .byte   CT_LOWER                ; 117/75 _____u_____
+        .byte   CT_LOWER                ; 118/76 _____v_____
+        .byte   CT_LOWER                ; 119/77 _____w_____
+        .byte   CT_LOWER                ; 120/78 _____x_____
+        .byte   CT_LOWER                ; 121/79 _____y_____
+        .byte   CT_LOWER                ; 122/7a _____z_____
+        .byte   CT_NONE                 ; 123/7b _____{_____
+        .byte   CT_NONE                 ; 124/7c _____|_____
+        .byte   CT_NONE                 ; 125/7d _____}_____
+        .byte   CT_NONE                 ; 126/7e _____~_____
+        .byte   CT_OTHER_WS             ; 127/7f ____DEL____
+
+        .res    128, CT_NONE            ; 128-255

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -380,19 +380,14 @@ static void CmdPrint (CmdDesc* Cmd, FILE* F)
 static void SetTargetFiles (void)
 /* Set the target system files */
 {
-    /* Determine the names of the target specific library file */
-    if (Target != TGT_NONE) {
+    /* Get a pointer to the system name and its length */
+    const char* TargetName = GetTargetName (Target);
+    unsigned    TargetNameLen = strlen (TargetName);
 
-        /* Get a pointer to the system name and its length */
-        const char* TargetName = GetTargetName (Target);
-        unsigned    TargetNameLen = strlen (TargetName);
-
-        /* Set the library file */
-        TargetLib = xmalloc (TargetNameLen + 4 + 1);
-        memcpy (TargetLib, TargetName, TargetNameLen);
-        strcpy (TargetLib + TargetNameLen, ".lib");
-
-    }
+    /* Set the library file */
+    TargetLib = xmalloc (TargetNameLen + 4 + 1);
+    memcpy (TargetLib, TargetName, TargetNameLen);
+    strcpy (TargetLib + TargetNameLen, ".lib");
 }
 
 


### PR DESCRIPTION
Adds `none.lib` which contains the cc65 library without any platform specific code.
Its only purpose is to be used for porting cc65 to a new platform out-of-tree and the user needs to supply a `crt0.o` module for the library to work.