### PR TITLE
[Telestrat] Fix bug in tgi_line : HRS(X) parameters are 16 bits.

### DIFF
--- a/libsrc/telestrat/tgi/telestrat-228-200-3.s
+++ b/libsrc/telestrat/tgi/telestrat-228-200-3.s
@@ -297,7 +297,13 @@ LINE:
         lda   Y2
         sta   HRS4
         
-        lda   #$ff
+        lda   #$00
+        sta   HRS1+1
+        sta   HRS2+1
+        sta   HRS3+1
+        sta   HRS4+1        
+
+        lda   #$FF
         sta   HRSPAT
 
         BRK_TELEMON(XDRAWA)

--- a/libsrc/telestrat/tgi/telestrat-228-200-3.s
+++ b/libsrc/telestrat/tgi/telestrat-228-200-3.s
@@ -296,12 +296,18 @@ LINE:
         sta   HRS3
         lda   Y2
         sta   HRS4
-        
-        lda   #$00
+
+        lda   X1+1
         sta   HRS1+1
+
+        lda   Y1+1 
         sta   HRS2+1
+
+        lda   X2+1
         sta   HRS3+1
-        sta   HRS4+1        
+        
+        lda   Y2+1        
+        sta   HRS4+1           
 
         lda   #$FF
         sta   HRSPAT

--- a/libsrc/telestrat/tgi/telestrat-240-200-2.s
+++ b/libsrc/telestrat/tgi/telestrat-240-200-2.s
@@ -291,10 +291,16 @@ LINE:
         sta   HRS4
         
 
-        lda   #$00
+        lda   X1+1
         sta   HRS1+1
+
+        lda   Y1+1 
         sta   HRS2+1
+
+        lda   X2+1
         sta   HRS3+1
+        
+        lda   Y2+1        
         sta   HRS4+1        
 
         lda   #$FF

--- a/libsrc/telestrat/tgi/telestrat-240-200-2.s
+++ b/libsrc/telestrat/tgi/telestrat-240-200-2.s
@@ -290,7 +290,14 @@ LINE:
         lda   Y2
         sta   HRS4
         
-        lda   #$ff
+
+        lda   #$00
+        sta   HRS1+1
+        sta   HRS2+1
+        sta   HRS3+1
+        sta   HRS4+1        
+
+        lda   #$FF
         sta   HRSPAT
 
         BRK_TELEMON(XDRAWA)


### PR DESCRIPTION
HRS1,HRS2,HRS3,HRS4 are 16 bits (signed).

This PR fix this bug : impossible to draw a line when X>127 or Y>127 