### PR TITLE
Add segment type "overlay".

### DIFF
--- a/src/ld65/bin.c
+++ b/src/ld65/bin.c
@@ -193,8 +193,13 @@ static void BinWriteMem (BinDesc* D, MemoryArea* M)
                     NewAddr += M->Start;
                 }
                 if (DoWrite || (M->Flags & MF_FILL) != 0) {
-                    WriteMult (D->F, M->FillVal, NewAddr-Addr);
-                    PrintNumVal ("SF_OFFSET", NewAddr - Addr);
+                    /* Seek back for "overlay" segments */
+                    if (NewAddr < Addr) {
+                        fseek(D->F, NewAddr - M->Start, SEEK_SET);
+                    } else {
+                        WriteMult (D->F, M->FillVal, NewAddr-Addr);
+                        PrintNumVal ("SF_OFFSET", NewAddr - Addr);
+                    }
                 }
                 Addr = NewAddr;
             }

--- a/src/ld65/config.h
+++ b/src/ld65/config.h
@@ -96,6 +96,7 @@ struct SegDesc {
 #define SF_RUN_DEF      0x0200          /* RUN symbols already defined */
 #define SF_LOAD_DEF     0x0400          /* LOAD symbols already defined */
 #define SF_FILLVAL      0x0800          /* Segment has separate fill value */
+#define SF_OVERLAY      0x1000          /* Segment can be overlayed on another one */
 
 
 

--- a/src/ld65/scanner.h
+++ b/src/ld65/scanner.h
@@ -105,6 +105,7 @@ typedef enum {
     CFGTOK_RW,
     CFGTOK_BSS,
     CFGTOK_ZP,
+    CFGTOK_OVERLAY,
 
     CFGTOK_O65,
     CFGTOK_BIN,


### PR DESCRIPTION
This patch adds a new segment type - the overlay. It is useful in situations where disassembled 3rd party code is used as a foundation that is subsequently patched by your code, yet you want to avoid modifying the disassembled source itself (because you expect it to change as you progress with reverse engineering, or maybe due to updates being released by said 3rd party).

Example use:

MEMORY {
    ROM:  file = %O, start = $8000, size = $8000;
}

SEGMENTS {
    CODE:     load = ROM, type = ro;
    MAXWEAPON:   load = ROM, start=$8342, type = overlay;
    NODEATH:   load = ROM, offset=$0500, type = overlay;
}


