### PR TITLE
[Gamate] Remove "eor RVS" in cputc.s + [Supervision] hello world example

### DIFF
--- a/libsrc/gamate/cputc.s
+++ b/libsrc/gamate/cputc.s
@@ -101,7 +101,6 @@ putchar:
         ldy     #$f8
 @copylp1:
         lda     (ptr3),y
-        eor     RVS
         sta     LCD_DATA
         iny
         bne     @copylp1
@@ -124,7 +123,6 @@ putchar:
         ldy     #$f8
 @copylp2:
         lda     (ptr3),y
-        eor     RVS
         sta     LCD_DATA
         iny
         bne     @copylp2

--- a/samples/supervisionhello.c
+++ b/samples/supervisionhello.c
@@ -23,7 +23,7 @@ void clear_screen(void)
 {
     unsigned short i;
     
-    for(i=0;i<160*160;++i)
+    for(i=0;i<0x2000;++i)
     {
         POKE(SV_VIDEO+i,0);
     }

--- a/samples/supervisionhello.c
+++ b/samples/supervisionhello.c
@@ -1,0 +1,71 @@
+#include <supervision.h>
+#include <peekpoke.h>
+
+#define SV_OFFSET (SV_VIDEO+0x0A*48+0x0A)
+
+unsigned char h_char[] = {0x66,0x66,0x66,0x7e,0x66,0x66,0x66,0x00};
+unsigned char e_char[] = {0x7e,0x60,0x60,0x78,0x60,0x60,0x7e,0x00};
+unsigned char l_char[] = {0x60,0x60,0x60,0x60,0x60,0x60,0x7e,0x00};
+unsigned char o_char[] = {0x3c,0x66,0x66,0x66,0x66,0x66,0x3c,0x00};
+unsigned char w_char[] = {0x63,0x63,0x63,0x6b,0x7f,0x77,0x63,0x00};
+unsigned char r_char[] = {0x7c,0x66,0x66,0x7c,0x78,0x6c,0x66,0x00};
+unsigned char d_char[] = {0x78,0x6c,0x66,0x66,0x66,0x6c,0x78,0x00};
+
+
+void INIT_GRAPHICS(void)
+{
+    SV_LCD.height = 0xA0;
+    SV_LCD.width = 0xA0;
+    SV_BANK = 0xC9;   
+}
+
+void clear_screen(void)
+{
+    unsigned short i;
+    
+    for(i=0;i<160*160;++i)
+    {
+        POKE(SV_VIDEO+i,0);
+    }
+}
+
+unsigned char bit_reverse_lookup[16] = 
+{
+    0x0, 0x8, 0x4, 0xC, 0x2, 0xA, 0x6, 0xE,
+    0x1, 0x9, 0x5, 0xD, 0x3, 0xB, 0x7, 0xF 
+};
+
+unsigned char bit_reverse(unsigned char n) 
+{
+   return (bit_reverse_lookup[n&0b1111] << 4) | bit_reverse_lookup[n>>4];
+}
+
+
+int main()
+{
+    unsigned char i;
+    
+    INIT_GRAPHICS();
+    clear_screen();
+    
+    for(i=0;i<8;++i)
+    {
+        POKE(SV_OFFSET+1 +i*48,bit_reverse(h_char[i]));
+        POKE(SV_OFFSET+2 +i*48,bit_reverse(e_char[i]));
+        POKE(SV_OFFSET+3 +i*48,bit_reverse(l_char[i]));
+        POKE(SV_OFFSET+4 +i*48,bit_reverse(l_char[i]));
+        POKE(SV_OFFSET+5 +i*48,bit_reverse(o_char[i]));
+        
+        POKE(SV_OFFSET+7 +i*48,bit_reverse(w_char[i]));
+        POKE(SV_OFFSET+8 +i*48,bit_reverse(o_char[i]));
+        POKE(SV_OFFSET+9 +i*48,bit_reverse(r_char[i]));
+        POKE(SV_OFFSET+10 +i*48,bit_reverse(l_char[i]));
+        POKE(SV_OFFSET+11+i*48,bit_reverse(d_char[i]));        
+    }
+
+    while(1) {};
+    
+    return 0;
+}
+
+

--- a/samples/supervisionhello.c
+++ b/samples/supervisionhello.c
@@ -59,7 +59,7 @@ int main()
         POKE(SV_OFFSET+7 +i*48,bit_reverse(w_char[i]));
         POKE(SV_OFFSET+8 +i*48,bit_reverse(o_char[i]));
         POKE(SV_OFFSET+9 +i*48,bit_reverse(r_char[i]));
-        POKE(SV_OFFSET+10 +i*48,bit_reverse(l_char[i]));
+        POKE(SV_OFFSET+10+i*48,bit_reverse(l_char[i]));
         POKE(SV_OFFSET+11+i*48,bit_reverse(d_char[i]));        
     }
 


### PR DESCRIPTION
1. [Gamate] Fix the wrong display of reversed characters in REAL hardware (this is not seen in Mame).
2. [Supervision] hello world example (badly needed because getting a working binary is not obvious from the doc and there is no example).

![image](https://user-images.githubusercontent.com/29057615/66074559-c31fc500-e559-11e9-8995-466e7b3672f3.png)

Tested by Plamen Vaysilov @PlamenVaysilov (https://wwwwww.facebook.com/vaysilov) on real hardware.