### PR TITLE
goto.c warning fix for implicit truncation

### DIFF
--- a/src/cc65/goto.c
+++ b/src/cc65/goto.c
@@ -100,7 +100,7 @@ void GotoStatement (void)
             ConsumeLBrack ();
 
             if (CurTok.Tok == TOK_ICONST) {
-                val = CurTok.IVal;
+                val = (unsigned char)CurTok.IVal;
                 NextToken ();
 
                 if (CPUIsets[CPU] & CPU_ISET_65SC02) {


### PR DESCRIPTION
This line generated a warning as error for the MSVC build.