### PR TITLE
Add support for Apple II ProDOS version 2.5+ to Direct I/O (DIO)

### DIFF
--- a/libsrc/apple2/dioopen.s
+++ b/libsrc/apple2/dioopen.s
@@ -9,6 +9,7 @@
 
         .include        "errno.inc"
         .include        "mli.inc"
+        .include        "zeropage.inc"
 
 _dio_open:
         ; Check for ProDOS 8
@@ -17,8 +18,24 @@ _dio_open:
         lda     #$01            ; "Bad system call number"
         bne     oserr           ; Branch always
 
+        ; Convert from 00DDDSSS format to DSSS00DD format
+:		tax
+        clc
+        asl
+        asl
+        asl
+        asl
+        sta     tmp1
+        txa
+        lsr
+        lsr
+        lsr
+        lsr
+        ora     tmp1
+
         ; Check for valid device
-:       tax
+        tax
+
         jsr     isdevice
         beq     :+
         lda     #$28            ; "No device connected"
@@ -29,10 +46,7 @@ oserr:  sta     __oserror
 
         ; Return success
 :       txa
-        asl
-        asl
-        asl
-        asl
+
         ldx     #$00
         stx     __oserror
         rts

--- a/libsrc/apple2/isdevice.s
+++ b/libsrc/apple2/isdevice.s
@@ -8,10 +8,16 @@
         .include        "mli.inc"
 
 isdevice:
+        lda     $bfff
+        cmp     #$25
+        lda     #$f0
+        bcc     :+
+        lda     #$f3
+:       sta     tmp1
         ldy     DEVCNT
-:       lda     DEVLST,y
-        sta     tmp1
-        cpx     tmp1
+:       txa
+        eor     DEVLST,y
+        and     tmp1
         beq     :+
         dey
         bpl     :-

--- a/libsrc/apple2/isdevice.s
+++ b/libsrc/apple2/isdevice.s
@@ -10,10 +10,6 @@
 isdevice:
         ldy     DEVCNT
 :       lda     DEVLST,y
-        lsr
-        lsr
-        lsr
-        lsr
         sta     tmp1
         cpx     tmp1
         beq     :+


### PR DESCRIPTION
ProDOS version 2.5 (currently in alpha testing) extends the number of drives that can be supported per slot from 2 to 8.

It does this by extending the device ID from the old `DSSS0000` format to an extended format `DSSS00DD` where the `D` represents drive and `S` represents the slot.  The two *least* significant bits of the device ID are the two *most* significant bytes of the drive number.

Modified cc65's `dio_open` and the `isdevice` support function to support this extended format.

My project [https://github.com/bobbimanners/ProDOS-Utils] needs this change to support drive numbers >2.