### PR TITLE
Warning about alignment when section address is defined by START or OFFSET

### DIFF
--- a/src/ld65/config.c
+++ b/src/ld65/config.c
@@ -1881,9 +1881,14 @@ unsigned CfgProcess (void)
                 */
 
                 /* Check if the alignment for the segment from the linker
-                ** config. is a multiple for that of the segment.
+                ** config is a multiple for that of the segment.
+                ** If START or OFFSET is provided instead of ALIGN, check
+                ** if its address fits alignment requirements.
                 */
-                if ((S->RunAlignment % S->Seg->Alignment) != 0) {
+                unsigned long AlignedBy = (S->Flags & SF_START) ? S->Addr
+                    : (S->Flags & SF_OFFSET) ? (S->Addr + M->Start)
+                    : S->RunAlignment;
+                if ((AlignedBy % S->Seg->Alignment) != 0) {
                     /* Segment requires another alignment than configured
                     ** in the linker.
                     */


### PR DESCRIPTION
I propose to don't output a warning about alignment when section address is defined by START or OFFSET and it fits alignment requirements.

Motivation: I have a project for NES. It has a segment where START is set, and it is not allowed to set ALIGN for such sections (where START or OFFSET is set). Using `.ALIGN` in this section causes an annoying warning. I propose to not display this warning if the segment address is already aligned well.