### PR TITLE
Support for "inline parameters" of subroutines

### DIFF
--- a/doc/da65.sgml
+++ b/doc/da65.sgml
@@ -542,6 +542,18 @@ code. The following attributes are recognized:
   range, where <tt/label/ is the label name given with the <tt/NAME/
   attribute, and <tt/offs/ is the offset within the data.
 
+  <tag><tt>VOPERAND</tt></tag>
+  This optional attribute is followed by a numerical value. It tells the
+  assembler that subroutine calls to this label follow "virtual operands"
+  of the given bytes like this:
+
+<tscreen><verb>
+       	JSR	LabelWith2BytesOfVoperand
+	.byte	$00, $10    ; virtual operands
+	; return here
+	BIT	$0F
+</verb></tscreen>
+
 </descrip>
 
 

--- a/doc/da65.sgml
+++ b/doc/da65.sgml
@@ -542,16 +542,16 @@ code. The following attributes are recognized:
   range, where <tt/label/ is the label name given with the <tt/NAME/
   attribute, and <tt/offs/ is the offset within the data.
 
-  <tag><tt>VOPERAND</tt></tag>
+  <tag><tt>PARAMSIZE</tt></tag>
   This optional attribute is followed by a numerical value. It tells the
-  assembler that subroutine calls to this label follow "virtual operands"
+  assembler that subroutine calls to this label follow "inline parameters"
   of the given bytes like this:
 
 <tscreen><verb>
-       	JSR	LabelWith2BytesOfVoperand
-	.byte	$00, $10    ; virtual operands
-	; return here
-	BIT	$0F
+        JSR     LabelWithParamSize2
+        .byte   $00, $10
+        (return here)
+        code...
 </verb></tscreen>
 
 </descrip>

--- a/doc/da65.sgml
+++ b/doc/da65.sgml
@@ -544,8 +544,8 @@ code. The following attributes are recognized:
 
   <tag><tt>PARAMSIZE</tt></tag>
   This optional attribute is followed by a numerical value. It tells the
-  assembler that subroutine calls to this label follow "inline parameters"
-  of the given bytes like this:
+  assembler that subroutine calls to this label are followed by
+  "inline parameters" with the given number of bytes, like this:
 
 <tscreen><verb>
         JSR     LabelWithParamSize2

--- a/src/da65/handler.c
+++ b/src/da65/handler.c
@@ -748,19 +748,19 @@ void OH_JmpAbsoluteXIndirect (const OpcDesc* D)
 
 void OH_JsrAbsolute (const OpcDesc* D)
 {
-    unsigned ParamSize = SubroutineParamSize[GetCodeWord(PC+1)];
+    unsigned ParamSize = SubroutineParamSize[GetCodeWord (PC+1)];
     OH_Absolute (D);
     if (ParamSize > 0) {
         unsigned RemainingBytes;
-	unsigned BytesLeft;
+        unsigned BytesLeft;
         PC += D->Size;
-        RemainingBytes = GetRemainingBytes();
+        RemainingBytes = GetRemainingBytes ();
         if (RemainingBytes < ParamSize) {
             ParamSize = RemainingBytes;
         }
         BytesLeft = ParamSize;
         while (BytesLeft > 0) {
-            unsigned Chunk = (BytesLeft > BytesPerLine)? BytesPerLine : BytesLeft;
+            unsigned Chunk = (BytesLeft > BytesPerLine) ? BytesPerLine : BytesLeft;
             DataByteLine (Chunk);
             BytesLeft -= Chunk;
             PC        += Chunk;

--- a/src/da65/handler.c
+++ b/src/da65/handler.c
@@ -51,6 +51,8 @@
 
 
 
+static unsigned short SubroutineVOperandSize[0x10000];
+
 /*****************************************************************************/
 /*                             Helper functions                              */
 /*****************************************************************************/
@@ -740,4 +742,32 @@ void OH_JmpAbsoluteXIndirect (const OpcDesc* D)
         LineFeed ();
     }
     SeparatorLine ();
+}
+
+
+
+void OH_JsrAbsolute (const OpcDesc* D)
+{
+    unsigned VOperandSize = SubroutineVOperandSize[GetCodeWord(PC+1)];
+    OH_Absolute (D);
+    if (VOperandSize > 0) {
+        unsigned RemainingBytes;
+        PC += D->Size;
+        RemainingBytes = GetRemainingBytes();
+        if (RemainingBytes < VOperandSize) {
+            VOperandSize = RemainingBytes;
+        }
+        if (VOperandSize > 0) {
+            DataByteLine (VOperandSize); /* FIXME: follow BytesPerLine */
+            PC += VOperandSize;
+        }
+        PC -= D->Size;
+    }
+}
+
+
+
+void SetSubroutineVOperand (unsigned Addr, unsigned Size)
+{
+    SubroutineVOperandSize[Addr] = Size;
 }

--- a/src/da65/handler.c
+++ b/src/da65/handler.c
@@ -51,7 +51,7 @@
 
 
 
-static unsigned short SubroutineVOperandSize[0x10000];
+static unsigned short SubroutineParamSize[0x10000];
 
 /*****************************************************************************/
 /*                             Helper functions                              */
@@ -748,18 +748,22 @@ void OH_JmpAbsoluteXIndirect (const OpcDesc* D)
 
 void OH_JsrAbsolute (const OpcDesc* D)
 {
-    unsigned VOperandSize = SubroutineVOperandSize[GetCodeWord(PC+1)];
+    unsigned ParamSize = SubroutineParamSize[GetCodeWord(PC+1)];
     OH_Absolute (D);
-    if (VOperandSize > 0) {
+    if (ParamSize > 0) {
         unsigned RemainingBytes;
+	unsigned BytesLeft;
         PC += D->Size;
         RemainingBytes = GetRemainingBytes();
-        if (RemainingBytes < VOperandSize) {
-            VOperandSize = RemainingBytes;
+        if (RemainingBytes < ParamSize) {
+            ParamSize = RemainingBytes;
         }
-        if (VOperandSize > 0) {
-            DataByteLine (VOperandSize); /* FIXME: follow BytesPerLine */
-            PC += VOperandSize;
+        BytesLeft = ParamSize;
+        while (BytesLeft > 0) {
+            unsigned Chunk = (BytesLeft > BytesPerLine)? BytesPerLine : BytesLeft;
+            DataByteLine (Chunk);
+            BytesLeft -= Chunk;
+            PC        += Chunk;
         }
         PC -= D->Size;
     }
@@ -767,7 +771,7 @@ void OH_JsrAbsolute (const OpcDesc* D)
 
 
 
-void SetSubroutineVOperand (unsigned Addr, unsigned Size)
+void SetSubroutineParamSize (unsigned Addr, unsigned Size)
 {
-    SubroutineVOperandSize[Addr] = Size;
+    SubroutineParamSize[Addr] = Size;
 }

--- a/src/da65/handler.h
+++ b/src/da65/handler.h
@@ -104,7 +104,9 @@ void OH_Rts (const OpcDesc*);
 void OH_JmpAbsolute (const OpcDesc*);
 void OH_JmpAbsoluteIndirect (const OpcDesc* D);
 void OH_JmpAbsoluteXIndirect (const OpcDesc* D);
+void OH_JsrAbsolute (const OpcDesc*);
 
+void SetSubroutineVOperand (unsigned Addr, unsigned Size);
 
 
 /* End of handler.h */

--- a/src/da65/handler.h
+++ b/src/da65/handler.h
@@ -106,7 +106,7 @@ void OH_JmpAbsoluteIndirect (const OpcDesc* D);
 void OH_JmpAbsoluteXIndirect (const OpcDesc* D);
 void OH_JsrAbsolute (const OpcDesc*);
 
-void SetSubroutineVOperand (unsigned Addr, unsigned Size);
+void SetSubroutineParamSize (unsigned Addr, unsigned Size);
 
 
 /* End of handler.h */

--- a/src/da65/infofile.c
+++ b/src/da65/infofile.c
@@ -59,6 +59,7 @@
 #include "opctable.h"
 #include "scanner.h"
 #include "segment.h"
+#include "handler.h"
 
 
 
@@ -380,6 +381,7 @@ static void LabelSection (void)
         {   "ADDR",     INFOTOK_ADDR    },
         {   "NAME",     INFOTOK_NAME    },
         {   "SIZE",     INFOTOK_SIZE    },
+        {   "VOPERAND", INFOTOK_VOPERAND },
     };
 
     /* Locals - initialize to avoid gcc warnings */
@@ -387,6 +389,7 @@ static void LabelSection (void)
     char* Comment = 0;
     long Value    = -1;
     long Size     = -1;
+    long VOperand = -1;
 
     /* Skip the token */
     InfoNextTok ();
@@ -448,6 +451,17 @@ static void LabelSection (void)
                 InfoNextTok ();
                 break;
 
+            case INFOTOK_VOPERAND:
+                InfoNextTok ();
+                if (VOperand >= 0) {
+                    InfoError ("VOperand already given");
+                }
+                InfoAssureInt ();
+                InfoRangeCheck (1, 0x10000);
+                VOperand = InfoIVal;
+                InfoNextTok ();
+                break;
+
             default:
                 Internal ("Unexpected token: %u", InfoTok);
         }
@@ -483,6 +497,9 @@ static void LabelSection (void)
         AddUnnamedLabel (Value);
     } else {
         AddExtLabelRange ((unsigned) Value, Name, Size);
+    }
+    if (VOperand >= 0) {
+        SetSubroutineVOperand ((unsigned) Value, (unsigned) VOperand);
     }
 
     /* Define the comment */

--- a/src/da65/infofile.c
+++ b/src/da65/infofile.c
@@ -377,19 +377,19 @@ static void LabelSection (void)
 /* Parse a label section */
 {
     static const IdentTok LabelDefs[] = {
-        {   "COMMENT",  INFOTOK_COMMENT },
-        {   "ADDR",     INFOTOK_ADDR    },
-        {   "NAME",     INFOTOK_NAME    },
-        {   "SIZE",     INFOTOK_SIZE    },
-        {   "PARAMSIZE", INFOTOK_PARAMSIZE },
+        {   "COMMENT",      INFOTOK_COMMENT     },
+        {   "ADDR",         INFOTOK_ADDR        },
+        {   "NAME",         INFOTOK_NAME        },
+        {   "SIZE",         INFOTOK_SIZE        },
+        {   "PARAMSIZE",    INFOTOK_PARAMSIZE   },
     };
 
     /* Locals - initialize to avoid gcc warnings */
-    char* Name    = 0;
-    char* Comment = 0;
-    long Value    = -1;
-    long Size     = -1;
-    long ParamSize = -1;
+    char* Name      = 0;
+    char* Comment   = 0;
+    long Value      = -1;
+    long Size       = -1;
+    long ParamSize  = -1;
 
     /* Skip the token */
     InfoNextTok ();

--- a/src/da65/infofile.c
+++ b/src/da65/infofile.c
@@ -381,7 +381,7 @@ static void LabelSection (void)
         {   "ADDR",     INFOTOK_ADDR    },
         {   "NAME",     INFOTOK_NAME    },
         {   "SIZE",     INFOTOK_SIZE    },
-        {   "VOPERAND", INFOTOK_VOPERAND },
+        {   "PARAMSIZE", INFOTOK_PARAMSIZE },
     };
 
     /* Locals - initialize to avoid gcc warnings */
@@ -389,7 +389,7 @@ static void LabelSection (void)
     char* Comment = 0;
     long Value    = -1;
     long Size     = -1;
-    long VOperand = -1;
+    long ParamSize = -1;
 
     /* Skip the token */
     InfoNextTok ();
@@ -451,14 +451,14 @@ static void LabelSection (void)
                 InfoNextTok ();
                 break;
 
-            case INFOTOK_VOPERAND:
+            case INFOTOK_PARAMSIZE:
                 InfoNextTok ();
-                if (VOperand >= 0) {
-                    InfoError ("VOperand already given");
+                if (ParamSize >= 0) {
+                    InfoError ("ParamSize already given");
                 }
                 InfoAssureInt ();
                 InfoRangeCheck (1, 0x10000);
-                VOperand = InfoIVal;
+                ParamSize = InfoIVal;
                 InfoNextTok ();
                 break;
 
@@ -498,8 +498,8 @@ static void LabelSection (void)
     } else {
         AddExtLabelRange ((unsigned) Value, Name, Size);
     }
-    if (VOperand >= 0) {
-        SetSubroutineVOperand ((unsigned) Value, (unsigned) VOperand);
+    if (ParamSize >= 0) {
+        SetSubroutineParamSize ((unsigned) Value, (unsigned) ParamSize);
     }
 
     /* Define the comment */

--- a/src/da65/opc6502.c
+++ b/src/da65/opc6502.c
@@ -79,7 +79,7 @@ const OpcDesc OpcTable_6502[256] = {
     {   "ora",  3,  flUseLabel|flAbsOverride, OH_AbsoluteX             }, /* $1d */
     {   "asl",  3,  flUseLabel|flAbsOverride, OH_AbsoluteX             }, /* $1e */
     {   "",     1,  flIllegal,                OH_Illegal,              }, /* $1f */
-    {   "jsr",  3,  flLabel,                  OH_Absolute              }, /* $20 */
+    {   "jsr",  3,  flLabel,                  OH_JsrAbsolute           }, /* $20 */
     {   "and",  2,  flUseLabel,               OH_DirectXIndirect       }, /* $21 */
     {   "",     1,  flIllegal,                OH_Illegal,              }, /* $22 */
     {   "",     1,  flIllegal,                OH_Illegal,              }, /* $23 */

--- a/src/da65/opc65816.c
+++ b/src/da65/opc65816.c
@@ -79,7 +79,7 @@ const OpcDesc OpcTable_65816[256] = {
     {   "ora",  3,  flUseLabel|flAbsOverride, OH_AbsoluteX             }, /* $1d */
     {   "asl",  3,  flUseLabel|flAbsOverride, OH_AbsoluteX             }, /* $1e */
     {   "ora",  4,  flUseLabel,               OH_AbsoluteLongX         }, /* $1f */
-    {   "jsr",  3,  flLabel,                  OH_Absolute              }, /* $20 */
+    {   "jsr",  3,  flLabel,                  OH_JsrAbsolute           }, /* $20 */
     {   "and",  2,  flUseLabel,               OH_DirectXIndirect       }, /* $21 */
     {   "jsl",  3,  flLabel,                  OH_AbsoluteLong          }, /* $22 */
     {   "and",  2,  flNone,                   OH_StackRelative         }, /* $23 */

--- a/src/da65/opc65c02.c
+++ b/src/da65/opc65c02.c
@@ -79,7 +79,7 @@ const OpcDesc OpcTable_65C02[256] = {
     {   "ora",  3,  flUseLabel|flAbsOverride, OH_AbsoluteX             }, /* $1d */
     {   "asl",  3,  flUseLabel|flAbsOverride, OH_AbsoluteX             }, /* $1e */
     {   "bbr1", 3,  flUseLabel,               OH_BitBranch             }, /* $1f */
-    {   "jsr",  3,  flLabel,                  OH_Absolute              }, /* $20 */
+    {   "jsr",  3,  flLabel,                  OH_JsrAbsolute           }, /* $20 */
     {   "and",  2,  flUseLabel,               OH_DirectXIndirect       }, /* $21 */
     {   "",     1,  flIllegal,                OH_Illegal,              }, /* $22 */
     {   "",     1,  flIllegal,                OH_Illegal,              }, /* $23 */

--- a/src/da65/opc65sc02.c
+++ b/src/da65/opc65sc02.c
@@ -79,7 +79,7 @@ const OpcDesc OpcTable_65SC02[256] = {
     {   "ora",  3,  flUseLabel|flAbsOverride, OH_AbsoluteX             }, /* $1d */
     {   "asl",  3,  flUseLabel|flAbsOverride, OH_AbsoluteX             }, /* $1e */
     {   "",     1,  flIllegal,                OH_Illegal,              }, /* $1f */
-    {   "jsr",  3,  flLabel,                  OH_Absolute              }, /* $20 */
+    {   "jsr",  3,  flLabel,                  OH_JsrAbsolute           }, /* $20 */
     {   "and",  2,  flUseLabel,               OH_DirectXIndirect       }, /* $21 */
     {   "",     1,  flIllegal,                OH_Illegal,              }, /* $22 */
     {   "",     1,  flIllegal,                OH_Illegal,              }, /* $23 */

--- a/src/da65/scanner.h
+++ b/src/da65/scanner.h
@@ -105,7 +105,7 @@ typedef enum token_t {
     INFOTOK_COMMENT,
     INFOTOK_ADDR,
     INFOTOK_SIZE,
-    INFOTOK_VOPERAND,
+    INFOTOK_PARAMSIZE,
 
     /* ASMINC section */
     INFOTOK_FILE,

--- a/src/da65/scanner.h
+++ b/src/da65/scanner.h
@@ -105,6 +105,7 @@ typedef enum token_t {
     INFOTOK_COMMENT,
     INFOTOK_ADDR,
     INFOTOK_SIZE,
+    INFOTOK_VOPERAND,
 
     /* ASMINC section */
     INFOTOK_FILE,


### PR DESCRIPTION
Example of 2 bytes virtual operands:
`jsr	SomeProc`
`.byte	$00, $01 ; argument to SomeProc`
`; return here from SomeProc`
`bit	$3F`