### PR TITLE
[cx16] Update ROM banks to new mapping

### DIFF
--- a/libsrc/cx16/crt0.s
+++ b/libsrc/cx16/crt0.s
@@ -62,6 +62,7 @@ L2:     lda     zpsave,x
         stx     VIA1::PRA2      ; Restore former RAM bank
         lda     VIA1::PRB
         and     #<~$07
+        ora     #$04
         sta     VIA1::PRB       ; Change back to BASIC ROM
 
 ; Back to BASIC.
@@ -77,7 +78,7 @@ init:
 ; Change from BASIC's ROM to Kernal's ROM.
 
         lda     VIA1::PRB
-        ora     #$07
+        and     #<~$07
         sta     VIA1::PRB
 
 ; Change to the first RAM bank.


### PR DESCRIPTION
This probably shouldn't be merged right away. This fixes an issue caused by a change in the HEAD version on git, and hasn't made it to a release version just yet. I wanted to get this here so that it isn't forgotten about.

The ROM banks on the cx16 have been shuffled around a bit. It appears that this change was to account for the VIA's default values when powered on. With this change, KERNAL has moved from 7 to 0, and BASIC has moved from 0 to 2.

commanderx16/x16-rom@38f40b2
commanderx16/x16-emulator@d98151f

This requires an update to the file `libsrc/cx16/crt0.s`, as this file switches to the KERNAL bank when starting the program and switches back to the BASIC bank when quitting. This PR changes the bank numbers being switched to.

This fixes compatibility with the HEAD version of the ROM (programs crash without this), but breaks it against the release version. My simple program does run fine compiled with this change on the release version, but I assume any program that uses any of the kernal functions (such as through `stdio.h`) or tries to cleanly exit will have problems. Because of this, it might be best to hold off and wait until a release is made with the new bank numbers before merging this change.