### PR TITLE
Remove text-shadow from documentation headings?

### DIFF
--- a/doc/doc.css
+++ b/doc/doc.css
@@ -19,14 +19,12 @@ h1, h2, h2 a:link, h2 a:active, h2 a:visited {
 
 h1 {
     font-size:          250%;
-    text-shadow:        2px 2px 6px #505050;
     letter-spacing:     2px;
     padding-top:        40px;
 }
 
 h2 {
     font-size:          160%;
-    text-shadow:        2px 2px 6px #303030;
     letter-spacing:     1px;
     margin-top:         2em;
     margin-bottom:      1em;


### PR DESCRIPTION
I don't know if this is a matter of taste, but personally I have found the blurry shadow under the red headings in the documents makes the words more difficult to read.

Suggesting the shadow be removed for clarity.

Comparison:
![style1c](https://user-images.githubusercontent.com/13027631/58853872-9ae68f00-8669-11e9-989e-5ebf2c020774.png) ![style2c](https://user-images.githubusercontent.com/13027631/58853873-9cb05280-8669-11e9-99d8-0d6aa69137af.png)

