### PR TITLE
NMI-friendly c64-hi.tgi

### DIFF
--- a/libsrc/c64/tgi/c64-hi.s
+++ b/libsrc/c64/tgi/c64-hi.s
@@ -272,7 +272,7 @@ CLEAR:  ldy     #$00
         sta     VBASE+$1C00,y
         sta     VBASE+$1D00,y
         sta     VBASE+$1E00,y
-        sta     VBASE+$1F40,y   ; preserve vectors
+        sta     VBASE+$1E40,y   ; preserve vectors
         iny
         bne     @L1
         rts

--- a/libsrc/c64/tgi/c64-hi.s
+++ b/libsrc/c64/tgi/c64-hi.s
@@ -131,7 +131,7 @@ VBASE           := $E000                ; Video memory base address
 ;
 
 INSTALL:
-        rts
+;       rts                     ; fall through
 
 
 ; ------------------------------------------------------------------------
@@ -272,9 +272,12 @@ CLEAR:  ldy     #$00
         sta     VBASE+$1C00,y
         sta     VBASE+$1D00,y
         sta     VBASE+$1E00,y
-        sta     VBASE+$1F00,y
         iny
         bne     @L1
+@L2:    sta     VBASE+$1F00,y
+        iny
+        cpy     #$40
+        bne     @L2
         rts
 
 ; ------------------------------------------------------------------------
@@ -285,7 +288,7 @@ CLEAR:  ldy     #$00
 ;
 
 SETVIEWPAGE:
-        rts
+;       rts                     ; fall through
 
 ; ------------------------------------------------------------------------
 ; SETDRAWPAGE: Set the drawable page. Called with the new page in A (0..n).

--- a/libsrc/c64/tgi/c64-hi.s
+++ b/libsrc/c64/tgi/c64-hi.s
@@ -272,12 +272,9 @@ CLEAR:  ldy     #$00
         sta     VBASE+$1C00,y
         sta     VBASE+$1D00,y
         sta     VBASE+$1E00,y
+        sta     VBASE+$1F40,y   ; preserve vectors
         iny
         bne     @L1
-@L2:    sta     VBASE+$1F00,y
-        iny
-        cpy     #$40
-        bne     @L2
         rts
 
 ; ------------------------------------------------------------------------


### PR DESCRIPTION
Don't clear all vectors, see #639.