### PR TITLE
Atari, Atari5200: disable "attract mode" on mouse or joystick input

### DIFF
--- a/libsrc/atari/joy/atrmj8.s
+++ b/libsrc/atari/joy/atrmj8.s
@@ -95,6 +95,8 @@ COUNT:
 ;
 
 READJOY:
+        and     #JOY_COUNT-1    ; fix joystick number
+        tax                     ; Joystick number into X
         asl     a
         asl     a
         asl     a
@@ -110,5 +112,14 @@ READJOY:
         asl     a
         ora     PORTA           ; add position information
         eor     #$1F
-        ldx     #0              ; fix X
+        cmp     oldval,x
+        beq     :+
+        sta     oldval,x
+        ldx     #0
+        stx     ATRACT          ; we have interaction, disable "attract mode"
+:       ldx     #0              ; fix X
         rts
+
+        .bss
+
+oldval: .res    JOY_COUNT

--- a/libsrc/atari/joy/atrstd.s
+++ b/libsrc/atari/joy/atrstd.s
@@ -93,8 +93,8 @@ _400800:
 ;
 
 READJOY:
-        and     #3              ; fix joystick number
-        tax                     ; Joystick number (0-3) into X
+        and     #JOY_COUNT-1    ; fix joystick number
+        tax                     ; Joystick number into X
 
 ; Read joystick
 
@@ -105,5 +105,14 @@ READJOY:
         asl     a
         ora     STICK0,x        ; add position information
         eor     #$1F
-        ldx     #0              ; fix X
+        cmp     oldval,x
+        beq     :+
+        sta     oldval,x
+        ldx     #0
+        stx     ATRACT          ; we have interaction, disable "attract mode"
+:       ldx     #0              ; fix X
         rts
+
+        .bss
+
+oldval: .res    JOY_COUNT

--- a/libsrc/atari/mou/atrjoy.s
+++ b/libsrc/atari/mou/atrjoy.s
@@ -89,6 +89,8 @@ YMin:           .res    2               ; Y1 value of bounding box
 XMax:           .res    2               ; X2 value of bounding box
 YMax:           .res    2               ; Y2 value of bounding box
 Buttons:        .res    1               ; Button mask
+OldDir:         .res    1               ; previous direction bits
+OldButton:      .res    1               ; previous buttons
 
 
 Temp:           .res    1               ; Temporary value used in the int handler
@@ -336,9 +338,24 @@ IRQ:
 
         jsr     CPREP
 
+; Check if user activity occurred, and if yes, disable "attract mode"
+
+        lda     Buttons
+        cmp     OldButton
+        beq     @ChkDir
+        sta     OldButton
+        lda     #0
+        sta     ATRACT                  ; disable "attract mode"
+@ChkDir:lda     Temp
+        cmp     OldDir
+        beq     @ChkCnt
+        sta     OldDir
+        lda     #0
+        sta     ATRACT
+
 ; Check left/right
 
-        lda     Temp                    ; Read joystick #0
+@ChkCnt:lda     Temp                    ; Read joystick #0
         and     #(JOY::LEFT | JOY::RIGHT)
         beq     @SkipX                  ;
 
@@ -437,4 +454,3 @@ IRQ:
 @SkipY: jsr     CDRAW
         clc                             ; Interrupt not "handled"
         rts
-

--- a/libsrc/atari5200/joy/atr5200std.s
+++ b/libsrc/atari5200/joy/atr5200std.s
@@ -82,6 +82,7 @@ SENSIVITY       = 16
 
 READJOY:
         and     #3              ; put joystick number in range, just in case
+        sta     jsnum           ; remember joystick number
         tay
         asl     a
         tax                     ; Joystick number * 2 (0-6) into X, index into ZP shadow registers
@@ -89,7 +90,7 @@ READJOY:
         lda     #0              ; Initialize return value
         cmp     TRIG0,y
         bne     @notrg
-        lda     #$10            ; JOY_BTN
+        ora     #$10            ; JOY_BTN
 
 ; Read joystick
 
@@ -119,4 +120,15 @@ READJOY:
 
         ora     #2              ; JOY_DOWN
 
-@done:  rts
+@done:  ldx     #0
+        ldy     jsnum
+        cmp     oldval,y
+        beq     @ret
+        sta     oldval,y
+        stx     ATRACT
+@ret:   rts
+
+.bss
+
+oldval:.res     4
+jsnum: .res     1


### PR DESCRIPTION
Fixes #736.