### PR TITLE
Change the type of a cc65 variable that holds both integers and pointers.

### DIFF
--- a/src/cc65/codegen.c
+++ b/src/cc65/codegen.c
@@ -40,6 +40,7 @@
 /* common */
 #include "check.h"
 #include "cpu.h"
+#include "inttypes.h"
 #include "strbuf.h"
 #include "xmalloc.h"
 #include "xsprintf.h"
@@ -92,7 +93,7 @@ static void CheckLocalOffs (unsigned Offs)
 
 
 
-static const char* GetLabelName (unsigned Flags, unsigned long Label, long Offs)
+static const char* GetLabelName (unsigned Flags, uintptr_t Label, long Offs)
 {
     static char Buf [256];              /* Label name */
 
@@ -119,7 +120,7 @@ static const char* GetLabelName (unsigned Flags, unsigned long Label, long Offs)
 
         case CF_ABSOLUTE:
             /* Absolute address */
-            xsprintf (Buf, sizeof (Buf), "$%04X", (int)((Label+Offs) & 0xFFFF));
+            xsprintf (Buf, sizeof (Buf), "$%04X", (unsigned)((Label+Offs) & 0xFFFF));
             break;
 
         case CF_REGVAR:
@@ -729,7 +730,7 @@ void g_getimmed (unsigned Flags, unsigned long Val, long Offs)
 
 
 
-void g_getstatic (unsigned flags, unsigned long label, long offs)
+void g_getstatic (unsigned flags, uintptr_t label, long offs)
 /* Fetch an static memory cell into the primary register */
 {
     /* Create the correct label name */
@@ -1008,7 +1009,7 @@ void g_leavariadic (int Offs)
 
 
 
-void g_putstatic (unsigned flags, unsigned long label, long offs)
+void g_putstatic (unsigned flags, uintptr_t label, long offs)
 /* Store the primary register into the specified static memory cell */
 {
     /* Create the correct label name */
@@ -1584,7 +1585,7 @@ void g_addlocal (unsigned flags, int offs)
 
 
 
-void g_addstatic (unsigned flags, unsigned long label, long offs)
+void g_addstatic (unsigned flags, uintptr_t label, long offs)
 /* Add a static variable to ax */
 {
     unsigned L;
@@ -1634,7 +1635,7 @@ void g_addstatic (unsigned flags, unsigned long label, long offs)
 
 
 
-void g_addeqstatic (unsigned flags, unsigned long label, long offs,
+void g_addeqstatic (unsigned flags, uintptr_t label, long offs,
                     unsigned long val)
 /* Emit += for a static variable */
 {
@@ -1857,7 +1858,7 @@ void g_addeqind (unsigned flags, unsigned offs, unsigned long val)
 
 
 
-void g_subeqstatic (unsigned flags, unsigned long label, long offs,
+void g_subeqstatic (unsigned flags, uintptr_t label, long offs,
                     unsigned long val)
 /* Emit -= for a static variable */
 {
@@ -2093,7 +2094,7 @@ void g_addaddr_local (unsigned flags attribute ((unused)), int offs)
 
 
 
-void g_addaddr_static (unsigned flags, unsigned long label, long offs)
+void g_addaddr_static (unsigned flags, uintptr_t label, long offs)
 /* Add the address of a static variable to ax */
 {
     /* Create the correct label name */
@@ -4276,7 +4277,7 @@ void g_initstatic (unsigned InitLabel, unsigned VarLabel, unsigned Size)
         g_getimmed (CF_STATIC, InitLabel, 0);
         AddCodeLine ("jsr pushax");
         g_getimmed (CF_INT | CF_UNSIGNED | CF_CONST, Size, 0);
-        AddCodeLine ("jsr %s", GetLabelName (CF_EXTERNAL, (unsigned long) "memcpy", 0));
+        AddCodeLine ("jsr %s", GetLabelName (CF_EXTERNAL, (uintptr_t) "memcpy", 0));
     }
 }
 

--- a/src/cc65/codegen.h
+++ b/src/cc65/codegen.h
@@ -40,6 +40,7 @@
 
 /* common */
 #include "coll.h"
+#include "inttypes.h"
 
 /* cc65 */
 #include "segments.h"
@@ -266,7 +267,7 @@ void g_restore_regvars (int StackOffs, int RegOffs, unsigned Bytes);
 void g_getimmed (unsigned Flags, unsigned long Val, long Offs);
 /* Load a constant into the primary register */
 
-void g_getstatic (unsigned Flags, unsigned long Label, long Offs);
+void g_getstatic (unsigned Flags, uintptr_t Label, long Offs);
 /* Fetch an static memory cell into the primary register */
 
 void g_getlocal (unsigned Flags, int Offs);
@@ -293,7 +294,7 @@ void g_leavariadic (int Offs);
 
 
 
-void g_putstatic (unsigned flags, unsigned long label, long offs);
+void g_putstatic (unsigned flags, uintptr_t label, long offs);
 /* Store the primary register into the specified static memory cell */
 
 void g_putlocal (unsigned Flags, int Offs, long Val);
@@ -315,7 +316,7 @@ void g_putind (unsigned flags, unsigned offs);
 void g_addlocal (unsigned flags, int offs);
 /* Add a local variable to ax */
 
-void g_addstatic (unsigned flags, unsigned long label, long offs);
+void g_addstatic (unsigned flags, uintptr_t label, long offs);
 /* Add a static variable to ax */
 
 
@@ -326,7 +327,7 @@ void g_addstatic (unsigned flags, unsigned long label, long offs);
 
 
 
-void g_addeqstatic (unsigned flags, unsigned long label, long offs,
+void g_addeqstatic (unsigned flags, uintptr_t label, long offs,
                     unsigned long val);
 /* Emit += for a static variable */
 
@@ -336,7 +337,7 @@ void g_addeqlocal (unsigned flags, int offs, unsigned long val);
 void g_addeqind (unsigned flags, unsigned offs, unsigned long val);
 /* Emit += for the location with address in ax */
 
-void g_subeqstatic (unsigned flags, unsigned long label, long offs,
+void g_subeqstatic (unsigned flags, uintptr_t label, long offs,
                     unsigned long val);
 /* Emit -= for a static variable */
 
@@ -357,7 +358,7 @@ void g_subeqind (unsigned flags, unsigned offs, unsigned long val);
 void g_addaddr_local (unsigned flags, int offs);
 /* Add the address of a local variable to ax */
 
-void g_addaddr_static (unsigned flags, unsigned long label, long offs);
+void g_addaddr_static (unsigned flags, uintptr_t label, long offs);
 /* Add the address of a static variable to ax */
 
 

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1,7 +1,7 @@
 /* expr.c
 **
 ** 1998-06-21, Ullrich von Bassewitz
-** 2015-06-26, Greg King
+** 2017-12-05, Greg King
 */
 
 
@@ -731,7 +731,7 @@ static void Primary (ExprDesc* E)
                 } else if ((Sym->Flags & SC_FUNC) == SC_FUNC) {
                     /* Function */
                     E->Flags = E_LOC_GLOBAL | E_RTYPE_LVAL;
-                    E->Name = (unsigned long) Sym->Name;
+                    E->Name = (uintptr_t) Sym->Name;
                 } else if ((Sym->Flags & SC_AUTO) == SC_AUTO) {
                     /* Local variable. If this is a parameter for a variadic
                     ** function, we have to add some address calculations, and the
@@ -754,7 +754,7 @@ static void Primary (ExprDesc* E)
                     /* Static variable */
                     if (Sym->Flags & (SC_EXTERN | SC_STORAGE)) {
                         E->Flags = E_LOC_GLOBAL | E_RTYPE_LVAL;
-                        E->Name = (unsigned long) Sym->Name;
+                        E->Name = (uintptr_t) Sym->Name;
                     } else {
                         E->Flags = E_LOC_STATIC | E_RTYPE_LVAL;
                         E->Name = Sym->V.Label;
@@ -798,7 +798,7 @@ static void Primary (ExprDesc* E)
                     Sym = AddGlobalSym (Ident, GetImplicitFuncType(), SC_EXTERN | SC_REF | SC_FUNC);
                     E->Type  = Sym->Type;
                     E->Flags = E_LOC_GLOBAL | E_RTYPE_RVAL;
-                    E->Name  = (unsigned long) Sym->Name;
+                    E->Name  = (uintptr_t) Sym->Name;
                 } else {
                     /* Undeclared Variable */
                     Sym = AddLocalSym (Ident, type_int, SC_AUTO | SC_REF, 0);
@@ -1308,7 +1308,7 @@ static void hie11 (ExprDesc *Expr)
                     ** Since we don't have a name, invent one.
                     */
                     ED_MakeConstAbs (Expr, 0, GetImplicitFuncType ());
-                    Expr->Name = (long) IllegalFunc;
+                    Expr->Name = (uintptr_t) IllegalFunc;
                 }
                 /* Call the function */
                 FunctionCall (Expr);

--- a/src/cc65/exprdesc.c
+++ b/src/cc65/exprdesc.c
@@ -44,7 +44,6 @@
 #include "exprdesc.h"
 #include "stackptr.h"
 #include "symentry.h"
-#include "exprdesc.h"
 
 
 
@@ -361,7 +360,7 @@ void PrintExprDesc (FILE* F, ExprDesc* E)
     if (Sep != '(') {
         fputc (')', F);
     }
-    fprintf (F, "\nName:     0x%08lX\n", E->Name);
+    fprintf (F, "\nName:     0x%08lX\n", (unsigned long)E->Name);
 }
 
 

--- a/src/cc65/exprdesc.h
+++ b/src/cc65/exprdesc.h
@@ -43,6 +43,7 @@
 /* common */
 #include "fp.h"
 #include "inline.h"
+#include "inttypes.h"
 
 /* cc65 */
 #include "asmcode.h"
@@ -98,7 +99,7 @@ struct ExprDesc {
     struct SymEntry*    Sym;            /* Symbol table entry if known */
     Type*               Type;           /* Type array of expression */
     unsigned            Flags;
-    unsigned long       Name;           /* Name or label number */
+    uintptr_t           Name;           /* Name pointer or label number */
     long                IVal;           /* Integer value if expression constant */
     Double              FVal;           /* Floating point value */
     struct Literal*     LVal;           /* Literal value */

--- a/src/common/inttypes.h
+++ b/src/common/inttypes.h
@@ -38,29 +38,28 @@
 
 
 
-/* If we have stdint.h, include it, otherwise try some quesswork on types.
+/* If we have <stdint.h>, include it; otherwise, adapt types from <stddef.h>.
 ** gcc and msvc don't define __STDC_VERSION__ without special flags, so check
-** for them explicitly. Undefined symbols are replaced by zero, so a check for
-** defined(__GNUC__) or defined(_MSC_VER) is not necessary.
+** for them explicitly.  Undefined symbols are replaced by zero; so, checks for
+** defined(__GNUC__) and defined(_MSC_VER) aren't necessary.
 */
 #if (__STDC_VERSION__ >= 199901) || (__GNUC__ >= 3) || (_MSC_VER >= 1600)
 #include <stdint.h>
 #else
 
-/* Assume long is the largest type available, and assume that pointers can be
-** safely converted into this type and back.
+/* Assume that ptrdiff_t and size_t are wide enough to hold pointers.
+** Assume that they are the widest type.
 */
-typedef long intptr_t;
-typedef unsigned long uintptr_t;
-typedef long intmax_t;
-typedef unsigned long uintmax_t;
+#include <stddef.h>
 
-
+typedef ptrdiff_t intptr_t;
+typedef size_t uintptr_t;
+typedef ptrdiff_t intmax_t;
+typedef size_t uintmax_t;
 
 #endif
 
 
 
 /* End of inttypes.h */
-
 #endif


### PR DESCRIPTION
The change avoids possible pointer truncation on 64-bit MS Windows.