### PR TITLE
+cc65 inline asm stp mnemonic support

### DIFF
--- a/src/cc65/codeent.c
+++ b/src/cc65/codeent.c
@@ -615,6 +615,9 @@ void CE_GenRegInfo (CodeEntry* E, RegContents* InputRegs)
         case OP65_BRK:
             break;
 
+        case OP65_STP:
+            break;
+
         case OP65_BVC:
             break;
 

--- a/src/cc65/codeent.c
+++ b/src/cc65/codeent.c
@@ -615,9 +615,6 @@ void CE_GenRegInfo (CodeEntry* E, RegContents* InputRegs)
         case OP65_BRK:
             break;
 
-        case OP65_STP:
-            break;
-
         case OP65_BVC:
             break;
 
@@ -1139,6 +1136,9 @@ void CE_GenRegInfo (CodeEntry* E, RegContents* InputRegs)
                 /* Invalidates all ZP registers */
                 RC_InvalidateZP (Out);
             }
+            break;
+
+        case OP65_STP:
             break;
 
         case OP65_STX:

--- a/src/cc65/opcodes.c
+++ b/src/cc65/opcodes.c
@@ -502,6 +502,13 @@ const OPCDesc OPCTable[OP65_COUNT] = {
         REG_NONE,                               /* chg */
         OF_STORE                                /* flags */
     },
+    {   OP65_STP,                               /* opcode */
+        "stp",                                  /* mnemonic */
+        1,                                      /* size */
+        REG_NONE,                               /* use */
+        REG_NONE,                               /* chg */
+        OF_NONE                                 /* flags */
+    },
     {   OP65_STX,                               /* opcode */
         "stx",                                  /* mnemonic */
         0,                                      /* size */

--- a/src/cc65/opcodes.h
+++ b/src/cc65/opcodes.h
@@ -114,6 +114,7 @@ typedef enum {
     OP65_SED,
     OP65_SEI,
     OP65_STA,
+    OP65_STP, /* 65c02, 65816 stop */
     OP65_STX,
     OP65_STY,
     OP65_STZ,

--- a/src/cc65/opcodes.h
+++ b/src/cc65/opcodes.h
@@ -114,7 +114,7 @@ typedef enum {
     OP65_SED,
     OP65_SEI,
     OP65_STA,
-    OP65_STP, /* 65c02, 65816 stop */
+    OP65_STP,                   /* 65c02, 65816 stop */
     OP65_STX,
     OP65_STY,
     OP65_STZ,


### PR DESCRIPTION
hi,

want to support stp mnemonic from within inline asm of a c program, to break into my emulator debugger.

cheers,

https://github.com/twoinke/steckschwein-emulator