### PR TITLE
gr65: Fix realloc bug

### DIFF
--- a/src/grc65/main.c
+++ b/src/grc65/main.c
@@ -861,7 +861,7 @@ static char *filterInput (FILE *F, char *tbl)
         }
         if (a == EOF) {
             tbl[i] = '\0';
-            xrealloc (tbl, i + 1);
+            tbl = xrealloc (tbl, i + 1);
             break;
         }
         if (IsSpace (a)) {


### PR DESCRIPTION
The pointer to the input buffer was not being updated after a call to `realloc()`, causing the program to crash if `realloc()` moved the buffer (which on my system, seems to be always).

This is just a quick fix, tested as far as "works on my machine, and valgrind doesn't complain about invalid accesses anymore."  Let me know if this needs any changes or further testing.