### PR TITLE
Fix ftell() on Apple II to return the correct value.

### DIFF
--- a/libsrc/apple2/lseek.s
+++ b/libsrc/apple2/lseek.s
@@ -84,6 +84,14 @@ seek_common:
         jsr     callmli
         bcs     oserr
 
+        ; Need to return the position in EAX
+        lda     #0
+        sta     sreg+1
+        lda     mliparam + MLI::MARK::POSITION+2
+        sta     sreg
+        ldx     mliparam + MLI::MARK::POSITION+1
+        lda     mliparam + MLI::MARK::POSITION
+
         rts
 
         ; Load errno code

--- a/libsrc/apple2/lseek.s
+++ b/libsrc/apple2/lseek.s
@@ -6,6 +6,7 @@
 
         .export         _lseek
         .import         popax, popptr1
+        .macpack        cpu
 
         .include        "zeropage.inc"
         .include        "errno.inc"
@@ -85,12 +86,12 @@ seek_common:
         bcs     oserr
 
         ; Need to return the position in EAX
-        .ifdef  __APPLE2ENH__
+.if (.cpu .bitand ::CPU_ISET_65SC02)
         stz     sreg+1
-        .else
-        lda     #0
+.else
+        lda     #$00
         sta     sreg+1
-        .endif
+.endif
         lda     mliparam + MLI::MARK::POSITION+2
         sta     sreg
         ldx     mliparam + MLI::MARK::POSITION+1
@@ -102,7 +103,13 @@ seek_common:
 einval: lda     #EINVAL
 
         ; Set __errno
-errno:  jmp     __directerrno
+errno:  ldx     #$FF
+        stx     sreg
+        stx     sreg+1
+        jmp     __directerrno
 
         ; Set __oserror
-oserr:  jmp     __mappederrno
+oserr:  ldx     #$FF
+        stx     sreg
+        stx     sreg+1
+        jmp     __mappederrno

--- a/libsrc/apple2/lseek.s
+++ b/libsrc/apple2/lseek.s
@@ -85,8 +85,12 @@ seek_common:
         bcs     oserr
 
         ; Need to return the position in EAX
+        .ifdef  __APPLE2ENH__
+        stz     sreg+1
+        .else
         lda     #0
         sta     sreg+1
+        .endif
         lda     mliparam + MLI::MARK::POSITION+2
         sta     sreg
         ldx     mliparam + MLI::MARK::POSITION+1

--- a/testcode/lib/seek.c
+++ b/testcode/lib/seek.c
@@ -23,6 +23,7 @@ int main(int argc, char **argv)
         if (!x) {
             return(0);
         }
+        x[strcspn(x, "\r\n")] = 0;
         filename = x;
     }
     else {

--- a/testcode/lib/seek.c
+++ b/testcode/lib/seek.c
@@ -173,6 +173,35 @@ int main(int argc, char **argv)
     }
     else {
         printf("NOT OK, no error\n");
+        fclose(file);
+        return(1);
+    }
+
+    /* ProDOS on the Apple II only supports 24-bit file offsets,
+    ** so anything beyond that should be an error.  I don't know
+    ** about other platforms, but I'm guessing no 6502-based
+    ** operating systems support 32-bit offsets?
+    */
+    printf("seeking to position 2^24:\n\t");
+    pos = lseek(fd, 0x1000000L, SEEK_SET);
+    if (pos == -1) {
+        printf("Ok, error %s\n", strerror(errno));
+    }
+    else {
+        printf("NOT OK, returned %ld but expected -1\n", pos);
+        fclose(file);
+        return(1);
+    }
+
+    printf("trying invalid value for whence:\n\t");
+    pos = lseek(fd, 0L, 3);
+    if (pos == -1) {
+        printf("Ok, error %s\n", strerror(errno));
+    }
+    else {
+        printf("NOT OK, returned %ld but expected -1\n", pos);
+        fclose(file);
+        return(1);
     }
 
     fclose(file);


### PR DESCRIPTION
Fixes #722: `ftell()` returns the value returned by `lseek()`, and `lseek()` for the
Apple II wasn't returning a value.
