### PR TITLE
[WIP] vic20/cputc: Fix incorrect CRAM_PTR at startup when using conio

### DIFF
--- a/asminc/c64.inc
+++ b/asminc/c64.inc
@@ -214,3 +214,14 @@ CASSMOT         = $20           ; Cassette motor on
 TP_FAST         = $80           ; Switch Rossmoeller TurboProcess to fast mode
 
 RAMONLY         = $F8           ; (~(LORAM | HIRAM | IOEN)) & $FF
+
+; --------------------------------------------------------------------------
+; Kernal routines, direct entries
+;
+; The proper home for this is actually asminc/cbm_kernal.inc, but unfortunately
+; that file cannot be used by conio code because it defines PLOT as the actual
+; PLOT routine in the ROM, conflicting with our replacement for PLOT in
+; libsrc/c64/kplot.s. It would be nice to work out a better way to handle that
+; conflict so that this could be moved there.
+
+UPDCRAMPTR      := $EA24        ; Update the color RAM pointer to match the screen RAM pointer

--- a/asminc/vic20.inc
+++ b/asminc/vic20.inc
@@ -115,3 +115,8 @@ VIA2_PCR        := VIA2+$C      ; Peripheral control register
 VIA2_IFR        := VIA2+$D      ; Interrupt flag register
 VIA2_IER        := VIA2+$E      ; Interrupt enable register
 VIA2_PA2        := VIA2+$F      ; Port register A w/o handshake
+
+; ---------------------------------------------------------------------------
+; Kernal routines, direct entries
+
+UPDCRAMPTR      := $EAB2        ; Update the color RAM pointer to match the screen RAM pointer

--- a/asminc/vic20.inc
+++ b/asminc/vic20.inc
@@ -118,5 +118,11 @@ VIA2_PA2        := VIA2+$F      ; Port register A w/o handshake
 
 ; ---------------------------------------------------------------------------
 ; Kernal routines, direct entries
+;
+; The proper home for this is actually asminc/cbm_kernal.inc, but unfortunately
+; that file cannot be used by conio code because it defines PLOT as the actual
+; PLOT routine in the ROM, conflicting with our replacement for PLOT in
+; libsrc/vic20/kplot.s. It would be nice to work out a better way to handle that
+; conflict so that this could be moved there.
 
 UPDCRAMPTR      := $EAB2        ; Update the color RAM pointer to match the screen RAM pointer

--- a/libsrc/c64/kplot.s
+++ b/libsrc/c64/kplot.s
@@ -7,12 +7,13 @@
 
         .export         PLOT
 
+        .include        "c64.inc"
 
 .proc   PLOT
 
         bcs     @L1
-        jsr     $FFF0                   ; Set cursor position
-        jmp     $EA24                   ; Set pointer to color RAM
+        jsr     $FFF0                   ; Set cursor position using original ROM PLOT
+        jmp     UPDCRAMPTR              ; Set pointer to color RAM
 
 @L1:    jmp     $FFF0                   ; Get cursor position
 

--- a/libsrc/vic20/cputc.s
+++ b/libsrc/vic20/cputc.s
@@ -13,6 +13,23 @@
         .include        "vic20.inc"
 
 
+; VIC-20 KERNAL routines (such as PLOT) do not always leave the color RAM
+; pointer CRAM_PTR pointing at the color RAM location matching the screen
+; RAM pointer SCREEN_PTR. Instead they update it when they need it to be
+; correct by calling UPDCRAMPTR.
+;
+; We make things more efficient by having conio always update CRAM_PTR when
+; we move the screen pointer to avoid extra calls to ensure it's updated
+; before doing screen output. (Among other things, We replace the ROM
+; version of PLOT with our own in libsrc/vic20/kplot.s to ensure this
+; precondition.)
+;
+; However, this means that CRAM_PTR may be (and is, after a cold boot)
+; incorrect for us at program startup, causing cputc() not to work. We fix
+; this with a constructor that ensures CRAM_PTR matches SCREEN_PTR.
+;
+        .constructor    UPDCRAMPTR
+
 _cputcxy:
         pha                     ; Save C
         jsr     gotoxy          ; Set cursor, drop x and y

--- a/libsrc/vic20/kplot.s
+++ b/libsrc/vic20/kplot.s
@@ -7,12 +7,13 @@
 
         .export         PLOT
 
+        .include        "vic20.inc"
 
 .proc   PLOT
 
         bcs     @L1
-        jsr     $FFF0                   ; Set cursor position
-        jmp     $EAB2                   ; Set pointer to color RAM
+        jsr     $FFF0                   ; Set cursor position using original ROM PLOT
+        jmp     UPDCRAMPTR              ; Set pointer to color RAM
 
 @L1:    jmp     $FFF0                   ; Get cursor position
 


### PR DESCRIPTION
This is a fix for the problem discussed in issue #946. I tested it using my framework in [`0cjs/vic20cc65`](https://github.com/0cjs/vic20cc65.git); you can just clone that repo and run `./Test` to do the same. (`README.md` there has more information, including how to demonstrate the original problem.)

Thanks go to @greg-king5 who in [this comment](https://github.com/cc65/cc65/issues/946#issuecomment-538502820) dug into the details of the VIC-20 ROM to clarify the problem and proposed the solution used here. If you wish to  examine the ROM code yourself, you may find it convenient to refer to copies of the original ROM source and various disassemblies in [`0cjs/vic20-stuff/rom`](https://github.com/0cjs/vic20-stuff/tree/master/rom).

I've tried to be as clear as possible (potentially to the point of overkill) in the commit message, comments I've added to the code, and the new label for the ROM routine used by this solution. That said, this is my first time even looking at cc65, so I welcome feedback if it doesn't fit the design or style of this project.