### PR TITLE
Add CBM kernal call SECOND to CBM library (see issue #525)

### DIFF
--- a/doc/c128.sgml
+++ b/doc/c128.sgml
@@ -125,6 +125,7 @@ declaration and usage.
 <item>cbm_k_bsout
 <item>cbm_k_clrch
 <item>cbm_k_tksa
+<item>cbm_k_second
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/doc/c16.sgml
+++ b/doc/c16.sgml
@@ -116,6 +116,7 @@ declaration and usage.
 <item>cbm_k_bsout
 <item>cbm_k_clrch
 <item>cbm_k_tksa
+<item>cbm_k_second
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/doc/c64.sgml
+++ b/doc/c64.sgml
@@ -218,6 +218,7 @@ declaration and usage.
 <item>cbm_k_bsout
 <item>cbm_k_clrch
 <item>cbm_k_tksa
+<item>cbm_k_second
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/doc/cbm510.sgml
+++ b/doc/cbm510.sgml
@@ -119,6 +119,7 @@ declaration and usage.
 <item>cbm_k_bsout
 <item>cbm_k_clrch
 <item>cbm_k_tksa
+<item>cbm_k_second
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/doc/cbm610.sgml
+++ b/doc/cbm610.sgml
@@ -122,6 +122,7 @@ declaration and usage.
 <item>cbm_k_bsout
 <item>cbm_k_clrch
 <item>cbm_k_tksa
+<item>cbm_k_second
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/doc/funcref.sgml
+++ b/doc/funcref.sgml
@@ -200,6 +200,7 @@ function.
 <item><ref id="cbm_k_readst" name="cbm_k_readst">
 <item><ref id="cbm_k_save" name="cbm_k_save">
 <item><ref id="cbm_k_scnkey" name="cbm_k_scnkey">
+<item><ref id="cbm_k_second" name="cbm_k_second">
 <item><ref id="cbm_k_setlfs" name="cbm_k_setlfs">
 <item><ref id="cbm_k_setnam" name="cbm_k_setnam">
 <item><ref id="cbm_k_talk" name="cbm_k_talk">
@@ -2220,6 +2221,31 @@ function, in order to provide input from the keyboard.
 <!-- <ref id="getc" name="getc"> -->
 <!-- <ref id="getchar" name="getchar"> -->
 <tag/Example/None.
+</descrip>
+</quote>
+
+
+<sect1>cmb_k_second<label id="cbm_k_second"><p>
+
+<quote>
+<descrip>
+<tag/Function/Send secondary address for LISTEN.
+<tag/Header/<tt/<ref id="cbm.h" name="cbm.h">/
+<tag/Declaration/<tt/void cbm_k_second (unsigned char addr);/
+<tag/Description/This function is used to send a secondary address to an I/O
+device after a call to LISTEN is made, and the device is commanded to LISTEN.
+<tag/Notes/<itemize>
+<item>The function is only available as fastcall function, so it may
+only be used in presence of a prototype.
+<item>The function can only be called after a call to LISTEN.
+<item>The function will not work after a TALK.
+<item>When a secondary address is to be sent to a device on the serial bus,
+the address must first be ORed with $60.
+</itemize>
+<tag/Availability/cc65
+<tag/See also/
+<ref id="cbm_k_listen" name="cbm_k_listen">
+<tag/Exampe/None.
 </descrip>
 </quote>
 

--- a/doc/funcref.sgml
+++ b/doc/funcref.sgml
@@ -2231,7 +2231,7 @@ function, in order to provide input from the keyboard.
 <descrip>
 <tag/Function/Send secondary address for LISTEN.
 <tag/Header/<tt/<ref id="cbm.h" name="cbm.h">/
-<tag/Declaration/<tt/void cbm_k_second (unsigned char addr);/
+<tag/Declaration/<tt/void __fastcall__ cbm_k_second (unsigned char addr);/
 <tag/Description/This function is used to send a secondary address to an I/O
 device after a call to LISTEN is made, and the device is commanded to LISTEN.
 <tag/Notes/<itemize>

--- a/doc/plus4.sgml
+++ b/doc/plus4.sgml
@@ -114,6 +114,7 @@ declaration and usage.
 <item>cbm_k_bsout
 <item>cbm_k_clrch
 <item>cbm_k_tksa
+<item>cbm_k_second
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/doc/vic20.sgml
+++ b/doc/vic20.sgml
@@ -100,6 +100,7 @@ declaration and usage.
 <item>cbm_k_bsout
 <item>cbm_k_clrch
 <item>cbm_k_tksa
+<item>cbm_k_second
 <item>cbm_load
 <item>cbm_open
 <item>cbm_opendir

--- a/include/cbm.h
+++ b/include/cbm.h
@@ -200,6 +200,7 @@ unsigned char cbm_k_open (void);
 unsigned char cbm_k_readst (void);
 unsigned char __fastcall__ cbm_k_save(unsigned int start, unsigned int end);
 void cbm_k_scnkey (void);
+void __fastcall__ cbm_k_second (unsigned char addr);
 void __fastcall__ cbm_k_setlfs (unsigned char LFN, unsigned char DEV,
                                 unsigned char SA);
 void __fastcall__ cbm_k_setnam (const char* Name);

--- a/libsrc/cbm/c_second.s
+++ b/libsrc/cbm/c_second.s
@@ -1,0 +1,12 @@
+;
+; Bas Wassink, 23.05.2018
+;
+; void __fastcall__ cbm_k_second (unsigned char addr)
+;
+
+
+        .import SECOND
+        .export _cbm_k_second
+
+_cbm_k_second = SECOND
+


### PR DESCRIPTION
This will add the CBM kernal call SECOND to the CBM library.