### PR TITLE
AddBitField: Rename Width arg to BitWidth

### DIFF
--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -597,7 +597,7 @@ SymEntry* AddStructSym (const char* Name, unsigned Type, unsigned Size, SymTable
 
 
 
-SymEntry* AddBitField (const char* Name, unsigned Offs, unsigned BitOffs, unsigned Width)
+SymEntry* AddBitField (const char* Name, unsigned Offs, unsigned BitOffs, unsigned BitWidth)
 /* Add a bit field to the local symbol table and return the symbol entry */
 {
     /* Do we have an entry with this name already? */
@@ -616,7 +616,7 @@ SymEntry* AddBitField (const char* Name, unsigned Offs, unsigned BitOffs, unsign
         Entry->Type         = type_uint;
         Entry->V.B.Offs     = Offs;
         Entry->V.B.BitOffs  = BitOffs;
-        Entry->V.B.BitWidth = Width;
+        Entry->V.B.BitWidth = BitWidth;
 
         /* Add the entry to the symbol table */
         AddSymEntry (SymTab, Entry);

--- a/src/cc65/symtab.h
+++ b/src/cc65/symtab.h
@@ -149,7 +149,7 @@ unsigned short FindSPAdjustment (const char* Name);
 SymEntry* AddStructSym (const char* Name, unsigned Type, unsigned Size, SymTable* Tab);
 /* Add a struct/union entry and return it */
 
-SymEntry* AddBitField (const char* Name, unsigned Offs, unsigned BitOffs, unsigned Width);
+SymEntry* AddBitField (const char* Name, unsigned Offs, unsigned BitOffs, unsigned BitWidth);
 /* Add a bit field to the local symbol table and return the symbol entry */
 
 SymEntry* AddConstSym (const char* Name, const Type* T, unsigned Flags, long Val);


### PR DESCRIPTION
This makes the arg consistent with the SymEntry field name.