### PR TITLE
Moved initcgetc to initcputc

### DIFF
--- a/libsrc/atmos/cgetc.s
+++ b/libsrc/atmos/cgetc.s
@@ -6,7 +6,6 @@
 ;
 
         .export         _cgetc
-        .constructor    initcgetc
 
         .import         cursor
         .forceimport    disable_caps
@@ -53,14 +52,3 @@
 @L3:    rts
 
 .endproc
-
-; ------------------------------------------------------------------------
-; Switch the cursor off. Code goes into the ONCE segment,
-; which will be reused after it is run.
-
-.segment        "ONCE"
-
-initcgetc:
-        lsr     STATUS
-        asl     STATUS          ; Clear bit zero
-        rts

--- a/libsrc/atmos/cputc.s
+++ b/libsrc/atmos/cputc.s
@@ -8,6 +8,7 @@
 
         .export         _cputcxy, _cputc
         .export         setscrptr, putchar
+        .constructor    initcputc
         .import         rvs
         .import         popax
         .importzp       ptr2
@@ -95,3 +96,13 @@ ScrTabHi:
                 .byte   >(SCREEN + Line * SCREEN_XSIZE)
         .endrep
 
+; ------------------------------------------------------------------------
+; Switch the cursor off. Code goes into the ONCE segment,
+; which will be reused after it is run.
+
+.segment        "ONCE"
+
+initcputc:
+        lsr     STATUS
+        asl     STATUS          ; Clear bit zero
+        rts


### PR DESCRIPTION
joy-test.c doesn't use cgetc therefore the output is corrupted by the cursor.
Related to #497