### PR TITLE
Update cbm510.sgml

### DIFF
--- a/doc/cbm510.sgml
+++ b/doc/cbm510.sgml
@@ -244,7 +244,7 @@ The default drivers, <tt/mouse_stddrv (mouse_static_stddrv)/, point to <tt/cbm51
 
 <sect1>Realtime clock<p>
 
-The realtime clock functions use the CIA1 TOD clock. As that clock only stores
+The realtime clock functions use the CIA2 TOD clock. As that clock only stores
 the time but not the date, the date set by <tt/clock_settime()/ is simply stored
 inside the C library for retrieval in the same program via <tt/clock_gettime()/.
 


### PR DESCRIPTION
There is just one CIA but it's not called "CIA1"...
https://github.com/cc65/cc65/blob/40f42e977f40a9a861345d77ef6f8b986fbece4b/libsrc/cbm510/extzp.inc#L9 **3** CIAs? Uz seems a little bit confused.

For your information
C64/C128:
* CIA1
* CIA2

CBM 510/610:
* IPC CIA (optional daughterboard)
* CIA (motherboard)