### PR TITLE
Fix gcc compile warning

### DIFF
--- a/src/ca65/scanner.c
+++ b/src/ca65/scanner.c
@@ -824,7 +824,7 @@ static void ReadStringConst (int StringTerm)
                             break;
                         }
                     }
-                    /* FALLTHRU */
+                    /* FALLTHROUGH */
                 default:
                     Error ("Unsupported escape sequence in string constant");
                     break;

--- a/src/ca65/scanner.c
+++ b/src/ca65/scanner.c
@@ -824,7 +824,7 @@ static void ReadStringConst (int StringTerm)
                             break;
                         }
                     }
-                    /* otherwise, fall through */
+                    /* FALLTHRU */
                 default:
                     Error ("Unsupported escape sequence in string constant");
                     break;


### PR DESCRIPTION
```c
ca65/scanner.c
ca65/scanner.c: In function ‘ReadStringConst’:
ca65/scanner.c:819:24: warning: this statement may fall through [-Wimplicit-fallthrough=]
                     if (IsXDigit (C)) {
                        ^
ca65/scanner.c:828:17: note: here
                 default:
                 ^~~~~~~
```
Fixed warning by adjusting the comment. It is now recognized by gcc.
For more information see:

https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/