### PR TITLE
C64 soft80 conio: save 4 bytes and 6 cycles in `firstinit`

### DIFF
--- a/libsrc/c64/soft80_conio.s
+++ b/libsrc/c64/soft80_conio.s
@@ -67,22 +67,21 @@ firstinit:
 
         inc     soft80_first_init
 
+        ; save 4 bytes due to soft80_lo_charset and soft80_hi_charset being
+        ; page-aligned.
+        ldy     #0
         lda     #<soft80_charset
         ldx     #>soft80_charset
         sta     ptr1
         stx     ptr1+1
-        lda     #<soft80_lo_charset
         ldx     #>soft80_lo_charset
-        sta     ptr2
+        sty     ptr2
         stx     ptr2+1
-        lda     #<soft80_hi_charset
         ldx     #>soft80_hi_charset
-        sta     ptr3
+        sty     ptr3
         stx     ptr3+1
 
         ldx     #4
-@l2:
-        ldy     #0
 @l1:
         lda     (ptr1),y
         sta     (ptr2),y
@@ -97,17 +96,17 @@ firstinit:
         inc     ptr2+1
         inc     ptr3+1
         dex
-        bne     @l2
+        bne     @l1
 
         ; copy the kplot tables to ram under I/O
         ;ldx     #0             ; is 0
-@l3:
+@l2:
         lda     soft80_tables_data_start,x
         sta     soft80_bitmapxlo,x
         lda     soft80_tables_data_start + (soft80_tables_data_end - soft80_tables_data_start - $0100),x
         sta     soft80_bitmapxlo + (soft80_tables_data_end - soft80_tables_data_start - $0100),x
         inx
-        bne     @l3
+        bne     @l2
 
         pla
         sta     $01

--- a/libsrc/c64/soft80_conio.s
+++ b/libsrc/c64/soft80_conio.s
@@ -67,20 +67,22 @@ firstinit:
 
         inc     soft80_first_init
 
-        ; save 6 bytes due to soft80_charset, soft80_lo_charset and
-        ; soft80_hi_charset being page-aligned.
-        ldy     #0
+        lda     #<soft80_charset
         ldx     #>soft80_charset
-        sty     ptr1
+        sta     ptr1
         stx     ptr1+1
+        lda     #<soft80_lo_charset
         ldx     #>soft80_lo_charset
-        sty     ptr2
+        sta     ptr2
         stx     ptr2+1
+        lda     #<soft80_hi_charset
         ldx     #>soft80_hi_charset
-        sty     ptr3
+        sta     ptr3
         stx     ptr3+1
 
         ldx     #4
+@l2:
+        ldy     #0
 @l1:
         lda     (ptr1),y
         sta     (ptr2),y
@@ -95,17 +97,17 @@ firstinit:
         inc     ptr2+1
         inc     ptr3+1
         dex
-        bne     @l1
+        bne     @l2
 
         ; copy the kplot tables to ram under I/O
         ;ldx     #0             ; is 0
-@l2:
+@l3:
         lda     soft80_tables_data_start,x
         sta     soft80_bitmapxlo,x
         lda     soft80_tables_data_start + (soft80_tables_data_end - soft80_tables_data_start - $0100),x
         sta     soft80_bitmapxlo + (soft80_tables_data_end - soft80_tables_data_start - $0100),x
         inx
-        bne     @l2
+        bne     @l3
 
         pla
         sta     $01

--- a/libsrc/c64/soft80_conio.s
+++ b/libsrc/c64/soft80_conio.s
@@ -67,8 +67,7 @@ firstinit:
 
         inc     soft80_first_init
 
-        ; save 4 bytes due to soft80_lo_charset and soft80_hi_charset being
-        ; page-aligned.
+        ; soft80_lo_charset and soft80_hi_charset are page-aligned
         ldy     #0
         lda     #<soft80_charset
         ldx     #>soft80_charset

--- a/libsrc/c64/soft80_conio.s
+++ b/libsrc/c64/soft80_conio.s
@@ -67,22 +67,20 @@ firstinit:
 
         inc     soft80_first_init
 
-        lda     #<soft80_charset
+        ; save 6 bytes due to soft80_charset, soft80_lo_charset and
+        ; soft80_hi_charset being page-aligned.
+        ldy     #0
         ldx     #>soft80_charset
-        sta     ptr1
+        sty     ptr1
         stx     ptr1+1
-        lda     #<soft80_lo_charset
         ldx     #>soft80_lo_charset
-        sta     ptr2
+        sty     ptr2
         stx     ptr2+1
-        lda     #<soft80_hi_charset
         ldx     #>soft80_hi_charset
-        sta     ptr3
+        sty     ptr3
         stx     ptr3+1
 
         ldx     #4
-@l2:
-        ldy     #0
 @l1:
         lda     (ptr1),y
         sta     (ptr2),y
@@ -97,17 +95,17 @@ firstinit:
         inc     ptr2+1
         inc     ptr3+1
         dex
-        bne     @l2
+        bne     @l1
 
         ; copy the kplot tables to ram under I/O
         ;ldx     #0             ; is 0
-@l3:
+@l2:
         lda     soft80_tables_data_start,x
         sta     soft80_bitmapxlo,x
         lda     soft80_tables_data_start + (soft80_tables_data_end - soft80_tables_data_start - $0100),x
         sta     soft80_bitmapxlo + (soft80_tables_data_end - soft80_tables_data_start - $0100),x
         inx
-        bne     @l3
+        bne     @l2
 
         pla
         sta     $01


### PR DESCRIPTION
Since the copies of the charset are page-aligned, we can save 4 bytes by using `#ldy 0` to set the LSB of ptr2 and ptr3, and further down we can remove the `ldy #0` from the loop. Skipping the `ldy #0` in the loop allow us to save 6 cycles.
Not a huge improvement, but every little bit helps.

I initially thought the source charset was also page-aligned, but alas, I was wrong, got some 'interesting' results :)