### PR TITLE
sim65: Fix "$2C: BIT abs" to access the correct address.

### DIFF
--- a/src/sim65/6502.c
+++ b/src/sim65/6502.c
@@ -739,7 +739,7 @@ static void OPC_6502_2C (void)
     unsigned Addr;
     unsigned char Val;
     Cycles = 4;
-    Addr = MemReadByte (Regs.PC+1);
+    Addr = MemReadWord (Regs.PC+1);
     Val = MemReadByte (Addr);
     SET_SF (Val & 0x80);
     SET_OF (Val & 0x40);


### PR DESCRIPTION
The BIT instruction (opcode 2C) does not work correctly in sim65.  The problem is demonstrated by this example:
```asm
        .export _main
        .import _exit

        .rodata
foo:    .byte $F0
        .code

        .proc _main
        lda #$0F
        bit foo
        beq zero
        lda #1
        ldx #0
        jmp _exit
zero:   lda #2
        ldx #0
        jmp _exit
        .endproc        ; _main
```

The test program should return 2; but, with the current version of sim65, it returns 1.

This pull request fixes sim65 so that the BIT instruction works correctly.