### PR TITLE
sim65 movable parameter stack pointer

### DIFF
--- a/cfg/sim6502.cfg
+++ b/cfg/sim6502.cfg
@@ -4,7 +4,7 @@ SYMBOLS {
 }
 MEMORY {
     ZP:     file = "",               start = $0000, size = $001B;
-    HEADER: file = %O,               start = $0000, size = $0001;
+    HEADER: file = %O,               start = $0000, size = $0002;
     MAIN:   file = %O, define = yes, start = $0200, size = $FDF0 - __STACKSIZE__;
 }
 SEGMENTS {

--- a/cfg/sim6502.cfg
+++ b/cfg/sim6502.cfg
@@ -4,7 +4,7 @@ SYMBOLS {
 }
 MEMORY {
     ZP:     file = "",               start = $0000, size = $001B;
-    HEADER: file = %O,               start = $0000, size = $0002;
+    HEADER: file = %O,               start = $0000, size = $000C;
     MAIN:   file = %O, define = yes, start = $0200, size = $FDF0 - __STACKSIZE__;
 }
 SEGMENTS {

--- a/cfg/sim65c02.cfg
+++ b/cfg/sim65c02.cfg
@@ -4,7 +4,7 @@ SYMBOLS {
 }
 MEMORY {
     ZP:     file = "",               start = $0000, size = $001B;
-    HEADER: file = %O,               start = $0000, size = $0001;
+    HEADER: file = %O,               start = $0000, size = $0002;
     MAIN:   file = %O, define = yes, start = $0200, size = $FDF0 - __STACKSIZE__;
 }
 SEGMENTS {

--- a/cfg/sim65c02.cfg
+++ b/cfg/sim65c02.cfg
@@ -4,7 +4,7 @@ SYMBOLS {
 }
 MEMORY {
     ZP:     file = "",               start = $0000, size = $001B;
-    HEADER: file = %O,               start = $0000, size = $0002;
+    HEADER: file = %O,               start = $0000, size = $000C;
     MAIN:   file = %O, define = yes, start = $0200, size = $FDF0 - __STACKSIZE__;
 }
 SEGMENTS {

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -140,28 +140,39 @@ Assembly tests may similarly be assembled and linked with
 and the sim65 library provides an <tt/exit/ symbol that the program may <tt/JMP/
 to terminate with the current A register value as an exit code.
 
-Without using the provided target library, there are some relevant internal details:
+The binary file has a 12 byte header:
 
 <itemize>
 
-<item>The binary input file has a 2 byte header. The first byte indicates CPU type:
- 0 = 6502, 1 = 65C02. The second byte is the address of the C parameter stack pointer
- <tt/sp/, used by the paravirtualization functions.
+<item>5 byte **signature**: <tt/$73, $69, $6D, $36, $35/ or <tt/'sim65'/
 
-<item>The rest of the input file, after the header, will be loaded at <tt/$0200/,
-and execution will begin at <tt/$0200/.
+<item>1 byte **version**: <tt/2/
+
+<item>1 byte **CPU type**: <tt/0/ = 6502, <tt/1/ = 65C02
+
+<item>1 byte **sp address**: the zero page address of the C parameter stack pointer <tt/sp/ used by the paravirtualization functions
+
+<item>1 word **load address**: where to load the data from the file into memory (default: <tt/$0200/)
+
+<item>1 word **reset address**: specifies where to begin execution after loading (default: <tt/$0200/)
+
+</itemize>
+
+Other internal details:
+
+<itemize>
 
 <item>The entire 64 kilobyte address space is writeable RAM.
 Aside from the loaded binary, the reset vector at <tt/$FFFC/ will be
-pre-loaded with <tt/$0200/ as the start address.
+pre-loaded with the given **reset address**.
 
 <item>The <tt/exit/ address is <tt/$FFF1/.
 Jumping to this address will terminate execution with the A register value as an exit code.
 
 <item>The built-in functions are provided by 6 paravirtualization hooks present at
 <tt/$FFF0-$FFF5/. Except for <tt/exit/, a <tt/JSR/ to one of these
-addresses will return immediately after performing a special function,
-intended for use with the sim65 target C library.
+addresses will return immediately after performing a special function.
+These use cc65 calling conventions, and are intended for use with the sim65 target C library.
 
 <item><tt/IRQ/ and <tt/NMI/ events will not be generated, though <tt/BRK/
 can be used if the IRQ vector at <tt/$FFFE/ is manually prepared by the test code.

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -144,17 +144,17 @@ The binary file has a 12 byte header:
 
 <itemize>
 
-<item>5 byte **signature**: <tt/$73, $69, $6D, $36, $35/ or <tt/'sim65'/
+<item>5 byte <bf/signature/: <tt/$73, $69, $6D, $36, $35/ or <tt/'sim65'/
 
-<item>1 byte **version**: <tt/2/
+<item>1 byte <bf/version/: <tt/2/
 
-<item>1 byte **CPU type**: <tt/0/ = 6502, <tt/1/ = 65C02
+<item>1 byte <bf/CPU type/: <tt/0/ = 6502, <tt/1/ = 65C02
 
-<item>1 byte **sp address**: the zero page address of the C parameter stack pointer <tt/sp/ used by the paravirtualization functions
+<item>1 byte <bf/sp address/: the zero page address of the C parameter stack pointer <tt/sp/ used by the paravirtualization functions
 
-<item>1 word **load address**: where to load the data from the file into memory (default: <tt/$0200/)
+<item>1 word <bf/load address/: where to load the data from the file into memory (default: <tt/$0200/)
 
-<item>1 word **reset address**: specifies where to begin execution after loading (default: <tt/$0200/)
+<item>1 word <bf/reset address/: specifies where to begin execution after loading (default: <tt/$0200/)
 
 </itemize>
 
@@ -164,7 +164,7 @@ Other internal details:
 
 <item>The entire 64 kilobyte address space is writeable RAM.
 Aside from the loaded binary, the reset vector at <tt/$FFFC/ will be
-pre-loaded with the given **reset address**.
+pre-loaded with the given <bf/reset address/.
 
 <item>The <tt/exit/ address is <tt/$FFF1/.
 Jumping to this address will terminate execution with the A register value as an exit code.

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -144,8 +144,9 @@ Without using the provided target library, there are some relevant internal deta
 
 <itemize>
 
-<item>The binary input file has a 1 byte header. A value of 0 indicates 6502 simulation,
-and 1 indicates 65C02.
+<item>The binary input file has a 2 byte header. The first byte indicates CPU type:
+ 0 = 6502, 1 = 65C02. The second byte is the address of the C parameter stack pointer
+ <tt/sp/, used by the paravirtualization functions.
 
 <item>The rest of the input file, after the header, will be loaded at <tt/$0200/,
 and execution will begin at <tt/$0200/.
@@ -160,7 +161,7 @@ Jumping to this address will terminate execution with the A register value as an
 <item>The built-in functions are provided by 6 paravirtualization hooks present at
 <tt/$FFF0-$FFF5/. Except for <tt/exit/, a <tt/JSR/ to one of these
 addresses will return immediately after performing a special function,
-intended only for use with the sim65 target C library.
+intended for use with the sim65 target C library.
 
 <item><tt/IRQ/ and <tt/NMI/ events will not be generated, though <tt/BRK/
 can be used if the IRQ vector at <tt/$FFFE/ is manually prepared by the test code.

--- a/libsrc/sim6502/crt0.s
+++ b/libsrc/sim6502/crt0.s
@@ -5,6 +5,7 @@
 ;
 
         .export         _exit
+        .export         sim65start
         .export         __STARTUP__ : absolute = 1      ; Mark as startup
         .import         zerobss, callmain
         .import         initlib, donelib
@@ -16,6 +17,7 @@
 
         .segment        "STARTUP"
 
+sim65start:
         cld
         ldx     #$FF
         txs

--- a/libsrc/sim6502/exehdr.s
+++ b/libsrc/sim6502/exehdr.s
@@ -1,8 +1,7 @@
 ;
 ; Oliver Schmidt, 2013-05-16
 ;
-; This module supplies a 2 byte header identifying the simulator type,
-; and parameter stack pointer sp.
+; This module supplies a header used by sim65.
 ;
 
         .export         __EXEHDR__ : absolute = 1       ; Linker referenced

--- a/libsrc/sim6502/exehdr.s
+++ b/libsrc/sim6502/exehdr.s
@@ -7,8 +7,14 @@
 
         .export         __EXEHDR__ : absolute = 1       ; Linker referenced
         .importzp       sp
+        .import         __MAIN_START__
+        .import         sim65start
 
         .segment        "EXEHDR"
 
-        .byte   .defined(__SIM65C02__)
-        .byte   sp
+        .byte   $73, $69, $6D, $36, $35        ; 'sim65'
+        .byte   2                              ; header version
+        .byte   .defined(__SIM65C02__)         ; CPU type
+        .byte   sp                             ; sp address
+        .addr   __MAIN_START__                 ; load address
+        .addr   sim65start                     ; reset address

--- a/libsrc/sim6502/exehdr.s
+++ b/libsrc/sim6502/exehdr.s
@@ -1,11 +1,14 @@
 ;
 ; Oliver Schmidt, 2013-05-16
 ;
-; This module supplies a 1 byte header identifying the simulator type
+; This module supplies a 2 byte header identifying the simulator type,
+; and parameter stack pointer sp.
 ;
 
         .export         __EXEHDR__ : absolute = 1       ; Linker referenced
+        .importzp       sp
 
         .segment        "EXEHDR"
 
         .byte   .defined(__SIM65C02__)
+        .byte   sp

--- a/src/common/version.c
+++ b/src/common/version.c
@@ -47,7 +47,7 @@
 
 
 #define VER_MAJOR       2U
-#define VER_MINOR       17U
+#define VER_MINOR       18U
 
 
 

--- a/src/sim65/error.c
+++ b/src/sim65/error.c
@@ -69,7 +69,21 @@ void Error (const char* Format, ...)
     vfprintf (stderr, Format, ap);
     putc ('\n', stderr);
     va_end (ap);
-    exit (EXIT_FAILURE);
+    exit (SIM65_ERROR);
+}
+
+
+
+void ErrorCode (int Code, const char* Format, ...)
+/* Print an error message and die with the given exit code */
+{
+    va_list ap;
+    va_start (ap, Format);
+    fprintf (stderr, "Error: ");
+    vfprintf (stderr, Format, ap);
+    putc ('\n', stderr);
+    va_end (ap);
+    exit (Code);
 }
 
 
@@ -83,5 +97,5 @@ void Internal (const char* Format, ...)
     vfprintf (stderr, Format, ap);
     putc ('\n', stderr);
     va_end (ap);
-    exit (EXIT_FAILURE);
+    exit (SIM65_ERROR);
 }

--- a/src/sim65/error.h
+++ b/src/sim65/error.h
@@ -44,6 +44,20 @@
 
 
 /*****************************************************************************/
+/*                                   Data                                    */
+/*****************************************************************************/
+
+
+
+#define SIM65_ERROR         256
+/* Does not use EXIT_FAILURE because it may overlap with test results. */
+
+#define SIM65_ERROR_TIMEOUT 257
+/* An error result for max CPU instructions exceeded. */
+
+
+
+/*****************************************************************************/
 /*                                   Code                                    */
 /*****************************************************************************/
 
@@ -54,6 +68,9 @@ void Warning (const char* Format, ...) attribute((format(printf,1,2)));
 
 void Error (const char* Format, ...) attribute((noreturn, format(printf,1,2)));
 /* Print an error message and die */
+
+void ErrorCode (int Code, const char* Format, ...) attribute((noreturn, format(printf,2,3)));
+/* Print an error message and die with the given exit code */
 
 void Internal (const char* Format, ...) attribute((noreturn, format(printf,1,2)));
 /* Print an internal error message and die */

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -137,7 +137,7 @@ static unsigned char ReadProgramFile (void)
 {
     int Val;
     unsigned Addr = 0x0200;
-    unsigned char SPAddr = 0x0000;
+    unsigned char SPAddr = 0x00;
 
     /* Open the file */
     FILE* F = fopen (ProgramFile, "rb");

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -159,7 +159,7 @@ static unsigned char ReadProgramFile (void)
     }
 
     /* Verify the header signature */
-    for (I=0; I<HEADER_SIGNATURE_LENGTH; ++I) {
+    for (I = 0; I < HEADER_SIGNATURE_LENGTH; ++I) {
         if ((Val = fgetc(F)) != HeaderSignature[I]) {
             Error ("'%s': Invalid header signature.", ProgramFile);
         }

--- a/src/sim65/memory.c
+++ b/src/sim65/memory.c
@@ -64,6 +64,15 @@ void MemWriteByte (unsigned Addr, unsigned char Val)
 
 
 
+void MemWriteWord (unsigned Addr, unsigned Val)
+/* Write a word to a memory location */
+{
+    MemWriteByte (Addr, Val & 0xFF);
+    MemWriteByte (Addr + 1, Val >> 8);
+}
+
+
+
 unsigned char MemReadByte (unsigned Addr)
 /* Read a byte from a memory location */
 {
@@ -82,7 +91,7 @@ unsigned MemReadWord (unsigned Addr)
 
 
 unsigned MemReadZPWord (unsigned char Addr)
-/* Read a word from the zero page. This function differs from ReadMemW in that
+/* Read a word from the zero page. This function differs from MemReadWord in that
 ** the read will always be in the zero page, even in case of an address
 ** overflow.
 */
@@ -96,10 +105,6 @@ unsigned MemReadZPWord (unsigned char Addr)
 void MemInit (void)
 /* Initialize the memory subsystem */
 {
-    /* Fill momory with illegal opcode */
+    /* Fill memory with illegal opcode */
     memset (Mem, 0xFF, sizeof (Mem));
-
-    /* Set RESET vector to 0x0200 */
-    Mem[0xFFFC] = 0x00;
-    Mem[0xFFFD] = 0x02;
 }

--- a/src/sim65/memory.h
+++ b/src/sim65/memory.h
@@ -47,6 +47,9 @@
 void MemWriteByte (unsigned Addr, unsigned char Val);
 /* Write a byte to a memory location */
 
+void MemWriteWord (unsigned Addr, unsigned Val);
+/* Write a word to a memory location */
+
 unsigned char MemReadByte (unsigned Addr);
 /* Read a byte from a memory location */
 
@@ -54,7 +57,7 @@ unsigned MemReadWord (unsigned Addr);
 /* Read a word from a memory location */
 
 unsigned MemReadZPWord (unsigned char Addr);
-/* Read a word from the zero page. This function differs from ReadMemW in that
+/* Read a word from the zero page. This function differs from MemReadWord in that
 ** the read will always be in the zero page, even in case of an address
 ** overflow.
 */

--- a/src/sim65/paravirt.c
+++ b/src/sim65/paravirt.c
@@ -103,15 +103,6 @@ static void SetAX (CPURegs* Regs, unsigned Val)
 
 
 
-static void MemWriteWord (unsigned Addr, unsigned Val)
-{
-    MemWriteByte (Addr, Val);
-    Val >>= 8;
-    MemWriteByte (Addr + 1, Val);
-}
-
-
-
 static unsigned char Pop (CPURegs* Regs)
 {
     return MemReadByte (0x0100 + ++Regs->SP);

--- a/src/sim65/paravirt.c
+++ b/src/sim65/paravirt.c
@@ -77,6 +77,7 @@
 typedef void (*PVFunc) (CPURegs* Regs);
 
 static unsigned ArgStart;
+static unsigned char SPAddr;
 
 
 
@@ -120,9 +121,9 @@ static unsigned char Pop (CPURegs* Regs)
 
 static unsigned PopParam (unsigned char Incr)
 {
-    unsigned SP = MemReadZPWord (0x00);
+    unsigned SP = MemReadZPWord (SPAddr);
     unsigned Val = MemReadWord (SP);
-    MemWriteWord (0x0000, SP + Incr);
+    MemWriteWord (SPAddr, SP + Incr);
     return Val;
 }
 
@@ -132,7 +133,7 @@ static void PVArgs (CPURegs* Regs)
 {
     unsigned ArgC = ArgCount - ArgStart;
     unsigned ArgV = GetAX (Regs);
-    unsigned SP   = MemReadZPWord (0x00);
+    unsigned SP   = MemReadZPWord (SPAddr);
     unsigned Args = SP - (ArgC + 1) * 2;
 
     Print (stderr, 2, "PVArgs ($%04X)\n", ArgV);
@@ -152,9 +153,9 @@ static void PVArgs (CPURegs* Regs)
         MemWriteWord (Args, SP);
         Args += 2;
     }
-    MemWriteWord (Args, 0x0000);
+    MemWriteWord (Args, SPAddr);
 
-    MemWriteWord (0x0000, SP);
+    MemWriteWord (SPAddr, SP);
     SetAX (Regs, ArgC);
 }
 
@@ -313,10 +314,11 @@ static const PVFunc Hooks[] = {
 
 
 
-void ParaVirtInit (unsigned aArgStart)
+void ParaVirtInit (unsigned aArgStart, unsigned char aSPAddr)
 /* Initialize the paravirtualization subsystem */
 {
     ArgStart = aArgStart;
+    SPAddr = aSPAddr;
 };
 
 

--- a/src/sim65/paravirt.h
+++ b/src/sim65/paravirt.h
@@ -44,7 +44,7 @@
 
 
 
-void ParaVirtInit (unsigned aArgStart);
+void ParaVirtInit (unsigned aArgStart, unsigned char aSPAddr);
 /* Initialize the paravirtualization subsystem */
 
 void ParaVirtHooks (CPURegs* Regs);

--- a/test/misc/endless.c
+++ b/test/misc/endless.c
@@ -9,5 +9,5 @@ int main(void)
         ;
     }
     printf("error: should not come here\n");
-    return EXIT_FAILURE;
+    return EXIT_SUCCESS; /* test verifies failure, not success */
 }


### PR DESCRIPTION
As an alternative to #905 this adds the location of `sp` to the sim65 binary header.

This is probably more intuitive than the assert approach, but it is not backwards compatible. PR includes a version bump for this reason.