### PR TITLE
Fix MSVC build broken by #1058

### DIFF
--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -772,7 +772,11 @@ static SymEntry* ParseStructDecl (const char* Name)
             */
             if (BitOffs > 0) {
                 if (FieldWidth <= 0 || (BitOffs + FieldWidth) > INT_BITS) {
-                    /* Bits needed to byte-align the next field. */
+                    /* Bits needed to byte-align the next field.  MSVC complains
+                    ** about unary negation of unsigned, but it's intended.
+                    ** Disable the warning for the next line only.
+                    */
+                    #pragma warning(disable: 4146)
                     unsigned PaddingBits = -BitOffs % CHAR_BITS;
 
                     /* We need an anonymous name */

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -776,7 +776,9 @@ static SymEntry* ParseStructDecl (const char* Name)
                     ** about unary negation of unsigned, but it's intended.
                     ** Disable the warning for the next line only.
                     */
+                    #ifdef _MSC_VER
                     #pragma warning(disable: 4146)
+                    #endif
                     unsigned PaddingBits = -BitOffs % CHAR_BITS;
 
                     /* We need an anonymous name */

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -772,14 +772,11 @@ static SymEntry* ParseStructDecl (const char* Name)
             */
             if (BitOffs > 0) {
                 if (FieldWidth <= 0 || (BitOffs + FieldWidth) > INT_BITS) {
-                    /* Bits needed to byte-align the next field.  MSVC complains
-                    ** about unary negation of unsigned, but it's intended.
-                    ** Disable the warning for the next line only.
+                    /* Bits needed to byte-align the next field.
+                    ** MSVC complains about unary negation of unsigned,
+                    ** so it has been rewritten as subtraction.
                     */
-                    #ifdef _MSC_VER
-                    #pragma warning(disable: 4146)
-                    #endif
-                    unsigned PaddingBits = -BitOffs % CHAR_BITS;
+                    unsigned PaddingBits = (0 - BitOffs) % CHAR_BITS;
 
                     /* We need an anonymous name */
                     AnonName (Ident, "bit-field");


### PR DESCRIPTION
MSVC complains about unary negation of unsigned, but it's
intended.  Suppress the warning.

https://github.com/cc65/cc65/pull/1058#discussion_r451757967

"Tested" with godbolt.org.