### PR TITLE
common/version: Increase static buffer to 100 chars.

### DIFF
--- a/src/common/version.c
+++ b/src/common/version.c
@@ -60,7 +60,7 @@
 const char* GetVersionAsString (void)
 /* Returns the version number as a string in a static buffer */
 {
-    static char Buf[60];
+    static char Buf[100];
 #if defined(BUILD_ID)
     xsnprintf (Buf, sizeof (Buf), "%u.%u - %s", VER_MAJOR, VER_MINOR, STRINGIZE (BUILD_ID));
 #else


### PR DESCRIPTION
In a previous commit we introduced BUILD_ID to replace GIT_HASH.  As this allows for strings of an arbitrary length to be appended to this buffer, we should increase its size a bit so longer strings will not get truncated.