### PR TITLE
Disable too-aggressive optimization in OptCmp8

### DIFF
--- a/src/cc65/coptcmp.c
+++ b/src/cc65/coptcmp.c
@@ -819,6 +819,7 @@ unsigned OptCmp8 (CodeSeg* S)
             /* We are able to evaluate the compare at compile time. Check if
             ** one or more branches are ahead.
             */
+            unsigned ProtectCompare = 0;
             unsigned JumpsChanged = 0;
             CodeEntry* N;
             while ((N = CS_GetNextEntry (S, I)) != 0 &&   /* Followed by something.. */
@@ -878,6 +879,21 @@ unsigned OptCmp8 (CodeSeg* S)
                     CodeEntry* X = NewCodeEntry (OP65_JMP, AM65_BRA, LabelName, L, N->LI);
                     CS_InsertEntry (S, X, I+2);
                     CS_DelEntry (S, I+1);
+                    /* Normally we can remove the compare as well,
+                    ** but some comparisons generate code with a
+                    ** shared branch operation. This prevents the unsafe
+                    ** removal of the compare for known problem cases.
+                    */
+                    if (
+                        /* Jump to branch that relies on the comparison. */
+                        (L->Owner->Info & (OF_CBRA | OF_ZBRA)) ||
+                        /* Jump to boolean transformer that relies on the comparison. */
+                        (L->Owner->OPC == OP65_JSR &&
+                         (FindBoolCmpCond (L->Owner->Arg)) != CMP_INV)
+                       )
+                    {
+                        ++ProtectCompare;
+                    }
                 }
 
                 /* Remember, we had changes */
@@ -885,16 +901,10 @@ unsigned OptCmp8 (CodeSeg* S)
                 ++Changes;
             }
 
-            /* "If we have made changes above, we may also remove the compare."
-            **
-            ** Removing the compare was too aggressive. E.g. for 16-bit compares the compiler
-            ** may generate a branch to a second shared branch that still requires the flag
-            ** result of the first compare instruction.
-            **
-            **if (JumpsChanged) {
-            **    CS_DelEntry (S, I);
-            **}
-            */
+            /* Delete the original compare, if safe to do so. */
+            if (JumpsChanged && !ProtectCompare) {
+                CS_DelEntry (S, I);
+            }
         }
 
 NextEntry:

--- a/src/cc65/coptcmp.c
+++ b/src/cc65/coptcmp.c
@@ -885,11 +885,16 @@ unsigned OptCmp8 (CodeSeg* S)
                 ++Changes;
             }
 
-            /* If we have made changes above, we may also remove the compare */
-            if (JumpsChanged) {
-                CS_DelEntry (S, I);
-            }
-
+            /* "If we have made changes above, we may also remove the compare."
+            **
+            ** Removing the compare was too aggressive. E.g. for 16-bit compares the compiler
+            ** may generate a branch to a second shared branch that still requires the flag
+            ** result of the first compare instruction.
+            **
+            **if (JumpsChanged) {
+            **    CS_DelEntry (S, I);
+            **}
+            */
         }
 
 NextEntry:

--- a/test/val/bug895.c
+++ b/test/val/bug895.c
@@ -1,0 +1,81 @@
+/** This test is related to GitHub issue 895
+ ** https://github.com/cc65/cc65/issues/895
+ **
+ ** The OptCmp8 optimization attempts to eliminate an unnecessary
+ ** comparison and branch when the operands of the comparison are
+ ** known to be constant at compile time.
+ **
+ ** For 8-bit types it worked well, but for larger types it failed
+ ** to generate correct code. The bug manifest as a branch on an
+ ** uninitialized carry flag.
+ **
+ ** This does four tests for each type tested:
+ **   1: < with carry clear
+ **   2: >= with carry clear
+ **   3: < with carry set
+ **   4: >= with carry set
+ */
+
+#include "unittest.h"
+
+signed char   sca, scb;
+signed int    sia, sib;
+signed long   sla, slb;
+
+unsigned char uca, ucb;
+unsigned int  uia, uib;
+unsigned long ula, ulb;
+
+#define OPTCMP8TEST(vara,varb,startb,starta,cmpa,setb,printterm,typename,name) \
+    void name ## 1(void) { \
+    varb = startb; \
+    asm("clc"); \
+    vara = starta; \
+    if (vara < cmpa) varb = setb; \
+    ASSERT_AreEqual(startb, varb, printterm, "Incorrect optimization of " typename " comparison (1: < clc)."); \
+    } \
+    void name ## 2(void) { \
+    varb = startb; \
+    asm("sec"); \
+    vara = starta; \
+    if (vara < cmpa) varb = setb; \
+    ASSERT_AreEqual(startb, varb, printterm, "Incorrect optimization of " typename " comparison (2: < sec)."); \
+    } \
+    void name ## 3(void) { \
+    varb = startb; \
+    asm("clc"); \
+    vara = starta; \
+    if (vara >= cmpa) varb = setb; \
+    ASSERT_AreEqual(setb, varb, printterm, "Incorrect optimization of " typename " comparison (3: >= clc)."); \
+    } \
+    void name ## 4(void) { \
+    varb = startb; \
+    asm("sec"); \
+    vara = starta; \
+    if (vara >= cmpa) varb = setb; \
+    ASSERT_AreEqual(setb, varb, printterm, "Incorrect optimization of " typename " comparison (4: >= sec)."); \
+    }
+
+#define RUNOPTCMP8TEST(name) \
+    name ## 1(); \
+    name ## 2(); \
+    name ## 3(); \
+    name ## 4();
+
+OPTCMP8TEST(sca,scb,-20,100,50,5,"%d","signed char",signed_char);
+OPTCMP8TEST(uca,ucb,20,100,50,5,"%u","unsigned char",unsigned_char);
+OPTCMP8TEST(sia,sib,-2000,1000,500,50,"%d","signed int",signed_int);
+OPTCMP8TEST(uia,uib,2000,1000,500,50,"%u","unsigned int",unsigned_int);
+OPTCMP8TEST(sla,slb,-200000L,100000L,50000L,5000L,"%d","signed long",signed_long);
+OPTCMP8TEST(ula,ulb,200000UL,100000UL,50000UL,5000UL,"%u","unsigned long",unsigned_long);
+
+TEST
+{
+    RUNOPTCMP8TEST(signed_char);
+    RUNOPTCMP8TEST(unsigned_char);
+    RUNOPTCMP8TEST(signed_int);
+    RUNOPTCMP8TEST(unsigned_int);
+    RUNOPTCMP8TEST(signed_long);
+    RUNOPTCMP8TEST(unsigned_long);
+}
+ENDTEST

--- a/test/val/bug895.c
+++ b/test/val/bug895.c
@@ -1,13 +1,13 @@
 /** This test is related to GitHub issue 895
  ** https://github.com/cc65/cc65/issues/895
  **
- ** The OptCmp8 optimization attempts to eliminate an unnecessary
+ ** The OptCmp8 optimization attempted to eliminate an unnecessary
  ** comparison and branch when the operands of the comparison are
  ** known to be constant at compile time.
  **
- ** For 8-bit types it worked well, but for larger types it failed
- ** to generate correct code. The bug manifest as a branch on an
- ** uninitialized carry flag.
+ ** For 8-bit types it worked well, but for 16-bit types it failed
+ ** to generate correct code for some cases. The bug manifest as a
+ ** branch on an uninitialized carry flag.
  */
 
 #include "unittest.h"


### PR DESCRIPTION
This optimization generates incorrect code for some 16-bit cases (possibly others). See: #895

I'm not sure if it would be better to re-evaluate how the compiler generates a shared branch so that this optimization could be kept, but this change is simple and will prevent it from being broken by the attempted optimization.