### PR TITLE
[cx16] waitvsync() looks at the wrong timer address and never returns

### DIFF
--- a/asminc/cx16.inc
+++ b/asminc/cx16.inc
@@ -517,7 +517,7 @@ NMIVec          := $0318
 ; Banked RAM and ROM
 
 KEY_COUNT       := $A00B        ; (bank 0) Number of keys in input buffer
-TIMER           := $A03E        ; (bank 0) 60 Hz. timer (3 bytes, big-endian)
+TIMER           := $A03D        ; (bank 0) 60 Hz. timer (3 bytes, big-endian)
 
 .struct BANK
         .org    $A000


### PR DESCRIPTION
The location for TIMEJ should be at $a03d instead. I don't know if this mistake was made in the ROM or the standard library itself.