### PR TITLE
cbm_kernal enhancements

### DIFF
--- a/asminc/cbm_kernal.inc
+++ b/asminc/cbm_kernal.inc
@@ -4,6 +4,13 @@
 ; Commodore kernal functions
 ;
 
+.if .def(__C128__)
+  ; C128 Extended jump table
+  C64MODE      := $FF4D
+  SWAPPER      := $FF5F
+  SETBNK       := $FF68
+.endif
+
 .if .def(__C64__) || .def(__C128__) || .def(__C16__)
   CINT         := $FF81
   IOINIT       := $FF84

--- a/libsrc/c128/kernal.s
+++ b/libsrc/c128/kernal.s
@@ -49,12 +49,3 @@
         .export         SCREEN
         .export         PLOT
         .export         IOBASE
-
-
-;-----------------------------------------------------------------------------
-; All functions are available in the kernal jump table
-
-; Extended jump table
-C64MODE         = $FF4D
-SWAPPER         = $FF5F
-SETBNK          = $FF68

--- a/libsrc/cbm510/kernal.s
+++ b/libsrc/cbm510/kernal.s
@@ -1,7 +1,7 @@
 ;
 ; Ullrich von Bassewitz, 2003-12-20
 ;
-; CBM610 kernal functions
+; CBM510 kernal functions
 ;
 
         .include "cbm_kernal.inc"

--- a/libsrc/pet/kernal.s
+++ b/libsrc/pet/kernal.s
@@ -4,25 +4,11 @@
 ; PET kernal functions
 ;
 
+        .include "cbm_kernal.inc"
+
         .export         CLRCH
         .export         BASIN
         .export         STOP
         .export         GETIN
         .export         CLALL
         .export         UDTIM
-
-
-
-
-
-
-;-----------------------------------------------------------------------------
-; Functions that are available in the kernal jump table
-
-CLRCH           = $FFCC
-BASIN           = $FFCF
-STOP            = $FFE1
-GETIN           = $FFE4
-CLALL           = $FFE7
-UDTIM           = $FFEA
-


### PR DESCRIPTION
PET was missing from previous PRs. Moved C128 extended jump table definitions from lib to cbm_kernal.inc
