### PR TITLE
Add an optimization for an indexed load from a pointer literal.

### DIFF
--- a/src/cc65/codeopt.c
+++ b/src/cc65/codeopt.c
@@ -704,6 +704,7 @@ static OptFunc DOptPtrLoad14    = { OptPtrLoad14,    "OptPtrLoad14",    108, 0, 
 static OptFunc DOptPtrLoad15    = { OptPtrLoad15,    "OptPtrLoad15",     86, 0, 0, 0, 0, 0 };
 static OptFunc DOptPtrLoad16    = { OptPtrLoad16,    "OptPtrLoad16",    100, 0, 0, 0, 0, 0 };
 static OptFunc DOptPtrLoad17    = { OptPtrLoad17,    "OptPtrLoad17",    190, 0, 0, 0, 0, 0 };
+static OptFunc DOptPtrLoad18    = { OptPtrLoad18,    "OptPtrLoad18",    100, 0, 0, 0, 0, 0 };
 static OptFunc DOptPtrStore1    = { OptPtrStore1,    "OptPtrStore1",     65, 0, 0, 0, 0, 0 };
 static OptFunc DOptPtrStore2    = { OptPtrStore2,    "OptPtrStore2",     65, 0, 0, 0, 0, 0 };
 static OptFunc DOptPtrStore3    = { OptPtrStore3,    "OptPtrStore3",    100, 0, 0, 0, 0, 0 };
@@ -794,6 +795,7 @@ static OptFunc* OptFuncs[] = {
     &DOptPtrLoad15,
     &DOptPtrLoad16,
     &DOptPtrLoad17,
+    &DOptPtrLoad18,
     &DOptPtrLoad2,
     &DOptPtrLoad3,
     &DOptPtrLoad4,
@@ -1134,6 +1136,7 @@ static unsigned RunOptGroup1 (CodeSeg* S)
     Changes += RunOptFunc (S, &DOptPtrLoad5, 1);
     Changes += RunOptFunc (S, &DOptPtrLoad6, 1);
     Changes += RunOptFunc (S, &DOptPtrLoad7, 1);
+    Changes += RunOptFunc (S, &DOptPtrLoad18, 1); /* Before OptPtrLoad11 */
     Changes += RunOptFunc (S, &DOptPtrLoad11, 1);
     Changes += RunOptFunc (S, &DOptPtrLoad12, 1);
     Changes += RunOptFunc (S, &DOptPtrLoad13, 1);

--- a/src/cc65/codeopt.c
+++ b/src/cc65/codeopt.c
@@ -1137,8 +1137,9 @@ static unsigned RunOptGroup1 (CodeSeg* S)
     Changes += RunOptFunc (S, &DOptPtrLoad4, 1);
     Changes += RunOptFunc (S, &DOptPtrLoad5, 1);
     Changes += RunOptFunc (S, &DOptPtrLoad6, 1);
+    Changes += RunOptFunc (S, &DOptPtrLoad18, 1); /* Before OptPtrLoad7 */
+    Changes += RunOptFunc (S, &DOptPtrLoad19, 1); /* Before OptPtrLoad7 */
     Changes += RunOptFunc (S, &DOptPtrLoad7, 1);
-    Changes += RunOptFunc (S, &DOptPtrLoad18, 1); /* Before OptPtrLoad11 */
     Changes += RunOptFunc (S, &DOptPtrLoad11, 1);
     Changes += RunOptFunc (S, &DOptPtrLoad12, 1);
     Changes += RunOptFunc (S, &DOptPtrLoad13, 1);
@@ -1146,7 +1147,6 @@ static unsigned RunOptGroup1 (CodeSeg* S)
     Changes += RunOptFunc (S, &DOptPtrLoad15, 1);
     Changes += RunOptFunc (S, &DOptPtrLoad16, 1);
     Changes += RunOptFunc (S, &DOptPtrLoad17, 1);
-    Changes += RunOptFunc (S, &DOptPtrLoad19, 1);
     Changes += RunOptFunc (S, &DOptBNegAX1, 1);
     Changes += RunOptFunc (S, &DOptBNegAX2, 1);
     Changes += RunOptFunc (S, &DOptBNegAX3, 1);

--- a/src/cc65/codeopt.c
+++ b/src/cc65/codeopt.c
@@ -705,6 +705,7 @@ static OptFunc DOptPtrLoad15    = { OptPtrLoad15,    "OptPtrLoad15",     86, 0, 
 static OptFunc DOptPtrLoad16    = { OptPtrLoad16,    "OptPtrLoad16",    100, 0, 0, 0, 0, 0 };
 static OptFunc DOptPtrLoad17    = { OptPtrLoad17,    "OptPtrLoad17",    190, 0, 0, 0, 0, 0 };
 static OptFunc DOptPtrLoad18    = { OptPtrLoad18,    "OptPtrLoad18",    100, 0, 0, 0, 0, 0 };
+static OptFunc DOptPtrLoad19    = { OptPtrLoad19,    "OptPtrLoad19",     65, 0, 0, 0, 0, 0 };
 static OptFunc DOptPtrStore1    = { OptPtrStore1,    "OptPtrStore1",     65, 0, 0, 0, 0, 0 };
 static OptFunc DOptPtrStore2    = { OptPtrStore2,    "OptPtrStore2",     65, 0, 0, 0, 0, 0 };
 static OptFunc DOptPtrStore3    = { OptPtrStore3,    "OptPtrStore3",    100, 0, 0, 0, 0, 0 };
@@ -796,6 +797,7 @@ static OptFunc* OptFuncs[] = {
     &DOptPtrLoad16,
     &DOptPtrLoad17,
     &DOptPtrLoad18,
+    &DOptPtrLoad19,
     &DOptPtrLoad2,
     &DOptPtrLoad3,
     &DOptPtrLoad4,
@@ -1144,6 +1146,7 @@ static unsigned RunOptGroup1 (CodeSeg* S)
     Changes += RunOptFunc (S, &DOptPtrLoad15, 1);
     Changes += RunOptFunc (S, &DOptPtrLoad16, 1);
     Changes += RunOptFunc (S, &DOptPtrLoad17, 1);
+    Changes += RunOptFunc (S, &DOptPtrLoad19, 1);
     Changes += RunOptFunc (S, &DOptBNegAX1, 1);
     Changes += RunOptFunc (S, &DOptBNegAX2, 1);
     Changes += RunOptFunc (S, &DOptBNegAX3, 1);

--- a/src/cc65/coptptrload.c
+++ b/src/cc65/coptptrload.c
@@ -1554,3 +1554,116 @@ unsigned OptPtrLoad18 (CodeSeg* S)
 
 
 
+unsigned OptPtrLoad19 (CodeSeg* S)
+/* Search for the sequence:
+**
+**	and	#mask		(any value < 128)
+**      jsr     aslax1/shlax1
+**      clc
+**      adc     #<(label+0)
+**      tay
+**      txa
+**      adc     #>(label+0)
+**      tax
+**      tya
+**      ldy     #$01
+**      jsr     ldaxidx
+**
+** and replace it by:
+**
+**	and	#mask		(remove if == 127)
+**	asl
+**	tay
+**	lda	label,y
+**	ldx	label+1,y
+*/
+{
+    unsigned Changes = 0;
+    unsigned I;
+
+    /* Walk over the entries */
+    I = 0;
+    while (I < CS_GetEntryCount (S)) {
+
+        CodeEntry* L[11];
+
+        /* Get next entry */
+        L[0] = CS_GetEntry (S, I);
+
+        /* Check for the sequence */
+        if (L[0]->OPC == OP65_AND                               &&
+            L[0]->AM == AM65_IMM                                &&
+            CE_HasNumArg (L[0]) && L[0]->Num <= 127             &&
+            CS_GetEntries (S, L+1, I+1, 10)                     &&
+            L[1]->OPC == OP65_JSR                               &&
+            (strcmp (L[1]->Arg, "aslax1") == 0          ||
+             strcmp (L[1]->Arg, "shlax1") == 0)                 &&
+            L[2]->OPC == OP65_CLC                               &&
+            L[3]->OPC == OP65_ADC                               &&
+            L[4]->OPC == OP65_TAY                               &&
+            L[5]->OPC == OP65_TXA                               &&
+            L[6]->OPC == OP65_ADC                               &&
+            L[7]->OPC == OP65_TAX                               &&
+            L[8]->OPC == OP65_TYA                               &&
+            L[9]->OPC == OP65_LDY                               &&
+            CE_IsKnownImm(L[9], 1)                              &&
+            strlen(L[3]->Arg) >= 3                              &&
+            L[3]->Arg[0] == '<'                                 &&
+            strlen(L[6]->Arg) >= 3                              &&
+            L[6]->Arg[0] == '>'                                 &&
+            !strcmp(L[3]->Arg+1, L[6]->Arg+1)                   &&
+            CE_IsCallTo (L[10], "ldaxidx")                      &&
+            !CS_RangeHasLabel (S, I+1, 10)) {
+
+            CodeEntry* X;
+            char* Label;
+            int Len = strlen(L[3]->Arg);
+
+            /* Track the insertion point */
+            unsigned IP = I + 11;
+
+            /* asl a */
+            X = NewCodeEntry (OP65_ASL, AM65_ACC, "a", 0, L[1]->LI);
+            CS_InsertEntry (S, X, IP++);
+
+            /* tay */
+            X = NewCodeEntry (OP65_TAY, AM65_IMP, 0, 0, L[1]->LI);
+            CS_InsertEntry (S, X, IP++);
+
+            /* lda label,y */
+            Label = memcpy (xmalloc (Len-2), L[3]->Arg+2, Len-3);
+            Label[Len-3] = '\0';
+            X = NewCodeEntry (OP65_LDA, AM65_ABSY, Label, 0, L[9]->LI);
+            CS_InsertEntry (S, X, IP++);
+            xfree (Label);
+
+            /* lda label+1,y */
+            Label = memcpy (xmalloc (Len), L[3]->Arg+2, Len-3);
+            strcpy(&Label[Len-3], "+1");
+            X = NewCodeEntry (OP65_LDX, AM65_ABSY, Label, 0, L[9]->LI);
+            CS_InsertEntry (S, X, IP++);
+            xfree (Label);
+
+            /* Remove the old code */
+            /* Remove the AND only if it's == 127, since ASL erases high bit */
+            if (L[0]->Num == 127)
+                CS_DelEntries (S, I, 11);
+            else
+                CS_DelEntries (S, I+1, 10);
+
+            /* Remember, we had changes */
+            ++Changes;
+
+        }
+
+        /* Next entry */
+        ++I;
+
+    }
+
+    /* Return the number of changes made */
+    return Changes;
+}
+
+
+

--- a/src/cc65/coptptrload.c
+++ b/src/cc65/coptptrload.c
@@ -1457,3 +1457,100 @@ unsigned OptPtrLoad17 (CodeSeg* S)
     /* Return the number of changes made */
     return Changes;
 }
+
+
+
+unsigned OptPtrLoad18 (CodeSeg* S)
+/* Search for the sequence:
+**
+**      ldx     #$xx
+**      lda     #$yy
+**      clc
+**      adc     xxx
+**      bcc     L
+**      inx
+** L:   ldy     #$00
+**      jsr     ldauidx
+**
+** and replace it by:
+**
+**      ldy     xxx
+**      ldx     #$00
+**      lda     $xxyy,y
+**
+** This is similar to OptPtrLoad3 but works on a constant address
+** instead of a label. Also, the initial X and A loads are reversed.
+** Must be run before OptPtrLoad11.
+*/
+{
+    unsigned Changes = 0;
+
+    /* Walk over the entries */
+    unsigned I = 0;
+    while (I < CS_GetEntryCount (S)) {
+
+        CodeEntry* L[8];
+
+        /* Get next entry */
+        L[0] = CS_GetEntry (S, I);
+
+        /* Check for the sequence */
+        if (L[0]->OPC == OP65_LDX                            &&
+            L[0]->AM == AM65_IMM                             &&
+            CS_GetEntries (S, L+1, I+1, 7)                   &&
+            L[1]->OPC == OP65_LDA                            &&
+            L[1]->AM == AM65_IMM                             &&
+            L[2]->OPC == OP65_CLC                            &&
+            L[3]->OPC == OP65_ADC                            &&
+            (L[3]->AM == AM65_ABS || L[3]->AM == AM65_ZP)    &&
+            (L[4]->OPC == OP65_BCC || L[4]->OPC == OP65_JCC) &&
+            L[4]->JumpTo != 0                                &&
+            L[4]->JumpTo->Owner == L[6]                      &&
+            L[5]->OPC == OP65_INX                            &&
+            L[6]->OPC == OP65_LDY                            &&
+            CE_IsKnownImm (L[6], 0)                          &&
+            CE_IsCallTo (L[7], "ldauidx")                    &&
+            !CS_RangeHasLabel (S, I+1, 5)                    &&
+            !CE_HasLabel (L[7])                              &&
+            strlen (L[0]->Arg) == 3                          &&
+            L[0]->Arg[0] == '$'                              &&
+            strlen (L[1]->Arg) == 3                          &&
+            L[1]->Arg[0] == '$'                              ) {
+
+            CodeEntry* X;
+            char* Label;
+
+            /* We will create all the new stuff behind the current one so
+            ** we keep the line references.
+            */
+            X = NewCodeEntry (OP65_LDY, L[3]->AM, L[3]->Arg, 0, L[0]->LI);
+            CS_InsertEntry (S, X, I+8);
+
+            X = NewCodeEntry (OP65_LDX, AM65_IMM, "$00", 0, L[0]->LI);
+            CS_InsertEntry (S, X, I+9);
+
+            Label = xmalloc(6);
+            sprintf(Label, "$%s%s", L[0]->Arg+1, L[1]->Arg+1);
+            X = NewCodeEntry (OP65_LDA, AM65_ABSY, Label, 0, L[0]->LI);
+            CS_InsertEntry (S, X, I+10);
+            xfree (Label);
+
+            /* Remove the old code */
+            CS_DelEntries (S, I, 8);
+
+            /* Remember, we had changes */
+            ++Changes;
+
+        }
+
+        /* Next entry */
+        ++I;
+
+    }
+
+    /* Return the number of changes made */
+    return Changes;
+}
+
+
+

--- a/src/cc65/coptptrload.c
+++ b/src/cc65/coptptrload.c
@@ -1633,16 +1633,14 @@ unsigned OptPtrLoad19 (CodeSeg* S)
             X = NewCodeEntry (OP65_TAY, AM65_IMP, 0, 0, L[2]->LI);
             CS_InsertEntry (S, X, IP++);
 
-            /* allocate Label memory */
-            Label = xmalloc (Len);
             /* lda label,y */
-            Label = memcpy (Label, L[4]->Arg+2, Len-3);
+            /* allocate Label memory */
+            Label = memcpy (xmalloc (Len), L[4]->Arg+2, Len-3);
             Label[Len-3] = '\0';
             X = NewCodeEntry (OP65_LDA, AM65_ABSY, Label, 0, L[10]->LI);
             CS_InsertEntry (S, X, IP++);
 
             /* ldx label+1,y */
-            Label = memcpy (Label, L[4]->Arg+2, Len-3);
             strcpy(&Label[Len-3], "+1");
             X = NewCodeEntry (OP65_LDX, AM65_ABSY, Label, 0, L[10]->LI);
             CS_InsertEntry (S, X, IP++);

--- a/src/cc65/coptptrload.h
+++ b/src/cc65/coptptrload.h
@@ -383,7 +383,7 @@ unsigned OptPtrLoad19 (CodeSeg* S);
 /* Search for the sequence:
 **
 **      ldx     #0
-**	and	#mask		(any value < 128)
+**      and     #mask          (any value < 0x80)
 **      jsr     aslax1/shlax1
 **      clc
 **      adc     #<(label+0)
@@ -397,12 +397,11 @@ unsigned OptPtrLoad19 (CodeSeg* S);
 **
 ** and replace it by:
 **
-**      ldx     #0
-**	and	#mask		(remove if == 127)
-**	asl
-**	tay
-**	lda	label,y
-**	ldx	label+1,y
+**      and     #mask          (remove if == 0x7F)
+**      asl
+**      tay
+**      lda     label,y
+**      ldx     label+1,y
 */
 
 

--- a/src/cc65/coptptrload.h
+++ b/src/cc65/coptptrload.h
@@ -382,6 +382,7 @@ unsigned OptPtrLoad18 (CodeSeg* S);
 unsigned OptPtrLoad19 (CodeSeg* S);
 /* Search for the sequence:
 **
+**      ldx     #0
 **	and	#mask		(any value < 128)
 **      jsr     aslax1/shlax1
 **      clc
@@ -396,6 +397,7 @@ unsigned OptPtrLoad19 (CodeSeg* S);
 **
 ** and replace it by:
 **
+**      ldx     #0
 **	and	#mask		(remove if == 127)
 **	asl
 **	tay

--- a/src/cc65/coptptrload.h
+++ b/src/cc65/coptptrload.h
@@ -379,6 +379,31 @@ unsigned OptPtrLoad18 (CodeSeg* S);
 */
 
 
+unsigned OptPtrLoad19 (CodeSeg* S);
+/* Search for the sequence:
+**
+**	and	#mask		(any value < 128)
+**      jsr     aslax1/shlax1
+**      clc
+**      adc     #<(label+0)
+**      tay
+**      txa
+**      adc     #>(label+0)
+**      tax
+**      tya
+**      ldy     #$01
+**      jsr     ldaxidx
+**
+** and replace it by:
+**
+**	and	#mask		(remove if == 127)
+**	asl
+**	tay
+**	lda	label,y
+**	ldx	label+1,y
+*/
+
+
 /* End of coptptrload.h */
 
 #endif

--- a/src/cc65/coptptrload.h
+++ b/src/cc65/coptptrload.h
@@ -356,6 +356,27 @@ unsigned OptPtrLoad17 (CodeSeg* S);
 ** the step with less than 200% so it gets executed when -Oi is in effect.
 */
 
+unsigned OptPtrLoad18 (CodeSeg* S);
+/* Search for the sequence:
+**
+**      ldx     #$xx
+**      lda     #$yy
+**      clc
+**      adc     xxx
+**      bcc     L
+**      inx
+** L:   ldy     #$00
+**      jsr     ldauidx
+**
+** and replace it by:
+**
+**      ldy     xxx
+**      ldx     #$00
+**      lda     $xxyy,y
+**
+** This is similar to OptPtrLoad3 but works on a constant address
+** instead of a label. Also, the initial X and A loads are reversed.
+*/
 
 
 /* End of coptptrload.h */


### PR DESCRIPTION
Closes #856. Optimizes expressions of the form: 
```c
unsigned char i, y;
y = ((unsigned char*)0x100)[i];
```
Also optimizes 16-bit masked array look-ups of the form:
```c
arr16[i & mask];  // where mask < 128
```