### PR TITLE
Guard against ld65 crashes when LineInfos is empty

### DIFF
--- a/src/ld65/lineinfo.h
+++ b/src/ld65/lineinfo.h
@@ -155,11 +155,13 @@ INLINE const char* GetSourceNameFromList (const Collection* LineInfos)
 /* Return the name of a source file from a list of line infos */
 {
     /* The relevant entry is in slot zero */
-    return GetSourceName (CollConstAt (LineInfos, 0));
+    return CollCount(LineInfos) ? GetSourceName (CollConstAt (LineInfos, 0)) :
+                                  "<unknown>";
 }
 #else
 #  define GetSourceNameFromList(LineInfos)      \
-        GetSourceName ((const LineInfo*) CollConstAt ((LineInfos), 0))
+        (CollCount(LineInfos) ? GetSourceName ( \
+            (const LineInfo*) CollConstAt ((LineInfos), 0)) : "<unknown>")
 #endif
 
 #if defined(HAVE_INLINE)
@@ -167,11 +169,13 @@ INLINE unsigned GetSourceLineFromList (const Collection* LineInfos)
 /* Return the source file line from a list of line infos */
 {
     /* The relevant entry is in slot zero */
-    return GetSourceLine (CollConstAt (LineInfos, 0));
+    return CollCount(LineInfos) ? GetSourceLine (CollConstAt (LineInfos, 0)) :
+                                  0;
 }
 #else
 #  define GetSourceLineFromList(LineInfos)      \
-        GetSourceLine ((const LineInfo*) CollConstAt ((LineInfos), 0))
+        (CollCount(LineInfos) ? GetSourceLine ( \
+            (const LineInfo*) CollConstAt ((LineInfos), 0)) : 0)
 #endif
 
 unsigned LineInfoCount (void);


### PR DESCRIPTION
Certain code paths in error handling can attempt to get source line info with empty LineInfos lists. This causes a precondition failure on the collection lookup.

The specific code path that was triggering this for me was a data segment containing a single condes table as the only data, meaning that there were no lines in the LineInfos collection. When the error handling in segments.c for SEG_EXPR_RANGE_ERROR (and others) triggered on the segment (for unrelated reasons) I got a precondition failure instead of a helpful error message. Other cases that create segments with no lines would also likely trigger similar errors elsewhere.