### PR TITLE
[telestrat] Fix some segment and ld65 doc is updated

### DIFF
--- a/asminc/telestrat.inc
+++ b/asminc/telestrat.inc
@@ -1,30 +1,28 @@
 ;
-; Oric Telemon definition
-; Telemon 2.4 & Telemon 3.x
-; For telemon 3.x check http://orix.oric.org
+; Oric TELEMON definition
+; TELEMON 2.4 & TELEMON 3.x
+; For TELEMON 3.x check http://orix.oric.org
 ;
-
 
 ; ---------------------------------------------------------------------------
 ; Constants
 
-SCREEN_XSIZE    = 40            ; screen columns
-SCREEN_YSIZE    = 28            ; screen rows
+SCREEN_XSIZE    = 40            ; Screen columns
+SCREEN_YSIZE    = 28            ; Screen rows
 
 FUNCTKEY        = $A5
 
-FNAME_LEN       = 11            ; maximum length of file-name
+FNAME_LEN       = 11            ; Maximum length of file-name
 
 ; ---------------------------------------------------------------------------
 ; I/O Identifier
-; theses identifers are used for channel management
+; Theses identifers are used for channel management
 ; 
 
-XKBD            = $80           ; keyboard
+XKBD            = $80           ; Keyboard
 XRSE            = $83           ; RS232 in
-XSCR            = $88           ; screen
+XSCR            = $88           ; Screen
 XRSS            = $90           ; RS232 out
-
 
 ; ---------------------------------------------------------------------------
 ; Zero page
@@ -43,7 +41,7 @@ TR5             := $11
 TR6             := $12
 TR7             := $13
 
-PTR_READ_DEST   := $2C           ; used for XFREAD and XWRITE only in telemon 3.x
+PTR_READ_DEST   := $2C           ; Used for XFREAD and XWRITE only in TELEMON 3.x
 
 HRSX            := $46
 HRSY            := $47
@@ -59,7 +57,7 @@ HRSFB           := $57
 ; RS232T
 ; b0-b3 : speed 
 ;         1111 => 19200 bps  (please note that telestrat can't handle this speed without stopping all IRQ except ACIA's one)
-;         1100 =>  9600 bps  (default from telemon)
+;         1100 =>  9600 bps  (default from TELEMON)
 ;         1110 =>  4800 bps 
 ;         1010 =>  2400 bps 
 ;         1000 =>  1200 bps 
@@ -91,8 +89,6 @@ RS232C          := $5A
 ; ---------------------------------------------------------------------------
 ; Low memory
 IRQVec          := $02FB        ; "fast" interrupt vector
-
-
 
 ; ---------------------------------------------------------------------------
 ; I/O locations
@@ -148,39 +144,40 @@ SCREEN          := $BB80
 ; ---------------------------------------------------------------------------
 ; ROM entries
 
-; telemon primitives (2.4 & 3.x)
+; TELEMON primitives (2.4 & 3.x)
 
 ; all values are used to call bank 7 of telestrat cardridge. It works with 'brk value' 
 XRD0             = $08
 XRDW0            = $0C
 XWR0             = $10 
-XWSTR0           = $14          ; write a string in text mode
+XWSTR0           = $14          ; Write a string in text mode
 XTEXT            = $19
 XHIRES           = $1A
 XFILLM           = $1C
 XMINMA           = $1F
-XVARS            = $24          ; only in TELEMON 3.x, in telemon 2.4, it's XNOMFI ($24)
-XCRLF            = $25          ; jump a line and return to the beginning of the line
-XFREAD           = $27          ; only in TELEMON 3.x
-XOPEN            = $30          ; only in TELEMON 3.x
-XCOSCR           = $34          ; switch off cursor
-XCSSCR           = $35          ; switch on cursor
-XCLOSE           = $3A          ; only in TELEMON 3.x Close file
-XFWRITE          = $3B          ; only in TELEMON 3.x write file
+XVARS            = $24          ; Only in TELEMON 3.x, in TELEMON 2.4, it's XNOMFI ($24)
+XCRLF            = $25          ; Jump a line and return to the beginning of the line
+XFREAD           = $27          ; Only in TELEMON 3.x (bank 7 of Orix)
+XOPEN            = $30          ; Only in TELEMON 3.x (bank 7 of Orix)
+XCOSCR           = $34          ; Switch off cursor
+XCSSCR           = $35          ; Switch on cursor
+XCLOSE           = $3A          ; Only in TELEMON 3.x close file (bank 7 of Orix)
+XFWRITE          = $3B          ; Only in TELEMON 3.x write file (bank 7 of Orix)
 XSONPS           = $40
-XOUPS            = $42          ; send Oups sound into PSG
+XOUPS            = $42          ; Send Oups sound into PSG
 XPLAY            = $43
 XSOUND           = $44 
 XMUSIC           = $45 
 XZAP             = $46
 XSHOOT           = $47
-XMKDIR           = $4B          ; create a folder. Only available in telemon 3.x
-XRM              = $4D          ; remove a folder or a file. Only available in telemon 3.x
-XMALLOC          = $5B          ; only in telemon 3.x
-XSOUT            = $67          ; send accumulator value (A) to RS232, available in telemon 2.4 & 3.x : if RS232 buffer is full, the Oric Telestrat freezes
-XHRSSE           = $8C          ; set hires position cursor
-XDRAWA           = $8D          ; draw a line 
-XDRAWR           = $8E          ; draw a line 
+XMKDIR           = $4B          ; Create a folder. Only available in TELEMON 3.x (bank 7 of Orix)
+XRM              = $4D          ; Remove a folder or a file. Only available in TELEMON 3.x (bank 7 of Orix)
+XMALLOC          = $5B          ; Only in TELEMON 3.x (bank 7 of Orix)
+XFREE            = $62          ; Only in TELEMON 3.x (bank 7 of Orix)
+XSOUT            = $67          ; Send accumulator value (A) to RS232, available in TELEMON 2.4 & 3.x : if RS232 buffer is full, the Oric Telestrat freezes
+XHRSSE           = $8C          ; Set hires position cursor
+XDRAWA           = $8D          ; Draw a line 
+XDRAWR           = $8E          ; Draw a line 
 XCIRCL           = $8F
 XCURSE           = $90
 XCURMO           = $91
@@ -190,7 +187,7 @@ XBOX             = $94
 XABOX            = $95
 XFILL            = $96
 XCHAR            = $97
-XSCHAR           = $98          ; draw a string in hires
+XSCHAR           = $98          ; Draw a string in hires
 XEXPLO           = $9C 
 XPING            = $9D
 
@@ -205,7 +202,7 @@ SCRX             := $220
 SCRY             := $224
 ADSCRL           := $218
 ADSCRH           := $21C
-HRSPAT           := $2AA        ; hires pattern : it's used to draw pattern for a line or a circle
+HRSPAT           := $2AA        ; Hires pattern : it's used to draw pattern for a line or a circle
 IRQVECTOR        := $2FA
 
 
@@ -217,10 +214,12 @@ BUFEDT           := $590
 
 MAX_BUFEDT_LENGTH=110
 
+; ---------------------------------------------------------------------------
 ; Hardware
 CH376_DATA       := $340
 CH376_COMMAND    := $341
 
+; ---------------------------------------------------------------------------
 ; MACRO 
 
 .macro  BRK_TELEMON   value

--- a/asminc/telestrat.inc
+++ b/asminc/telestrat.inc
@@ -149,6 +149,8 @@ SCREEN          := $BB80
 ; ROM entries
 
 ; telemon primitives (2.4 & 3.x)
+
+; all values are used to call bank 7 of telestrat cardridge. It works with 'brk value' 
 XRD0             = $08
 XRDW0            = $0C
 XWR0             = $10 
@@ -158,6 +160,7 @@ XHIRES           = $1A
 XFILLM           = $1C
 XMINMA           = $1F
 XVARS            = $24          ; only in TELEMON 3.x, in telemon 2.4, it's XNOMFI ($24)
+XCRLF            = $25          ; jump a line and return to the beginning of the line
 XFREAD           = $27          ; only in TELEMON 3.x
 XOPEN            = $30          ; only in TELEMON 3.x
 XCOSCR           = $34          ; switch off cursor
@@ -173,6 +176,7 @@ XZAP             = $46
 XSHOOT           = $47
 XMKDIR           = $4B          ; create a folder. Only available in telemon 3.x
 XRM              = $4D          ; remove a folder or a file. Only available in telemon 3.x
+XMALLOC          = $5B          ; only in telemon 3.x
 XSOUT            = $67          ; send accumulator value (A) to RS232, available in telemon 2.4 & 3.x : if RS232 buffer is full, the Oric Telestrat freezes
 XHRSSE           = $8C          ; set hires position cursor
 XDRAWA           = $8D          ; draw a line 

--- a/cfg/telestrat.cfg
+++ b/cfg/telestrat.cfg
@@ -6,8 +6,8 @@ SYMBOLS {
 MEMORY {
     ZP:      file = "", define = yes, start = $00B0,            size = $003A;
     ORIXHDR: file = %O, type   = ro,  start = $0000,            size = $001F;
-    BASHEAD: file = %O, define = yes, start = $0801,            size = $000D;
-    MAIN:    file = %O, define = yes, start = __BASHEAD_LAST__, size = __RAMEND__ - __MAIN_START__;
+#    BASHEAD: file = %O, define = yes, start = $0801,            size = $000D;
+    MAIN:    file = %O, define = yes, start = $0800, size = __RAMEND__ - __MAIN_START__;
     BSS:     file = "",               start = __ONCE_RUN__,     size = __RAMEND__ - __STACKSIZE__ - __ONCE_RUN__;
 }
 SEGMENTS {

--- a/cfg/telestrat.cfg
+++ b/cfg/telestrat.cfg
@@ -1,7 +1,7 @@
 SYMBOLS {
     __ORIXHDR__:   type = import;
     __STACKSIZE__: type = weak, value = $0800; # 2K stack
-    __GRAB__:      type = weak, value = 1;     # 0=don't grab graphics RAM, 1=grab graphics RAM	
+    __GRAB__:      type = weak, value = 0;     # 0=don't grab graphics RAM, 1=grab graphics RAM
     __RAMEND__:    type = weak, value = $9800 + $1C00 * __GRAB__;		
 }
 MEMORY {

--- a/cfg/telestrat.cfg
+++ b/cfg/telestrat.cfg
@@ -1,7 +1,8 @@
 SYMBOLS {
     __ORIXHDR__:   type = import;
     __STACKSIZE__: type = weak, value = $0800; # 2K stack
-    __RAMEND__:    type = weak, value = $9800;
+    __GRAB__:      type = weak, value = 1;     # 0=don't grab graphics RAM, 1=grab graphics RAM	
+    __RAMEND__:    type = weak, value = $9800 + $1C00 * __GRAB__;		
 }
 MEMORY {
     ZP:      file = "", define = yes, start = $00B0,            size = $003A;

--- a/cfg/telestrat.cfg
+++ b/cfg/telestrat.cfg
@@ -6,8 +6,7 @@ SYMBOLS {
 MEMORY {
     ZP:      file = "", define = yes, start = $00B0,            size = $003A;
     ORIXHDR: file = %O, type   = ro,  start = $0000,            size = $001F;
-#    BASHEAD: file = %O, define = yes, start = $0801,            size = $000D;
-    MAIN:    file = %O, define = yes, start = $0800, size = __RAMEND__ - __MAIN_START__;
+    MAIN:    file = %O, define = yes, start = $0800,            size = __RAMEND__ - __MAIN_START__;
     BSS:     file = "",               start = __ONCE_RUN__,     size = __RAMEND__ - __STACKSIZE__ - __ONCE_RUN__;
 }
 SEGMENTS {

--- a/doc/ld65.sgml
+++ b/doc/ld65.sgml
@@ -175,6 +175,7 @@ Here is a description of all of the command-line options:
   <item>sim6502
   <item>sim65c02
   <item>supervision
+  <item>telestrat
   <item>vic20
   </itemize>
 

--- a/libsrc/telestrat/orixhdr.s
+++ b/libsrc/telestrat/orixhdr.s
@@ -17,19 +17,19 @@
 
 .segment        "ORIXHDR"
 
-    .byte   $01, $00                ; non C64 marker (same as o65 format)
+    .byte   $01, $00                ; Non C64 marker (same as o65 format)
 
-    .byte   "ori"                   ; magic number
+    .byte   "ori"                   ; Magic number
 
-    .byte   $01                     ; version of the header
+    .byte   $01                     ; Version of the header
     .byte   $00,%00000000           ; 6502 only
-    .byte   $00,$00                 ; type of language
+    .byte   $00,$00                 ; Type of language
     .byte   $00,$00                 ; OS version 
 
-    .byte   $00                     ;  reserved
-    .byte   $00                     ;  auto or not
+    .byte   $00                     ; Reserved
+    .byte   $00                     ; Auto or not
 
     .word   __MAIN_START__          ; Address of start of file
-    .word   __MAIN_LAST__ - 1       ;  Address of end of file
-    .word   __MAIN_START__          ;  Address of start of file
+    .word   __MAIN_LAST__ - 1       ; Address of end of file
+    .word   __MAIN_START__          ; Address of start of file
 

--- a/libsrc/telestrat/orixhdr.s
+++ b/libsrc/telestrat/orixhdr.s
@@ -9,7 +9,7 @@
 
     ; These symbols, also, come from the configuration file.
     .import __AUTORUN__, __PROGFLAG__
-    .import __BASHEAD_START__, __MAIN_LAST__
+    .import __MAIN_START__, __MAIN_LAST__
 
 
 ; ------------------------------------------------------------------------
@@ -29,7 +29,7 @@
     .byte   $00                     ;  reserved
     .byte   $00                     ;  auto or not
 
-    .word   __BASHEAD_START__       ; Address of start of file
+    .word   __MAIN_START__          ; Address of start of file
     .word   __MAIN_LAST__ - 1       ;  Address of end of file
-    .word   __BASHEAD_START__       ;  Address of start of file
+    .word   __MAIN_START__          ;  Address of start of file
 

--- a/libsrc/telestrat/wherey.s
+++ b/libsrc/telestrat/wherey.s
@@ -3,8 +3,6 @@
 ; 
     .export    _wherey
 	
-    .importzp  sp
-
     .include   "telestrat.inc"
 
 .proc _wherey


### PR DESCRIPTION
This pull request contains : 

- ld65.sgml updated with telestrat target
- bashead segment removed (not useful for telestrat target)
- remove importzp (sp) for wherey.s (not useful for wherey.s)
- some rom calls added (XCRLF ...)
- grab segment added (like atmos target) in order to get extra memory when binary does not need to switch to hires mode.


