### PR TITLE
vic20/cputc: Fix incorrect CRAM_PTR at startup when using conio

### DIFF
--- a/asminc/cbm_kernal.inc
+++ b/asminc/cbm_kernal.inc
@@ -100,14 +100,26 @@ UDTIM          := $FFEA
 
 ; ---------------------------------------------------------------------------
 ; Kernal routines, direct entries
+;
+; Unlike the above, these are not standard functions with entries in the jump
+; table. They do not exist in all Kernals, and where they do the entry point is
+; specific to that particular machine and possibly even Kernal version.
+;
+; This list is not comprehensive: missing items for particular machines
+; should be added as needed.
+;
+; UPDCRAMPTR: Updates the color RAM pointer to match the screen RAM pointer.
+;
 
 .if .def(__VIC20__)
   CLRSCR       := $E55F
   KBDREAD      := $E5CF
+  UPDCRAMPTR   := $EAB2
 .elseif .def(__C64__)
   CLRSCR       := $E544
   KBDREAD      := $E5B4
   NMIEXIT      := $FEBC
+  UPDCRAMPTR   := $EA24
 .elseif .def(__C128__)
   CLRSCR       := $C142
   KBDREAD      := $C006

--- a/libsrc/c64/kplot.s
+++ b/libsrc/c64/kplot.s
@@ -7,15 +7,16 @@
 
         .export         PLOT
 
+.scope  KERNAL
+        .include        "cbm_kernal.inc"
+.endscope
 
 .proc   PLOT
 
         bcs     @L1
-        jsr     $FFF0                   ; Set cursor position
-        jmp     $EA24                   ; Set pointer to color RAM
+        jsr     KERNAL::PLOT            ; Set cursor position using original ROM PLOT
+        jmp     KERNAL::UPDCRAMPTR      ; Set pointer to color RAM to match new cursor position
 
-@L1:    jmp     $FFF0                   ; Get cursor position
+@L1:    jmp     KERNAL::PLOT            ; Get cursor position
 
 .endproc
-
-

--- a/libsrc/plus4/kplot.s
+++ b/libsrc/plus4/kplot.s
@@ -6,16 +6,17 @@
 
         .export         PLOT
 
+.scope  KERNAL
+        .include        "cbm_kernal.inc"
+.endscope
+
         .include        "plus4.inc"
 
 .segment        "LOWCODE"               ; Must go into low memory
 
 .proc   PLOT
         sta     ENABLE_ROM              ; Enable the ROM
-        jsr     $FFF0                   ; Call the ROM routine
+        jsr     KERNAL::PLOT            ; Call the ROM routine
         sta     ENABLE_RAM              ; Switch back to RAM
         rts                             ; Return to caller
 .endproc
-
-
-                    

--- a/libsrc/vic20/kplot.s
+++ b/libsrc/vic20/kplot.s
@@ -7,14 +7,16 @@
 
         .export         PLOT
 
+.scope  KERNAL
+        .include        "cbm_kernal.inc"
+.endscope
 
 .proc   PLOT
 
         bcs     @L1
-        jsr     $FFF0                   ; Set cursor position
-        jmp     $EAB2                   ; Set pointer to color RAM
+        jsr     KERNAL::PLOT            ; Set cursor position using original ROM PLOT
+        jmp     KERNAL::UPDCRAMPTR      ; Set pointer to color RAM to match new cursor position
 
-@L1:    jmp     $FFF0                   ; Get cursor position
+@L1:    jmp     KERNAL::PLOT            ; Get cursor position
 
 .endproc
-


### PR DESCRIPTION
This fixes the problem discussed in issue #946 and is an improved solution over that in PR #953.

The first commit is a refactoring to replace hardcoded addresses in VIC-20, C64 and Plus/4 `kplot.s` with symbols from `cbm_kernal.inc`. The second commit fixes the VIC-20 bug by adding a constructor call to `UPDCRAMPTR` so that `CRAM_PTR` is set correctly when the program starts. (This adds two additional bytes to programs using `cputc()` or other routines that call it. These are in theory recoverable, but the VIC-20 runtime does not yet free space used by constructors after the constructors have been called.)

These changes have been tested on the VICE emulators for all three platforms. You can replicate this using my framework in [`0cjs/vic20cc65`](https://github.com/0cjs/vic20cc65.git); just clone that repo and run `./Test`, editing the variables in that file to choose the platform and test to run. (`README.md` there has more information, including how to demonstrate the original problem.)

Thanks to @greg-king5 who in [this comment](https://github.com/cc65/cc65/issues/946#issuecomment-538502820) dug into the details of the VIC-20 ROM to clarify the problem and proposed the solution used here. (And also for the comments on the previous PR that led to the refactoring done before this fix.)

If you wish to  examine the ROM code yourself, you may find it convenient to refer to copies of the original ROM source and various disassemblies in [`0cjs/vic20-stuff/rom`](https://github.com/0cjs/vic20-stuff/tree/master/rom).