### PR TITLE
Adds address after JVB instruction in the display list example.

### DIFF
--- a/doc/atari.sgml
+++ b/doc/atari.sgml
@@ -392,7 +392,8 @@ void DisplayList =
     DL_CHR20x8x2,
     DL_BLK4,
     DL_CHR20x8x2,
-    DL_JVB
+    DL_JVB,
+    &DisplayList
 };
 ...
 OS.sdlst = &amp;DisplayList;


### PR DESCRIPTION
The correct address is needed as argument to the JVB instruction.
