### PR TITLE
Fix optimization bug when an external jmp is directly generated

### DIFF
--- a/src/cc65/codeseg.c
+++ b/src/cc65/codeseg.c
@@ -429,7 +429,7 @@ static CodeEntry* ParseInsn (CodeSeg* S, LineInfo* LI, const char* L)
         /* If we don't have the label, it's a forward ref - create it unless
         ** it's an external function.
         */
-        if (Label == 0 && IsLocalLabelName(Arg)) {
+        if (Label == 0 && (OPC->OPC != OP65_JMP || IsLocalLabelName(Arg)) ) {
             /* Generate a new label */
             Label = CS_NewCodeLabel (S, Arg, Hash);
         }

--- a/src/cc65/codeseg.c
+++ b/src/cc65/codeseg.c
@@ -426,8 +426,10 @@ static CodeEntry* ParseInsn (CodeSeg* S, LineInfo* LI, const char* L)
         unsigned Hash = HashStr (Arg) % CS_LABEL_HASH_SIZE;
         Label = CS_FindLabel (S, Arg, Hash);
 
-        /* If we don't have the label, it's a forward ref - create it */
-        if (Label == 0) {
+        /* If we don't have the label, it's a forward ref - create it unless
+        ** it's an external function.
+        */
+        if (Label == 0 && IsLocalLabelName(Arg)) {
             /* Generate a new label */
             Label = CS_NewCodeLabel (S, Arg, Hash);
         }

--- a/test/val/jmp-callax.c
+++ b/test/val/jmp-callax.c
@@ -1,0 +1,21 @@
+static unsigned char val;
+
+static void foo(void) {
+	val = 5;
+}
+
+static void wrap() {
+
+	asm("lda #<%v", foo);
+	asm("ldx #>%v", foo);
+	asm("jmp callax");
+
+}
+
+int main() {
+
+	val = 0;
+	wrap();
+
+	return val == 5 ? 0 : 1;
+}


### PR DESCRIPTION
When the optimizers turn a jsr to a jmp, it inherits the function's register info. When there's a direct jmp however, the function's register info was never gathered, and needed loads were removed.