### PR TITLE
Add CBM kernal call TKSA to CBM library (see issue #525)

### DIFF
--- a/doc/c128.sgml
+++ b/doc/c128.sgml
@@ -124,6 +124,7 @@ declaration and usage.
 <item>cbm_k_basin
 <item>cbm_k_bsout
 <item>cbm_k_clrch
+<item>cbm_k_tksa
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/doc/c16.sgml
+++ b/doc/c16.sgml
@@ -115,6 +115,7 @@ declaration and usage.
 <item>cbm_k_basin
 <item>cbm_k_bsout
 <item>cbm_k_clrch
+<item>cbm_k_tksa
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/doc/c64.sgml
+++ b/doc/c64.sgml
@@ -217,6 +217,7 @@ declaration and usage.
 <item>cbm_k_basin
 <item>cbm_k_bsout
 <item>cbm_k_clrch
+<item>cbm_k_tksa
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/doc/cbm510.sgml
+++ b/doc/cbm510.sgml
@@ -118,6 +118,7 @@ declaration and usage.
 <item>cbm_k_basin
 <item>cbm_k_bsout
 <item>cbm_k_clrch
+<item>cbm_k_tksa
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/doc/cbm610.sgml
+++ b/doc/cbm610.sgml
@@ -121,6 +121,7 @@ declaration and usage.
 <item>cbm_k_basin
 <item>cbm_k_bsout
 <item>cbm_k_clrch
+<item>cbm_k_tksa
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/doc/funcref.sgml
+++ b/doc/funcref.sgml
@@ -203,6 +203,7 @@ function.
 <item><ref id="cbm_k_setlfs" name="cbm_k_setlfs">
 <item><ref id="cbm_k_setnam" name="cbm_k_setnam">
 <item><ref id="cbm_k_talk" name="cbm_k_talk">
+<item><ref id="cbm_k_tksa" name="cbm_k_tksa">
 <item><ref id="cbm_k_udtim" name="cbm_k_udtim">
 <item><ref id="cbm_k_unlsn" name="cbm_k_unlsn">
 <!-- <item><ref id="cbm_load" name="cbm_load"> -->
@@ -2279,6 +2280,28 @@ only be used in presence of a prototype.
 <tag/Availability/cc65
 <tag/See also/
 <ref id="cbm_k_acptr" name="cbm_k_acptr">
+<tag/Example/None.
+</descrip>
+</quote>
+
+
+<sect1>cbm_k_tksa<label id="cbm_k_tksa"><p>
+
+<quote>
+<descrip>
+<tag/Function/Send TALK secondary address to serial bus
+<tag/Header/<tt/<ref id="cbm.h" name="cbm.h">/
+<tag/Declaration/<tt/void __fastcall__ cbm_k_tksa (unsigned char addr);/
+<tag/Description/This function transmits a secondary address on the serial bus for a TALK device.
+<tag/Notes/<itemize>
+<item>The function is only available as fastcall function, so it may
+only be used in presence of a prototype.
+<item>The function can only be called after a call to TALK.
+<item>The function will not work after a LISTEN.
+</itemize>
+<tag/Availability/cc65
+<tag/See also/
+<ref id="cbm_k_talk" name="cbm_k_talk">
 <tag/Example/None.
 </descrip>
 </quote>

--- a/doc/pet.sgml
+++ b/doc/pet.sgml
@@ -99,6 +99,7 @@ declaration and usage.
 <item>cbm_k_basin
 <item>cbm_k_bsout
 <item>cbm_k_clrch
+<item>cbm_k_tksa
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/doc/pet.sgml
+++ b/doc/pet.sgml
@@ -99,7 +99,6 @@ declaration and usage.
 <item>cbm_k_basin
 <item>cbm_k_bsout
 <item>cbm_k_clrch
-<item>cbm_k_tksa
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/doc/plus4.sgml
+++ b/doc/plus4.sgml
@@ -113,6 +113,7 @@ declaration and usage.
 <item>cbm_k_basin
 <item>cbm_k_bsout
 <item>cbm_k_clrch
+<item>cbm_k_tksa
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/doc/vic20.sgml
+++ b/doc/vic20.sgml
@@ -99,6 +99,7 @@ declaration and usage.
 <item>cbm_k_basin
 <item>cbm_k_bsout
 <item>cbm_k_clrch
+<item>cbm_k_tksa
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/include/cbm.h
+++ b/include/cbm.h
@@ -204,6 +204,7 @@ void __fastcall__ cbm_k_setlfs (unsigned char LFN, unsigned char DEV,
                                 unsigned char SA);
 void __fastcall__ cbm_k_setnam (const char* Name);
 void __fastcall__ cbm_k_talk (unsigned char dev);
+void __fastcall__ cbm_k_tksa (unsigned char addr);
 void cbm_k_udtim (void);
 void cbm_k_unlsn (void);
 void cbm_k_untlk (void);

--- a/libsrc/cbm/c_tksa.s
+++ b/libsrc/cbm/c_tksa.s
@@ -1,0 +1,12 @@
+;
+; Bas Wassink, 22.05.2018
+;
+; void __fastcall__ cbm_k_tksa (unsigned char addr)
+;
+
+
+        .import TKSA
+        .export _cbm_k_tksa
+
+_cbm_k_tksa = TKSA
+


### PR DESCRIPTION
This commit adds the CBM kernal call TKSA as cbm_k_tksa() to the CBM library.