### PR TITLE
Add segment type "overwrite".

### DIFF
--- a/doc/ld65.sgml
+++ b/doc/ld65.sgml
@@ -655,8 +655,8 @@ SEGMENTS {
 </verb></tscreen>
 
 Segment named ORIGINAL contains the original code, disassembled or provided in
-a binary form (i.e. using <tt><ref id=".INCBIN" name=".incbin"></tt>
-directive).  Subsequent four segments will be relocated to addresses specified
+a binary form (i.e. using <tt/.INCBIN/ directive; see the <tt/ca65/ assembler
+document).  Subsequent four segments will be relocated to addresses specified
 by their "start" attributes ("offset" can also be used) and then will overwrite
 whatever was at these locations in the ORIGINAL segment. In the end, resulting
 binary output file will thus contain original data with the exception of four

--- a/doc/ld65.sgml
+++ b/doc/ld65.sgml
@@ -519,7 +519,7 @@ specify a segment attribute. There are five possible segment attributes:
         rw          means read/write
         bss         means that this is an uninitialized segment
         zp          a zeropage segment
-        overwrite   a segment that overwrites another one
+        overwrite   a segment that overwrites (parts of) another one
 
 </verb></tscreen>
 
@@ -635,8 +635,8 @@ Here is an example:
 
 <tscreen><verb>
 MEMORY {
-    RAM: file = "", start = $6000, size = $2000, type=bss;
-    ROM:  file = %O, start = $8000, size = $8000, type=ro;
+    RAM: file = "", start = $6000, size = $2000, type=rw;
+    ROM: file = %O, start = $8000, size = $8000, type=ro;
 }
 </verb></tscreen>
 
@@ -655,14 +655,15 @@ SEGMENTS {
 </verb></tscreen>
 
 Segment named ORIGINAL contains the original code, disassembled or provided in
-a binary form. Subsequent four segments will be relocated to addresses
-specified by their "start" attributes ("offset" can also be used) and then will
-overwrite whatever was at these locations in the ORIGINAL segment. In the end,
-resulting binary output file will thus contain original data with the exception
-of four sequences starting at $9000, $f7e8, $8000 and $e5b7, which will sport
-code from their respective segments. How long these sequences will be depends
-on the lengths of corresponding segments - they can even overlap, so think what
-you're doing.
+a binary form (i.e. using <tt><ref id=".INCBIN" name=".incbin"></tt>
+directive).  Subsequent four segments will be relocated to addresses specified
+by their "start" attributes ("offset" can also be used) and then will overwrite
+whatever was at these locations in the ORIGINAL segment. In the end, resulting
+binary output file will thus contain original data with the exception of four
+sequences starting at $9000, $f7e8, $8000 and $e5b7, which will sport code from
+their respective segments. How long these sequences will be depends on the
+lengths of corresponding segments - they can even overlap, so think what you're
+doing.
 
 Finally, note that OVERWRITE segments should be the final segments loaded to a
 particular memory area, and that they need at least one of "start" or "offset"

--- a/doc/ld65.sgml
+++ b/doc/ld65.sgml
@@ -512,13 +512,15 @@ What we are doing here is telling the linker, that all segments go into the
 the linker will first write the <tt/CODE/ segment, then the <tt/RODATA/
 segment, then the <tt/DATA/ segment - but it will not write the <tt/BSS/
 segment. Why? Here enters the segment type: For each segment specified, you may also
-specify a segment attribute. There are four possible segment attributes:
+specify a segment attribute. There are five possible segment attributes:
 
 <tscreen><verb>
-        ro      means readonly
-        rw      means read/write
-        bss     means that this is an uninitialized segment
-        zp      a zeropage segment
+        ro          means readonly
+        rw          means read/write
+        bss         means that this is an uninitialized segment
+        zp          a zeropage segment
+        overwrite   a segment that overwrites another one
+
 </verb></tscreen>
 
 So, because we specified that the segment with the name BSS is of type bss,
@@ -617,6 +619,54 @@ would write two files that start with the name of the output file specified on
 the command line, with "-1.bin" and "-2.bin" appended respectively. Because
 '%' is used as an escape char, the sequence "%%" has to be used if a single
 percent sign is required.
+
+<sect1>OVERWRITE segments<p>
+
+There are situations when you may wish to overwrite some part (or parts) of a
+segment with another one. Perhaps you are modifying an OS ROM that has its
+public subroutines at fixed, well-known addresses, and you want to prevent them
+from shifting to other locations in memory if your changed code takes less
+space. Or you are updating a block of code available in binary-only form with
+fixes that are scattered in various places. Generally, whenever you want to
+minimize disturbance to an existing code brought on by your updates, OVERWRITE
+segments are worth considering.
+
+Here is an example:
+
+<tscreen><verb>
+MEMORY {
+    RAM: file = "", start = $6000, size = $2000, type=bss;
+    ROM:  file = %O, start = $8000, size = $8000, type=ro;
+}
+</verb></tscreen>
+
+Nothing unusual so far, just two memory blocks - one RAM, one ROM. Now let's
+look at the segment configuration:
+
+<tscreen><verb>
+SEGMENTS {
+    RAM:       load = RAM, type = bss;
+    ORIGINAL:  load = ROM, type = ro;
+    FASTCOPY:  load = ROM, start=$9000, type = overwrite;
+    JMPPATCH1: load = ROM, start=$f7e8, type = overwrite;
+    DEBUG:     load = ROM, start=$8000, type = overwrite;
+    VERSION:   load = ROM, start=$e5b7, type = overwrite;
+}
+</verb></tscreen>
+
+Segment named ORIGINAL contains the original code, disassembled or provided in
+a binary form. Subsequent four segments will be relocated to addresses
+specified by their "start" attributes ("offset" can also be used) and then will
+overwrite whatever was at these locations in the ORIGINAL segment. In the end,
+resulting binary output file will thus contain original data with the exception
+of four sequences starting at $9000, $f7e8, $8000 and $e5b7, which will sport
+code from their respective segments. How long these sequences will be depends
+on the lengths of corresponding segments - they can even overlap, so think what
+you're doing.
+
+Finally, note that OVERWRITE segments should be the final segments loaded to a
+particular memory area, and that they need at least one of "start" or "offset"
+attributes specified.
 
 <sect1>LOAD and RUN addresses (ROMable code)<p>
 

--- a/src/ld65/bin.c
+++ b/src/ld65/bin.c
@@ -193,8 +193,8 @@ static void BinWriteMem (BinDesc* D, MemoryArea* M)
                     NewAddr += M->Start;
                 }
                 if (DoWrite || (M->Flags & MF_FILL) != 0) {
-                    /* Seek back for "overlay" segments */
-                    if (NewAddr < Addr) {
+                    /* Seek in "overlay" segments */
+                    if (S->Flags & SF_OVERLAY) {
                         fseek(D->F, NewAddr - M->Start, SEEK_SET);
                     } else {
                         WriteMult (D->F, M->FillVal, NewAddr-Addr);

--- a/src/ld65/bin.c
+++ b/src/ld65/bin.c
@@ -193,8 +193,13 @@ static void BinWriteMem (BinDesc* D, MemoryArea* M)
                     NewAddr += M->Start;
                 }
                 if (DoWrite || (M->Flags & MF_FILL) != 0) {
-                    WriteMult (D->F, M->FillVal, NewAddr-Addr);
-                    PrintNumVal ("SF_OFFSET", NewAddr - Addr);
+                    /* Seek back for "overlay" segments */
+                    if (NewAddr < Addr) {
+                        fseek(D->F, NewAddr - M->Start, SEEK_SET);
+                    } else {
+                        WriteMult (D->F, M->FillVal, NewAddr-Addr);
+                        PrintNumVal ("SF_OFFSET", NewAddr - Addr);
+                    }
                 }
                 Addr = NewAddr;
             }

--- a/src/ld65/bin.c
+++ b/src/ld65/bin.c
@@ -193,8 +193,8 @@ static void BinWriteMem (BinDesc* D, MemoryArea* M)
                     NewAddr += M->Start;
                 }
                 if (DoWrite || (M->Flags & MF_FILL) != 0) {
-                    /* Seek in "replace" segments */
-                    if (S->Flags & SF_REPLACE) {
+                    /* Seek in "overwrite" segments */
+                    if (S->Flags & SF_OVERWRITE) {
                         fseek (D->F, NewAddr - M->Start, SEEK_SET);
                     } else {
                         WriteMult (D->F, M->FillVal, NewAddr-Addr);

--- a/src/ld65/bin.c
+++ b/src/ld65/bin.c
@@ -193,7 +193,7 @@ static void BinWriteMem (BinDesc* D, MemoryArea* M)
                     NewAddr += M->Start;
                 }
                 if (DoWrite || (M->Flags & MF_FILL) != 0) {
-                    /* Seek in "overlay" segments */
+                    /* Seek in "replace" segments */
                     if (S->Flags & SF_REPLACE) {
                         fseek (D->F, NewAddr - M->Start, SEEK_SET);
                     } else {

--- a/src/ld65/bin.c
+++ b/src/ld65/bin.c
@@ -194,8 +194,8 @@ static void BinWriteMem (BinDesc* D, MemoryArea* M)
                 }
                 if (DoWrite || (M->Flags & MF_FILL) != 0) {
                     /* Seek in "overlay" segments */
-                    if (S->Flags & SF_OVERLAY) {
-                        fseek(D->F, NewAddr - M->Start, SEEK_SET);
+                    if (S->Flags & SF_REPLACE) {
+                        fseek (D->F, NewAddr - M->Start, SEEK_SET);
                     } else {
                         WriteMult (D->F, M->FillVal, NewAddr-Addr);
                         PrintNumVal ("SF_OFFSET", NewAddr - Addr);

--- a/src/ld65/config.c
+++ b/src/ld65/config.c
@@ -1797,7 +1797,7 @@ unsigned CfgProcess (void)
     for (I = 0; I < CollCount (&MemoryAreas); ++I) {
         unsigned J;
         unsigned long Addr;
-        unsigned Overlays = 0;
+        unsigned Replaces = 0;
 
         /* Get the next memory area */
         MemoryArea* M = CollAtUnchecked (&MemoryAreas, I);
@@ -1851,23 +1851,23 @@ unsigned CfgProcess (void)
             /* Remember the start address before handling this segment */
             unsigned long StartAddr = Addr;
 
-            /* Take note of overlayed segments and make sure there are no other
+            /* Take note of "replace" segments and make sure there are no other
             ** segment types following them in current memory region.
             */
             if (S->Flags & SF_REPLACE) {
                 if (S->Flags & (SF_OFFSET | SF_START)) {
-                    ++Overlays;
+                    ++Replaces;
                 } else {
                     CfgError (GetSourcePos (M->LI),
-                              "Segment `%s' of type `overlay' requires either"
+                              "Segment `%s' of type `replace' requires either"
                               " `Start' or `Offset' attribute to be specified",
                               GetString (S->Name));
                 }
             } else {
-                if (Overlays > 0) {
+                if (Replaces > 0) {
                     CfgError (GetSourcePos (M->LI),
                               "Segment `%s' is preceded by at least one segment"
-                              " of type `overlay'",
+                              " of type `replace'",
                               GetString (S->Name));
                 }
             }

--- a/src/ld65/config.h
+++ b/src/ld65/config.h
@@ -96,7 +96,7 @@ struct SegDesc {
 #define SF_RUN_DEF      0x0200          /* RUN symbols already defined */
 #define SF_LOAD_DEF     0x0400          /* LOAD symbols already defined */
 #define SF_FILLVAL      0x0800          /* Segment has separate fill value */
-#define SF_OVERLAY      0x1000          /* Segment can be overlayed on another one */
+#define SF_REPLACE      0x1000          /* Segment can replace (part of) another one */
 
 
 

--- a/src/ld65/config.h
+++ b/src/ld65/config.h
@@ -96,7 +96,7 @@ struct SegDesc {
 #define SF_RUN_DEF      0x0200          /* RUN symbols already defined */
 #define SF_LOAD_DEF     0x0400          /* LOAD symbols already defined */
 #define SF_FILLVAL      0x0800          /* Segment has separate fill value */
-#define SF_REPLACE      0x1000          /* Segment can replace (part of) another one */
+#define SF_OVERWRITE    0x1000          /* Segment can overwrite (part of) another one */
 
 
 

--- a/src/ld65/config.h
+++ b/src/ld65/config.h
@@ -96,6 +96,7 @@ struct SegDesc {
 #define SF_RUN_DEF      0x0200          /* RUN symbols already defined */
 #define SF_LOAD_DEF     0x0400          /* LOAD symbols already defined */
 #define SF_FILLVAL      0x0800          /* Segment has separate fill value */
+#define SF_OVERLAY      0x1000          /* Segment can be overlayed on another one */
 
 
 

--- a/src/ld65/scanner.h
+++ b/src/ld65/scanner.h
@@ -105,7 +105,7 @@ typedef enum {
     CFGTOK_RW,
     CFGTOK_BSS,
     CFGTOK_ZP,
-    CFGTOK_REPLACE,
+    CFGTOK_OVERWRITE,
 
     CFGTOK_O65,
     CFGTOK_BIN,

--- a/src/ld65/scanner.h
+++ b/src/ld65/scanner.h
@@ -105,6 +105,7 @@ typedef enum {
     CFGTOK_RW,
     CFGTOK_BSS,
     CFGTOK_ZP,
+    CFGTOK_OVERLAY,
 
     CFGTOK_O65,
     CFGTOK_BIN,

--- a/src/ld65/scanner.h
+++ b/src/ld65/scanner.h
@@ -105,7 +105,7 @@ typedef enum {
     CFGTOK_RW,
     CFGTOK_BSS,
     CFGTOK_ZP,
-    CFGTOK_OVERLAY,
+    CFGTOK_REPLACE,
 
     CFGTOK_O65,
     CFGTOK_BIN,


### PR DESCRIPTION
This patch adds a new segment type - the overlay. It is useful in situations where disassembled 3rd party code is used as a foundation that is subsequently patched by your code, yet you want to avoid modifying the disassembled source itself (because you expect it to change as you progress with reverse engineering, or maybe due to updates being released by said 3rd party).

Example use:
```ini
MEMORY {
    ROM: file = %O, start = $8000, size = $8000;
}

SEGMENTS {
    CODE: load = ROM, type = ro;
    MAXWEAPON: load = ROM, start=$8342, type = overlay;
    NODEATH: load = ROM, offset=$0500, type = overlay;
}
```