### PR TITLE
Update vpeek.s to enable Bank 1 of Vera to be inspected.

### DIFF
--- a/libsrc/cx16/vpeek.s
+++ b/libsrc/cx16/vpeek.s
@@ -12,6 +12,6 @@
 
 
 _vpeek: jsr     vaddr0          ; put VERA's address
-        ldx     #>$0000
+;        ldx     #>$0000
         lda     VERA::DATA0     ; read VERA port zero
         rts


### PR DESCRIPTION
The ldx line prevents vpeek from working in bank 1 of vera. Not sure why this was here and commenting this line out makes it work. Not sure why it is there? Thanks.