### PR TITLE
switch2.c: Remove REFCC, REFCC_UNSIGNED_CHARS, and UNSIGNED_CHARS

### DIFF
--- a/test/ref/Makefile
+++ b/test/ref/Makefile
@@ -54,7 +54,7 @@ $(WORKDIR):
 
 $(WORKDIR)/%.ref: %.c | $(WORKDIR)
 	$(if $(QUIET),echo ref/$*.host)
-	$(CC) $(CFLAGS) -o $(WORKDIR)/$*.host $< $(NULLERR)
+	$(CC) $(CFLAGS) -DREFCC -DREFCC_UNSIGNED_CHARS -o $(WORKDIR)/$*.host $< $(NULLERR)
 	$(WORKDIR)$S$*.host > $@
 
 $(DIFF): ../bdiff.c | $(WORKDIR)

--- a/test/ref/Makefile
+++ b/test/ref/Makefile
@@ -54,7 +54,7 @@ $(WORKDIR):
 
 $(WORKDIR)/%.ref: %.c | $(WORKDIR)
 	$(if $(QUIET),echo ref/$*.host)
-	$(CC) $(CFLAGS) -DREFCC -DREFCC_UNSIGNED_CHARS -o $(WORKDIR)/$*.host $< $(NULLERR)
+	$(CC) $(CFLAGS) -DREFCC -o $(WORKDIR)/$*.host $< $(NULLERR)
 	$(WORKDIR)$S$*.host > $@
 
 $(DIFF): ../bdiff.c | $(WORKDIR)

--- a/test/ref/Makefile
+++ b/test/ref/Makefile
@@ -54,7 +54,7 @@ $(WORKDIR):
 
 $(WORKDIR)/%.ref: %.c | $(WORKDIR)
 	$(if $(QUIET),echo ref/$*.host)
-	$(CC) $(CFLAGS) -DREFCC -o $(WORKDIR)/$*.host $< $(NULLERR)
+	$(CC) $(CFLAGS) -o $(WORKDIR)/$*.host $< $(NULLERR)
 	$(WORKDIR)$S$*.host > $@
 
 $(DIFF): ../bdiff.c | $(WORKDIR)

--- a/test/ref/switch2.c
+++ b/test/ref/switch2.c
@@ -37,20 +37,8 @@ void testlimits(int i) {
 }
 
 void testdefault1(unsigned char i) {
-/* we want a signed char */
-#ifdef REFCC
 
-signed char k;
-        
-#else
-        
-#ifdef UNSIGNED_CHARS
-signed char k;
-#else
-char k;
-#endif
-
-#endif
+        signed char k;
 
         for(;i<254;) {
                 k = i;
@@ -138,20 +126,8 @@ char k;
 }
 
 void testdefault2(unsigned char i) {
-/* we want a unsigned char */
-#ifdef REFCC
 
-unsigned char k;
-        
-#else
-        
-#ifdef UNSIGNED_CHARS
-char k;
-#else
-unsigned char k;
-#endif
-
-#endif
+        unsigned char k;
 
         for(;i<254;) {
                 k = i;

--- a/test/ref/switch2.c
+++ b/test/ref/switch2.c
@@ -40,11 +40,7 @@ void testdefault1(unsigned char i) {
 /* we want a signed char */
 #ifdef REFCC
 
-#ifdef REFCC_UNSIGNED_CHARS
 signed char k;
-#else
-char k;
-#endif
         
 #else
         
@@ -145,11 +141,7 @@ void testdefault2(unsigned char i) {
 /* we want a unsigned char */
 #ifdef REFCC
 
-#ifdef REFCC_UNSIGNED_CHARS
-char k;
-#else
 unsigned char k;
-#endif
         
 #else
         


### PR DESCRIPTION
switch2.c uses these macros.  With them unset, signed chars
are not tested.