### PR TITLE
Significantly faster rand() implementation

### DIFF
--- a/libsrc/common/rand.s
+++ b/libsrc/common/rand.s
@@ -35,27 +35,17 @@ rand:   .dword   1
 .code
 
 _rand:  clc
-        lda     rand+0          ; SEED *= $01010101
-        adc     rand+1
+        lda     rand+0          ; SEED += $B3
+        adc     #$B3
+        sta     rand+0
+        adc     rand+1          ; SEED *= $01010101
         sta     rand+1
         adc     rand+2
         sta     rand+2
-        adc     rand+3
-        sta     rand+3
-        clc
-        lda     rand+0          ; SEED += $31415927
-        adc     #$27
-        sta     rand+0
-        lda     rand+1
-        adc     #$59
-        sta     rand+1
-        lda     rand+2
-        adc     #$41
-        sta     rand+2
         and     #$7f            ; Suppress sign bit (make it positive)
         tax
-        lda     rand+3
-        adc     #$31
+        lda     rand+2
+        adc     rand+3
         sta     rand+3
         rts                     ; return bit (16-22,24-31) in (X,A)
 

--- a/libsrc/common/rand.s
+++ b/libsrc/common/rand.s
@@ -3,6 +3,7 @@
 ;
 ; Written and donated by Sidney Cadot - sidney@ch.twi.tudelft.nl
 ; 2016-11-07, modified by Brad Smith
+; 2019-10-07, modified by Lewis "LRFLEW" Fox
 ;
 ; May be distributed with the cc65 runtime using the same license.
 ;
@@ -23,6 +24,17 @@
 ;  low byte A to provide the best entropy in the
 ;  most commonly used part of the return value.
 ;
+;  Uses the following LCG values for ax + c (mod m)
+;  a = $01010101
+;  c = $B3B3B3B3
+;  m = $100000000 (32-bit truncation)
+;
+;  The multiplier was carefully chosen such that it can
+;  be computed with 3 adc instructions, and the increment
+;  was chosen to have the same value in each byte to allow
+;  the addition to be performed in conjunction with the
+;  multiplication, adding only 1 additional adc instruction.
+;
 
         .export         _rand, _srand
 
@@ -35,10 +47,10 @@ rand:   .dword   1
 .code
 
 _rand:  clc
-        lda     rand+0          ; SEED += $B3
+        lda     rand+0
         adc     #$B3
         sta     rand+0
-        adc     rand+1          ; SEED *= $01010101
+        adc     rand+1
         sta     rand+1
         adc     rand+2
         sta     rand+2


### PR DESCRIPTION
I was experimenting with PRNG's and I found an interesting optimization for the version used for the stdlib.h function `rand()`. It's likely slightly weaker in terms of entropy, but it is still an [LCG](https://en.wikipedia.org/wiki/Linear_congruential_generator) with a period of 2<sup>32</sup>. To make this work, I had to make two changes to the LCG.

Firstly, the order of operations is changed. Instead of calculating `ax + c (mod m)` each step, it calculates `a(x + c) (mod m)` instead. This is still an LCG despite this change, as it's just pulling values at a different point in the LCG generation sequence. If we consider an LCG as being the sequence `x_1 = a*x_0, x_2 = x_1 + c, x_3 = a*x_2, x_4 = x_3 + c, ... (mod m)`, then this is just sampling the odd `x`'s instead of the even ones. Since `x (mod m) → x + c (mod m)` is a bijection, there is no loss in entropy making this change.

Secondly, I changed the `c` value for the LCG. Specifically, to make this optimization work, I had to get the `c` value to be only 8 bits. This is an easy change to make, as the only requirement to maintain the maximum period is that `c` must be an odd number. Making this change may result in a lower apparent entropy, but from a visual check it didn't appear to be noticeably worse (and LCG's aren't known for great spectral properties anyways).

Now for the optimization. First, the algorithm performs the addition `(rand) + c` on the least significant byte `rand+0`. Since `c` is only 8 bits, the other bytes of the state don't need any value specifically added to them. However, the addition sets the carry flag `C` that needs to be accounted for in the other bytes. For the next significant byte `rand+1`, we can describe this requirement as `(rand+1) + $00 + C → (rand+1)`. However, the multiplication `rand*a` also requires an addition in the form of `(rand+0) + (rand+1) + 0 → (rand+1)` (i.e. with the `C` flag cleared). With the 0's in both additions, we can combine them into a single addition `(rand+0) + (rand+1) + C → (rand+1)`. The assembly for this addition looks like this: 
```
; (rand+0) is in A due to the last addition
adc rand+1
sta rand+1
```
Now `C` has a carry value from the combination of both the addition and multiplication steps. This means that continuing the multiplication on to the third and most significant bytes is the same as just the multiplication alone.

The key to this optimization is that now we only need to read, modify, and write each byte of the state once in a single pass, opposed to the two separate passes in the existing version. I calculated the clock cycles required for both versions (excluding the `rts` instruction, as I'm unclear on how to time it based on the WDC 65C02S documentation). Assuming that the `rand` value is not in the zero page, I got that this version takes 44 clock cycles, while the original version takes 76 clock cycles (1.73x improvement). Making this change produced a very noticeable speed improvement in my `rand()` heavy test program (producing white noise bitmaps), with it running 1.42x faster.