### PR TITLE
atari5200: put default display list into its own memory area

### DIFF
--- a/cfg/atari5200.cfg
+++ b/cfg/atari5200.cfg
@@ -1,16 +1,18 @@
 SYMBOLS {
     __CARTSIZE__:        type = weak,   value = $4000;   # possible values: $4000 and $8000
+    __DLISTSIZE__:       type = weak,   value = $0000;
     __CART_ENTRY__:      type = import;
     __STACKSIZE__:       type = weak,   value = $0400;   # 4 pages stack
     __RESERVED_MEMORY__: type = export, value = $01E0;   # space for 20x24 screen buffer (default display list is in ROM)
 }
 MEMORY {
-    ZP:        file = "", start = $001D,                size = $00E3,                                               define = yes;
-    RAM:       file = "", start = $021C,                size = $4000 - __STACKSIZE__ - __RESERVED_MEMORY__ - $021C, define = yes;
-    ROM:       file = %O, start = $C000 - __CARTSIZE__, size = __CARTSIZE__ - $18,                                  define = yes, fill = yes, fillval = $FF;
-    CARTNAME:  file = %O, start = $BFE8,                size = $0014                                                              fill = yes, fillval = $40;
-    CARTYEAR:  file = %O, start = $BFFC,                size = $0002                                                              fill = yes, fillval = $59;
-    CARTENTRY: file = %O, start = $BFFE,                size = $0002;
+    ZP:        file = "", start = $001D,                 size = $00E3,                                               define = yes;
+    RAM:       file = "", start = $021C,                 size = $4000 - __STACKSIZE__ - __RESERVED_MEMORY__ - $021C, define = yes;
+    ROM:       file = %O, start = $C000 - __CARTSIZE__,  size = __CARTSIZE__ - __DLISTSIZE__ - $18,                  define = yes, fill = yes, fillval = $FF;
+    DLIST:     file = %O, start = $BFE8 - __DLISTSIZE__, size = __DLISTSIZE__;
+    CARTNAME:  file = %O, start = $BFE8,                 size = $0014                                                              fill = yes, fillval = $40;
+    CARTYEAR:  file = %O, start = $BFFC,                 size = $0002                                                              fill = yes, fillval = $59;
+    CARTENTRY: file = %O, start = $BFFE,                 size = $0002;
 }
 SEGMENTS {
     ZEROPAGE:  load = ZP,             type = zp,                optional = yes;
@@ -22,6 +24,7 @@ SEGMENTS {
     RODATA:    load = ROM,            type = ro,                optional = yes;
     DATA:      load = ROM, run = RAM, type = rw,  define = yes, optional = yes;
     BSS:       load = RAM,            type = bss, define = yes, optional = yes;
+    DLIST:     load = DLIST,          type = ro,  define = yes, optional = yes;
     CARTNAME:  load = CARTNAME,       type = ro,  define = yes;
     CARTYEAR:  load = CARTYEAR,       type = ro,  define = yes;
     CARTENTRY: load = CARTENTRY,      type = ro,  define = yes;

--- a/cfg/atari5200.cfg
+++ b/cfg/atari5200.cfg
@@ -1,6 +1,5 @@
 SYMBOLS {
     __CARTSIZE__:        type = weak,   value = $4000;   # possible values: $4000 and $8000
-    __DLISTSIZE__:       type = weak,   value = $0000;
     __CART_ENTRY__:      type = import;
     __STACKSIZE__:       type = weak,   value = $0400;   # 4 pages stack
     __RESERVED_MEMORY__: type = export, value = $01E0;   # space for 20x24 screen buffer (default display list is in ROM)
@@ -8,8 +7,7 @@ SYMBOLS {
 MEMORY {
     ZP:        file = "", start = $001D,                 size = $00E3,                                               define = yes;
     RAM:       file = "", start = $021C,                 size = $4000 - __STACKSIZE__ - __RESERVED_MEMORY__ - $021C, define = yes;
-    ROM:       file = %O, start = $C000 - __CARTSIZE__,  size = __CARTSIZE__ - __DLISTSIZE__ - $18,                  define = yes, fill = yes, fillval = $FF;
-    DLIST:     file = %O, start = $BFE8 - __DLISTSIZE__, size = __DLISTSIZE__;
+    ROM:       file = %O, start = $C000 - __CARTSIZE__,  size = __CARTSIZE__ - $18,                                  define = yes, fill = yes, fillval = $FF;
     CARTNAME:  file = %O, start = $BFE8,                 size = $0014                                                              fill = yes, fillval = $40;
     CARTYEAR:  file = %O, start = $BFFC,                 size = $0002                                                              fill = yes, fillval = $59;
     CARTENTRY: file = %O, start = $BFFE,                 size = $0002;
@@ -17,6 +15,7 @@ MEMORY {
 SEGMENTS {
     ZEROPAGE:  load = ZP,             type = zp,                optional = yes;
     EXTZP:     load = ZP,             type = zp,                optional = yes;
+    DLIST:     load = ROM  ,          type = ro,  define = yes, optional = yes;
     STARTUP:   load = ROM,            type = ro,  define = yes, optional = yes;
     LOWCODE:   load = ROM,            type = ro,  define = yes, optional = yes;
     ONCE:      load = ROM,            type = ro,                optional = yes;
@@ -24,10 +23,9 @@ SEGMENTS {
     RODATA:    load = ROM,            type = ro,                optional = yes;
     DATA:      load = ROM, run = RAM, type = rw,  define = yes, optional = yes;
     BSS:       load = RAM,            type = bss, define = yes, optional = yes;
-    DLIST:     load = DLIST,          type = ro,  define = yes, optional = yes;
-    CARTNAME:  load = CARTNAME,       type = ro,  define = yes;
-    CARTYEAR:  load = CARTYEAR,       type = ro,  define = yes;
-    CARTENTRY: load = CARTENTRY,      type = ro,  define = yes;
+    CARTNAME:  load = CARTNAME,       type = ro;
+    CARTYEAR:  load = CARTYEAR,       type = ro;
+    CARTENTRY: load = CARTENTRY,      type = ro;
 }
 FEATURES {
     CONDES: type    = constructor,

--- a/cfg/atari5200.cfg
+++ b/cfg/atari5200.cfg
@@ -5,12 +5,12 @@ SYMBOLS {
     __RESERVED_MEMORY__: type = export, value = $01E0;   # space for 20x24 screen buffer (default display list is in ROM)
 }
 MEMORY {
-    ZP:        file = "", start = $001D,                 size = $00E3,                                               define = yes;
-    RAM:       file = "", start = $021C,                 size = $4000 - __STACKSIZE__ - __RESERVED_MEMORY__ - $021C, define = yes;
-    ROM:       file = %O, start = $C000 - __CARTSIZE__,  size = __CARTSIZE__ - $18,                                  define = yes, fill = yes, fillval = $FF;
-    CARTNAME:  file = %O, start = $BFE8,                 size = $0014                                                              fill = yes, fillval = $40;
-    CARTYEAR:  file = %O, start = $BFFC,                 size = $0002                                                              fill = yes, fillval = $59;
-    CARTENTRY: file = %O, start = $BFFE,                 size = $0002;
+    ZP:        file = "", start = $001D,                size = $00E3,                                               define = yes;
+    RAM:       file = "", start = $021C,                size = $4000 - __STACKSIZE__ - __RESERVED_MEMORY__ - $021C, define = yes;
+    ROM:       file = %O, start = $C000 - __CARTSIZE__, size = __CARTSIZE__ - $18,                                  define = yes, fill = yes, fillval = $FF;
+    CARTNAME:  file = %O, start = $BFE8,                size = $0014                                                              fill = yes, fillval = $40;
+    CARTYEAR:  file = %O, start = $BFFC,                size = $0002                                                              fill = yes, fillval = $59;
+    CARTENTRY: file = %O, start = $BFFE,                size = $0002;
 }
 SEGMENTS {
     ZEROPAGE:  load = ZP,             type = zp,                optional = yes;

--- a/libsrc/atari5200/conioscreen.s
+++ b/libsrc/atari5200/conioscreen.s
@@ -58,7 +58,7 @@ clrscr:         sta     (SAVMSC),y
                 rts
 
 
-                .segment "RODATA"
+                .segment "DLIST"
 
 ; display list for 20x24 text mode
 
@@ -77,6 +77,9 @@ dlist:          .repeat 3
                 .word   dlist
 
 ; end of display list
+
+.export         __DLISTSIZE__
+__DLISTSIZE__   = * - dlist
 
 .assert ((* >> 10) = (dlist >> 10)), error, "Display list crosses 1K boundary"
 

--- a/libsrc/atari5200/conioscreen.s
+++ b/libsrc/atari5200/conioscreen.s
@@ -78,9 +78,6 @@ dlist:          .repeat 3
 
 ; end of display list
 
-.export         __DLISTSIZE__
-__DLISTSIZE__   = * - dlist
-
 .assert ((* >> 10) = (dlist >> 10)), error, "Display list crosses 1K boundary"
 
                 .end


### PR DESCRIPTION
This avoids 1K boundary crossing of the display list. Fixes #560.