### PR TITLE
Changes in INSTALL routine from emd/c128-vdc.s.

### DIFF
--- a/libsrc/c128/emd/c128-vdc.s
+++ b/libsrc/c128/emd/c128-vdc.s
@@ -54,7 +54,7 @@ VDC_DATA          = 31
 
 .bss
 
-pagecount:      .res    1                  ; $0000-$3fff as 16k default
+pagecount:      .res    2                  ; $0000-$3fff as 16k default
 curpage:        .res    2                  ; currently mapped-in page (invalid)
 vdc_cset_save:  .res    1
 window:         .res    256                ; memory window


### PR DESCRIPTION
tmp1 was used at two places resulting in the bug that VDC_CSET was set to garbage on 16k VDC.
pagecount and curpage were not reset on INSTALL resulting in non-reentrant code on static linkage of emd driver.

I used the "both-c128-vdc.s" from greg-king as a base for this pr.
