### PR TITLE
Tentative solution for cgetc in Lynx

### DIFF
--- a/libsrc/lynx/cgetc.s
+++ b/libsrc/lynx/cgetc.s
@@ -20,13 +20,13 @@
 ; So the keyboard returns '1', '2', '3', 'P', 'R', 'F' or '?'.
 
 _cgetc:
-        lda     KBSTL
-        ora     KBEDG
-        bne     @L1
         jsr     _kbhit          ; Check for char available
+        bne     @L1        
         tax                             ; Test result
         bra     _cgetc
 @L1:
+        lda     KBSTL
+        ora     KBEDG
         ldx     #0
         and     #1
         beq     @L6


### PR DESCRIPTION
@greg-king5 could you please take a look at this code? I am a very poor Assembly coder. 
The bug is about cgetc not blocking after the first time, as if it were not consuming the input.
It seems I have fixed this problem.
You can use the following test code to verify it:
```
#include <tgi.h>
#include <conio.h>
#define CLI() asm("\tcli")
int main(void)
{
    unsigned short i;
    unsigned char str[2];
    str[1] = '\0';
    tgi_install (tgi_static_stddrv);
    tgi_init ();        
    CLI();
    tgi_clear();
    while (tgi_busy())  {  };
    tgi_setpalette(tgi_getdefpalette());
    tgi_setbgcolor(TGI_COLOR_GREY);
    tgi_setcolor(TGI_COLOR_RED);
    tgi_outtextxy(8,8*0,"press a key"); 
    for(i=0;i<30000;++i){}
    str[0] = cgetc();   
    tgi_outtextxy(8,8*1,"step 1"); 
    tgi_outtextxy(8*8,8*1,str); 
    for(i=0;i<30000;++i){}
    str[0] = cgetc();   
    tgi_outtextxy(8,8*2,"step 2"); 
    tgi_outtextxy(8*8,8*2,str); 
    for(i=0;i<30000;++i){}
    str[0] = cgetc();   
    tgi_outtextxy(8,8*3,"step 3");
    tgi_outtextxy(8*8,8*3,str);     
    for(i=0;i<30000;++i){}
    while(!kbhit())
    {
        str[0] = cgetc();
        tgi_outtextxy(8,8*4,"step 4");
        tgi_outtextxy(8*8,8*4,str);     
    }   
    while(1){};
    return 0;
}
```