### PR TITLE
Fix joystick for the Supervision target

### DIFF
--- a/libsrc/supervision/joy/supervision-stdjoy.s
+++ b/libsrc/supervision/joy/supervision-stdjoy.s
@@ -77,5 +77,6 @@ COUNT:
 
 READJOY:
         lda     sv_control
+	eor     #$FF
         ldx     #0
         rts

--- a/libsrc/supervision/joy/supervision-stdjoy.s
+++ b/libsrc/supervision/joy/supervision-stdjoy.s
@@ -77,6 +77,6 @@ COUNT:
 
 READJOY:
         lda     sv_control
-	eor     #$FF
+        eor     #$FF
         ldx     #0
         rts


### PR DESCRIPTION
This PR fixes the Supervision joystick detection (same fix as the one I found for the Gamate target)

I have tested with my game (CROSS CHASE).
I have tested the Fire 1 button and  UP, DOWN, LEFT, RIGHT movements. 