### PR TITLE
ar65/LibClose: Include filename in error messages

### DIFF
--- a/src/ar65/library.c
+++ b/src/ar65/library.c
@@ -399,9 +399,11 @@ void LibClose (void)
         Error ("Problem closing '%s': %s", LibName, strerror (errno));
     }
     if (NewLib && fclose (NewLib) != 0) {
-        Error ("Problem closing temporary library file: %s", strerror (errno));
+        Error ("Problem closing temporary library file '%s': %s",
+               NewLibName, strerror (errno));
     }
     if (NewLibName && remove (NewLibName) != 0) {
-        Error ("Problem deleting temporary library file: %s", strerror (errno));
+        Error ("Problem deleting temporary library file '%s': %s",
+               NewLibName, strerror (errno));
     }
 }


### PR DESCRIPTION
```
ar65: Error: Problem deleting temporary library file '../lib/apple2enh.lib.temp': No such file or directory
```
is the error I'm getting with `make -j 19` when trying to debug #1080.