### PR TITLE
Output bit-field data as chars instead of ints

### DIFF
--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -2137,7 +2137,7 @@ NextMember:
     ConsumeRCurly ();
 
     /* If we have data from a bit-field left, output it now */
-    CHECK(SI.ValBits < CHAR_BITS);
+    CHECK (SI.ValBits < CHAR_BITS);
     OutputBitFieldData (&SI);
 
     /* If there are struct fields left, reserve additional storage */

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -2137,6 +2137,7 @@ NextMember:
     ConsumeRCurly ();
 
     /* If we have data from a bit-field left, output it now */
+    CHECK(SI.ValBits < CHAR_BITS);
     OutputBitFieldData (&SI);
 
     /* If there are struct fields left, reserve additional storage */

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -2087,7 +2087,7 @@ static unsigned ParseStructInit (Type* T, int AllowFlexibleMembers)
             Shift = (Entry->V.B.Offs - SI.Offs) * CHAR_BITS + Entry->V.B.BitOffs;
             SI.BitVal |= (Val << Shift);
 
-            /* Account for the data and output it if we have a full word */
+            /* Account for the data and output any full bytes we have. */
             SI.ValBits += Entry->V.B.BitWidth;
             /* Make sure unsigned is big enough to hold the value, 22 bits.
             ** This is 22 bits because the most we can have is 7 bits left


### PR DESCRIPTION
This prepares for #1058, which will pad bit-fields only to
the next byte, instead of the next `sizeof(int)` (two bytes).

`OutputBitFieldData` now outputs chars instead of ints, and
calls to this function loop until there is less than one byte
to output.  A final partial byte is written out with zero padding
as a final partial int was previously.