### PR TITLE
Add CHKOUT and CLRCHN to cbm_kernal.inc

### DIFF
--- a/asminc/cbm_kernal.inc
+++ b/asminc/cbm_kernal.inc
@@ -56,7 +56,9 @@
 ; Available on all platforms including PET
 CHKIN          := $FFC6
 CKOUT          := $FFC9
+CHKOUT         := $FFC9
 CLRCH          := $FFCC
+CLRCHN         := $FFCC
 BASIN          := $FFCF
 CHRIN          := $FFCF
 BSOUT          := $FFD2


### PR DESCRIPTION
These names for kernal entry points are used in VIC-20 and C64 Programmer's Reference Guide.