### PR TITLE
Fix `make` failing in parent directories containing spaces

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -64,8 +64,8 @@ endif
 
 CFLAGS += -MMD -MP -O3 -I common \
           -Wall -Wextra -Wno-char-subscripts $(USER_CFLAGS) \
-          -DCA65_INC=$(CA65_INC) -DCC65_INC=$(CC65_INC) -DCL65_TGT=$(CL65_TGT) \
-          -DLD65_LIB=$(LD65_LIB) -DLD65_OBJ=$(LD65_OBJ) -DLD65_CFG=$(LD65_CFG) \
+          -DCA65_INC="$(CA65_INC)" -DCC65_INC="$(CC65_INC)" -DCL65_TGT="$(CL65_TGT)" \
+          -DLD65_LIB="$(LD65_LIB)" -DLD65_OBJ="$(LD65_OBJ)" -DLD65_CFG="$(LD65_CFG)" \
           -DGIT_SHA=$(GIT_SHA)
 
 LDLIBS += -lm
@@ -148,7 +148,7 @@ endef # PROG_template
 
 ../wrk/%.o: %.c
 	@echo $<
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(CC) -c $(CFLAGS) -o $@ $<
 
 ../bin:
 	@$(call MKDIR,$@)

--- a/src/Makefile
+++ b/src/Makefile
@@ -148,7 +148,7 @@ endef # PROG_template
 
 ../wrk/%.o: %.c
 	@echo $<
-	$(CC) -c $(CFLAGS) -o $@ $<
+	@$(CC) -c $(CFLAGS) -o $@ $<
 
 ../bin:
 	@$(call MKDIR,$@)


### PR DESCRIPTION
Fails to build when running `make` while the repo is in a parent directory containing a space.

Output for directory `/example dir/cc65`:
```
ar65/del.c
gcc: error: dir/cc65/asminc: No such file or directory
gcc: error: dir/cc65/include: No such file or directory
gcc: error: dir/cc65/target: No such file or directory
gcc: error: dir/cc65/lib: No such file or directory
gcc: error: dir/cc65/lib: No such file or directory
gcc: error: dir/cc65/cfg: No such file or directory
make[1]: *** [Makefile:151: ../wrk/ar65/del.o] Error 1
make: *** [Makefile:6: all] Error 2
```

To replicate:
1. Clone into a directory with a space in its name
2. `cd cc65`
3. `make`