### PR TITLE
Commander x16

### DIFF
--- a/asminc/cx16.inc
+++ b/asminc/cx16.inc
@@ -1,5 +1,5 @@
 ;
-; CX16 r36 definitions
+; CX16 r37 definitions
 ;
 
 ; ---------------------------------------------------------------------------
@@ -516,8 +516,8 @@ NMIVec          := $0318
 ; ---------------------------------------------------------------------------
 ; Banked RAM and ROM
 
-KEY_COUNT       := $A00B        ; (bank 0) Number of keys in input buffer
-TIMER           := $A03E        ; (bank 0) 60 Hz. timer (3 bytes, big-endian)
+KEY_COUNT       := $A00A        ; (bank 0) Number of keys in input buffer
+TIMER           := $A037        ; (bank 0) 60 Hz. timer (3 bytes, big-endian)
 
 .struct BANK
         .org    $A000

--- a/asminc/cx16.inc
+++ b/asminc/cx16.inc
@@ -282,6 +282,41 @@ NMIVec          := $0318
   CTRL          .byte           ; Control register
   IRQ_EN        .byte           ; Interrupt enable bits
   IRQ_FLAGS     .byte           ; Interrupt flags
+  IRQ_LINE      .byte           ; IRQ_LINE
+  .union
+  .struct
+  ; Enabled if DCSEL = 0
+  DC_VIDEO      .byte           ; 
+  DC_HSCALE     .byte           ; Active display H-Scale 
+  DC_VSCALE     .byte           ; Active display V-Scale
+  DC_BORDER     .byte           ; Border color
+  .endstruct
+  .struct
+  ; Enabled if DCSEL = 1
+  DC_HSTART     .byte           ; Active display H-Start 9:2
+  DC_HSTOP      .byte           ; Active display H-Stop 9:2
+  DC_VSTART     .byte           ; Active Display V-Start 8:1
+  DC_VSTOP      .byte           ; Active Display V-Stop 8:1
+  .endstruct
+  .endunion
+  L0_CONFIG     .byte           ; Layer 0 configuration
+  L0_MAPBASE    .byte           ; Layer 0 map base address 16:9
+  L0_TILEBASE   .byte           ; Layer 0 tile base address 16:11
+  L0_HSCROLL_L  .byte           ; Layer 0 hscroll 7:0
+  L0_HSCROLL_H  .byte           ; Layer 0 hscroll 11:8
+  L0_VSCROLL_L  .byte           ; Layer 0 vscroll 7:0
+  L0_VSCROLL_H  .byte           ; Layer 0 vscroll 11:8
+  L1_CONFIG     .byte           ; Layer 1 configuration
+  L1_MAPBASE    .byte           ; Layer 1 map base address 16:9
+  L1_TILEBASE   .byte           ; Layer 1 tile base address 16:11
+  L1_HSCROLL_L  .byte           ; Layer 1 hscroll 7:0
+  L1_HSCROLL_H  .byte           ; Layer 1 hscroll 11:8
+  L1_VSCROLL_L  .byte           ; Layer 1 vscroll 7:0
+  L1_VSCROLL_H  .byte           ; Layer 1 vscroll 11:8
+  AUDIO_CTRL    .byte           ; Audio control
+  AUDIO_RATE    .byte           ; PCM sample rate
+  SPI_DATA      .byte           ; SPI Data
+  SPI_CTRL      .byte           ; SPI control
   .endstruct
   .enum                         ; Address automatic increment amounts
   INC0          =       0 << 4
@@ -295,11 +330,11 @@ NMIVec          := $0318
   INC128        =       8 << 4
   INC256        =       9 << 4
   INC512        =       10 << 4
-  INC1024       =       11 << 4
-  INC2048       =       12 << 4
-  INC4096       =       13 << 4
-  INC8192       =       14 << 4
-  INC16384      =       15 << 4
+  INC40         =       11 << 4
+  INC80         =       12 << 4
+  INC160        =       13 << 4
+  INC320        =       14 << 4
+  INC640        =       15 << 4
   .endenum
   .enum                         ; Interrupt request flags
   VERT_SYNC     =       %00000001

--- a/include/cx16.h
+++ b/include/cx16.h
@@ -175,6 +175,44 @@ struct __vera {
     unsigned char       control;        /* Control register */
     unsigned char       irq_enable;     /* Interrupt enable bits */
     unsigned char       irq_flags;      /* Interrupt flags */
+    unsigned char       irq_line;       /* IRQ line */
+    union {
+        /* The following 4 registers are available at $9F29-$9F2C when DCSEL=0 */
+        struct {
+            unsigned char       dc_video;       /* Display Composer video */
+            unsigned char       dc_hscale;      /* DC HSCALE */
+            unsigned char       dc_vscale;      /* DC VSCALE */
+            unsigned char       dc_border;      /* DC border */
+        };
+    
+        /* The following 4 registers are available at $9F29-$9F2C when DCSEL=1 */
+        struct {
+            unsigned char       dc_hstart;      /* DC horizontal start */
+            unsigned char       dc_hstop;       /* DC horizontal stop */
+            unsigned char       dc_vstart;      /* DC vertical start */
+            unsigned char       dc_vstop;       /* DC vertical stop */
+        };
+    };
+    unsigned char       l0_config;      /* Layer 0 config */
+    unsigned char       l0_mapbase;     /* Layer 0 mapbase */
+    unsigned char       l0_tilebase;    /* Layer 0 tilebase */
+    unsigned char       l0_hscroll;     /* Layer 0 hscroll */
+    unsigned char       l0_hscroll_hi;
+    unsigned char       l0_vscroll;     /* Layer 0 vscroll */
+    unsigned char       l0_vscroll_hi;
+    unsigned char       l1_config;      /* Layer 1 config */
+    unsigned char       l1_mapbase;     /* Layer 1 mapbase */
+    unsigned char       l1_tilebase;    /* Layer 1 tilebase */
+    unsigned char       l1_hscroll;     /* Layer 1 hscroll */
+    unsigned char       l1_hscroll_hi;
+    unsigned char       l1_vscroll;     /* Layer 1 vscroll */
+    unsigned char       l1_vscroll_hi;
+    unsigned char       audio_ctrl;     /* Audio control */
+    unsigned char       audio_rate;     /* Audio rate */
+    unsigned char       audio_data;     /* Audio data */
+    unsigned char       spi_data;       /* SPI data */
+    unsigned char       spi_ctrl;       /* SPI control */
+
 };
 #define VERA    (*(volatile struct __vera *)0x9F20)
 

--- a/libsrc/cx16/bordercolor.s
+++ b/libsrc/cx16/bordercolor.s
@@ -12,16 +12,11 @@
 _bordercolor:
         tax
 
-        ; Point to the border color register.
+        ; Ensure DCSEL=0
+        lda     VERA::CTRL
+        and     #$01
+        sta     VERA::CTRL
 
-        stz     VERA::CTRL              ; Use port 0
-        lda     #<VERA::COMPOSER::FRAME
-        sta     VERA::ADDR
-        lda     #>VERA::COMPOSER::FRAME
-        sta     VERA::ADDR+1
-        ldy     #^VERA::COMPOSER::FRAME | VERA::INC0
-        sty     VERA::ADDR+2
-
-        lda     VERA::DATA0             ; get old value
-        stx     VERA::DATA0             ; set new value
+        lda     VERA::DC_BORDER             ; get old value
+        stx     VERA::DC_BORDER             ; set new value
         rts

--- a/libsrc/cx16/get_tv.s
+++ b/libsrc/cx16/get_tv.s
@@ -11,17 +11,10 @@
 
 
 .proc   _get_tv
-        ; Point to the video output register.
-
-        stz     VERA::CTRL              ; Use port 0
-        lda     #<VERA::COMPOSER::VIDEO
-        ldx     #>VERA::COMPOSER::VIDEO
-        ldy     #^VERA::COMPOSER::VIDEO
-        sta     VERA::ADDR
-        stx     VERA::ADDR+1
-        sty     VERA::ADDR+2
-
-        lda     VERA::DATA0
+        ; Get the current setting from the DC_VIDEO register
+        
+        lda     VERA::DC_VIDEO
         and     #$07                    ; Get the type of output signal
         rts
+
 .endproc

--- a/libsrc/cx16/set_tv.s
+++ b/libsrc/cx16/set_tv.s
@@ -7,20 +7,25 @@
 
         .export         _set_tv
 
+        .importzp       tmp1
         .include        "cx16.inc"
 
 
 .proc   _set_tv
         ; Point to the video output register.
 
-        stz     VERA::CTRL              ; Use port 0
-        ldx     #<VERA::COMPOSER::VIDEO
-        ldy     #>VERA::COMPOSER::VIDEO
-        stx     VERA::ADDR
-        sty     VERA::ADDR+1
-        ldx     #^VERA::COMPOSER::VIDEO
-        stx     VERA::ADDR+2
+        ; Only set bits for the Output field (0-1)
+        and     #$03
+        sta     tmp1
 
-        sta     VERA::DATA0
+        ; Clear out bits 0-1 from current DC_VIDEO
+        lda     VERA::DC_VIDEO
+        and     #$FC
+
+        ; Set bits 0-1 from tmp1
+        ora     tmp1
+
+        ; Update DC_VIDEO
+        sta     VERA::DC_VIDEO
         rts
 .endproc

--- a/libsrc/cx16/vaddr0.s
+++ b/libsrc/cx16/vaddr0.s
@@ -8,6 +8,7 @@
         .export         vaddr0
 
         .importzp       sreg
+        .importzp       tmp1
         .include        "cx16.inc"
 
 
@@ -15,5 +16,10 @@ vaddr0: stz     VERA::CTRL      ; set address for VERA's data port zero
         ldy     sreg
         sta     VERA::ADDR
         stx     VERA::ADDR+1
-        sty     VERA::ADDR+2
+        tya
+        and     #$01            ; VERA ADDR_H now limited to bit 16
+        sta     tmp1
+        lda     VERA::ADDR+2    ; Load current register to preserve Address Increment and DECR fields
+        ora     tmp1            ; incorporate high bit of address
+        sta     VERA::ADDR+2
         rts

--- a/libsrc/cx16/vaddr0.s
+++ b/libsrc/cx16/vaddr0.s
@@ -16,10 +16,5 @@ vaddr0: stz     VERA::CTRL      ; set address for VERA's data port zero
         ldy     sreg
         sta     VERA::ADDR
         stx     VERA::ADDR+1
-        tya
-        and     #$01            ; VERA ADDR_H now limited to bit 16
-        sta     tmp1
-        lda     VERA::ADDR+2    ; Load current register to preserve Address Increment and DECR fields
-        ora     tmp1            ; incorporate high bit of address
-        sta     VERA::ADDR+2
+        sty     VERA::ADDR+2
         rts

--- a/libsrc/cx16/vaddr0.s
+++ b/libsrc/cx16/vaddr0.s
@@ -8,7 +8,6 @@
         .export         vaddr0
 
         .importzp       sreg
-        .importzp       tmp1
         .include        "cx16.inc"
 
 


### PR DESCRIPTION
This is a candidate set of changes to add support for the Commander X16 rom version r37.  See https://github.com/cc65/cc65/issues/1020.

Comments welcome, or if you want to proceed with @greg-king5's set of changes when they're available that is fine too.

Testing has included updated versions of the cc65-sprite and cc65-audio programs from the x16-demo repo (https://github.com/commanderx16/x16-demo), my Lode Runner port to the cx16 (https://github.com/CJLove/x16-LodeRunner) and a handful of small test programs I created which exercise functions touched by this set of change (https://github.com/CJLove/x16-cc65-testprogs)