### PR TITLE
Replace GIT_SHA with a more versatile BUILD_ID definition.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -52,13 +52,13 @@ ifdef USER_CFLAGS
   $(info USER_CFLAGS: $(USER_CFLAGS))
 endif
 
-ifdef GIT_SHA
-  $(info GIT_SHA: $(GIT_SHA))
+ifdef BUILD_ID
+  $(info BUILD_ID: $(BUILD_ID))
 else
-  GIT_SHA := $(shell git rev-parse --short HEAD 2>$(NULLDEV) || svnversion 2>$(NULLDEV))
-  ifneq ($(words $(GIT_SHA)),1)
-    GIT_SHA := N/A
-    $(info GIT_SHA: N/A)
+  BUILD_ID := Git $(shell git rev-parse --short HEAD 2>$(NULLDEV) || svnversion 2>$(NULLDEV))
+  ifneq ($(words $(BUILD_ID)),2)
+    BUILD_ID := N/A
+    $(info BUILD_ID: N/A)
   endif
 endif
 
@@ -66,7 +66,7 @@ CFLAGS += -MMD -MP -O3 -I common \
           -Wall -Wextra -Wno-char-subscripts $(USER_CFLAGS) \
           -DCA65_INC="$(CA65_INC)" -DCC65_INC="$(CC65_INC)" -DCL65_TGT="$(CL65_TGT)" \
           -DLD65_LIB="$(LD65_LIB)" -DLD65_OBJ="$(LD65_OBJ)" -DLD65_CFG="$(LD65_CFG)" \
-          -DGIT_SHA=$(GIT_SHA)
+          -DBUILD_ID="$(BUILD_ID)"
 
 LDLIBS += -lm
 

--- a/src/common/version.c
+++ b/src/common/version.c
@@ -61,8 +61,8 @@ const char* GetVersionAsString (void)
 /* Returns the version number as a string in a static buffer */
 {
     static char Buf[60];
-#if defined(GIT_SHA)
-    xsnprintf (Buf, sizeof (Buf), "%u.%u - Git %s", VER_MAJOR, VER_MINOR, STRINGIZE (GIT_SHA));
+#if defined(BUILD_ID)
+    xsnprintf (Buf, sizeof (Buf), "%u.%u - %s", VER_MAJOR, VER_MINOR, STRINGIZE (BUILD_ID));
 #else
     xsnprintf (Buf, sizeof (Buf), "%u.%u", VER_MAJOR, VER_MINOR);
 #endif


### PR DESCRIPTION
When compiling cc65, it will by default place the git hash (if available) of the checked out commit in the version string.  This isn't useful when building a package for a Linux distribution, since there either won't be an upstream git hash if there is one at all.

Thus we replace GIT_SHA with a more versatile BUILD_ID, which can be defined to any arbitrary string.  When building, its contents will be appended to the version string instead of the git hash.

If BUILD_ID is not defined by the user the behaviour will be exactly the same as before.  That means BUILD_ID gets automatically defined to Git <GIT_SHA>, if it can be determined from a checkout.