### PR TITLE
sim6502 protection assert for hardcoded sp address

### DIFF
--- a/libsrc/sim6502/crt0.s
+++ b/libsrc/sim6502/crt0.s
@@ -5,14 +5,16 @@
 ;
 
         .export         _exit
+        .export         exit
         .export         __STARTUP__ : absolute = 1      ; Mark as startup
         .import         zerobss, callmain
         .import         initlib, donelib
-        .import         exit
         .import         __MAIN_START__, __MAIN_SIZE__   ; Linker generated
         .import         __STACKSIZE__                   ; Linker generated
 
         .include        "zeropage.inc"
+
+exit           := $FFF1
 
         .segment        "STARTUP"
 

--- a/libsrc/sim6502/paravirt.s
+++ b/libsrc/sim6502/paravirt.s
@@ -8,10 +8,10 @@
 ;
 
         .importzp       sp
-        .export         args, exit, _open, _close, _read, _write
+        .export         args, _open, _close, _read, _write
 
 args            := $FFF0
-exit            := $FFF1
+;exit           := $FFF1 ; crt0.s (not affected by assert below)
 _open           := $FFF2
 _close          := $FFF3
 _read           := $FFF4

--- a/libsrc/sim6502/paravirt.s
+++ b/libsrc/sim6502/paravirt.s
@@ -7,6 +7,7 @@
 ; int __fastcall__ write (int fd, const void* buf, unsigned count);
 ;
 
+        .importzp       sp
         .export         args, exit, _open, _close, _read, _write
 
 args            := $FFF0
@@ -15,3 +16,5 @@ _open           := $FFF2
 _close          := $FFF3
 _read           := $FFF4
 _write          := $FFF5
+
+.assert sp=0, error, "sim6502 paravirtualization functions require parameter stack pointer (sp) at $00"

--- a/libsrc/sim6502/paravirt.s
+++ b/libsrc/sim6502/paravirt.s
@@ -11,7 +11,7 @@
         .export         args, _open, _close, _read, _write
 
 args            := $FFF0
-;exit           := $FFF1 ; crt0.s (not affected by assert below)
+;exit           := $FFF1 ; in crt0.s, doesn't need .assert below
 _open           := $FFF2
 _close          := $FFF3
 _read           := $FFF4


### PR DESCRIPTION
sim65 hard codes the parameter stack pointer `sp` at $0000 for its paravirtualization functions that need it (`args`, `open`, `read`, `write`). If you're trying to use it with a custom .CFG, or basically try to add anything to the `ZEROPAGE` segment it's easy to break these by accident. Since it breaks `printf` too, it's really hard to diagnose the problem.

Added an assert to `paravirt.s` to make it clear when this assumption is being broken.

Shifted the definition of `exit` to `crt0.s` so that the assert is not triggered if `main` is used without args, or the other affects functions are never linked in from the library.