### PR TITLE
add support for detecting 45GS02

### DIFF
--- a/include/6502.h
+++ b/include/6502.h
@@ -55,6 +55,7 @@ typedef unsigned size_t;
 #define CPU_65CE02      5
 #define CPU_HUC6280     6
 #define CPU_2A0x        7
+#define CPU_45GS02      8
 
 unsigned char getcpu (void);
 /* Detect the CPU the program is running on */

--- a/libsrc/common/getcpu.s
+++ b/libsrc/common/getcpu.s
@@ -17,6 +17,7 @@
 ;   - carry set and 5 in A for a 65CE02
 ;   - carry set and 6 in A for a HuC6280
 ;   - carry clear and 7 in A for a 2a03/2a07
+;   - carry set and 8 in A for a 45GS02
 ;
 ; This function uses a $1A opcode which is a INA on the 816 and ignored
 ; (interpreted as a NOP) on a NMOS 6502. There are several CMOS versions
@@ -26,52 +27,118 @@
 .p816                           ; Enable 65816 instructions
 
 _getcpu:
+
         lda     #0
         inc     a               ; .byte $1A ; nop on nmos, inc on every cmos
         cmp     #1
-        bcc     @L8
+        bcc     @IsNMOS
 
 ; This is at least a 65C02, check for a 65CE02/4510
 
         .byte   $42,$EA         ; neg on 65CE02/4510, nop #$EA on 65C02, wdm $EA on 65816
         cmp     #1
-        beq     @L6
+        beq     @HasINCA
 
 ; This is at least a 65CE02, check for 4510
 
         lda     #5              ; CPU_65CE02 constant
+	ldx	#0		; To make sure MAP doesn't do anything, the upper nybl of X and Z must be clear
         .byte   $5C             ; map on 4510, aug on 65CE02 (acts like 4 byte nop)
         lda     #3              ; CPU_4510 constant
         nop
-        bne     @L9
+	cmp	#5
+        beq     @LoadXAndReturn
+
+; It is either a 4510 (C65) or a 45GS02 (MEGA65)
+
+        ; 45GS02 supports 32-bit ZP indirect, so use that to check CPU type
+        ; without requiring a functioning MEGA65 hypervisor.
+        ; We setup a read of $200FF, then store a different value in $00FF
+        ; and then re-read $200FF to see if it is unchanged.
+
+        ; Save the 32-bit ZP pointer and data byte
+        ldx     #$04
+@L10:   lda     $fb,x
+        sta     @GetCPUTemp,x
+        dex
+        bpl     @L10
+
+        ; Setup 32-bit pointer
+        lda     #$ff
+        sta     $fb
+        lda     #$00
+        sta     $fc
+        sta     $fe
+        lda     #$02
+        sta     $fd
+
+        ; Prefixing LDA ($nn),Z with a NOP uses 32-bit ZP pointer on 45GS02,
+        ; but normal 16-bit ZP pointer on 4510
+        ; (We assume Z=$00, which will be the normal case)
+        nop                     ; prefix to tell next instruction to be 32-bit ZP
+        .byte   $b2,$fb         ; LDA ($nn),Z
+        eor     #$ff            ; change the value
+        sta     $ff             ; store in $FF
+        ; now try again to load it: If the same, then 45GS02, as $200FF is unchanged
+        nop                     ; prefix to tell next instruction to be 32-bit ZP
+        .byte   $b2,$fb         ; LDA ($nn),Z
+        cmp     $ff             ; does the loaded value match what is in $FF?
+        beq     @Is4510         ; matches, so must be a 4510 = C65
+        bne     @Is45GS02       ; $200FF and $FF have different values, so must be a MEGA65 45GS02
+@Is4510:
+        jsr     @RestoreGetCPUTemp
+        lda     #$03            ; CPU_4510 constant
+        ldx     #0              ; Load high byte of word
+        rts
+
+@Is45GS02:
+        jsr     @RestoreGetCPUTemp
+        lda     #$08            ; CPU_45GS02 constant
+        ldx     #0              ; Load high byte of word
+        rts
+
+@RestoreGetCPUTemp:
+        ; Save the 32-bit ZP pointer and data byte
+        ldx     #$04
+@L11:   lda     @GetCPUTemp,x
+        sta     $fb,x
+        dex
+        bpl     @L11
+        rts
+
+        ; Temporary storage for the ZP locations we modify above
+@GetCPUTemp:    .byte   0,0,0,0,0
+
+
 
 ; 6502 type of cpu, check for a 2a03/2a07
-@L8:
+@IsNMOS:
         sed                     ; set decimal mode, no decimal mode on the 2a03/2a07
         lda     #9
         clc
         adc     #1              ; $01+$09 = $10 on 6502, $01+$09 = $0A on 2a03/2a07
         cld
         cmp     #$0a
-        beq     @L5
+        beq     @Is2a03
         lda     #0              ; CPU_6502 constant
-        beq     @L9
-@L5:
+        beq     @LoadXAndReturn
+@Is2a03:
         lda     #7              ; CPU_2A0x constant
-        bne     @L9
+        bne     @LoadXAndReturn
 
 ; 65C02 cpu type, check for HuC6280
-@L4:    ldx     #6              ; CPU_HUC6280 constant
+@CheckHuC6280:    ldx     #6              ; CPU_HUC6280 constant
         .byte   $22,$EA         ; sax nop on HuC6280 (A=$06, X=$01), nop #$EA on 65C02 (A=$01, X=$06)
-        bne     @L9
+        bne     @LoadXAndReturn
 
 ; Check for 65816/65802
-@L6:    xba                     ; .byte $EB, put $01 in B accu (nop on 65C02/65SC02)
+@HasINCA:
+	xba                     ; .byte $EB, put $01 in B accu (nop on 65C02/65SC02)
         dec     a               ; .byte $3A, A=$00
         xba                     ; .byte $EB, A=$01 if 65816/65802 and A=$00 if 65C02/65SC02
         inc     a               ; .byte $1A, A=$02 if 65816/65802 and A=$01 if 65C02/65SC02
         cmp     #2
-        beq     @L9
+        beq     @LoadXAndReturn
 
 ; check for 65SC02
 
@@ -82,9 +149,8 @@ _getcpu:
         ldx     $F7
         sty     $F7
         cpx     #$00
-        bne     @L4
+        bne     @CheckHuC6280
         lda     #4              ; CPU_65SC02 constant
-
-@L9:    ldx     #0              ; Load high byte of word
-        rts
-
+@LoadXAndReturn:
+	ldx	#0
+	rts


### PR DESCRIPTION
Added support for detecting for MEGA65 45GS02 CPU.
Also renamed a bunch of labels to make it easier to follow the flow of getcpu().