### PR TITLE
Change none.cfg's "__STACKSTART__" to "__HIMEM__".

### DIFF
--- a/cfg/none.cfg
+++ b/cfg/none.cfg
@@ -2,13 +2,13 @@ FEATURES {
     STARTADDRESS: default = $1000;
 }
 SYMBOLS {
-    __STACKSIZE__:  type = weak, value = $0800; # 2k stack
-    __STACKSTART__: type = weak, value = $8000;
-    __ZPSTART__:    type = weak, value = $0080;
+    __STACKSIZE__: type = weak, value = $0800; # 2k stack
+    __HIMEM__:     type = weak, value = $8000;
+    __ZPSTART__:   type = weak, value = $0080;
 }
 MEMORY {
     ZP:   file = "", define = yes, start = __ZPSTART__, size = $001F;
-    MAIN: file = %O,               start = %S,          size = __STACKSTART__ - __STACKSIZE__ - %S;
+    MAIN: file = %O,               start = %S,          size = __HIMEM__ - __STACKSIZE__ - %S;
 }
 SEGMENTS {
     ZEROPAGE: load = ZP,   type = zp;


### PR DESCRIPTION
Other configure files that let the command line control the size of the `main:` memory area use the name `__HIMEM__` to set where the top of RAM is.  This PR makes `none.cfg` be consistent with them.