### PR TITLE
Fix how the PC-Engine calls functions through pointers.

### DIFF
--- a/libsrc/pce/call.s
+++ b/libsrc/pce/call.s
@@ -1,0 +1,16 @@
+;
+; CC65 runtime: call function via pointer in ax
+;
+; 1998-08-06, Ullrich von Bassewitz
+; 2018-02-28, Greg King
+;
+
+        .export         callax
+        .importzp       ptr1
+
+callax: sta     ptr1
+        stx     ptr1+1
+
+; The PC-Engine puts the zero-page at $2000.
+
+        jmp     (ptr1 + $2000)  ; go there

--- a/libsrc/pce/callptr4.s
+++ b/libsrc/pce/callptr4.s
@@ -1,0 +1,14 @@
+;
+; CC65 runtime: call function via pointer in ptr4
+;
+; 2018-02-28, Greg King
+;
+
+        .export         callptr4
+        .importzp       ptr4
+
+callptr4:
+
+; The PC-Engine puts the zero-page at $2000.
+
+        jmp     (ptr4 + $2000)


### PR DESCRIPTION
The problem was mentioned by @EtchedPixels in #498.

Two call functions in the `runtime` library are used to call functions through pointers.  They store the pointer in zero-page variables; then, jump indirectly through those variables.

But, the HuC6280 CPU makes zero-page addressing modes go to addresses $2000 - $20FF.  Most other addressing modes aren't redirected.  Therefore, the indirect jumps don't access the same locations that the zero-page store instructions access.  Programs that use function pointers will crash on the PC-Engine.

This patch substitutes, on the PC-Engine, library functions that jump through locations in $2000 - $20FF instead of $0000 - $00FF.

Fixes #596.