### PR TITLE
[Supervision][fix] Screen init code fix + Hello world example for the Supervision

### DIFF
--- a/cfg/supervision.cfg
+++ b/cfg/supervision.cfg
@@ -19,7 +19,7 @@ SEGMENTS {
     CODE:     load = ROM,            type = ro,  define   = yes;
     RODATA:   load = ROM,            type = ro,  define   = yes;
     DATA:     load = ROM, run = RAM, type = rw,  define   = yes;
-    FFF0:     load = ROM,            type = ro,  offset   = $7FEA;
+    FFEA:     load = ROM,            type = ro,  offset   = $7FEA;
     VECTOR:   load = ROM,            type = ro,  offset   = $7FFA;
     BSS:      load = RAM,            type = bss, define   = yes;
 }

--- a/cfg/supervision.cfg
+++ b/cfg/supervision.cfg
@@ -19,7 +19,7 @@ SEGMENTS {
     CODE:     load = ROM,            type = ro,  define   = yes;
     RODATA:   load = ROM,            type = ro,  define   = yes;
     DATA:     load = ROM, run = RAM, type = rw,  define   = yes;
-    FFF0:     load = ROM,            type = ro,  offset   = $7FF0;
+    FFF0:     load = ROM,            type = ro,  offset   = $7FEA;
     VECTOR:   load = ROM,            type = ro,  offset   = $7FFA;
     BSS:      load = RAM,            type = bss, define   = yes;
 }

--- a/cfg/supervision.cfg
+++ b/cfg/supervision.cfg
@@ -19,7 +19,7 @@ SEGMENTS {
     CODE:     load = ROM,            type = ro,  define   = yes;
     RODATA:   load = ROM,            type = ro,  define   = yes;
     DATA:     load = ROM, run = RAM, type = rw,  define   = yes;
-    FFEA:     load = ROM,            type = ro,  offset   = $7FEA;
+    FFF0:     load = ROM,            type = ro,  offset   = $7FF0;
     VECTOR:   load = ROM,            type = ro,  offset   = $7FFA;
     BSS:      load = RAM,            type = bss, define   = yes;
 }

--- a/libsrc/supervision/crt0.s
+++ b/libsrc/supervision/crt0.s
@@ -67,7 +67,7 @@ not_dma:
 ; Removing this segment gives only a warning.
         .segment "FFEA"
 .proc reset32kcode
-        lda     #$A0
+        lda     #160
         sta     lcd_width
         sta     lcd_height
         lda     #(6<<5) | SV_LCD_ON | SV_NMI_ENABLE_ON 

--- a/libsrc/supervision/crt0.s
+++ b/libsrc/supervision/crt0.s
@@ -65,11 +65,8 @@ not_dma:
 .endproc
 
 ; Removing this segment gives only a warning.
-        .segment "FFEA"
+        .segment "FFF0"
 .proc reset32kcode
-        lda     #160
-        sta     lcd_width
-        sta     lcd_height
         lda     #(6<<5) | SV_LCD_ON | SV_NMI_ENABLE_ON 
         sta     sv_bank
 ; Now, the 32Kbyte image can reside in the top of 64Kbyte and 128Kbyte ROMs.

--- a/libsrc/supervision/crt0.s
+++ b/libsrc/supervision/crt0.s
@@ -65,12 +65,12 @@ not_dma:
 .endproc
 
 ; Removing this segment gives only a warning.
-        .segment "FFF0"
+        .segment "FFEA"
 .proc reset32kcode
         lda     #$A0
         sta     lcd_width
         sta     lcd_height
-        lda     #$C9
+        lda     #(6<<5) | SV_LCD_ON | SV_NMI_ENABLE_ON 
         sta     sv_bank
 ; Now, the 32Kbyte image can reside in the top of 64Kbyte and 128Kbyte ROMs.
         jmp     reset

--- a/libsrc/supervision/crt0.s
+++ b/libsrc/supervision/crt0.s
@@ -67,7 +67,10 @@ not_dma:
 ; Removing this segment gives only a warning.
         .segment "FFF0"
 .proc reset32kcode
-        lda     #(6<<5)
+        lda     #$A0
+        sta     lcd_width
+        sta     lcd_height
+        lda     #$C9
         sta     sv_bank
 ; Now, the 32Kbyte image can reside in the top of 64Kbyte and 128Kbyte ROMs.
         jmp     reset

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -198,6 +198,9 @@ EXELIST_atarixl = $(EXELIST_atari)
 
 EXELIST_atari2600 = \
         atari2600hello
+        
+EXELIST_supervision = \
+        supervisionhello
 
 # Unlisted targets will try to build everything.
 # That lets us learn what they cannot build, and what settings

--- a/samples/supervisionhello.c
+++ b/samples/supervisionhello.c
@@ -1,17 +1,15 @@
 #include <supervision.h>
 #include <peekpoke.h>
 
-#define SV_OFFSET 0x0A
-#define SV_INIT_POSITION (SV_VIDEO+0x0A*48+0x0A)
+#define BYTES_PER_LINE 48
 
-unsigned char h_char[] = {0x66,0x66,0x66,0x7e,0x66,0x66,0x66,0x00};
-unsigned char e_char[] = {0x7e,0x60,0x60,0x78,0x60,0x60,0x7e,0x00};
-unsigned char l_char[] = {0x60,0x60,0x60,0x60,0x60,0x60,0x7e,0x00};
-unsigned char o_char[] = {0x3c,0x66,0x66,0x66,0x66,0x66,0x3c,0x00};
-unsigned char w_char[] = {0x63,0x63,0x63,0x6b,0x7f,0x77,0x63,0x00};
-unsigned char r_char[] = {0x7c,0x66,0x66,0x7c,0x78,0x6c,0x66,0x00};
-unsigned char d_char[] = {0x78,0x6c,0x66,0x66,0x66,0x6c,0x78,0x00};
-
+const unsigned char h_char[] = {0x66,0x66,0x66,0x7E,0x66,0x66,0x66,0x00};
+const unsigned char e_char[] = {0x7E,0x60,0x60,0x78,0x60,0x60,0x7E,0x00};
+const unsigned char l_char[] = {0x60,0x60,0x60,0x60,0x60,0x60,0x7E,0x00};
+const unsigned char o_char[] = {0x3C,0x66,0x66,0x66,0x66,0x66,0x3C,0x00};
+const unsigned char w_char[] = {0x63,0x63,0x63,0x6B,0x7F,0x77,0x63,0x00};
+const unsigned char r_char[] = {0x7C,0x66,0x66,0x7C,0x78,0x6C,0x66,0x00};
+const unsigned char d_char[] = {0x78,0x6C,0x66,0x66,0x66,0x6C,0x78,0x00};
 
 void clear_screen(void)
 {
@@ -23,37 +21,48 @@ void clear_screen(void)
     }
 }
 
-unsigned char bit_reverse_lookup[16] = 
+unsigned char reversed_map_one_to_two_lookup[16] = 
 {
-    0x0, 0x8, 0x4, 0xC, 0x2, 0xA, 0x6, 0xE,
-    0x1, 0x9, 0x5, 0xD, 0x3, 0xB, 0x7, 0xF 
+    0x00, 0xC0, 0x30, 0xF0, 0x0C, 0xCC, 0x3C, 0xFC,
+    0x03, 0xC3, 0x33, 0xF3, 0x0F, 0xCF, 0x3F, 0xFF
 };
 
-unsigned char bit_reverse(unsigned char n) 
+unsigned char left_map_one_to_two(unsigned char n)
 {
-    return (bit_reverse_lookup[n&0b1111] << 4) | bit_reverse_lookup[n>>4];
+    return reversed_map_one_to_two_lookup[n >> 4];
+}
+
+unsigned char right_map_one_to_two(unsigned char n)
+{
+    return reversed_map_one_to_two_lookup[n&0x0F];
+}
+
+void display_char(const unsigned char x, const unsigned char y, const unsigned char *ch)
+{
+    unsigned char k;
+    
+    for(k=0;k<8;++k)
+    { \
+        SV_VIDEO[2*(y)+BYTES_PER_LINE*k+BYTES_PER_LINE*(x<<3)]    = left_map_one_to_two(ch[k]); 
+        SV_VIDEO[2*(y)+BYTES_PER_LINE*k+BYTES_PER_LINE*(x<<3)+1]  = right_map_one_to_two(ch[k]); 
+    } 
 }
 
 int main()
-{
-    unsigned char i;
-    
+{    
     clear_screen();
     
-    for(i=0;i<8;++i)
-    {
-        POKE(SV_INIT_POSITION+1 +i*48,bit_reverse(h_char[i]));
-        POKE(SV_INIT_POSITION+2 +i*48,bit_reverse(e_char[i]));
-        POKE(SV_INIT_POSITION+3 +i*48,bit_reverse(l_char[i]));
-        POKE(SV_INIT_POSITION+4 +i*48,bit_reverse(l_char[i]));
-        POKE(SV_INIT_POSITION+5 +i*48,bit_reverse(o_char[i]));
-        
-        POKE(SV_INIT_POSITION+7 +i*48,bit_reverse(w_char[i]));
-        POKE(SV_INIT_POSITION+8 +i*48,bit_reverse(o_char[i]));
-        POKE(SV_INIT_POSITION+9 +i*48,bit_reverse(r_char[i]));
-        POKE(SV_INIT_POSITION+10+i*48,bit_reverse(l_char[i]));
-        POKE(SV_INIT_POSITION+11+i*48,bit_reverse(d_char[i]));        
-    }
+    display_char(3,2, h_char);
+    display_char(3,3, e_char);
+    display_char(3,4, l_char);
+    display_char(3,5, l_char);
+    display_char(3,6, o_char);
+    
+    display_char(3,8, w_char);
+    display_char(3,9, o_char);
+    display_char(3,10,r_char);
+    display_char(3,11,l_char);
+    display_char(3,12,d_char);    
 
     while(1) {};
     

--- a/samples/supervisionhello.c
+++ b/samples/supervisionhello.c
@@ -9,10 +9,10 @@
 #include <supervision.h>
 #include <peekpoke.h>
 
-// Last 8 bytes are not displayed
+// Number of bytes per screen line (Remark: Last 8 bytes are not displayed)
 #define BYTES_PER_LINE 48
 
-// Characters definitions in 8x8 format
+// Character definitions in 8x8 format
 const unsigned char h_char[] = {0x66,0x66,0x66,0x7E,0x66,0x66,0x66,0x00};
 const unsigned char e_char[] = {0x7E,0x60,0x60,0x78,0x60,0x60,0x7E,0x00};
 const unsigned char l_char[] = {0x60,0x60,0x60,0x60,0x60,0x60,0x7E,0x00};
@@ -32,6 +32,7 @@ void clear_screen(void)
 }
 
 // Necessary conversion to have 2 bits per pixel with darkest hue
+// Remark: The Supervision uses 2 bits per pixel and bits are mapped into pixel in reversed order
 unsigned char reversed_map_one_to_two_lookup[16] = 
 {
     0x00, 0xC0, 0x30, 0xF0, 0x0C, 0xCC, 0x3C, 0xFC,

--- a/samples/supervisionhello.c
+++ b/samples/supervisionhello.c
@@ -34,18 +34,9 @@ unsigned char bit_reverse(unsigned char n)
     return (bit_reverse_lookup[n&0b1111] << 4) | bit_reverse_lookup[n>>4];
 }
 
-void init_screen(void)
-{
-    SV_LCD.height = 0xA0;
-    SV_LCD.width = 0xA0;
-    SV_BANK = 0xC9;     
-}
-
 int main()
 {
     unsigned char i;
-    
-    init_screen();
     
     clear_screen();
     

--- a/samples/supervisionhello.c
+++ b/samples/supervisionhello.c
@@ -60,8 +60,15 @@ void display_char(const unsigned char x, const unsigned char y, const unsigned c
     } 
 }
 
+void init_lcd(void)
+{
+    SV_LCD.width = 160;
+    SV_LCD.height = 160;
+}
+
 int main()
-{    
+{   
+    init_lcd();
     clear_screen();
     
     display_char(3,2, h_char);

--- a/samples/supervisionhello.c
+++ b/samples/supervisionhello.c
@@ -1,8 +1,18 @@
+/*****************************************************************************/
+/*                                                                           */
+/* Watara Supervision sample C program                                       */
+/*                                                                           */
+/* Fabrizio Caruso (fabrizio_caruso@hotmail.com), 2019                       */
+/*                                                                           */
+/*****************************************************************************/
+
 #include <supervision.h>
 #include <peekpoke.h>
 
+// Last 8 bytes are not displayed
 #define BYTES_PER_LINE 48
 
+// Characters definitions in 8x8 format
 const unsigned char h_char[] = {0x66,0x66,0x66,0x7E,0x66,0x66,0x66,0x00};
 const unsigned char e_char[] = {0x7E,0x60,0x60,0x78,0x60,0x60,0x7E,0x00};
 const unsigned char l_char[] = {0x60,0x60,0x60,0x60,0x60,0x60,0x7E,0x00};
@@ -21,6 +31,7 @@ void clear_screen(void)
     }
 }
 
+// Necessary conversion to have 2 bits per pixel with darkest hue
 unsigned char reversed_map_one_to_two_lookup[16] = 
 {
     0x00, 0xC0, 0x30, 0xF0, 0x0C, 0xCC, 0x3C, 0xFC,

--- a/samples/supervisionhello.c
+++ b/samples/supervisionhello.c
@@ -1,0 +1,72 @@
+#include <supervision.h>
+#include <peekpoke.h>
+
+#define SV_OFFSET 0x0A
+#define SV_INIT_POSITION (SV_VIDEO+0x0A*48+0x0A)
+
+unsigned char h_char[] = {0x66,0x66,0x66,0x7e,0x66,0x66,0x66,0x00};
+unsigned char e_char[] = {0x7e,0x60,0x60,0x78,0x60,0x60,0x7e,0x00};
+unsigned char l_char[] = {0x60,0x60,0x60,0x60,0x60,0x60,0x7e,0x00};
+unsigned char o_char[] = {0x3c,0x66,0x66,0x66,0x66,0x66,0x3c,0x00};
+unsigned char w_char[] = {0x63,0x63,0x63,0x6b,0x7f,0x77,0x63,0x00};
+unsigned char r_char[] = {0x7c,0x66,0x66,0x7c,0x78,0x6c,0x66,0x00};
+unsigned char d_char[] = {0x78,0x6c,0x66,0x66,0x66,0x6c,0x78,0x00};
+
+
+void clear_screen(void)
+{
+    unsigned short i;
+    
+    for(i=0;i<0x2000;++i)
+    {
+        POKE(SV_VIDEO+i,0);
+    }
+}
+
+unsigned char bit_reverse_lookup[16] = 
+{
+    0x0, 0x8, 0x4, 0xC, 0x2, 0xA, 0x6, 0xE,
+    0x1, 0x9, 0x5, 0xD, 0x3, 0xB, 0x7, 0xF 
+};
+
+unsigned char bit_reverse(unsigned char n) 
+{
+    return (bit_reverse_lookup[n&0b1111] << 4) | bit_reverse_lookup[n>>4];
+}
+
+void init_screen(void)
+{
+    SV_LCD.height = 0xA0;
+    SV_LCD.width = 0xA0;
+    SV_BANK = 0xC9;     
+}
+
+int main()
+{
+    unsigned char i;
+    
+    init_screen();
+    
+    clear_screen();
+    
+    for(i=0;i<8;++i)
+    {
+        POKE(SV_INIT_POSITION+1 +i*48,bit_reverse(h_char[i]));
+        POKE(SV_INIT_POSITION+2 +i*48,bit_reverse(e_char[i]));
+        POKE(SV_INIT_POSITION+3 +i*48,bit_reverse(l_char[i]));
+        POKE(SV_INIT_POSITION+4 +i*48,bit_reverse(l_char[i]));
+        POKE(SV_INIT_POSITION+5 +i*48,bit_reverse(o_char[i]));
+        
+        POKE(SV_INIT_POSITION+7 +i*48,bit_reverse(w_char[i]));
+        POKE(SV_INIT_POSITION+8 +i*48,bit_reverse(o_char[i]));
+        POKE(SV_INIT_POSITION+9 +i*48,bit_reverse(r_char[i]));
+        POKE(SV_INIT_POSITION+10+i*48,bit_reverse(l_char[i]));
+        POKE(SV_INIT_POSITION+11+i*48,bit_reverse(d_char[i]));        
+    }
+
+    while(1) {};
+    
+    return 0;
+}
+
+


### PR DESCRIPTION
This is a simple helloworld example for the Supervision.
I have managed to move screen init code into crt0.s
This has required changing the linker cfg by 6 bytes.
The helloworld example is a unit-test for the init code.

Remark: Do NOT test this on Potator 0.6/0.7. Either use real hardware or at least Wataro or Mame.

It has been tested with the accurate emulator Wataro and on REAL hardware by Plamen @PlamenVaysilov.

@greg-king5, @oliverschmidt could you please take a look at this fix?