### PR TITLE
Pad bit-fields only to the next byte

### DIFF
--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -772,7 +772,7 @@ static SymEntry* ParseStructDecl (const char* Name)
             if (BitOffs > 0) {
                 if (FieldWidth <= 0 || (BitOffs + FieldWidth) > INT_BITS) {
                     /* Bits needed to byte-align the next field. */
-                    unsigned PaddingBitWidth = -BitOffs % CHAR_BITS;
+                    unsigned PaddingBits = -BitOffs % CHAR_BITS;
 
                     /* We need an anonymous name */
                     AnonName (Ident, "bit-field");
@@ -780,10 +780,10 @@ static SymEntry* ParseStructDecl (const char* Name)
                     /* Add an anonymous bit-field that aligns to the next
                     ** byte.
                     */
-                    AddBitField (Ident, StructSize, BitOffs, PaddingBitWidth);
+                    AddBitField (Ident, StructSize, BitOffs, PaddingBits);
 
                     /* No bits left */
-                    StructSize += (BitOffs + PaddingBitWidth) / CHAR_BITS;
+                    StructSize += (BitOffs + PaddingBits) / CHAR_BITS;
                     BitOffs = 0;
                 }
             }

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -771,17 +771,19 @@ static SymEntry* ParseStructDecl (const char* Name)
             */
             if (BitOffs > 0) {
                 if (FieldWidth <= 0 || (BitOffs + FieldWidth) > INT_BITS) {
+                    /* Bits needed to byte-align the next field. */
+                    unsigned PaddingBitWidth = -BitOffs % CHAR_BITS;
 
                     /* We need an anonymous name */
                     AnonName (Ident, "bit-field");
 
                     /* Add an anonymous bit-field that aligns to the next
-                    ** storage unit.
+                    ** byte.
                     */
-                    AddBitField (Ident, StructSize, BitOffs, INT_BITS - BitOffs);
+                    AddBitField (Ident, StructSize, BitOffs, PaddingBitWidth);
 
                     /* No bits left */
-                    StructSize += SIZEOF_INT;
+                    StructSize += (BitOffs + PaddingBitWidth) / CHAR_BITS;
                     BitOffs = 0;
                 }
             }


### PR DESCRIPTION
Fixes #1054.

Previously, a bit-field followed by a non-bit field was expanded to two bytes.  A bit-field ending the struct was (and continues to be) expanded to only a single byte.
```c
struct s {
  unsigned int x : 4;
};

struct t {
  unsigned int x : 4;
  unsigned int y;
};
```
Before: `sizeof (struct s) == 1`, `sizeof (struct t) == 4`

After: `sizeof (struct s) == 1`, `sizeof (struct t) == 3`