### PR TITLE
Fix for #830 supplied by UvB

### DIFF
--- a/test/val/bug830.c
+++ b/test/val/bug830.c
@@ -1,0 +1,13 @@
+#include "unittest.h"
+
+char test[1];
+char *dst = &test[0];
+
+TEST
+{
+    char src = 0;
+    *dst = (src == 0) ? 42 : src;
+
+    ASSERT_AreEqual(42, *dst, "%u", "Incorrect ternary expression evaluation!");
+}
+ENDTEST


### PR DESCRIPTION
I've added the test, too.
Uz suggested to check several sources if the patch has any drawbacks (which I did with my own ones and the ones in the test folder) -- I found no issues so far (besides that the generated code isn't convincing with it's 'double' `lda     (sp),y` -- but that's independent from the fix).

If you like to check also your sources, here's the shell-script Uz supplied:
```sh
#!/bin/bash
mkdir old new
for SRC in *.c; do
    ASM=$(basename $SRC .c).s
    /path/to/old/cc65 -t <system> -Oirs $SRC
    mv $ASM old
    /path/to/new/cc65 -t <system> -Oirs $SRC
    mv $ASM new
done
diff -r old new
```
Since it works on a single folder with a bunch of C-files, you may have to flatten your sources for this test, and resolve naming-conflicts/include-path locations.