### PR TITLE
Added missing external declaration of c64_65816_emd.

### DIFF
--- a/include/c64.h
+++ b/include/c64.h
@@ -137,6 +137,7 @@
 
 
 /* The addresses of the static drivers */
+extern void c64_65816_emd[];
 extern void c64_c256k_emd[];
 extern void c64_dqbb_emd[];
 extern void c64_georam_emd[];


### PR DESCRIPTION
The code and documentation are there, just the declaration in the header file was missing.