### PR TITLE
Update get_ostype.s for the Apple //e card

### DIFF
--- a/libsrc/apple2/get_ostype.s
+++ b/libsrc/apple2/get_ostype.s
@@ -36,7 +36,7 @@ index:  .byte   $B3, $00                ; Apple ][
         .byte   $B3, $1E, $00           ; Apple ][+
         .byte   $B3, $1E, $00           ; Apple /// (emulation)
         .byte   $B3, $C0, $00           ; Apple //e
-        .byte   $B3, $C0, $DD, $BE, $00 ; Apple //e Option Card
+        .byte   $B3, $C0, $DD, $00      ; Apple //e Option Card
         .byte   $B3, $C0, $00           ; Apple //e (enhanced)
         .byte   $B3, $C0, $BF, $00      ; Apple //c
         .byte   $B3, $C0, $BF, $00      ; Apple //c (3.5 ROM)
@@ -49,7 +49,7 @@ value:  .byte   $38, $10                ; Apple ][
         .byte   $EA, $AD, $11           ; Apple ][+
         .byte   $EA, $8A, $20           ; Apple /// (emulation)
         .byte   $06, $EA, $30           ; Apple //e
-        .byte   $06, $E0, $02, $00, $40 ; Apple //e Option Card
+        .byte   $06, $E0, $02, $40      ; Apple //e Option Card
         .byte   $06, $E0, $31           ; Apple //e (enhanced)
         .byte   $06, $00, $FF, $50      ; Apple //c
         .byte   $06, $00, $00, $51      ; Apple //c (3.5 ROM)


### PR DESCRIPTION
This change removes the check of $fbbe when detecting the Apple //e card.  This byte is a version number for the Apple //e card according to misc technote `#7`, and it appears that the last version of the software that I am aware of has a 3 at this location.

Prior to this change, Apple //e cards which were not version 0 would be detected as an Apple //e enhanced.

Note that I do not have access to this HW but one of my projects was tested by someone with this HW and we found this issue.  The tech note can be found here:

http://www.1000bit.it/support/manuali/apple/technotes/misc/tn.misc.07.html

Another alternative would be to create OS types $41, $42, $43 (perhaps more) based on the value of the version byte in the ROM for the Apple //e card which would allow projects to differentiate between these variants.  If an approach like that is preferred, I can make that change but I don't know for sure how many versions there may be in existence.