### PR TITLE
C64 TGI driver: reformat comments to style guide rules

### DIFF
--- a/libsrc/c64/tgi/c64-hi.s
+++ b/libsrc/c64/tgi/c64-hi.s
@@ -131,7 +131,7 @@ VBASE           := $E000                ; Video memory base address
 ;
 
 INSTALL:
-;       rts                     ; fall through
+;       rts                     ; Fall through
 
 
 ; ------------------------------------------------------------------------
@@ -272,7 +272,7 @@ CLEAR:  ldy     #$00
         sta     VBASE+$1C00,y
         sta     VBASE+$1D00,y
         sta     VBASE+$1E00,y
-        sta     VBASE+$1E40,y   ; preserve vectors
+        sta     VBASE+$1E40,y   ; Preserve vectors
         iny
         bne     @L1
         rts
@@ -285,7 +285,7 @@ CLEAR:  ldy     #$00
 ;
 
 SETVIEWPAGE:
-;       rts                     ; fall through
+;       rts                     ; Fall through
 
 ; ------------------------------------------------------------------------
 ; SETDRAWPAGE: Set the drawable page. Called with the new page in A (0..n).
@@ -460,14 +460,14 @@ GETPIXEL:
 
 LINE:
 
-@CHECK: lda     X2           ;Make sure x1<x2
+@CHECK: lda     X2              ; Make sure x1<x2
         sec
         sbc     X1
         tax
         lda     X2+1
         sbc     X1+1
         bpl     @CONT
-        lda     Y2           ;If not, swap P1 and P2
+        lda     Y2              ; If not, swap P1 and P2
         ldy     Y1
         sta     Y1
         sty     Y2
@@ -488,19 +488,19 @@ LINE:
 @CONT:  sta     DX+1
         stx     DX
 
-        ldx     #$C8         ;INY
-        lda     Y2           ;Calculate dy
+        ldx     #$C8            ; INY
+        lda     Y2              ; Calculate dy
         sec
         sbc     Y1
         tay
         lda     Y2+1
         sbc     Y1+1
-        bpl     @DYPOS       ;Is y2>=y1?
-        lda     Y1           ;Otherwise dy=y1-y2
+        bpl     @DYPOS          ; Is y2>=y1?
+        lda     Y1              ; Otherwise dy=y1-y2
         sec
         sbc     Y2
         tay
-        ldx     #$88         ;DEY
+        ldx     #$88            ; DEY
 
 @DYPOS: sty     DY              ; 8-bit DY -- FIX ME?
         stx     YINCDEC
@@ -516,8 +516,8 @@ LINE:
         sta     $01
 
         ldx     DY
-        cpx     DX           ;Who's bigger: dy or dx?
-        bcc     STEPINX      ;If dx, then...
+        cpx     DX              ; Who's bigger: dy or dx?
+        bcc     STEPINX         ; If dx, then...
         lda     DX+1
         bne     STEPINX
 
@@ -535,14 +535,14 @@ LINE:
 ;   Y1 AND #$07
 STEPINY:
         lda     #00
-        sta     OLDCHUNK     ;So plotting routine will work right
+        sta     OLDCHUNK        ; So plotting routine will work right
         lda     CHUNK
-        lsr                  ;Strip the bit
+        lsr                     ; Strip the bit
         eor     CHUNK
         sta     CHUNK
         txa
-        beq     YCONT2       ;If dy=0, it's just a point
-@CONT:  lsr                  ;Init counter to dy/2
+        beq     YCONT2          ; If dy=0, it's just a point
+@CONT:  lsr                     ; Init counter to dy/2
 ;
 ; Main loop
 ;
@@ -554,17 +554,17 @@ YLOOP:  sta     TEMP
         eor     (POINT),y
         sta     (POINT),y
 YINCDEC:
-        iny                  ;Advance Y coordinate
+        iny                     ; Advance Y coordinate
         cpy     #8
-        bcc     @CONT        ;No prob if Y=0..7
+        bcc     @CONT           ; No prob if Y=0..7
         jsr     FIXY
-@CONT:  lda     TEMP         ;Restore A
+@CONT:  lda     TEMP            ; Restore A
         sec
         sbc     DX
         bcc     YFIXX
-YCONT:  dex                  ;X is counter
+YCONT:  dex                     ; X is counter
         bne     YLOOP
-YCONT2: lda     (POINT),y    ;Plot endpoint
+YCONT2: lda     (POINT),y       ; Plot endpoint
         eor     BITMASK
         and     CHUNK
         eor     (POINT),y
@@ -574,13 +574,13 @@ YCONT2: lda     (POINT),y    ;Plot endpoint
         cli
         rts
 
-YFIXX:                    ;x=x+1
+YFIXX:                          ; X = X + 1
         adc     DY
         lsr     CHUNK
-        bne     YCONT        ;If we pass a column boundary...
-        ror     CHUNK        ;then reset CHUNK to $80
+        bne     YCONT           ; If we pass a column boundary...
+        ror     CHUNK           ; Then reset CHUNK to $80
         sta     TEMP2
-        lda     POINT        ;And add 8 to POINT
+        lda     POINT           ; And add 8 to POINT
         adc     #8
         sta     POINT
         bcc     @CONT
@@ -598,34 +598,33 @@ YFIXX:                    ;x=x+1
 
 .bss
 COUNTHI:
-        .byte   $00       ;Temporary counter
-                          ;only used once
+        .byte   $00             ; Temporary counter, only used once
 .code
 STEPINX:
         ldx     DX
         lda     DX+1
         sta     COUNTHI
         cmp     #$80
-        ror                  ;Need bit for initialization
-        sta     Y1           ;High byte of counter
+        ror                     ; Need bit for initialization
+        sta     Y1              ; High byte of counter
         txa
-        bne     @CONT        ;Could be $100
+        bne     @CONT           ; Could be $100
         dec     COUNTHI
 @CONT:  ror
 ;
 ; Main loop
 ;
 XLOOP:  lsr     CHUNK
-        beq     XFIXC        ;If we pass a column boundary...
+        beq     XFIXC           ; If we pass a column boundary...
 XCONT1: sbc     DY
-        bcc     XFIXY        ;Time to step in Y?
+        bcc     XFIXY           ; Time to step in Y?
 XCONT2: dex
         bne     XLOOP
-        dec     COUNTHI      ;High bits set?
+        dec     COUNTHI         ; High bits set?
         bpl     XLOOP
 
-        lsr     CHUNK        ;Advance to last point
-        jsr     LINEPLOT     ;Plot the last chunk
+        lsr     CHUNK           ; Advance to last point
+        jsr     LINEPLOT        ; Plot the last chunk
         lda     #$36
         sta     $01
         cli
@@ -651,22 +650,22 @@ XFIXC:  sta     TEMP
 ; Check to make sure there isn't a high bit, plot chunk,
 ; and update Y-coordinate.
 ;
-XFIXY:  dec     Y1           ;Maybe high bit set
+XFIXY:  dec     Y1              ; Maybe high bit set
         bpl     XCONT2
         adc     DX
         sta     TEMP
         lda     DX+1
-        adc     #$FF         ;Hi byte
+        adc     #$FF            ; Hi byte
         sta     Y1
 
-        jsr     LINEPLOT     ;Plot chunk
+        jsr     LINEPLOT        ; Plot chunk
         lda     CHUNK
         sta     OLDCHUNK
 
         lda     TEMP
 XINCDEC:
-        iny                  ;Y-coord
-        cpy     #8           ;0..7 is ok
+        iny                     ; Y-coord
+        cpy     #8              ; 0..7 is ok
         bcc     XCONT2
         sta     TEMP
         jsr     FIXY
@@ -691,11 +690,11 @@ LINEPLOT:                       ; Plot the line chunk
 ; Subroutine to fix up pointer when Y decreases through
 ; zero or increases through 7.
 ;
-FIXY:   cpy     #255         ;Y=255 or Y=8
+FIXY:   cpy     #255            ; Y=255 or Y=8
         beq     @DECPTR
 
-@INCPTR:                     ;Add 320 to pointer
-        ldy     #0           ;Y increased through 7
+@INCPTR:                        ; Add 320 to pointer
+        ldy     #0              ; Y increased through 7
         lda     POINT
         adc     #<320
         sta     POINT
@@ -704,8 +703,8 @@ FIXY:   cpy     #255         ;Y=255 or Y=8
         sta     POINT+1
         rts
 
-@DECPTR:                     ;Okay, subtract 320 then
-        ldy     #7           ;Y decreased through 0
+@DECPTR:                        ; Okay, subtract 320 then
+        ldy     #7              ; Y decreased through 0
         lda     POINT
         sec
         sbc     #<320
@@ -861,10 +860,10 @@ CALC:   lda     Y1
         ror     POINT
         cmp     #$80
         ror
-        ror     POINT           ; row*64
-        adc     TEMP2           ; +row*256
+        ror     POINT           ; Row * 64
+        adc     TEMP2           ; + Row * 256
         clc
-        adc     #>VBASE         ; +bitmap base
+        adc     #>VBASE         ; + Bitmap base
         sta     POINT+1
 
         lda     X1


### PR DESCRIPTION
As per discussion in #967 (where I borrowed heavily from it to make a TGI driver for the plus4), an attempt to make the c64-hi TGI driver source better adhere to the style guide.