### PR TITLE
ld65: give an error for multiply defined global symbols.

### DIFF
--- a/doc/ld65.sgml
+++ b/doc/ld65.sgml
@@ -71,23 +71,24 @@ Short options:
   -vm                   Verbose map file
 
 Long options:
-  --cfg-path path       Specify a config file search path
-  --config name         Use linker config file
-  --dbgfile name        Generate debug information
-  --define sym=val      Define a symbol
-  --end-group           End a library group
-  --force-import sym    Force an import of symbol 'sym'
-  --help                Help (this text)
-  --lib file            Link this library
-  --lib-path path       Specify a library search path
-  --mapfile name        Create a map file
-  --module-id id        Specify a module id
-  --obj file            Link this object file
-  --obj-path path       Specify an object file search path
-  --start-addr addr     Set the default start address
-  --start-group         Start a library group
-  --target sys          Set the target system
-  --version             Print the linker version
+  --allow-multiple-definition   Allow multiple definitions
+  --cfg-path path               Specify a config file search path
+  --config name                 Use linker config file
+  --dbgfile name                Generate debug information
+  --define sym=val              Define a symbol
+  --end-group                   End a library group
+  --force-import sym            Force an import of symbol 'sym'
+  --help                        Help (this text)
+  --lib file                    Link this library
+  --lib-path path               Specify a library search path
+  --mapfile name                Create a map file
+  --module-id id                Specify a module id
+  --obj file                    Link this object file
+  --obj-path path               Specify an object file search path
+  --start-addr addr             Set the default start address
+  --start-group                 Start a library group
+  --target sys                  Set the target system
+  --version                     Print the linker version
 ---------------------------------------------------------------------------
 </verb></tscreen>
 
@@ -97,6 +98,14 @@ Long options:
 Here is a description of all of the command-line options:
 
 <descrip>
+
+  <tag><tt>--allow-multiple-definition</tt></tag>
+
+  Normally when a global symbol is defined multiple times, ld65 will
+  issue an error and not create the output file. This option lets it
+  silently ignore this fact and continue. The first definition of a
+  symbol will be used.
+
 
   <label id="option--start-group">
   <tag><tt>-(, --start-group</tt></tag>

--- a/src/ld65/exports.c
+++ b/src/ld65/exports.c
@@ -481,8 +481,8 @@ void InsertExport (Export* E)
                         Imp->Exp = E;
                         Imp = Imp->Next;
                     }
-                } else {
-                    /* Duplicate entry, this is fatal */
+                } else if (AllowMultDef == 0) {
+                    /* Duplicate entry, this is fatal unless allowed by the user */
                     Error ("Duplicate external identifier: '%s'",
                            GetString (L->Name));
                 }

--- a/src/ld65/exports.c
+++ b/src/ld65/exports.c
@@ -482,9 +482,9 @@ void InsertExport (Export* E)
                         Imp = Imp->Next;
                     }
                 } else {
-                    /* Duplicate entry, ignore it */
-                    Warning ("Duplicate external identifier: '%s'",
-                             GetString (L->Name));
+                    /* Duplicate entry, this is fatal */
+                    Error ("Duplicate external identifier: '%s'",
+                           GetString (L->Name));
                 }
                 return;
             }

--- a/src/ld65/global.c
+++ b/src/ld65/global.c
@@ -53,6 +53,7 @@ unsigned char HaveStartAddr = 0;        /* Start address not given */
 unsigned long StartAddr     = 0x200;    /* Start address */
 
 unsigned char VerboseMap    = 0;        /* Verbose map file */
+unsigned char AllowMultDef  = 0;        /* Allow multiple definitions */
 const char* MapFileName     = 0;        /* Name of the map file */
 const char* LabelFileName   = 0;        /* Name of the label file */
 const char* DbgFileName     = 0;        /* Name of the debug file */

--- a/src/ld65/global.h
+++ b/src/ld65/global.h
@@ -53,6 +53,7 @@ extern unsigned char    HaveStartAddr;  /* True if start address was given */
 extern unsigned long    StartAddr;      /* Start address */
 
 extern unsigned char    VerboseMap;     /* Verbose map file */
+extern unsigned char    AllowMultDef;   /* Allow multiple definitions */
 extern const char*      MapFileName;    /* Name of the map file */
 extern const char*      LabelFileName;  /* Name of the label file */
 extern const char*      DbgFileName;    /* Name of the debug file */

--- a/src/ld65/main.c
+++ b/src/ld65/main.c
@@ -552,7 +552,7 @@ static void OptVersion (const char* Opt attribute ((unused)),
 
 static void OptMultDef (const char* Opt attribute ((unused)),
                         const char* Arg attribute ((unused)))
-/* Print the assembler version */
+/* Set flag to allow multiple definitions of a global symbol */
 {
     AllowMultDef = 1;
 }

--- a/src/ld65/main.c
+++ b/src/ld65/main.c
@@ -128,23 +128,24 @@ static void Usage (void)
             "  -vm\t\t\tVerbose map file\n"
             "\n"
             "Long options:\n"
-            "  --cfg-path path\tSpecify a config file search path\n"
-            "  --config name\t\tUse linker config file\n"
-            "  --dbgfile name\tGenerate debug information\n"
-            "  --define sym=val\tDefine a symbol\n"
-            "  --end-group\t\tEnd a library group\n"
-            "  --force-import sym\tForce an import of symbol 'sym'\n"
-            "  --help\t\tHelp (this text)\n"
-            "  --lib file\t\tLink this library\n"
-            "  --lib-path path\tSpecify a library search path\n"
-            "  --mapfile name\tCreate a map file\n"
-            "  --module-id id\tSpecify a module id\n"
-            "  --obj file\t\tLink this object file\n"
-            "  --obj-path path\tSpecify an object file search path\n"
-            "  --start-addr addr\tSet the default start address\n"
-            "  --start-group\t\tStart a library group\n"
-            "  --target sys\t\tSet the target system\n"
-            "  --version\t\tPrint the linker version\n",
+            "  --allow-multiple-definition\tAllow multiple definitions\n"
+            "  --cfg-path path\t\tSpecify a config file search path\n"
+            "  --config name\t\t\tUse linker config file\n"
+            "  --dbgfile name\t\tGenerate debug information\n"
+            "  --define sym=val\t\tDefine a symbol\n"
+            "  --end-group\t\t\tEnd a library group\n"
+            "  --force-import sym\t\tForce an import of symbol 'sym'\n"
+            "  --help\t\t\tHelp (this text)\n"
+            "  --lib file\t\t\tLink this library\n"
+            "  --lib-path path\t\tSpecify a library search path\n"
+            "  --mapfile name\t\tCreate a map file\n"
+            "  --module-id id\t\tSpecify a module id\n"
+            "  --obj file\t\t\tLink this object file\n"
+            "  --obj-path path\t\tSpecify an object file search path\n"
+            "  --start-addr addr\t\tSet the default start address\n"
+            "  --start-group\t\t\tStart a library group\n"
+            "  --target sys\t\t\tSet the target system\n"
+            "  --version\t\t\tPrint the linker version\n",
             ProgName);
 }
 
@@ -549,6 +550,15 @@ static void OptVersion (const char* Opt attribute ((unused)),
 
 
 
+static void OptMultDef (const char* Opt attribute ((unused)),
+                        const char* Arg attribute ((unused)))
+/* Print the assembler version */
+{
+    AllowMultDef = 1;
+}
+
+
+
 static void CmdlOptStartGroup (const char* Opt attribute ((unused)),
                                const char* Arg attribute ((unused)))
 /* Remember 'start group' occurrence in input files array */
@@ -599,23 +609,24 @@ static void ParseCommandLine(void)
 {
     /* Program long options */
     static const LongOpt OptTab[] = {
-        { "--cfg-path",         1,      OptCfgPath              },
-        { "--config",           1,      CmdlOptConfig           },
-        { "--dbgfile",          1,      OptDbgFile              },
-        { "--define",           1,      OptDefine               },
-        { "--end-group",        0,      CmdlOptEndGroup         },
-        { "--force-import",     1,      OptForceImport          },
-        { "--help",             0,      OptHelp                 },
-        { "--lib",              1,      OptLib                  },
-        { "--lib-path",         1,      OptLibPath              },
-        { "--mapfile",          1,      OptMapFile              },
-        { "--module-id",        1,      OptModuleId             },
-        { "--obj",              1,      OptObj                  },
-        { "--obj-path",         1,      OptObjPath              },
-        { "--start-addr",       1,      OptStartAddr            },
-        { "--start-group",      0,      CmdlOptStartGroup       },
-        { "--target",           1,      CmdlOptTarget           },
-        { "--version",          0,      OptVersion              },
+        { "--allow-multiple-definition", 0,      OptMultDef              },
+        { "--cfg-path",                  1,      OptCfgPath              },
+        { "--config",                    1,      CmdlOptConfig           },
+        { "--dbgfile",                   1,      OptDbgFile              },
+        { "--define",                    1,      OptDefine               },
+        { "--end-group",                 0,      CmdlOptEndGroup         },
+        { "--force-import",              1,      OptForceImport          },
+        { "--help",                      0,      OptHelp                 },
+        { "--lib",                       1,      OptLib                  },
+        { "--lib-path",                  1,      OptLibPath              },
+        { "--mapfile",                   1,      OptMapFile              },
+        { "--module-id",                 1,      OptModuleId             },
+        { "--obj",                       1,      OptObj                  },
+        { "--obj-path",                  1,      OptObjPath              },
+        { "--start-addr",                1,      OptStartAddr            },
+        { "--start-group",               0,      CmdlOptStartGroup       },
+        { "--target",                    1,      CmdlOptTarget           },
+        { "--version",                   0,      OptVersion              },
     };
 
     unsigned I;


### PR DESCRIPTION
Closes #878.