### PR TITLE
Use xrealloc in cl65

### DIFF
--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -228,12 +228,8 @@ static char* CmdAllocArg (const char* Arg, unsigned Len)
 static void CmdExpand (CmdDesc* Cmd)
 /* Expand the argument vector */
 {
-    unsigned NewMax  = Cmd->ArgMax + 10;
-    char**       NewArgs = xmalloc (NewMax * sizeof (char*));
-    memcpy (NewArgs, Cmd->Args, Cmd->ArgMax * sizeof (char*));
-    xfree (Cmd->Args);
-    Cmd->Args   = NewArgs;
-    Cmd->ArgMax = NewMax;
+    Cmd->ArgMax += 10;
+    Cmd->Args    = xrealloc (Cmd->Args, Cmd->ArgMax * sizeof (char*));
 }
 
 
@@ -321,12 +317,8 @@ static void CmdAddFile (CmdDesc* Cmd, const char* File)
 {
     /* Expand the file vector if needed */
     if (Cmd->FileCount == Cmd->FileMax) {
-        unsigned NewMax   = Cmd->FileMax + 10;
-        char**   NewFiles = xmalloc (NewMax * sizeof (char*));
-        memcpy (NewFiles, Cmd->Files, Cmd->FileMax * sizeof (char*));
-        xfree (Cmd->Files);
-        Cmd->Files   = NewFiles;
-        Cmd->FileMax = NewMax;
+        Cmd->FileMax += 10;
+        Cmd->Files    = xrealloc(Cmd->Files, Cmd->FileMax * sizeof(char*));
     }
 
     /* If the file name is not NULL (which is legal and is used to terminate

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -318,7 +318,7 @@ static void CmdAddFile (CmdDesc* Cmd, const char* File)
     /* Expand the file vector if needed */
     if (Cmd->FileCount == Cmd->FileMax) {
         Cmd->FileMax += 10;
-        Cmd->Files    = xrealloc(Cmd->Files, Cmd->FileMax * sizeof(char*));
+        Cmd->Files    = xrealloc (Cmd->Files, Cmd->FileMax * sizeof(char*));
     }
 
     /* If the file name is not NULL (which is legal and is used to terminate

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -318,7 +318,7 @@ static void CmdAddFile (CmdDesc* Cmd, const char* File)
     /* Expand the file vector if needed */
     if (Cmd->FileCount == Cmd->FileMax) {
         Cmd->FileMax += 10;
-        Cmd->Files    = xrealloc (Cmd->Files, Cmd->FileMax * sizeof(char*));
+        Cmd->Files    = xrealloc (Cmd->Files, Cmd->FileMax * sizeof (char*));
     }
 
     /* If the file name is not NULL (which is legal and is used to terminate


### PR DESCRIPTION
Previously, xmalloc and xfree were used.