### PR TITLE
In Atari XEX output format, join memory areas if possible.

### DIFF
--- a/doc/ld65.sgml
+++ b/doc/ld65.sgml
@@ -932,7 +932,8 @@ the standard format used by Atari DOS 2.0 and upward file managers in the Atari
 </verb></tscreen>
 
 In the Atari segmented file format, the linker will write each <tt/MEMORY/ area
-as a new segment, including a header with the start and end address.
+as including a header with the start and end address. If two memory areas are
+contiguous, the headers will be joined if possible.
 
 The necessary o65 or Atari attributes are defined in a special section labeled
 <ref id="FORMAT" name="FORMAT">.

--- a/src/ld65/xex.c
+++ b/src/ld65/xex.c
@@ -241,9 +241,6 @@ static unsigned long XexWriteMem (XexDesc* D, MemoryArea* M)
     /* Store initial position to get total file size */
     unsigned long StartPos = ftell (D->F);
 
-    /* Always write a segment header for each memory area */
-    D->HeadPos = 0;
-
     /* Get the start address and size of this memory area */
     unsigned long Addr = M->Start;
 
@@ -400,6 +397,7 @@ void XexWriteTarget (XexDesc* D, struct File* F)
     if (D->F == 0) {
         Error ("Cannot open `%s': %s", D->Filename, strerror (errno));
     }
+    D->HeadPos = 0;
 
     /* Keep the user happy */
     Print (stdout, 1, "Opened `%s'...\n", D->Filename);
@@ -415,6 +413,8 @@ void XexWriteTarget (XexDesc* D, struct File* F)
             Write16 (D->F, 0x2E2);
             Write16 (D->F, 0x2E3);
             Write16 (D->F, GetExportVal (I->InitAd->Exp));
+            /* Always write a new segment header after an INITAD segment */
+            D->HeadPos = 0;
         }
     }
 


### PR DESCRIPTION
This makes executables shorter if two memory areas are consecutive.