### PR TITLE
add support for detecting 45GS02, give labels in getcpu.s useful names

### DIFF
--- a/include/6502.h
+++ b/include/6502.h
@@ -55,6 +55,7 @@ typedef unsigned size_t;
 #define CPU_65CE02      5
 #define CPU_HUC6280     6
 #define CPU_2A0x        7
+#define CPU_45GS02      8
 
 unsigned char getcpu (void);
 /* Detect the CPU the program is running on */

--- a/libsrc/common/getcpu.s
+++ b/libsrc/common/getcpu.s
@@ -76,7 +76,6 @@ _getcpu:
         nop                     ; prefix to tell next instruction to be 32-bit ZP
         .byte   $b2,regsave     ; LDA (regsave),Z
         cmp     tmp1            ; does the loaded value match what is in $FF?
-        beq     @Is4510         ; matches, so must be a 4510 = C65
         bne     @Is45GS02       ; $200FF and $FF have different values, so must be a MEGA65 45GS02
 @Is4510:
         lda     #3              ; CPU_4510 constant

--- a/libsrc/common/getcpu.s
+++ b/libsrc/common/getcpu.s
@@ -75,8 +75,8 @@ _getcpu:
         ; now try again to load it: If the same, then 45GS02, as $200xx is unchanged
         nop                     ; prefix to tell next instruction to be 32-bit ZP
         .byte   $b2,regsave     ; LDA (regsave),Z
-        cmp     tmp1            ; does the loaded value match what is in $FF?
-        bne     @Is45GS02       ; $200FF and $FF have different values, so must be a MEGA65 45GS02
+        cmp     tmp1            ; does the loaded value match what is in $xx?
+        bne     @Is45GS02       ; $200xx and $xx have different values, so must be a MEGA65 45GS02
 @Is4510:
         lda     #3              ; CPU_4510 constant
         ldx     #0              ; load high byte of word


### PR DESCRIPTION
This is the pull request to replace the previous one, with all requested changes made.