### PR TITLE
SEGMENT start of 0 should be valid?

### DIFF
--- a/src/ld65/config.c
+++ b/src/ld65/config.c
@@ -753,7 +753,7 @@ static void ParseSegments (void)
 
                 case CFGTOK_START:
                     FlagAttr (&S->Attr, SA_START, "START");
-                    S->Addr   = CfgCheckedConstExpr (1, 0x1000000);
+                    S->Addr   = CfgCheckedConstExpr (0, 0x1000000);
                     S->Flags |= SF_START;
                     break;
 


### PR DESCRIPTION
I don't understand why a segment with start address of 0 generates a range error. Is there some reason this is disallowed? The change to enable it is very small.