### PR TITLE
Improved tv timing detection for the c64.

### DIFF
--- a/asminc/get_tv.inc
+++ b/asminc/get_tv.inc
@@ -11,6 +11,8 @@
 .enum TV
     NTSC
     PAL
+    NTSC_OLD
+    PAL_N
     OTHER
 .endenum
 

--- a/include/cbm.h
+++ b/include/cbm.h
@@ -150,7 +150,9 @@ struct cbm_dirent {
 
 #define TV_NTSC         0
 #define TV_PAL          1
-#define TV_OTHER        2
+#define TV_NTSC_OLD     2
+#define TV_PAL_N        3
+#define TV_OTHER        4
 
 unsigned char get_tv (void);
 /* Return the video mode the machine is using. */

--- a/libsrc/c64/get_tv.s
+++ b/libsrc/c64/get_tv.s
@@ -4,6 +4,11 @@
 ; unsigned char get_tv (void);
 ; /* Return the video mode the machine is using */
 ;
+; Changed to actually detect the mode instead of using a flag
+; Marco van den Heuvel, 2018-03-08
+;
+; The detection goes wrong on accelerated machines for now.
+;
 
         .include        "c64.inc"
         .include        "get_tv.inc"
@@ -13,8 +18,42 @@
 
 .proc   _get_tv
 
-        lda     PALFLAG
-        ldx     #0
+        php
+        sei
+timing_loop_0:
+        lda     VIC_HLINE
+timing_loop_1:
+        cmp     VIC_HLINE
+        beq     timing_loop_1
+        bmi     timing_loop_0
+        and     #$03
+        cmp     #$01
+        bne     check_ntsc
+        lda     #TV::NTSC_OLD         ; NTSC OLD constant
+        bne     detected
+check_ntsc:
+        cmp     #$03
+        bcc     ntsc
+
+; check for PAL and PAL-N
+
+        ldx     #$00
+        lda     #$10
+timing_loop_2:
+        inx
+        cmp     VIC_HLINE
+        bne     timing_loop_2
+        lda     #TV::PAL              ; PAL constant
+        cpx     #$70
+        bcc     detected
+        lda     #TV::PAL_N            ; PAL-N constant
+detected:
+        ldx     #$00
+        plp
         rts
+
+ntsc:
+        lda     #TV::NTSC             ; NTSC constant
+        beq     detected
 
 .endproc


### PR DESCRIPTION
Improved tv timing detection for the c64.

This does not work correctly when there is a cpu that has a turbo mode, this will be dealt with in a future pull request.