### PR TITLE
Adds suport for Atari XEX file format to LD65

### DIFF
--- a/cfg/atari-xex.cfg
+++ b/cfg/atari-xex.cfg
@@ -1,0 +1,24 @@
+FEATURES {
+    STARTADDRESS: default = $2E00;
+}
+SYMBOLS {
+    __STARTADDRESS__: type = export, value = %S;
+}
+MEMORY {
+    ZP:      file = "", define = yes, start = $0082, size = $007E;
+    MAIN:    file = %O, define = yes, start = %S,    size = $BC20 - %S;
+}
+FILES {
+    %O: format = atari;
+}
+FORMATS {
+    atari: runad = start;
+}
+SEGMENTS {
+    ZEROPAGE: load = ZP,      type = zp,  optional = yes;
+    EXTZP:    load = ZP,      type = zp,  optional = yes; # to enable modules to be able to link to C and assembler programs
+    CODE:     load = MAIN,    type = rw,                  define = yes;
+    RODATA:   load = MAIN,    type = ro   optional = yes;
+    DATA:     load = MAIN,    type = rw   optional = yes;
+    BSS:      load = MAIN,    type = bss, optional = yes, define = yes;
+}

--- a/doc/atari.sgml
+++ b/doc/atari.sgml
@@ -203,6 +203,18 @@ is <it/left out/, keep this in mind.
 The values you assign to the two symbols <tt/__AUTOSTART__/ and <tt/__EXEHDR__/
 don't matter.
 
+<sect2><tt/atari-xex.cfg/<p>
+
+This config file allows writing multi segment binaries easily, without having to
+write the header explicitly on each segment.
+
+It is similar to the <tt/atari-asm.cfg/ above, but uses the ATARI (xex) file
+format support on LD65 instead of the standard binary output, so it does not
+have the <tt/__AUTOSTART/ nor the <tt/__EXEHDR__/ symbols.
+
+Note that each <tt/MEMORY/ area in the configuration file will have it's own
+segment in the output file with the correct headers.
+
 <sect2><tt/atari-cart.cfg/<p>
 
 This config file can be used to create 8K or 16K cartridges. It's suited both

--- a/doc/ld65.sgml
+++ b/doc/ld65.sgml
@@ -894,7 +894,7 @@ look like this:
         }
 </verb></tscreen>
 
-The only other available output format is the o65 format specified by Andre
+There are two other available formats, one is the o65 format specified by Andre
 Fachat (see the <url url="http://www.6502.org/users/andre/o65/fileformat.html"
 name="6502 binary relocation format specification">). It is defined like this:
 
@@ -904,7 +904,20 @@ name="6502 binary relocation format specification">). It is defined like this:
         }
 </verb></tscreen>
 
-The necessary o65 attributes are defined in a special section labeled
+The other format available is the Atari (xex) segmented file format, this is
+the standard format used by Atari DOS 2.0 and upward file managers in the Atari
+8-bit computers, and it is defined like this:
+
+<tscreen><verb>
+        FILES {
+            %O: format = atari;
+        }
+</verb></tscreen>
+
+In the Atari segmented file format, the linker will write each <tt/MEMORY/ area
+as a new segment, including a header with the start and end address.
+
+The necessary o65 or Atari attributes are defined in a special section labeled
 <ref id="FORMAT" name="FORMAT">.
 
 
@@ -925,6 +938,15 @@ has several attributes that may be defined here.
     }
 </verb></tscreen>
 
+The Atari file format has only one attribute, <tt/RUNAD/ that allows to specify
+a symbol as the run address of the binary. If the attribute is omiteed, no run
+address is specified.
+
+<tscreen><verb>
+    FORMATS {
+        atari: runad = _start;
+    }
+</verb></tscreen>
 
 
 <sect1>The FEATURES section<label id="FEATURES"><p>

--- a/src/ld65.vcxproj
+++ b/src/ld65.vcxproj
@@ -106,6 +106,7 @@
     <ClInclude Include="ld65\span.h" />
     <ClInclude Include="ld65\spool.h" />
     <ClInclude Include="ld65\tpool.h" />
+    <ClInclude Include="ld65\xex.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ld65\asserts.c" />
@@ -139,6 +140,7 @@
     <ClCompile Include="ld65\span.c" />
     <ClCompile Include="ld65\spool.c" />
     <ClCompile Include="ld65\tpool.c" />
+    <ClCompile Include="ld65\xex.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/ld65/binfmt.c
+++ b/src/ld65/binfmt.c
@@ -73,6 +73,7 @@ int RelocatableBinFmt (unsigned Format)
     switch (Format) {
 
         case BINFMT_BINARY:
+        case BINFMT_ATARIEXE:
             Reloc = 0;
             break;
 

--- a/src/ld65/config.c
+++ b/src/ld65/config.c
@@ -68,6 +68,7 @@
 #include "objdata.h"
 #include "scanner.h"
 #include "spool.h"
+#include "xex.h"
 
 
 
@@ -149,6 +150,7 @@ static Collection       CfgSymbols = STATIC_COLLECTION_INITIALIZER;
 /* Descriptor holding information about the binary formats */
 static BinDesc* BinFmtDesc      = 0;
 static O65Desc* O65FmtDesc      = 0;
+static XexDesc* XexFmtDesc      = 0;
 
 
 
@@ -543,6 +545,7 @@ static void ParseFiles (void)
         {   "FORMAT",   CFGTOK_FORMAT   },
     };
     static const IdentTok Formats [] = {
+        {   "ATARI",    CFGTOK_ATARIEXE },
         {   "O65",      CFGTOK_O65      },
         {   "BIN",      CFGTOK_BIN      },
         {   "BINARY",   CFGTOK_BIN      },
@@ -605,6 +608,10 @@ static void ParseFiles (void)
 
                         case CFGTOK_O65:
                             F->Format = BINFMT_O65;
+                            break;
+
+                        case CFGTOK_ATARIEXE:
+                            F->Format = BINFMT_ATARIEXE;
                             break;
 
                         default:
@@ -1023,6 +1030,7 @@ static void ParseFormats (void)
                 break;
 
             case CFGTOK_BIN:
+            case CFGTOK_ATARIEXE:
                 /* No attribibutes available */
                 break;
 
@@ -1559,6 +1567,7 @@ void CfgRead (void)
     /* Create the descriptors for the binary formats */
     BinFmtDesc = NewBinDesc ();
     O65FmtDesc = NewO65Desc ();
+    XexFmtDesc = NewXexDesc ();
 
     /* If we have a config name given, open the file, otherwise we will read
     ** from a buffer.
@@ -2096,6 +2105,10 @@ void CfgWriteTarget (void)
 
                     case BINFMT_O65:
                         O65WriteTarget (O65FmtDesc, F);
+                        break;
+
+                    case BINFMT_ATARIEXE:
+                        XexWriteTarget (XexFmtDesc, F);
                         break;
 
                     default:

--- a/src/ld65/scanner.h
+++ b/src/ld65/scanner.h
@@ -93,6 +93,7 @@ typedef enum {
     CFGTOK_ID,
     CFGTOK_VERSION,
     CFGTOK_FORMAT,
+    CFGTOK_RUNAD,
 
     CFGTOK_LOAD,
     CFGTOK_RUN,

--- a/src/ld65/scanner.h
+++ b/src/ld65/scanner.h
@@ -107,6 +107,7 @@ typedef enum {
     CFGTOK_ZP,
     CFGTOK_OVERWRITE,
 
+    CFGTOK_ATARIEXE,
     CFGTOK_O65,
     CFGTOK_BIN,
 

--- a/src/ld65/xex.c
+++ b/src/ld65/xex.c
@@ -1,0 +1,344 @@
+/*****************************************************************************/
+/*                                                                           */
+/*                                   xex.c                                   */
+/*                                                                           */
+/*               Module to handle the Atari XEX binary format                */
+/*                                                                           */
+/*                                                                           */
+/*                                                                           */
+/* (C) 2018 Daniel Serpell                                                   */
+/*                                                                           */
+/*                                                                           */
+/* This software is provided 'as-is', without any expressed or implied       */
+/* warranty.  In no event will the authors be held liable for any damages    */
+/* arising from the use of this software.                                    */
+/*                                                                           */
+/* Permission is granted to anyone to use this software for any purpose,     */
+/* including commercial applications, and to alter it and redistribute it    */
+/* freely, subject to the following restrictions:                            */
+/*                                                                           */
+/* 1. The origin of this software must not be misrepresented; you must not   */
+/*    claim that you wrote the original software. If you use this software   */
+/*    in a product, an acknowledgment in the product documentation would be  */
+/*    appreciated but is not required.                                       */
+/* 2. Altered source versions must be plainly marked as such, and must not   */
+/*    be misrepresented as being the original software.                      */
+/* 3. This notice may not be removed or altered from any source              */
+/*    distribution.                                                          */
+/*                                                                           */
+/*****************************************************************************/
+
+
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+/* common */
+#include "alignment.h"
+#include "print.h"
+#include "xmalloc.h"
+
+/* ld65 */
+#include "xex.h"
+#include "config.h"
+#include "exports.h"
+#include "expr.h"
+#include "error.h"
+#include "global.h"
+#include "fileio.h"
+#include "lineinfo.h"
+#include "memarea.h"
+#include "segments.h"
+#include "spool.h"
+
+
+
+/*****************************************************************************/
+/*                                   Data                                    */
+/*****************************************************************************/
+
+
+
+struct XexDesc {
+    unsigned    Undef;          /* Count of undefined externals */
+    FILE*       F;              /* Output file */
+    const char* Filename;       /* Name of output file */
+};
+
+
+
+/*****************************************************************************/
+/*                                   Code                                    */
+/*****************************************************************************/
+
+
+
+XexDesc* NewXexDesc (void)
+/* Create a new XEX format descriptor */
+{
+    /* Allocate memory for a new XexDesc struct */
+    XexDesc* D = xmalloc (sizeof (XexDesc));
+
+    /* Initialize the fields */
+    D->Undef    = 0;
+    D->F        = 0;
+    D->Filename = 0;
+
+    /* Return the created struct */
+    return D;
+}
+
+
+
+void FreeXexDesc (XexDesc* D)
+/* Free a XEX format descriptor */
+{
+    xfree (D);
+}
+
+
+
+static unsigned XexWriteExpr (ExprNode* E, int Signed, unsigned Size,
+                              unsigned long Offs attribute ((unused)),
+                              void* Data)
+/* Called from SegWrite for an expression. Evaluate the expression, check the
+** range and write the expression value to the file.
+*/
+{
+    /* There's a predefined function to handle constant expressions */
+    return SegWriteConstExpr (((XexDesc*)Data)->F, E, Signed, Size);
+}
+
+
+
+static void PrintBoolVal (const char* Name, int B)
+/* Print a boolean value for debugging */
+{
+    Print (stdout, 2, "      %s = %s\n", Name, B? "true" : "false");
+}
+
+
+
+static void PrintNumVal (const char* Name, unsigned long V)
+/* Print a numerical value for debugging */
+{
+    Print (stdout, 2, "      %s = 0x%lx\n", Name, V);
+}
+
+
+
+static void XexWriteMem (XexDesc* D, MemoryArea* M)
+/* Write the segments of one memory area to a file */
+{
+    unsigned I;
+
+    /* Get the start address and size of this memory area */
+    unsigned long Addr = M->Start;
+
+    /* Walk over segments twice: first to get real area size, then to write
+     * all segments. */
+    for (I = 0; I < CollCount (&M->SegList); ++I) {
+
+        /* Get the segment */
+        SegDesc* S = CollAtUnchecked (&M->SegList, I);
+
+        /* Keep the user happy */
+        Print (stdout, 1, "    Allocating `%s'\n", GetString (S->Name));
+
+        /* If this is the run memory area, we must apply run alignment. If
+        ** this is not the run memory area but the load memory area (which
+        ** means that both are different), we must apply load alignment.
+        ** Beware: DoWrite may be true even if this is the run memory area,
+        ** because it may be also the load memory area.
+        */
+        if (S->Run == M) {
+
+            /* Handle ALIGN and OFFSET/START */
+            if (S->Flags & SF_ALIGN) {
+                /* Align the address */
+                Addr = AlignAddr (Addr, S->RunAlignment);
+            } else if (S->Flags & (SF_OFFSET | SF_START)) {
+                Addr = S->Addr;
+                if (S->Flags & SF_OFFSET) {
+                    /* It's an offset, not a fixed address, make an address */
+                    Addr += M->Start;
+                }
+            }
+
+        } else if (S->Load == M) {
+
+            /* Handle ALIGN_LOAD */
+            if (S->Flags & SF_ALIGN_LOAD) {
+                /* Align the address */
+                Addr = AlignAddr (Addr, S->LoadAlignment);
+            }
+
+        }
+
+        /* Calculate the new address */
+        Addr += S->Seg->Size;
+    }
+
+    /* Write header */
+    Write16(D->F, 0xFFFF);
+    Write16(D->F, M->Start);
+    Write16(D->F, Addr-1);
+
+    /* Redo */
+    Addr = M->Start;
+    for (I = 0; I < CollCount (&M->SegList); ++I) {
+
+        int DoWrite;
+
+        /* Get the segment */
+        SegDesc* S = CollAtUnchecked (&M->SegList, I);
+
+        /* Keep the user happy */
+        Print (stdout, 1, "    Allocating `%s'\n", GetString (S->Name));
+
+        /* Writes do only occur in the load area and not for BSS segments */
+        DoWrite = (S->Flags & SF_BSS) == 0      &&      /* No BSS segment */
+                   S->Load == M                 &&      /* LOAD segment */
+                   S->Seg->Dumped == 0;                 /* Not already written */
+
+        /* If this is the run memory area, we must apply run alignment. If
+        ** this is not the run memory area but the load memory area (which
+        ** means that both are different), we must apply load alignment.
+        ** Beware: DoWrite may be true even if this is the run memory area,
+        ** because it may be also the load memory area.
+        */
+        if (S->Run == M) {
+
+            /* Handle ALIGN and OFFSET/START */
+            if (S->Flags & SF_ALIGN) {
+                /* Align the address */
+                unsigned long NewAddr = AlignAddr (Addr, S->RunAlignment);
+                if (DoWrite || (M->Flags & MF_FILL) != 0) {
+                    WriteMult (D->F, M->FillVal, NewAddr - Addr);
+                    PrintNumVal ("SF_ALIGN", NewAddr - Addr);
+                }
+                Addr = NewAddr;
+            } else if (S->Flags & (SF_OFFSET | SF_START)) {
+                unsigned long NewAddr = S->Addr;
+                if (S->Flags & SF_OFFSET) {
+                    /* It's an offset, not a fixed address, make an address */
+                    NewAddr += M->Start;
+                }
+                if (DoWrite || (M->Flags & MF_FILL) != 0) {
+                    /* Seek in "overwrite" segments */
+                    if (S->Flags & SF_OVERWRITE) {
+                        fseek (D->F, NewAddr - M->Start, SEEK_SET);
+                    } else {
+                        WriteMult (D->F, M->FillVal, NewAddr-Addr);
+                        PrintNumVal ("SF_OFFSET", NewAddr - Addr);
+                    }
+                }
+                Addr = NewAddr;
+            }
+
+        } else if (S->Load == M) {
+
+            /* Handle ALIGN_LOAD */
+            if (S->Flags & SF_ALIGN_LOAD) {
+                /* Align the address */
+                unsigned long NewAddr = AlignAddr (Addr, S->LoadAlignment);
+                if (DoWrite || (M->Flags & MF_FILL) != 0) {
+                    WriteMult (D->F, M->FillVal, NewAddr - Addr);
+                    PrintNumVal ("SF_ALIGN_LOAD", NewAddr - Addr);
+                }
+                Addr = NewAddr;
+            }
+
+        }
+
+        /* Now write the segment to disk if it is not a BSS type segment and
+        ** if the memory area is the load area.
+        */
+        if (DoWrite) {
+            unsigned long P = ftell (D->F);
+            SegWrite (D->Filename, D->F, S->Seg, XexWriteExpr, D);
+            PrintNumVal ("Wrote", (unsigned long) (ftell (D->F) - P));
+        } else if (M->Flags & MF_FILL) {
+            WriteMult (D->F, S->Seg->FillVal, S->Seg->Size);
+            PrintNumVal ("Filled", (unsigned long) S->Seg->Size);
+        }
+
+        /* If this was the load memory area, mark the segment as dumped */
+        if (S->Load == M) {
+            S->Seg->Dumped = 1;
+        }
+
+        /* Calculate the new address */
+        Addr += S->Seg->Size;
+    }
+
+    /* If a fill was requested, fill the remaining space */
+    if ((M->Flags & MF_FILL) != 0 && M->FillLevel < M->Size) {
+        unsigned long ToFill = M->Size - M->FillLevel;
+        Print (stdout, 2, "    Filling 0x%lx bytes with 0x%02x\n",
+               ToFill, M->FillVal);
+        WriteMult (D->F, M->FillVal, ToFill);
+        M->FillLevel = M->Size;
+    }
+}
+
+
+
+static int XexUnresolved (unsigned Name attribute ((unused)), void* D)
+/* Called if an unresolved symbol is encountered */
+{
+    /* Unresolved symbols are an error in XEX format. Bump the counter
+    ** and return zero telling the caller that the symbol is indeed
+    ** unresolved.
+    */
+    ((XexDesc*) D)->Undef++;
+    return 0;
+}
+
+
+
+void XexWriteTarget (XexDesc* D, struct File* F)
+/* Write a XEX output file */
+{
+    unsigned I;
+
+    /* Place the filename in the control structure */
+    D->Filename = GetString (F->Name);
+
+    /* Check for unresolved symbols. The function XexUnresolved is called
+    ** if we get an unresolved symbol.
+    */
+    D->Undef = 0;               /* Reset the counter */
+    CheckUnresolvedImports (XexUnresolved, D);
+    if (D->Undef > 0) {
+        /* We had unresolved symbols, cannot create output file */
+        Error ("%u unresolved external(s) found - cannot create output file", D->Undef);
+    }
+
+    /* Open the file */
+    D->F = fopen (D->Filename, "wb");
+    if (D->F == 0) {
+        Error ("Cannot open `%s': %s", D->Filename, strerror (errno));
+    }
+
+    /* Keep the user happy */
+    Print (stdout, 1, "Opened `%s'...\n", D->Filename);
+
+    /* Dump all memory areas */
+    for (I = 0; I < CollCount (&F->MemoryAreas); ++I) {
+        /* Get this entry */
+        MemoryArea* M = CollAtUnchecked (&F->MemoryAreas, I);
+        Print (stdout, 1, "  XEX Dumping `%s'\n", GetString (M->Name));
+        XexWriteMem (D, M);
+    }
+
+    /* Close the file */
+    if (fclose (D->F) != 0) {
+        Error ("Cannot write to `%s': %s", D->Filename, strerror (errno));
+    }
+
+    /* Reset the file and filename */
+    D->F        = 0;
+    D->Filename = 0;
+}

--- a/src/ld65/xex.c
+++ b/src/ld65/xex.c
@@ -112,14 +112,6 @@ static unsigned XexWriteExpr (ExprNode* E, int Signed, unsigned Size,
 
 
 
-static void PrintBoolVal (const char* Name, int B)
-/* Print a boolean value for debugging */
-{
-    Print (stdout, 2, "      %s = %s\n", Name, B? "true" : "false");
-}
-
-
-
 static void PrintNumVal (const char* Name, unsigned long V)
 /* Print a numerical value for debugging */
 {

--- a/src/ld65/xex.h
+++ b/src/ld65/xex.h
@@ -1,15 +1,12 @@
 /*****************************************************************************/
 /*                                                                           */
-/*                                 target.h                                  */
+/*                                   xex.h                                   */
 /*                                                                           */
-/*                           Target specification                            */
+/*               Module to handle the Atari EXE binary format                */
 /*                                                                           */
 /*                                                                           */
 /*                                                                           */
-/* (C) 2000-2011, Ullrich von Bassewitz                                      */
-/*                Roemerstrasse 52                                           */
-/*                D-70794 Filderstadt                                        */
-/* EMail:         uz@cc65.org                                                */
+/* (C) 2018 Daniel Serpell                                                   */
 /*                                                                           */
 /*                                                                           */
 /* This software is provided 'as-is', without any expressed or implied       */
@@ -33,13 +30,12 @@
 
 
 
-#ifndef TARGET_H
-#define TARGET_H
+#ifndef XEX_H
+#define XEX_H
 
 
 
-/* common */
-#include "cpu.h"
+#include "config.h"
 
 
 
@@ -49,61 +45,8 @@
 
 
 
-/* Supported target systems */
-typedef enum {
-    TGT_UNKNOWN = -1,           /* Not specified or invalid target */
-    TGT_NONE,
-    TGT_MODULE,
-    TGT_ATARI,
-    TGT_ATARI2600,
-    TGT_ATARI5200,
-    TGT_ATARIXL,
-    TGT_VIC20,
-    TGT_C16,
-    TGT_C64,
-    TGT_C128,
-    TGT_PLUS4,
-    TGT_CBM510,
-    TGT_CBM610,
-    TGT_OSIC1P,
-    TGT_PET,
-    TGT_BBC,
-    TGT_APPLE2,
-    TGT_APPLE2ENH,
-    TGT_GEOS_CBM,
-    TGT_CREATIVISION,
-    TGT_GEOS_APPLE,
-    TGT_LUNIX,
-    TGT_ATMOS,
-    TGT_TELESTRAT,
-    TGT_NES,
-    TGT_SUPERVISION,
-    TGT_LYNX,
-    TGT_SIM6502,
-    TGT_SIM65C02,
-    TGT_PCENGINE,
-    TGT_GAMATE,
-    TGT_C65,
-    TGT_COUNT                   /* Number of target systems */
-} target_t;
-
-/* Collection of target properties */
-typedef struct TargetProperties TargetProperties;
-struct TargetProperties {
-    const char              Name[13];   /* Name of the target */
-    cpu_t                   DefaultCPU; /* Default CPU for this target */
-    unsigned char           BinFmt;     /* Default binary format for this target */
-    const unsigned char*    CharMap;    /* Character translation table */
-};
-
-/* Target system */
-extern target_t         Target;
-
-/* Types of available output formats */
-#define BINFMT_DEFAULT          0       /* Default (binary) */
-#define BINFMT_BINARY           1       /* Straight binary format */
-#define BINFMT_O65              2       /* Andre Fachats o65 format */
-#define BINFMT_ATARIEXE         3       /* Standard Atari binary load */
+/* Structure describing the format */
+typedef struct XexDesc XexDesc;
 
 
 
@@ -113,19 +56,17 @@ extern target_t         Target;
 
 
 
-target_t FindTarget (const char* Name);
-/* Find a target by name and return the target id. TGT_UNKNOWN is returned if
-** the given name is no valid target.
-*/
+XexDesc* NewXexDesc (void);
+/* Create a new XEX format descriptor */
 
-const TargetProperties* GetTargetProperties (target_t Target);
-/* Return the properties for a target */
+void FreeXexDesc (XexDesc* D);
+/* Free a XEX format descriptor */
 
-const char* GetTargetName (target_t Target);
-/* Return the name of a target */
+void XexWriteTarget (XexDesc* D, File* F);
+/* Write a XEX output file */
 
 
 
-/* End of target.h */
+/* End of xex.h */
 
 #endif

--- a/src/ld65/xex.h
+++ b/src/ld65/xex.h
@@ -36,6 +36,7 @@
 
 
 #include "config.h"
+#include "exports.h"
 
 
 
@@ -65,6 +66,8 @@ void FreeXexDesc (XexDesc* D);
 void XexWriteTarget (XexDesc* D, File* F);
 /* Write a XEX output file */
 
+void XexSetRunAd (XexDesc* D, Import *RunAd);
+/* Set the RUNAD export */
 
 
 /* End of xex.h */

--- a/testcode/lib/atari/asm-xex.s
+++ b/testcode/lib/atari/asm-xex.s
@@ -1,0 +1,51 @@
+; Sample using ATARI file format, by "atari-xex.cfg" linker configuration.
+;
+; This is a very simple example, shows a message to the screen, waits and
+; returns to DOS.
+;
+; Compile with:
+;    cl65 -tatari -Catari-xex.cfg asm-xex.s -o prog.xex
+
+        .include        "atari.inc"
+
+; Default RUNAD is "start", export that:
+        .export         start
+
+
+; Write string to screen
+.proc   puts
+        sta     ICBAL
+        stx     ICBAH
+        lda     #PUTREC
+        sta     ICCOM
+        ldx     #$FF
+        stx     ICBLL
+        inx
+        stx     ICBLH
+        jsr     CIOV
+        rts
+.endproc
+
+
+; Write a message and exit
+
+.proc   start
+        lda     #<msg
+        ldx     #>msg
+        jsr     puts
+
+
+        ; Delay before returning to DOS
+        lda     #0
+        tax
+loop:
+        inx
+        cpx     #$FF
+        adc     #0
+        bcc     loop
+
+        rts
+.endproc
+
+msg:    .byte   "Hello world", ATEOL
+

--- a/testcode/lib/atari/multi-xex.cfg
+++ b/testcode/lib/atari/multi-xex.cfg
@@ -1,0 +1,31 @@
+FEATURES {
+    STARTADDRESS: default = $2E00;
+}
+MEMORY {
+    ZP:      file = "", define = yes, start = $0082, size = $007E;
+    # First memory segment in file, load over COLOR registers:
+    COLOR:   file = %O, start = $2C4, size = 5;
+    # Second memory segment, load at page 6:
+    PAGE6:   file = %O, start = $600, size = 256;
+    # Third memory segment in file, load over SDLST register:
+    SDLST:   file = %O, start = $230, size = 2;
+    # Main segment, load at "STARTADDRESS"
+    MAIN:    file = %O, start = %S,   size = $BC20 - %S;
+}
+FILES {
+    %O: format = atari;
+}
+FORMATS {
+    atari: runad = start;
+}
+SEGMENTS {
+    ZEROPAGE: load = ZP,      type = zp,  optional = yes;
+    # Place segments in memory areas:
+    COLOR:    load = COLOR,   type = rw;
+    PAGE6:    load = PAGE6,   type = rw;
+    SDLST:    load = SDLST,   type = rw;
+    CODE:     load = MAIN,    type = rw;
+    RODATA:   load = MAIN,    type = ro   optional = yes;
+    DATA:     load = MAIN,    type = rw   optional = yes;
+    BSS:      load = MAIN,    type = bss, optional = yes, define = yes;
+}

--- a/testcode/lib/atari/multi-xex.s
+++ b/testcode/lib/atari/multi-xex.s
@@ -1,0 +1,63 @@
+; Multiple segment ATARI file format sample, using custom linker script.
+;
+; This sample defines a custom display-list screen with no code, writing all
+; memory areas directly.
+;
+; See the linker script (multi-xex.cfg) for the definition of memory areas and
+; segments.
+;
+; Compile with:
+;    cl65 -tatari -Cmulti-xex.cfg multi-xex.s -o prog.xex
+
+        .include        "atari.inc"
+
+        .macpack        atari
+
+; Default RUNAD is "start", export that:
+        .export         start
+
+
+; We load color values directly into registers
+        .segment        "COLOR"
+
+        .byte           $16     ; COLOR0
+        .byte           $46     ; COLOR1
+        .byte           $00     ; COLOR2
+        .byte           $6A     ; COLOR3
+        .byte           $82     ; COLOR4
+
+; We load our display list over page 6
+        .segment        "PAGE6"
+
+display_list:
+        .byte   DL_BLK8
+        .byte   DL_BLK8
+        .byte   DL_BLK8
+        .byte   DL_BLK8
+        .byte   DL_BLK8
+        .byte   DL_BLK8
+        .byte   DL_CHR20x8x2 | DL_LMS
+        .word   screen_memory
+        .byte   DL_CHR40x8x1
+        .byte   DL_JVB
+        .word   display_list
+
+screen_memory:
+        ; first text line: 20 bytes
+        scrcode   "    HeLlO wOrLd!    "
+        ; second text line, 40 bytes
+        .byte    0, 0, 0, 0, 0, 0, 0, 0,70,71,70,71,70,71,70,71,70,71,70,71
+        .byte   70,71,70,71,70,71,70,71,70,71,70,71, 0, 0, 0, 0, 0, 0, 0, 0
+
+; We write directly to the display list pointer
+        .segment        "SDLST"
+        .word   display_list
+
+; And we load our main program
+        .code
+
+.proc   start
+        ; Jump forever
+        jmp     start
+.endproc
+


### PR DESCRIPTION
The standard binary format in Atari DOS supports multiple loadable sections with address and size.

By adding support for this file format to the linker, we can simplify linker scripts and remove the headers from assembly files, this simplifies creation of custom linker scripts that load data at non-default addresses.

This pull request is for commenting on the feature, first commits add support for XEX format without changing the default liner scripts, the last one modifies all the Atari linker scripts.
