### PR TITLE
Implementation of clock_[gs]ettime() functions for Atari

### DIFF
--- a/asminc/atari.inc
+++ b/asminc/atari.inc
@@ -7,6 +7,7 @@
 ; - Atari OS manual - XL addendum
 ; - Atari XL/XE rev.2 source code, Atari 1984
 ; - Mapping the Atari - revised edition, Ian Chadwick 1985
+; - SpartaDOS-X User Guide  (Aug-8-2016)
 ;
 ; ##old##       old OS rev.B label - moved or deleted
 ; ##1200xl##    new label introduced in 1200XL OS (rev.10/11)
@@ -756,6 +757,34 @@ FPSCR1  = $05EC         ;6-byte floating point temporary
 
 
 DOS     = $0700
+
+;-------------------------------------------------------------------------
+; SpartaDOS-X Definitions
+;-------------------------------------------------------------------------
+
+SDX_FLAG     = DOS              ; 'S' for SpartaDOS
+SDX_VERSION  = $0701            ; SD version (e.g. $32 = 3.2, $40 = 4.0)
+                                ; address $0702 contains sub-version, e.g.
+				; 8 in case of SDX 4.48
+SDX_KERNEL   = $0703            ; SDX kernel entry point
+SDX_BLOCK_IO = $0706            ; block I/O entry point
+SDX_MISC     = $0709            ; "misc" entry point
+SDX_DEVICE   = $0761
+SDX_DATE     = $077B            ; day, month, year (3 bytes)
+SDX_TIME     = $077E            ; hour, min, sec (3 bytes)
+SDX_DATESET  = $0781
+SDX_PATH     = $07A0            ; 64 bytes
+SDX_IFSYMBOL = $07EB            ; only valid on SDX 4.40 or newer
+SDX_S_LOOKUP = SDX_IFSYMBOL     ; alternative name for SDX_IFSYMBOL
+
+; values for SDX_DEVICE
+
+SDX_CLK_DEV  = $10              ; clock device
+
+; clock device functions
+
+SDX_KD_GETTD = 100              ; get time and date
+SDX_KD_SETTD = 101              ; set time and date
 
 ;-------------------------------------------------------------------------
 ; Cartridge Address Equates

--- a/asminc/atari.inc
+++ b/asminc/atari.inc
@@ -765,7 +765,7 @@ DOS     = $0700
 SDX_FLAG     = DOS              ; 'S' for SpartaDOS
 SDX_VERSION  = $0701            ; SD version (e.g. $32 = 3.2, $40 = 4.0)
                                 ; address $0702 contains sub-version, e.g.
-				; 8 in case of SDX 4.48
+                                ; 8 in case of SDX 4.48
 SDX_KERNEL   = $0703            ; SDX kernel entry point
 SDX_BLOCK_IO = $0706            ; block I/O entry point
 SDX_MISC     = $0709            ; "misc" entry point

--- a/libsrc/atari/gettime.s
+++ b/libsrc/atari/gettime.s
@@ -1,0 +1,114 @@
+;
+; Oliver Schmidt, 14.08.2018
+; Christian Groessler, 25.09.2018
+;
+; int __fastcall__ clock_gettime (clockid_t clk_id, struct timespec *tp);
+;
+
+        .import         pushax, steaxspidx, incsp1, incsp3, return0
+        .import         __dos_type
+        .import         sdxtry
+
+        .include        "time.inc"
+        .include        "zeropage.inc"
+        .include        "errno.inc"
+        .include        "atari.inc"
+
+_clock_gettime:
+        jsr     pushax
+
+; clear tp
+
+        sta     ptr1
+        stx     ptr1+1
+        lda     #$00
+        ldy     #.sizeof(timespec)-1
+:       sta     (ptr1),y
+        dey
+        bpl     :-
+
+; only supported on SpartaDOS-X >= 4.40
+
+        lda     #SPARTADOS
+        cmp     __dos_type
+        bne     notsupp
+        lda     SDX_VERSION
+        cmp     #$44
+        bcc     notsupp
+
+; get date/time from system (SD-X call)
+; see settime.s for reasons of using sdxtry
+
+        lda     #0              ; init loop count (256)
+        sta     sdxtry
+
+try_get:lda     #SDX_CLK_DEV    ; CLK device
+        sta     SDX_DEVICE
+        ldy     #SDX_KD_GETTD   ; GETTD function
+        jsr     SDX_KERNEL      ; do the call
+        bcc     done
+
+        dec     sdxtry
+        bne     try_get
+
+        lda     #EBUSY
+        bne     errexit
+
+; fill timespec
+
+; date
+done:   lda     SDX_DATE        ; mday
+        sta     TM + tm::tm_mday
+        ldx     SDX_DATE+1      ; month
+        dex
+        stx     TM + tm::tm_mon
+        lda     SDX_DATE+2      ; year
+        cmp     #79             ; 1979: the Atari 800 came out
+        bcs     :+
+        adc     #100            ; adjust century
+:       sta     TM + tm::tm_year
+
+; time
+        lda     SDX_TIME
+        sta     TM + tm::tm_hour
+        lda     SDX_TIME+1
+        sta     TM + tm::tm_min
+        lda     SDX_TIME+2
+        sta     TM + tm::tm_sec
+
+; make time_t
+
+        lda     #<TM
+        ldx     #>TM
+        jsr     _mktime
+
+; store tv_sec into output tp struct
+
+        ldy     #timespec::tv_sec
+        jsr     steaxspidx
+
+; cleanup stack
+
+        jsr     incsp1
+
+; return success
+
+        jmp     return0
+
+; load errno code
+
+notsupp:lda     #ENOSYS
+
+; cleanup stack
+
+errexit:jsr     incsp3          ; Preserves A
+
+; set __errno
+
+        jmp     __directerrno
+
+; -------
+
+        .bss
+
+TM:     .tag    tm

--- a/libsrc/atari/sdxtime-bss.s
+++ b/libsrc/atari/sdxtime-bss.s
@@ -1,0 +1,9 @@
+; .bss variable used by SpartaDOS-X implementations of
+; gettime.s and settime.s
+
+        .export sdxtry
+
+        .bss
+
+sdxtry: .res    1       ; limit of unsuccessful tries to call GETTD/SETTD
+                        ; (see settime.s)

--- a/libsrc/atari/settime.s
+++ b/libsrc/atari/settime.s
@@ -1,8 +1,99 @@
 ;
-; int clock_settime (clockid_t clk_id, const struct timespec *tp);
+; Oliver Schmidt, 15.08.2018
+; Christian Groessler, 25.09.2018
 ;
-        .include "errno.inc"
-        .export _clock_settime
+; int __fastcall__ clock_settime (clockid_t clk_id, const struct timespec *tp);
+;
+
+        .import         __dos_type
+        .import         incsp1, return0
+        .import         sdxtry
+
+        .include        "time.inc"
+        .include        "zeropage.inc"
+        .include        "errno.inc"
+        .include        "atari.inc"
+
 _clock_settime:
-        lda     #ENOSYS
-        jmp     __directerrno
+
+; cleanup stack
+
+        jsr     incsp1          ; preserves AX
+
+; only supported on SpartaDOS-X >= 4.40
+
+        ldy     #SPARTADOS
+        cpy     __dos_type
+        bne     enosys
+        ldy     SDX_VERSION
+        cpy     #$44
+        bcc     enosys
+
+; create tm from tp (tv_sec) input parameter
+
+        .assert timespec::tv_sec = 0, error
+        jsr     _localtime
+        sta     ptr1
+        stx     ptr1+1
+
+; set date
+
+        ldy     #tm::tm_mday
+        lda     (ptr1),y        ; get day of month
+        sta     SDX_DATE        ; set day of month
+
+        ldy     #tm::tm_mon
+        lda     (ptr1),y        ; get month (0-based)
+        tax
+        inx                     ; move [0..11] to [1..12]
+        stx     SDX_DATE+1
+
+        ldy     #tm::tm_year
+        lda     (ptr1),y        ; get year (0 = year 1900)
+        cmp     #100
+        bcc     :+
+        sbc     #100
+:       sta     SDX_DATE+2
+
+        ldy     #tm::tm_hour
+        lda     (ptr1),y        ; get hour
+        sta     SDX_TIME
+
+        ldy     #tm::tm_min
+        lda     (ptr1),y        ; get minutes
+        sta     SDX_TIME+1
+
+        ldy     #tm::tm_sec
+        lda     (ptr1),y        ; get seconds
+        sta     SDX_TIME+2
+
+; set new time/date (SD-X call)
+; SpartaDOS-X User's Guide (4.48) states at page 145:
+; "In the I_GETTD and I_SETTD procedures a set Carry-Flag means that the clock driver is
+; busy at the moment. You should call the routine again."
+; It goes on to mention that one should provide an upper limit on the number of calls,
+; in order not to "hang". We are doing this here...
+
+        lda     #0              ; init loop count (256)
+        sta     sdxtry
+
+try_set:lda     #SDX_CLK_DEV    ; CLK device
+        sta     SDX_DEVICE
+        ldy     #SDX_KD_SETTD   ; SETTD function
+        jsr     SDX_KERNEL      ; do the call
+        bcc     done
+
+        dec     sdxtry
+        bne     try_set
+
+        lda     #EBUSY
+        bne     drcter          ; jump always
+
+; return success
+
+done:   jmp     return0
+
+; load errno code
+
+enosys: lda     #ENOSYS
+drcter: jmp     __directerrno

--- a/testcode/lib/clock-test.c
+++ b/testcode/lib/clock-test.c
@@ -1,0 +1,100 @@
+/* Clock test program
+ *
+ * 25-Sep-2018, chris@groessler.org
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <errno.h>
+
+#ifdef __CC65__
+#include <conio.h>
+#include <cc65.h>
+
+static void exitfn(void)
+{
+    if (doesclrscrafterexit()) cgetc();
+}
+#endif /* #ifdef __CC65__ */
+
+static void print_time(void)
+{
+    struct tm *cur_tm;
+    time_t cur_time = time(NULL);
+    if (cur_time == -1) {
+        printf("time() failed: %s\n", strerror(errno));
+        return;
+    }
+    cur_tm = localtime(&cur_time);
+
+    printf("time: %s\n", asctime(cur_tm));
+    // DEBUG:
+    printf("mday=%d mon=%d year=%d\nhour=%d min=%d sec=%d\n", cur_tm->tm_mday, cur_tm->tm_mon, cur_tm->tm_year, cur_tm->tm_hour, cur_tm->tm_min, cur_tm->tm_sec);
+}
+
+int main(int argc, char **argv)
+{
+    static char c;
+    static int s;
+    static struct tm cur_time;
+    static struct timespec new_time;
+
+#ifdef __CC65__
+    atexit(exitfn);
+#endif
+
+    if (argc <= 1) {
+        print_time();
+        return 0;
+    }
+
+    if (argc != 3 || strcasecmp(*(argv + 1), "set")) {
+        printf("usage: CLOCKTST [set DD-MM-YY-HH-MM-SS]\n");
+        return 1;
+    }
+
+    s = sscanf(*(argv + 2), "%d-%d-%d-%d-%d-%d", &cur_time.tm_mday, &cur_time.tm_mon, &cur_time.tm_year, &cur_time.tm_hour, &cur_time.tm_min, &cur_time.tm_sec);
+    if (s != 6 || cur_time.tm_year > 99 /* other input values aren't being verified... */) {
+        printf("invalid time/date format\n");
+        return 1;
+    }
+    --cur_time.tm_mon;
+    if (cur_time.tm_year < 79)
+        cur_time.tm_year += 100;  /* adjust century */
+
+    memset(&new_time, 0, sizeof(new_time));
+    new_time.tv_sec = mktime(&cur_time);
+
+    printf("\nyou are about to set the time to\n-->  %s\n\nContinue (y/n)?", ctime(&new_time.tv_sec));
+
+    while (c != 'y' && c != 'Y' && c != 'n' && c != 'N') {
+#ifdef __CC65__
+        c = cgetc();
+#else
+        c = getchar();
+#endif
+    }
+    printf("%c\n", c);
+
+    if (c == 'n' || c == 'N') {
+        printf("user abort\n");
+        return 0;
+    }
+
+    s = clock_settime(CLOCK_REALTIME, &new_time);
+    if (s) {
+        printf("clock_settime() failed: %s\n", strerror(errno));
+        return 1;
+    }
+    printf("time set!\n");
+    //DEBUG test begin
+    print_time();
+    //DEBUG test end
+    return 0;
+}
+/* Local Variables: */
+/* c-file-style: "cpg" */
+/* c-basic-offset: 4 */
+/* End: */

--- a/testcode/lib/clock-test.c
+++ b/testcode/lib/clock-test.c
@@ -31,10 +31,10 @@ static void print_time(void)
 
 int main(int argc, char **argv)
 {
-    static char c;
-    static int s;
-    static struct tm cur_time;
-    static struct timespec new_time;
+    char c = 0;
+    int s;
+    struct tm cur_time;
+    struct timespec new_time;
 
 #ifdef __CC65__
     /* if DOS will automatically clear the screen after the program exits, wait for a keypress... */
@@ -52,6 +52,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    memset(&cur_time, 0, sizeof(cur_time));
     s = sscanf(*(argv + 2), "%d-%d-%d-%d-%d-%d", &cur_time.tm_mday, &cur_time.tm_mon, &cur_time.tm_year, &cur_time.tm_hour, &cur_time.tm_min, &cur_time.tm_sec);
     if (s != 6 || cur_time.tm_year > 99 /* other input values aren't being verified... */) {
         printf("invalid time/date format\n");

--- a/testcode/lib/clock-test.c
+++ b/testcode/lib/clock-test.c
@@ -12,11 +12,6 @@
 #ifdef __CC65__
 #include <conio.h>
 #include <cc65.h>
-
-static void exitfn(void)
-{
-    if (doesclrscrafterexit()) cgetc();
-}
 #endif /* #ifdef __CC65__ */
 
 static void print_time(void)
@@ -42,7 +37,9 @@ int main(int argc, char **argv)
     static struct timespec new_time;
 
 #ifdef __CC65__
-    atexit(exitfn);
+    /* if DOS will automatically clear the screen after the program exits, wait for a keypress... */
+    if (doesclrscrafterexit())
+        atexit((void (*)(void))cgetc);
 #endif
 
     if (argc <= 1) {


### PR DESCRIPTION
Only SpartaDOS-X is supported. On other DOSes ENOSYS is returned.

This PR also adds a simple test program, testcode/lib/clock-test.c.