### PR TITLE
Range checking for 65816 mode when abs addresses are assumed rather than known

### DIFF
--- a/src/ca65/expr.c
+++ b/src/ca65/expr.c
@@ -1865,6 +1865,28 @@ ExprNode* GenWordExpr (ExprNode* Expr)
 
 
 
+ExprNode* GenNearAddrExpr (ExprNode* Expr)
+/* A word sized expression that will error if given a far expression at assemble time. */
+{
+    long      Val;
+    /* Special handling for const expressions */
+    if (IsEasyConst (Expr, &Val)) {
+        FreeExpr (Expr);
+        Expr = GenLiteralExpr (Val & 0xFFFF);
+        if (Val > 0xFFFF)
+        {
+            Error("Range error: constant too large for assumed near address.");
+        }
+    } else {
+        ExprNode* Operand = Expr;
+        Expr = NewExprNode (EXPR_NEARADDR);
+        Expr->Left = Operand;
+    }
+    return Expr;
+}
+
+
+
 ExprNode* GenFarAddrExpr (ExprNode* Expr)
 /* Force the given expression into a far address and return the result. */
 {

--- a/src/ca65/expr.h
+++ b/src/ca65/expr.h
@@ -109,6 +109,9 @@ ExprNode* GenByteExpr (ExprNode* Expr);
 ExprNode* GenWordExpr (ExprNode* Expr);
 /* Force the given expression into a word and return the result. */
 
+ExprNode* GenNearAddrExpr (ExprNode* Expr);
+/* A word sized expression that will error if given a far expression at assemble time. */
+
 ExprNode* GenFarAddrExpr (ExprNode* Expr);
 /* Force the given expression into a far address and return the result. */
 

--- a/src/ca65/instr.c
+++ b/src/ca65/instr.c
@@ -1217,7 +1217,7 @@ static void EmitCode (EffAddr* A)
                 ** mode, force this address into 16 bit range to allow
                 ** addressing inside a 64K segment.
                 */
-                Emit2 (A->Opcode, GenWordExpr (A->Expr));
+                Emit2 (A->Opcode, GenNearAddrExpr (A->Expr));
             } else {
                 Emit2 (A->Opcode, A->Expr);
             }

--- a/src/ca65/studyexpr.c
+++ b/src/ca65/studyexpr.c
@@ -1447,16 +1447,16 @@ static void StudyExprInternal (ExprNode* Expr, ExprDesc* D)
             StudyWord1 (Expr, D);
             break;
 
-        case EXPR_NEARADDR:
-            StudyNearAddr (Expr, D);
-            break;
-
         case EXPR_FARADDR:
             StudyFarAddr (Expr, D);
             break;
 
         case EXPR_DWORD:
             StudyDWord (Expr, D);
+            break;
+
+        case EXPR_NEARADDR:
+            StudyNearAddr (Expr, D);
             break;
 
         default:

--- a/src/ca65/studyexpr.c
+++ b/src/ca65/studyexpr.c
@@ -1278,7 +1278,7 @@ static void StudyDWord (ExprNode* Expr, ExprDesc* D)
 
 
 static void StudyNearAddr (ExprNode* Expr, ExprDesc* D)
-/* Study an EXPR_NearAddr expression node */
+/* Study an EXPR_NEARADDR expression node */
 {
     /* Study the expression */
     StudyExprInternal (Expr->Left, D);

--- a/src/ca65/studyexpr.c
+++ b/src/ca65/studyexpr.c
@@ -1277,6 +1277,26 @@ static void StudyDWord (ExprNode* Expr, ExprDesc* D)
 
 
 
+static void StudyNearAddr (ExprNode* Expr, ExprDesc* D)
+/* Study an EXPR_NearAddr expression node */
+{
+    /* Study the expression */
+    StudyExprInternal (Expr->Left, D);
+
+    /* We can handle only const expressions */
+    if (!ED_IsConst (D)) {
+        ED_Invalidate (D);
+    }
+
+    /* Promote to absolute if smaller. */
+    if (D->AddrSize < ADDR_SIZE_ABS)
+    {
+        D->AddrSize = ADDR_SIZE_ABS;
+    }
+}
+
+
+
 static void StudyExprInternal (ExprNode* Expr, ExprDesc* D)
 /* Study an expression tree and place the contents into D */
 {
@@ -1425,6 +1445,10 @@ static void StudyExprInternal (ExprNode* Expr, ExprDesc* D)
 
         case EXPR_WORD1:
             StudyWord1 (Expr, D);
+            break;
+
+        case EXPR_NEARADDR:
+            StudyNearAddr (Expr, D);
             break;
 
         case EXPR_FARADDR:

--- a/src/common/exprdefs.c
+++ b/src/common/exprdefs.c
@@ -210,16 +210,16 @@ static void InternalDumpExpr (const ExprNode* Expr, const ExprNode* (*ResolveSym
             printf (" WORD1");
             break;
 
-        case EXPR_NEARADDR:
-            printf (" NEARADDR");
-            break;
-
         case EXPR_FARADDR:
             printf (" FARADDR");
             break;
 
         case EXPR_DWORD:
             printf (" DWORD");
+            break;
+
+        case EXPR_NEARADDR:
+            printf (" NEARADDR");
             break;
 
         default:

--- a/src/common/exprdefs.c
+++ b/src/common/exprdefs.c
@@ -210,6 +210,10 @@ static void InternalDumpExpr (const ExprNode* Expr, const ExprNode* (*ResolveSym
             printf (" WORD1");
             break;
 
+        case EXPR_NEARADDR:
+            printf (" NEARADDR");
+            break;
+
         case EXPR_FARADDR:
             printf (" FARADDR");
             break;

--- a/src/common/exprdefs.h
+++ b/src/common/exprdefs.h
@@ -97,9 +97,9 @@
 #define EXPR_BYTE3              (EXPR_UNARYNODE | 0x0B)
 #define EXPR_WORD0              (EXPR_UNARYNODE | 0x0C)
 #define EXPR_WORD1              (EXPR_UNARYNODE | 0x0D)
-#define EXPR_NEARADDR           (EXPR_UNARYNODE | 0x0E)
-#define EXPR_FARADDR            (EXPR_UNARYNODE | 0x0F)
-#define EXPR_DWORD              (EXPR_UNARYNODE | 0x10)
+#define EXPR_FARADDR            (EXPR_UNARYNODE | 0x0E)
+#define EXPR_DWORD              (EXPR_UNARYNODE | 0x0F)
+#define EXPR_NEARADDR           (EXPR_UNARYNODE | 0x10)
 
 
 

--- a/src/common/exprdefs.h
+++ b/src/common/exprdefs.h
@@ -97,8 +97,9 @@
 #define EXPR_BYTE3              (EXPR_UNARYNODE | 0x0B)
 #define EXPR_WORD0              (EXPR_UNARYNODE | 0x0C)
 #define EXPR_WORD1              (EXPR_UNARYNODE | 0x0D)
-#define EXPR_FARADDR            (EXPR_UNARYNODE | 0x0E)
-#define EXPR_DWORD              (EXPR_UNARYNODE | 0x0F)
+#define EXPR_NEARADDR           (EXPR_UNARYNODE | 0x0E)
+#define EXPR_FARADDR            (EXPR_UNARYNODE | 0x0F)
+#define EXPR_DWORD              (EXPR_UNARYNODE | 0x10)
 
 
 

--- a/src/ld65/expr.c
+++ b/src/ld65/expr.c
@@ -436,15 +436,15 @@ long GetExprVal (ExprNode* Expr)
         case EXPR_WORD1:
             return (GetExprVal (Expr->Left) >> 16) & 0xFFFF;
 
-        case EXPR_NEARADDR:
-            /* Assembler was expected to validate this truncation. */
-            return GetExprVal (Expr->Left) & 0xFFFF;
-
         case EXPR_FARADDR:
             return GetExprVal (Expr->Left) & 0xFFFFFF;
 
         case EXPR_DWORD:
             return GetExprVal (Expr->Left) & 0xFFFFFFFF;
+
+        case EXPR_NEARADDR:
+            /* Assembler was expected to validate this truncation. */
+            return GetExprVal (Expr->Left) & 0xFFFF;
 
         default:
             Internal ("Unknown expression Op type: %u", Expr->Op);

--- a/src/ld65/expr.c
+++ b/src/ld65/expr.c
@@ -436,6 +436,10 @@ long GetExprVal (ExprNode* Expr)
         case EXPR_WORD1:
             return (GetExprVal (Expr->Left) >> 16) & 0xFFFF;
 
+        case EXPR_NEARADDR:
+            /* Assembler was expected to validate this truncation. */
+            return GetExprVal (Expr->Left) & 0xFFFF;
+
         case EXPR_FARADDR:
             return GetExprVal (Expr->Left) & 0xFFFFFF;
 

--- a/src/ld65/o65.c
+++ b/src/ld65/o65.c
@@ -633,7 +633,8 @@ static unsigned O65WriteExpr (ExprNode* E, int Signed, unsigned Size,
     if (E->Op == EXPR_BYTE0   || E->Op == EXPR_BYTE1 ||
         E->Op == EXPR_BYTE2   || E->Op == EXPR_BYTE3 ||
         E->Op == EXPR_WORD0   || E->Op == EXPR_WORD1 ||
-        E->Op == EXPR_FARADDR || E->Op == EXPR_DWORD) {
+        E->Op == EXPR_FARADDR || E->Op == EXPR_DWORD ||
+        E->Op == EXPR_NEARADDR) {
         /* Use the real expression */
         Expr = E->Left;
     }
@@ -678,6 +679,7 @@ static unsigned O65WriteExpr (ExprNode* E, int Signed, unsigned Size,
         case EXPR_WORD1:    BinVal = (BinVal >> 16) & 0xFFFF;   break;
         case EXPR_FARADDR:  BinVal &= 0xFFFFFFUL;               break;
         case EXPR_DWORD:    BinVal &= 0xFFFFFFFFUL;             break;
+        case EXPR_NEARADDR: BinVal &= 0xFFFF;                   break;
     }
     WriteVal (D->F, BinVal, Size);
 


### PR DESCRIPTION
This is a possible resolution to issue: #879 

It looks like a satisfactory resolution to me, but I could use code review and/or assistance in testing before I would be confident that this should be merged.

.

What I found was that when the address size of an operand was not sufficiently known in 65816 mode, it would use `GenWordExpr` which creates an `EXPR_WORD0` type expression that automatically truncates to 16-bit. Otherwise if it is known at that line, the assembler will just generate an instruction of known size.

See: https://github.com/cc65/cc65/blob/392e6e10fc40a046d4e7dbc083a1e0bfd2e07d69/src/ca65/instr.c#L1220

I believe the idea is that by truncating it, the address was prepared in advance for the linker, which in 65816 correctly has to truncate near addresses to remove their bank byte. However, this disabled the ability to check if this was a valid truncation.

My replacement creates a new expression type `EXPR_NEARADDR`, which the linker will treat the same as `EXPR_WORD0` as a 16-bit truncation, but now the assembler can range check it in `SegDone` (unless the relaxed checking mode is used).

This change seems to correctly catch the error of accidentally making a reference to a symbol from a `far` segment before that segment is declared. If the instruction was assumed near, but the symbol was later declared far, this now gets caught during `SegDone`.

One caveat: a later (or prior) export via `.global` + `: far` does not override the address modifier of the symbol's containing segment. I think this is correct behaviour, so that near addresses used within the file can be exported globally, but the consequence might be unintuitive: a `.global : far` will cause a symbol to assume far addressing until its containing segment is reached, which overrides it. (This feels correct to me, but still weird to think through.)

.

Also, was it appropriate to add the EXPR_NEARADDR enum in the middle of the list, or should it have been appended to the end? (Would that invalidate existing object files?)