### PR TITLE
CL65: --no-rtl option for disabling default runtime library

### DIFF
--- a/doc/cl65.sgml
+++ b/doc/cl65.sgml
@@ -103,7 +103,7 @@ Long options:
   --memory-model model          Set the memory model
   --module                      Link as a module
   --module-id id                Specify a module id for the linker
-  --no-crt-lib                  Don't link default C runtime library
+  --no-std-lib                  Don't link standard runtime library
   --o65-model model             Override the o65 model
   --obj file                    Link this object file
   --obj-path path               Specify an object file search path
@@ -186,9 +186,10 @@ There are a few remaining options that control the behaviour of cl65:
   seem to use cc65 to develop for the C64.
 
 
-  <tag><tt>--no-crt-lib</tt></tag>
+  <tag><tt>--no-std-lib</tt></tag>
 
-  This option tells the cl65 to not include default C runtime library into the list of libraries.
+  This option tells the cl65 to not include standard runtime library into the
+  list of libraries.
 
 
 

--- a/doc/cl65.sgml
+++ b/doc/cl65.sgml
@@ -103,6 +103,7 @@ Long options:
   --memory-model model          Set the memory model
   --module                      Link as a module
   --module-id id                Specify a module id for the linker
+  --no-rtl                      Don't link default runtime library
   --o65-model model             Override the o65 model
   --obj file                    Link this object file
   --obj-path path               Specify an object file search path
@@ -183,6 +184,11 @@ There are a few remaining options that control the behaviour of cl65:
   and linker) will use the "none" system settings by default, cl65 will use
   "c64" as a target system by default. That was chosen because most people
   seem to use cc65 to develop for the C64.
+
+
+  <tag><tt>--no-rtl</tt></tag>
+
+  This option disables default runtime library of target system.
 
 
   <tag><tt>-Wa options, --asm-args options</tt></tag>

--- a/doc/cl65.sgml
+++ b/doc/cl65.sgml
@@ -103,7 +103,7 @@ Long options:
   --memory-model model          Set the memory model
   --module                      Link as a module
   --module-id id                Specify a module id for the linker
-  --no-rtl                      Don't link default runtime library
+  --no-crt-lib                  Don't link default C runtime library
   --o65-model model             Override the o65 model
   --obj file                    Link this object file
   --obj-path path               Specify an object file search path
@@ -186,9 +186,10 @@ There are a few remaining options that control the behaviour of cl65:
   seem to use cc65 to develop for the C64.
 
 
-  <tag><tt>--no-rtl</tt></tag>
+  <tag><tt>--no-crt-lib</tt></tag>
 
-  This option disables default runtime library of target system.
+  This option tells the cl65 to not include default C runtime library into the list of libraries.
+
 
 
   <tag><tt>-Wa options, --asm-args options</tt></tag>

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -139,6 +139,7 @@ static int Module = 0;
 
 /* Name of the target specific runtime library */
 static char* TargetLib  = 0;
+static int   NoRTL      = 0;
 
 
 
@@ -413,6 +414,12 @@ static void SetTargetFiles (void)
     /* Get a pointer to the system name and its length */
     const char* TargetName = GetTargetName (Target);
     unsigned    TargetNameLen = strlen (TargetName);
+
+    if (NoRTL)
+    {
+        /* Default RunTime Library is disabled */
+        return;
+    }
 
     /* Set the library file */
     TargetLib = xmalloc (TargetNameLen + 4 + 1);
@@ -812,6 +819,7 @@ static void Usage (void)
             "  --memory-model model\t\tSet the memory model\n"
             "  --module\t\t\tLink as a module\n"
             "  --module-id id\t\tSpecify a module ID for the linker\n"
+            "  --no-rtl\t\t\tDon't link default runtime library\n"
             "  --o65-model model\t\tOverride the o65 model\n"
             "  --obj file\t\t\tLink this object file\n"
             "  --obj-path path\t\tSpecify an object file search path\n"
@@ -1167,6 +1175,15 @@ static void OptModuleId (const char* Opt attribute ((unused)), const char* Arg)
 
 
 
+static void OptNoRTL (const char* Opt attribute ((unused)),
+                      const char* Arg attribute ((unused)))
+/* Disable default runtime library */
+{
+    NoRTL = 1;
+}
+
+
+
 static void OptO65Model (const char* Opt attribute ((unused)), const char* Arg)
 /* Handle the --o65-model option */
 {
@@ -1369,6 +1386,7 @@ int main (int argc, char* argv [])
         { "--memory-model",      1, OptMemoryModel    },
         { "--module",            0, OptModule         },
         { "--module-id",         1, OptModuleId       },
+        { "--no-rtl",            0, OptNoRTL          },
         { "--o65-model",         1, OptO65Model       },
         { "--obj",               1, OptObj            },
         { "--obj-path",          1, OptObjPath        },

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -139,7 +139,7 @@ static int Module = 0;
 
 /* Name of the target specific runtime library */
 static char* TargetLib  = 0;
-static int   NoRTL      = 0;
+static int   NoCrtLib   = 0;
 
 
 
@@ -415,12 +415,6 @@ static void SetTargetFiles (void)
     const char* TargetName = GetTargetName (Target);
     unsigned    TargetNameLen = strlen (TargetName);
 
-    if (NoRTL)
-    {
-        /* Default RunTime Library is disabled */
-        return;
-    }
-
     /* Set the library file */
     TargetLib = xmalloc (TargetNameLen + 4 + 1);
     memcpy (TargetLib, TargetName, TargetNameLen);
@@ -498,8 +492,11 @@ static void Link (void)
         CmdSetTarget (&LD65, Target);
     }
 
-    /* Determine which target libraries are needed */
-    SetTargetFiles ();
+    if (!NoCrtLib)
+    {
+        /* Determine which target libraries are needed */
+        SetTargetFiles ();
+    }
 
     /* Add all object files as parameters */
     for (I = 0; I < LD65.FileCount; ++I) {
@@ -819,7 +816,7 @@ static void Usage (void)
             "  --memory-model model\t\tSet the memory model\n"
             "  --module\t\t\tLink as a module\n"
             "  --module-id id\t\tSpecify a module ID for the linker\n"
-            "  --no-rtl\t\t\tDon't link default runtime library\n"
+            "  --no-crt-lib\t\t\tDon't link default C runtime library\n"
             "  --o65-model model\t\tOverride the o65 model\n"
             "  --obj file\t\t\tLink this object file\n"
             "  --obj-path path\t\tSpecify an object file search path\n"
@@ -1175,11 +1172,11 @@ static void OptModuleId (const char* Opt attribute ((unused)), const char* Arg)
 
 
 
-static void OptNoRTL (const char* Opt attribute ((unused)),
+static void OptNoCrtLib (const char* Opt attribute ((unused)),
                       const char* Arg attribute ((unused)))
 /* Disable default runtime library */
 {
-    NoRTL = 1;
+    NoCrtLib = 1;
 }
 
 
@@ -1386,7 +1383,7 @@ int main (int argc, char* argv [])
         { "--memory-model",      1, OptMemoryModel    },
         { "--module",            0, OptModule         },
         { "--module-id",         1, OptModuleId       },
-        { "--no-rtl",            0, OptNoRTL          },
+        { "--no-crt-lib",        0, OptNoCrtLib       },
         { "--o65-model",         1, OptO65Model       },
         { "--obj",               1, OptObj            },
         { "--obj-path",          1, OptObjPath        },

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -139,7 +139,7 @@ static int Module = 0;
 
 /* Name of the target specific runtime library */
 static char* TargetLib  = 0;
-static int   NoCrtLib   = 0;
+static int   NoStdLib   = 0;
 
 
 
@@ -492,20 +492,20 @@ static void Link (void)
         CmdSetTarget (&LD65, Target);
     }
 
-    if (!NoCrtLib)
-    {
-        /* Determine which target libraries are needed */
-        SetTargetFiles ();
-    }
-
     /* Add all object files as parameters */
     for (I = 0; I < LD65.FileCount; ++I) {
         CmdAddArg (&LD65, LD65.Files [I]);
     }
 
-    /* Add the system runtime library */
-    if (TargetLib) {
-        CmdAddArg (&LD65, TargetLib);
+    /* Add the standard runtime library if it is not disabled */
+    if (!NoStdLib)
+    {
+        /* Determine which target library is needed */
+        SetTargetFiles ();
+
+        if (TargetLib) {
+            CmdAddArg (&LD65, TargetLib);
+        }
     }
 
     /* Terminate the argument list with a NULL pointer */
@@ -816,7 +816,7 @@ static void Usage (void)
             "  --memory-model model\t\tSet the memory model\n"
             "  --module\t\t\tLink as a module\n"
             "  --module-id id\t\tSpecify a module ID for the linker\n"
-            "  --no-crt-lib\t\t\tDon't link default C runtime library\n"
+            "  --no-std-lib\t\t\tDon't link standard runtime library\n"
             "  --o65-model model\t\tOverride the o65 model\n"
             "  --obj file\t\t\tLink this object file\n"
             "  --obj-path path\t\tSpecify an object file search path\n"
@@ -1172,11 +1172,11 @@ static void OptModuleId (const char* Opt attribute ((unused)), const char* Arg)
 
 
 
-static void OptNoCrtLib (const char* Opt attribute ((unused)),
-                      const char* Arg attribute ((unused)))
-/* Disable default runtime library */
+static void OptNoStdLib (const char* Opt attribute ((unused)),
+                         const char* Arg attribute ((unused)))
+/* Disable standard runtime library */
 {
-    NoCrtLib = 1;
+    NoStdLib = 1;
 }
 
 
@@ -1383,7 +1383,7 @@ int main (int argc, char* argv [])
         { "--memory-model",      1, OptMemoryModel    },
         { "--module",            0, OptModule         },
         { "--module-id",         1, OptModuleId       },
-        { "--no-crt-lib",        0, OptNoCrtLib       },
+        { "--no-std-lib",        0, OptNoStdLib       },
         { "--o65-model",         1, OptO65Model       },
         { "--obj",               1, OptObj            },
         { "--obj-path",          1, OptObjPath        },


### PR DESCRIPTION
Sometimes it is useful to have an ability to disable default runtime library. All modern toolsets have this option. For example, `/NODEFAULTLIB` in the MSVC, and `-nodefaultlibs -nostdlib` in Clang. I propose to add such an option to the CL65. It could be useful for pure assembly projects, for example. 