### PR TITLE
Make test/ slightly more make--j-friendly

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -16,8 +16,6 @@ WORKDIR = ../testwrk
 
 all: dotests
 
-.NOTPARALLEL:
-
 dotests: mostlyclean continue
 
 continue:

--- a/test/asm/Makefile
+++ b/test/asm/Makefile
@@ -41,9 +41,6 @@ CPUDETECT_BINS = $(foreach cpu,$(CPUDETECT_CPUS),$(WORKDIR)/$(cpu)-cpudetect.bin
 
 all: $(OPCODE_BINS) $(CPUDETECT_BINS)
 
-# cpudetect.o is written by multiple rules
-.NOTPARALLEL:
-
 $(WORKDIR):
 	$(call MKDIR,$(WORKDIR))
 
@@ -60,6 +57,9 @@ $(WORKDIR)/$1-opcodes.bin: $1-opcodes.s $(DIFF)
 endef # OPCODE_template
 
 $(foreach cpu,$(OPCODE_CPUS),$(eval $(call OPCODE_template,$(cpu))))
+
+# cpudetect.o is written by multiple rules
+.NOTPARALLEL:
 
 define CPUDETECT_template
 

--- a/test/asm/Makefile
+++ b/test/asm/Makefile
@@ -41,6 +41,9 @@ CPUDETECT_BINS = $(foreach cpu,$(CPUDETECT_CPUS),$(WORKDIR)/$(cpu)-cpudetect.bin
 
 all: $(OPCODE_BINS) $(CPUDETECT_BINS)
 
+# cpudetect.o is written by multiple rules
+.NOTPARALLEL:
+
 $(WORKDIR):
 	$(call MKDIR,$(WORKDIR))
 

--- a/test/misc/Makefile
+++ b/test/misc/Makefile
@@ -50,6 +50,11 @@ TESTS += $(foreach option,$(OPTIONS),$(SOURCES:%.c=$(WORKDIR)/%.$(option).65c02.
 
 all: $(TESTS)
 
+# The same input file is processed with different cl65 args,
+# but cl65 uses the input file name to make the temp file name,
+# and they stomp each other.
+.NOTPARALLEL:
+
 $(WORKDIR):
 	$(call MKDIR,$(WORKDIR))
 

--- a/test/misc/Makefile
+++ b/test/misc/Makefile
@@ -69,13 +69,13 @@ $(WORKDIR)/endless.$1.$2.prg: endless.c | $(WORKDIR)
 $(WORKDIR)/limits.$1.$2.prg: limits.c $(DIFF)
 	$(if $(QUIET),echo misc/limits.$1.$2.prg)
 	$(CL65) -t sim$2 -$1 -o $$@ $$< $(NULLERR)
-	$(SIM65) $(SIM65FLAGS) $$@ > $(WORKDIR)/limits.$1.out
-	$(DIFF) $(WORKDIR)/limits.$1.out limits.ref
+	$(SIM65) $(SIM65FLAGS) $$@ > $(WORKDIR)/limits.$1.$2.out
+	$(DIFF) $(WORKDIR)/limits.$1.$2.out limits.ref
 
 $(WORKDIR)/goto.$1.$2.prg: goto.c $(DIFF)
 	$(if $(QUIET),echo misc/goto.$1.$2.prg)
-	$(CL65) -t sim$2 -$1 -o $$@ $$< 2>$(WORKDIR)/goto.$1.out
-	$(DIFF) $(WORKDIR)/goto.$1.out goto.ref
+	$(CL65) -t sim$2 -$1 -o $$@ $$< 2>$(WORKDIR)/goto.$1.$2.out
+	$(DIFF) $(WORKDIR)/goto.$1.$2.out goto.ref
 
 # the rest are tests that fail currently for one reason or another
 $(WORKDIR)/fields.$1.$2.prg: fields.c | $(WORKDIR)

--- a/test/ref/Makefile
+++ b/test/ref/Makefile
@@ -71,8 +71,8 @@ define PRG_template
 $(WORKDIR)/%.$1.$2.prg: %.c $(WORKDIR)/%.ref $(DIFF)
 	$(if $(QUIET),echo ref/$$*.$1.$2.prg)
 	$(CL65) -t sim$2 $$(CC65FLAGS) -$1 -o $$@ $$< $(NULLERR)
-	$(SIM65) $(SIM65FLAGS) $$@ > $(WORKDIR)/$$*.out
-	$(DIFF) $(WORKDIR)/$$*.out $(WORKDIR)/$$*.ref
+	$(SIM65) $(SIM65FLAGS) $$@ > $(WORKDIR)/$$*.$1.$2.out
+	$(DIFF) $(WORKDIR)/$$*.$1.$2.out $(WORKDIR)/$$*.ref
 
 endef # PRG_template
 

--- a/test/val/Makefile
+++ b/test/val/Makefile
@@ -41,6 +41,11 @@ TESTS += $(foreach option,$(OPTIONS),$(SOURCES:%.c=$(WORKDIR)/%.$(option).65c02.
 
 all: $(TESTS)
 
+# The same input file is processed with different cl65 args,
+# but cl65 uses the input file name to make the temp file name,
+# and they stomp each other.
+.NOTPARALLEL:
+
 $(WORKDIR):
 	$(call MKDIR,$(WORKDIR))
 


### PR DESCRIPTION
Move `.NOTPARALLEL` from `test/Makefile` to the subdir `Makefile`s that need it.

Add `.$1.$2` suffixes to some rules in `misc`.

There is still a problem with `cl65` intermediate files overwriting each other, which I'm working on separately.

On my eight-year-old computer, `cd test; make -j 5` runs in 4.5 minutes compared to 5.5 for `make`.