### PR TITLE
[cc65] Fix for Issues #1075 and #1077

### DIFF
--- a/src/cc65/assignment.c
+++ b/src/cc65/assignment.c
@@ -98,7 +98,7 @@ void Assignment (ExprDesc* Expr)
         if (UseReg) {
             PushAddr (Expr);
         } else {
-            ED_MakeRVal (Expr);
+            ED_MarkExprAsRVal (Expr);
             LoadExpr (CF_NONE, Expr);
             g_push (CF_PTR | CF_UNSIGNED, 0);
         }
@@ -127,7 +127,7 @@ void Assignment (ExprDesc* Expr)
             } else {
 
                 /* We will use memcpy. Push the address of the rhs */
-                ED_MakeRVal (&Expr2);
+                ED_MarkExprAsRVal (&Expr2);
                 LoadExpr (CF_NONE, &Expr2);
 
                 /* Push the address (or whatever is in ax in case of errors) */
@@ -264,5 +264,5 @@ void Assignment (ExprDesc* Expr)
     }
 
     /* Value is still in primary and not an lvalue */
-    ED_MakeRValExpr (Expr);
+    ED_FinalizeRValLoad (Expr);
 }

--- a/src/cc65/codegen.c
+++ b/src/cc65/codegen.c
@@ -100,6 +100,11 @@ static const char* GetLabelName (unsigned Flags, uintptr_t Label, long Offs)
     /* Create the correct label name */
     switch (Flags & CF_ADDRMASK) {
 
+        case CF_IMM:
+            /* Immediate constant values */
+            xsprintf (Buf, sizeof (Buf), "$%04X", (unsigned)((Offs) & 0xFFFF));
+            break;
+
         case CF_STATIC:
             /* Static memory cell */
             if (Offs) {

--- a/src/cc65/codegen.c
+++ b/src/cc65/codegen.c
@@ -1349,7 +1349,7 @@ unsigned g_typeadjust (unsigned lhs, unsigned rhs)
         rtype = CF_LONG;
     } else if (ltype != CF_LONG && (lhs & CF_CONST) == 0 && rtype == CF_LONG) {
         /* We must promote the lhs to long */
-        if (lhs & CF_REG) {
+        if (lhs & CF_PRIMARY) {
             g_reglong (lhs);
         } else {
             g_toslong (lhs);
@@ -2338,7 +2338,7 @@ void g_call (unsigned Flags, const char* Label, unsigned ArgSize)
 void g_callind (unsigned Flags, unsigned ArgSize, int Offs)
 /* Call subroutine indirect */
 {
-    if ((Flags & CF_LOCAL) == 0) {
+    if ((Flags & CF_STACK) == 0) {
         /* Address is in a/x */
         if ((Flags & CF_FIXARGC) == 0) {
             /* Pass arg count */

--- a/src/cc65/codegen.h
+++ b/src/cc65/codegen.h
@@ -81,11 +81,12 @@
 #define CF_TEST         0x0080  /* Test value */
 #define CF_FIXARGC      0x0100  /* Function has fixed arg count */
 #define CF_FORCECHAR    0x0200  /* Handle chars as chars, not ints */
-#define CF_REG          0x0800  /* Value is in primary register */
 
 /* Type of static address */
-#define CF_ADDRMASK     0xF000  /* Type of address */
-#define CF_STATIC       0x0000  /* Static local */
+#define CF_ADDRMASK     0xFC00  /* Type of address */
+#define CF_IMM          0x0000  /* Value is pure rvalue and has no address */
+#define CF_REG          0x0400  /* Value is in primary register */
+#define CF_STATIC       0x0800  /* Static local */
 #define CF_EXTERNAL     0x1000  /* Static external */
 #define CF_ABSOLUTE     0x2000  /* Numeric absolute address */
 #define CF_LOCAL        0x4000  /* Auto variable */

--- a/src/cc65/codegen.h
+++ b/src/cc65/codegen.h
@@ -62,35 +62,38 @@
 #define CF_NONE         0x0000  /* No special flags */
 
 /* Values for the actual type */
-#define CF_CHAR         0x0003  /* Operation on characters */
-#define CF_INT          0x0001  /* Operation on ints */
+#define CF_CHAR         0x0007  /* Operation on characters */
+#define CF_INT          0x0003  /* Operation on ints */
+#define CF_SHORT        CF_INT  /* Alias */
 #define CF_PTR          CF_INT  /* Alias for readability */
-#define CF_LONG         0x0000  /* Operation on longs */
-#define CF_FLOAT        0x0004  /* Operation on a float */
+#define CF_LONG         0x0001  /* Operation on longs */
+#define CF_FLOAT        0x0010  /* Operation on a float */
 
 /* Signedness */
 #define CF_UNSIGNED     0x0008  /* Value is unsigned */
 
 /* Masks for retrieving type information */
-#define CF_TYPEMASK     0x0007  /* Type information */
-#define CF_STYPEMASK    0x000F  /* Includes signedness */
+#define CF_TYPEMASK     0x0017  /* Type information */
+#define CF_STYPEMASK    0x001F  /* Includes signedness */
 
-#define CF_NOKEEP       0x0010  /* Value may get destroyed when storing */
-#define CF_CONST        0x0020  /* Constant value available */
-#define CF_CONSTADDR    0x0040  /* Constant address value available */
+#define CF_CONST        0x0040  /* Constant value available */
 #define CF_TEST         0x0080  /* Test value */
 #define CF_FIXARGC      0x0100  /* Function has fixed arg count */
 #define CF_FORCECHAR    0x0200  /* Handle chars as chars, not ints */
+#define CF_NOKEEP       0x0400  /* Value may get destroyed when storing */
 
-/* Type of static address */
-#define CF_ADDRMASK     0xFC00  /* Type of address */
-#define CF_IMM          0x0000  /* Value is pure rvalue and has no address */
-#define CF_REG          0x0400  /* Value is in primary register */
-#define CF_STATIC       0x0800  /* Static local */
-#define CF_EXTERNAL     0x1000  /* Static external */
-#define CF_ABSOLUTE     0x2000  /* Numeric absolute address */
-#define CF_LOCAL        0x4000  /* Auto variable */
-#define CF_REGVAR       0x8000  /* Register variable */
+/* Type of address */
+#define CF_ADDRMASK     0xF000  /* Bit mask of address type */
+#define CF_IMM          0x0000  /* Value is pure rvalue and has no storage */
+#define CF_ABSOLUTE     0x1000  /* Numeric absolute address */
+#define CF_EXTERNAL     0x2000  /* External */
+#define CF_REGVAR       0x4000  /* Register variable */
+#define CF_LITERAL      0x7000  /* Literal */
+#define CF_PRIMARY      0x8000  /* Value is in primary register */
+#define CF_EXPR         0x9000  /* Value is addressed by primary register */
+#define CF_STATIC       0xA000  /* Local static */
+#define CF_CODE         0xB000  /* C code label location */
+#define CF_STACK        0xC000  /* Function-local auto on stack */
 
 
 

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -1780,7 +1780,7 @@ static void DefineData (ExprDesc* Expr)
 
         case E_LOC_ABS:
             /* Absolute numeric address */
-            g_defdata (CF_ABSOLUTE | TypeOf(Expr->Type) | CF_CONST, Expr->IVal, 0);
+            g_defdata (CF_ABSOLUTE | TypeOf (Expr->Type) | CF_CONST, Expr->IVal, 0);
             break;
 
         case E_LOC_GLOBAL:

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -1773,9 +1773,14 @@ static void DefineData (ExprDesc* Expr)
 {
     switch (ED_GetLoc (Expr)) {
 
+        case E_LOC_NONE:
+            /* Immediate numeric value with no storage */
+            g_defdata (CF_IMM | TypeOf (Expr->Type) | CF_CONST, Expr->IVal, 0);
+            break;
+
         case E_LOC_ABS:
-            /* Absolute: numeric address or const */
-            g_defdata (TypeOf (Expr->Type) | CF_CONST, Expr->IVal, 0);
+            /* Absolute numeric address */
+            g_defdata (CF_ABSOLUTE | TypeOf(Expr->Type) | CF_CONST, Expr->IVal, 0);
             break;
 
         case E_LOC_GLOBAL:

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1841,9 +1841,12 @@ void hie10 (ExprDesc* Expr)
                     /* Do it anyway, just to avoid further warnings */
                     Expr->Flags &= ~E_BITFIELD;
                 }
+                /* It's allowed in C to take the address of an array this way */
+                if (!IsTypeFunc (Expr->Type) && !IsTypeArray (Expr->Type)) {
+                    /* The & operator yields an rvalue address */
+                    ED_AddrExpr (Expr);
+                }
                 Expr->Type = PointerTo (Expr->Type);
-                /* The & operator yields an rvalue address */
-                ED_AddrExpr (Expr);
             }
             break;
 

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -88,10 +88,10 @@ static unsigned GlobalModeFlags (const ExprDesc* Expr)
         case E_LOC_GLOBAL:      return CF_EXTERNAL;
         case E_LOC_STATIC:      return CF_STATIC;
         case E_LOC_REGISTER:    return CF_REGVAR;
-        case E_LOC_STACK:       return CF_NONE;
-        case E_LOC_PRIMARY:     return CF_NONE;
-        case E_LOC_EXPR:        return CF_NONE;
-        case E_LOC_LITERAL:     return CF_STATIC;       /* Same as static */
+        case E_LOC_STACK:       return CF_STACK;
+        case E_LOC_PRIMARY:     return CF_PRIMARY;
+        case E_LOC_EXPR:        return CF_EXPR;
+        case E_LOC_LITERAL:     return CF_LITERAL;
         default:
             Internal ("GlobalModeFlags: Invalid location flags value: 0x%04X", Expr->Flags);
             /* NOTREACHED */
@@ -189,7 +189,7 @@ static unsigned typeadjust (ExprDesc* lhs, ExprDesc* rhs, int NoPush)
     }
     if (NoPush) {
         /* Value is in primary register*/
-        ltype |= CF_REG;
+        ltype |= CF_PRIMARY;
     }
     rtype = TypeOf (rhst);
     if (ED_IsLocNone (rhs)) {
@@ -587,7 +587,7 @@ static void FunctionCall (ExprDesc* Expr)
             ** Since fastcall functions may never be variadic, we can use the
             ** index register for this purpose.
             */
-            g_callind (CF_LOCAL, ParamSize, PtrOffs);
+            g_callind (CF_STACK, ParamSize, PtrOffs);
         }
 
         /* If we have a pointer on stack, remove it */
@@ -2068,7 +2068,7 @@ static void hie_internal (const GenDesc* Ops,   /* List of generators */
             if ((Gen->Flags & GEN_NOPUSH) == 0) {
                 g_push (ltype, 0);
             } else {
-                ltype |= CF_REG;        /* Value is in register */
+                ltype |= CF_PRIMARY;        /* Value is in register */
             }
 
             /* Determine the type of the operation result. */
@@ -2100,7 +2100,7 @@ static void hie_internal (const GenDesc* Ops,   /* List of generators */
                 }
                 if ((Gen->Flags & GEN_NOPUSH) != 0) {
                     RemoveCode (&Mark2);
-                    ltype |= CF_REG;    /* Value is in register */
+                    ltype |= CF_PRIMARY;    /* Value is in register */
                 }
             }
 
@@ -2276,7 +2276,7 @@ static void hie_compare (const GenDesc* Ops,    /* List of generators */
                 flags |= CF_CONST;
                 if ((Gen->Flags & GEN_NOPUSH) != 0) {
                     RemoveCode (&Mark2);
-                    ltype |= CF_REG;    /* Value is in register */
+                    ltype |= CF_PRIMARY;    /* Value is in register */
                 }
             }
 
@@ -2550,7 +2550,7 @@ static void parseadd (ExprDesc* Expr)
                 flags |= CF_CONST;
             } else {
                 /* Constant address label */
-                flags |= GlobalModeFlags (Expr) | CF_CONSTADDR;
+                flags |= GlobalModeFlags (Expr);
             }
 
             /* Check for pointer arithmetic */

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1029,7 +1029,6 @@ static void ArrayRef (ExprDesc* Expr)
             /* Adjust the offset */
             Expr->IVal += Subscript.IVal;
 
-
         } else {
 
             /* Scale the rhs value according to the element type */

--- a/src/cc65/exprdesc.h
+++ b/src/cc65/exprdesc.h
@@ -59,22 +59,57 @@
 
 /* Defines for the flags field of the expression descriptor */
 enum {
-    /* Location: Where is the value we're talking about? */
+    /* Location: Where is the value we're talking about?
+    **
+    ** Remarks:
+    ** - E_LOC_<else> refers to any other than E_LOC_NONE and E_LOC_PRIMARY.
+    ** - E_LOC_EXPR can be regarded as a generalized E_LOC_<else>.
+    ** - E_LOC_NONE can be regarded as E_LOC_PRIMARY + E_ADDRESS_OF unless
+    **   remarked otherwise (see below).
+    ** - An E_LOC_NONE value is not considered to be an "address".
+    ** - ref-load doesn't change the location, while rval-load puts into the
+    **   primary register a "temporary" that is the straight integer rvalue or
+    **   a "delegate" to the real rvalue somewhere else.
+    ** - ref-load doesn't change the rval/lval category of the expression,
+    **   while rval-load converts it to an rvalue if it wasn't.
+    ** - In practice, ref-load is unimplemented, and can be simulated with
+    **   adding E_ADDRESS_OF temporaily through LoadExpr + FinalizeLoad, 
+    **   whilst val-load is done with LoadExpr + FinalizeRValLoad.
+    **
+    ** E_LOC_NONE     -- ref-load     -> + E_LOADED (int rvalue)
+    ** E_LOC_PRIMARY  -- ref-load     -> + E_LOADED (unchanged)
+    ** E_LOC_<else>   -- ref-load     -> + E_LOADED (reference lvalue)
+    ** + E_ADDRESS_OF -- ref-load     -> + E_LOADED (address rvalue)
+    ** E_LOC_NONE     -- val-load     -> E_LOC_PRIMARY (int rvalue)
+    ** E_LOC_PRIMARY  -- val-load     -> E_LOC_PRIMARY (unchanged)
+    ** E_LOC_<else>   -- val-load     -> E_LOC_PRIMARY (rvalue/delegate)
+    ** + E_ADDRESS_OF -- val-load     -> E_LOC_PRIMARY (address rvalue)
+    ** E_LOC_NONE     -- take address -> (error)
+    ** E_LOC_PRIMARY  -- take address -> + E_ADDRESS_OF (or error)
+    ** E_LOC_EXPR     -- take address -> E_LOC_PRIMARY (address)
+    ** E_LOC_<else>   -- take address -> + E_ADDRESS_OF (address)
+    ** + E_ADDRESS_OF -- take address -> (error)
+    ** E_LOC_NONE     -- dereference  -> E_LOC_ABS (lvalue reference)
+    ** E_LOC_PRIMARY  -- dereference  -> E_LOC_EXPR (lvalue reference)
+    ** E_LOC_<else>   -- dereference  -> E_LOC_EXPR (pointed-to-value, must load)
+    ** + E_ADDRESS_OF -- dereference  -> (lvalue reference)
+    */
     E_MASK_LOC          = 0x00FF,
-    E_LOC_ABS           = 0x0001,       /* Absolute: numeric address or const */
+    E_LOC_NONE          = 0x0000,       /* Pure rvalue with no storage */
+    E_LOC_ABS           = 0x0001,       /* Absolute numeric addressed variable */
     E_LOC_GLOBAL        = 0x0002,       /* Global variable */
     E_LOC_STATIC        = 0x0004,       /* Static variable */
     E_LOC_REGISTER      = 0x0008,       /* Register variable */
     E_LOC_STACK         = 0x0010,       /* Value on the stack */
-    E_LOC_PRIMARY       = 0x0020,       /* The primary register */
-    E_LOC_EXPR          = 0x0040,       /* An expression in the primary register */
+    E_LOC_PRIMARY       = 0x0020,       /* Temporary in primary register */
+    E_LOC_EXPR          = 0x0040,       /* A location that the primary register points to */
     E_LOC_LITERAL       = 0x0080,       /* Literal in the literal pool */
 
     /* Constant location of some sort (only if rval) */
-    E_LOC_CONST         = E_LOC_ABS | E_LOC_GLOBAL | E_LOC_STATIC |
+    E_LOC_CONST         = E_LOC_NONE | E_LOC_ABS | E_LOC_GLOBAL | E_LOC_STATIC |
                           E_LOC_REGISTER | E_LOC_LITERAL,
 
-    /* Reference? */
+    /* lvalue/rvalue in C language's sense */
     E_MASK_RTYPE        = 0x0100,
     E_RTYPE_RVAL        = 0x0000,
     E_RTYPE_LVAL        = 0x0100,
@@ -87,6 +122,10 @@ enum {
     E_CC_SET            = 0x0800,       /* Condition codes are set */
 
     E_HAVE_MARKS        = 0x1000,       /* Code marks are valid */
+
+    E_LOADED            = 0x4000,       /* Expression is loaded in primary */
+
+    E_ADDRESS_OF        = 0x8000,       /* Expression is the address of the lvalue */
 
 };
 
@@ -135,8 +174,18 @@ INLINE int ED_GetLoc (const ExprDesc* Expr)
 #endif
 
 #if defined(HAVE_INLINE)
-INLINE int ED_IsLocAbs (const ExprDesc* Expr)
+INLINE int ED_IsLocNone (const ExprDesc* Expr)
 /* Return true if the expression is an absolute value */
+{
+    return (Expr->Flags & E_MASK_LOC) == E_LOC_NONE;
+}
+#else
+#  define ED_IsLocNone(Expr)    (((Expr)->Flags & E_MASK_LOC) == E_LOC_NONE)
+#endif
+
+#if defined(HAVE_INLINE)
+INLINE int ED_IsLocAbs (const ExprDesc* Expr)
+/* Return true if the expression is referenced with an absolute address */
 {
     return (Expr->Flags & E_MASK_LOC) == E_LOC_ABS;
 }
@@ -151,7 +200,7 @@ INLINE int ED_IsLocRegister (const ExprDesc* Expr)
     return (Expr->Flags & E_MASK_LOC) == E_LOC_REGISTER;
 }
 #else
-#  define ED_IsLocRegister(Expr)    (((Expr)->Flags & E_MASK_LOC) == E_LOC_REGISTER)
+#  define ED_IsLocRegister(Expr)  (((Expr)->Flags & E_MASK_LOC) == E_LOC_REGISTER)
 #endif
 
 #if defined(HAVE_INLINE)
@@ -198,50 +247,25 @@ INLINE int ED_IsLocLiteral (const ExprDesc* Expr)
 INLINE int ED_IsLocConst (const ExprDesc* Expr)
 /* Return true if the expression is a constant location of some sort */
 {
-    return (Expr->Flags & E_LOC_CONST) != 0;
+    return ((Expr)->Flags & E_MASK_LOC & ~E_LOC_CONST) == 0;
 }
 #else
-#  define ED_IsLocConst(Expr)  (((Expr)->Flags & E_LOC_CONST) != 0)
+#  define ED_IsLocConst(Expr)   (((Expr)->Flags & E_MASK_LOC & ~E_LOC_CONST) == 0)
 #endif
 
 #if defined(HAVE_INLINE)
-INLINE int ED_IsLVal (const ExprDesc* Expr)
-/* Return true if the expression is a reference */
+INLINE int ED_IsLocQuasiConst (const ExprDesc* Expr)
+/* Return true if the expression is a constant location of some sort or on the
+** stack.
+*/
 {
-    return (Expr->Flags & E_MASK_RTYPE) == E_RTYPE_LVAL;
+    return ED_IsLocConst (Expr) || ED_IsLocStack (Expr);
 }
 #else
-#  define ED_IsLVal(Expr)       (((Expr)->Flags & E_MASK_RTYPE) == E_RTYPE_LVAL)
-#endif
-
-#if defined(HAVE_INLINE)
-INLINE int ED_IsRVal (const ExprDesc* Expr)
-/* Return true if the expression is a rvalue */
-{
-    return (Expr->Flags & E_MASK_RTYPE) == E_RTYPE_RVAL;
-}
-#else
-#  define ED_IsRVal(Expr)       (((Expr)->Flags & E_MASK_RTYPE) == E_RTYPE_RVAL)
-#endif
-
-#if defined(HAVE_INLINE)
-INLINE void ED_MakeLVal (ExprDesc* Expr)
-/* Make the expression a lvalue. */
-{
-    Expr->Flags |= E_RTYPE_LVAL;
-}
-#else
-#  define ED_MakeLVal(Expr)     do { (Expr)->Flags |= E_RTYPE_LVAL; } while (0)
-#endif
-
-#if defined(HAVE_INLINE)
-INLINE void ED_MakeRVal (ExprDesc* Expr)
-/* Make the expression a rvalue. */
-{
-    Expr->Flags &= ~E_RTYPE_LVAL;
-}
-#else
-#  define ED_MakeRVal(Expr)     do { (Expr)->Flags &= ~E_RTYPE_LVAL; } while (0)
+int ED_IsLocQuasiConst (const ExprDesc* Expr);
+/* Return true if the expression denotes a constant address of some sort. This
+** can be the address of a global variable (maybe with offset) or similar.
+*/
 #endif
 
 #if defined(HAVE_INLINE)
@@ -308,6 +332,52 @@ INLINE void ED_MarkAsUntested (ExprDesc* Expr)
 #  define ED_MarkAsUntested(Expr)   do { (Expr)->Flags &= ~E_CC_SET; } while (0)
 #endif
 
+#if defined(HAVE_INLINE)
+INLINE int ED_IsLoaded (const ExprDesc* Expr)
+/* Check if the expression is loaded.
+** NOTE: This is currently unused and not working due to code complexity.
+*/
+{
+    return (Expr->Flags & E_LOADED) != 0;
+}
+#else
+#  define ED_IsLoaded(Expr)   (((Expr)->Flags & E_LOADED) != 0)
+#endif
+
+#if defined(HAVE_INLINE)
+INLINE int ED_IsLocPrimaryOrExpr (const ExprDesc* Expr)
+/* Return true if the expression is E_LOC_PRIMARY or E_LOC_EXPR */
+{
+    return ED_IsLocPrimary (Expr) || ED_IsLocExpr (Expr);
+}
+#else
+int ED_IsLocPrimaryOrExpr (const ExprDesc* Expr);
+/* Return true if the expression is E_LOC_PRIMARY or E_LOC_EXPR */
+#endif
+
+#if defined(HAVE_INLINE)
+INLINE int ED_IsAddrExpr (const ExprDesc* Expr)
+/* Check if the expression is taken address of instead of its value.
+*/
+{
+    return (Expr->Flags & E_ADDRESS_OF) != 0;
+}
+#else
+#  define ED_IsAddrExpr(Expr) (((Expr)->Flags & E_ADDRESS_OF) != 0)
+#endif
+
+#if defined(HAVE_INLINE)
+INLINE int ED_IsIndExpr (const ExprDesc* Expr)
+/* Check if the expression is a reference to its value */
+{
+    return (Expr->Flags & E_ADDRESS_OF) == 0 &&
+           !ED_IsLocNone (Expr) && !ED_IsLocPrimary (Expr);
+}
+#else
+int ED_IsIndExpr (const ExprDesc* Expr);
+/* Check if the expression is a reference to its value */
+#endif
+
 void ED_SetCodeRange (ExprDesc* Expr, const CodeMark* Start, const CodeMark* End);
 /* Set the code range for this expression */
 
@@ -326,26 +396,79 @@ int ED_GetStackOffs (const ExprDesc* Expr, int Offs);
 */
 
 ExprDesc* ED_MakeConstAbs (ExprDesc* Expr, long Value, Type* Type);
-/* Make Expr an absolute const with the given value and type. */
+/* Replace Expr with an absolute const with the given value and type */
 
 ExprDesc* ED_MakeConstAbsInt (ExprDesc* Expr, long Value);
-/* Make Expr a constant integer expression with the given value */
+/* Replace Expr with an constant integer with the given value */
 
-ExprDesc* ED_MakeRValExpr (ExprDesc* Expr);
-/* Convert Expr into a rvalue which is in the primary register without an
-** offset.
-*/
+ExprDesc* ED_FinalizeRValLoad (ExprDesc* Expr);
+/* Finalize the result of LoadExpr to be an rvalue in the primary register */
 
-ExprDesc* ED_MakeLValExpr (ExprDesc* Expr);
-/* Convert Expr into a lvalue which is in the primary register without an
-** offset.
-*/
+#if defined(HAVE_INLINE)
+INLINE int ED_IsLVal (const ExprDesc* Expr)
+/* Return true if the expression is a reference */
+{
+    return ((Expr)->Flags & E_MASK_RTYPE) == E_RTYPE_LVAL;
+}
+#else
+#  define ED_IsLVal(Expr)       (((Expr)->Flags & E_MASK_RTYPE) == E_RTYPE_LVAL)
+#endif
 
-int ED_IsConst (const ExprDesc* Expr);
-/* Return true if the expression denotes a constant of some sort. This can be a
-** numeric constant, the address of a global variable (maybe with offset) or
-** similar.
+#if defined(HAVE_INLINE)
+INLINE int ED_IsRVal (const ExprDesc* Expr)
+/* Return true if the expression is an rvalue */
+{
+    return ((Expr)->Flags & E_MASK_RTYPE) == E_RTYPE_RVAL;
+}
+#else
+#  define ED_IsRVal(Expr)       (((Expr)->Flags & E_MASK_RTYPE) == E_RTYPE_RVAL)
+#endif
+
+#if defined(HAVE_INLINE)
+INLINE void ED_MarkExprAsLVal (ExprDesc* Expr)
+/* Mark the expression as an lvalue.
+** HINT: Consider using ED_IndExpr instead of this, unless you know what
+**       consequence there will be, as there are both a big part in the code
+**       assuming rvalue = const and a big part assuming rvalue = address.
 */
+{
+    Expr->Flags |= E_RTYPE_LVAL;
+}
+#else
+#  define ED_MarkExprAsLVal(Expr)   do { (Expr)->Flags |= E_RTYPE_LVAL; } while (0)
+#endif
+
+#if defined(HAVE_INLINE)
+INLINE void ED_MarkExprAsRVal (ExprDesc* Expr)
+/* Mark the expression as an rvalue.
+** HINT: Consider using ED_AddrExpr instead of this, unless you know what
+**       consequence there will be, as there are both a big part in the code
+**       assuming rvalue = const and a big part assuming rvalue = address.
+*/
+{
+    Expr->Flags &= ~E_RTYPE_LVAL;
+}
+#else
+#  define ED_MarkExprAsRVal(Expr)   do { (Expr)->Flags &= ~E_RTYPE_LVAL; } while (0)
+#endif
+
+ExprDesc* ED_AddrExpr (ExprDesc* Expr);
+/* Take address of Expr */
+
+ExprDesc* ED_IndExpr (ExprDesc* Expr);
+/* Dereference Expr */
+
+#if defined(HAVE_INLINE)
+INLINE int ED_IsAbs (const ExprDesc* Expr)
+/* Return true if the expression denotes a numeric value or address. */
+{
+    return (Expr->Flags & (E_MASK_LOC)) == (E_LOC_NONE) ||
+           (Expr->Flags & (E_MASK_LOC|E_ADDRESS_OF)) == (E_LOC_ABS|E_ADDRESS_OF);
+}
+#else
+int ED_IsAbs (const ExprDesc* Expr);
+/* Return true if the expression denotes a numeric value or address. */
+#endif
 
 #if defined(HAVE_INLINE)
 INLINE int ED_IsConstAbs (const ExprDesc* Expr)
@@ -353,15 +476,33 @@ INLINE int ED_IsConstAbs (const ExprDesc* Expr)
 ** a numeric constant, cast to any type.
 */
 {
-    return (Expr->Flags & (E_MASK_LOC|E_MASK_RTYPE)) == (E_LOC_ABS|E_RTYPE_RVAL);
+    return ED_IsRVal (Expr) && ED_IsAbs (Expr);
 }
 #else
-#  define ED_IsConstAbs(E)      \
-        (((E)->Flags & (E_MASK_LOC|E_MASK_RTYPE)) == (E_LOC_ABS|E_RTYPE_RVAL))
+int ED_IsConstAbs (const ExprDesc* Expr);
+/* Return true if the expression denotes a constant absolute value. This can be
+** a numeric constant, cast to any type.
+*/
 #endif
 
 int ED_IsConstAbsInt (const ExprDesc* Expr);
 /* Return true if the expression is a constant (numeric) integer. */
+
+int ED_IsConst (const ExprDesc* Expr);
+/* Return true if the expression denotes a constant of some sort. This can be a
+** numeric constant, the address of a global variable (maybe with offset) or
+** similar.
+*/
+
+int ED_IsConstAddr (const ExprDesc* Expr);
+/* Return true if the expression denotes a constant address of some sort. This
+** can be the address of a global variable (maybe with offset) or similar.
+*/
+
+int ED_IsQuasiConstAddr (const ExprDesc* Expr);
+/* Return true if the expression denotes a quasi-constant address of some sort.
+** This can be a constant address or a stack variable address.
+*/
 
 int ED_IsNullPtr (const ExprDesc* Expr);
 /* Return true if the given expression is a NULL pointer constant */

--- a/src/cc65/locals.c
+++ b/src/cc65/locals.c
@@ -260,7 +260,7 @@ static void ParseAutoDecl (Declaration* Decl)
                     Flags |= CF_CONST;
                 } else {
                     LoadExpr (CF_NONE, &Expr);
-                    ED_MakeRVal (&Expr);
+                    ED_MarkExprAsRVal (&Expr);
                 }
 
                 /* Push the value */

--- a/src/cc65/shiftexpr.c
+++ b/src/cc65/shiftexpr.c
@@ -173,8 +173,8 @@ void ShiftExpr (struct ExprDesc* Expr)
                 goto Next;
             }
 
-            /* If we're shifting an integer or unsigned to the right, the
-            ** lhs has a const address, and the shift count is larger than 8,
+            /* If we're shifting an integer or unsigned to the right, the lhs
+            ** has a quasi-const address, and the shift count is larger than 8,
             ** we can load just the high byte as a char with the correct
             ** signedness, and reduce the shift count by 8. If the remaining
             ** shift count is zero, we're done.
@@ -182,7 +182,7 @@ void ShiftExpr (struct ExprDesc* Expr)
             if (Tok == TOK_SHR &&
                 IsTypeInt (Expr->Type) &&
                 ED_IsLVal (Expr) &&
-                (ED_IsLocConst (Expr) || ED_IsLocStack (Expr)) &&
+                ED_IsLocQuasiConst (Expr) &&
                 Expr2.IVal >= 8) {
 
                 Type* OldType; 
@@ -227,8 +227,8 @@ void ShiftExpr (struct ExprDesc* Expr)
         }
 
 MakeRVal:
-        /* We have a rvalue in the primary now */
-        ED_MakeRValExpr (Expr);
+        /* We have an rvalue in the primary now */
+        ED_FinalizeRValLoad (Expr);
 
 Next:
         /* Set the type of the result */

--- a/src/cc65/stdfunc.c
+++ b/src/cc65/stdfunc.c
@@ -343,7 +343,7 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
             ** address calculation could overflow in the linker.
             */
             int AllowOneIndex = !ED_IsLocRegister (&Arg2.Expr) &&
-                                !(ED_IsLocAbs (&Arg2.Expr) && Arg2.Expr.IVal < 256);
+                                !(ED_IsLocNone (&Arg2.Expr) && Arg2.Expr.IVal < 256);
 
             /* Calculate the real stack offset */
             Offs = ED_GetStackOffs (&Arg1.Expr, 0);
@@ -421,7 +421,7 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
             ** address calculation could overflow in the linker.
             */
             int AllowOneIndex = !ED_IsLocRegister (&Arg1.Expr) &&
-                                !(ED_IsLocAbs (&Arg1.Expr) && Arg1.Expr.IVal < 256);
+                                !(ED_IsLocNone (&Arg1.Expr) && Arg1.Expr.IVal < 256);
 
             /* Calculate the real stack offset */
             Offs = ED_GetStackOffs (&Arg2.Expr, 0);
@@ -520,7 +520,7 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
             AddCodeLine ("lda ptr1");
 
             /* The function result is an rvalue in the primary register */
-            ED_MakeRValExpr (Expr);
+            ED_FinalizeRValLoad (Expr);
             Expr->Type = GetFuncReturn (Expr->Type);
 
             /* Bail out, no need for further processing */
@@ -529,7 +529,7 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
     }
 
     /* The function result is an rvalue in the primary register */
-    ED_MakeRValExpr (Expr);
+    ED_FinalizeRValLoad (Expr);
     Expr->Type = GetFuncReturn (Expr->Type);
 
 ExitPoint:
@@ -743,7 +743,7 @@ static void StdFunc_memset (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
             AddCodeLine ("lda ptr1");
 
             /* The function result is an rvalue in the primary register */
-            ED_MakeRValExpr (Expr);
+            ED_FinalizeRValLoad (Expr);
             Expr->Type = GetFuncReturn (Expr->Type);
 
             /* Bail out, no need for further processing */
@@ -752,7 +752,7 @@ static void StdFunc_memset (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
     }
 
     /* The function result is an rvalue in the primary register */
-    ED_MakeRValExpr (Expr);
+    ED_FinalizeRValLoad (Expr);
     Expr->Type = GetFuncReturn (Expr->Type);
 
 ExitPoint:
@@ -955,7 +955,7 @@ static void StdFunc_strcmp (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
     }
 
     /* The function result is an rvalue in the primary register */
-    ED_MakeRValExpr (Expr);
+    ED_FinalizeRValLoad (Expr);
     Expr->Type = GetFuncReturn (Expr->Type);
 
     /* We expect the closing brace */
@@ -1069,7 +1069,7 @@ static void StdFunc_strcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
             ** address calculation could overflow in the linker.
             */
             int AllowOneIndex = !ED_IsLocRegister (&Arg1.Expr) &&
-                                !(ED_IsLocAbs (&Arg1.Expr) && Arg1.Expr.IVal < 256);
+                                !(ED_IsLocNone (&Arg1.Expr) && Arg1.Expr.IVal < 256);
 
             /* Calculate the real stack offset */
             int Offs = ED_GetStackOffs (&Arg2.Expr, 0);
@@ -1116,7 +1116,7 @@ static void StdFunc_strcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
             ** address calculation could overflow in the linker.
             */
             int AllowOneIndex = !ED_IsLocRegister (&Arg2.Expr) &&
-                                !(ED_IsLocAbs (&Arg2.Expr) && Arg2.Expr.IVal < 256);
+                                !(ED_IsLocNone (&Arg2.Expr) && Arg2.Expr.IVal < 256);
 
             /* Calculate the real stack offset */
             int Offs = ED_GetStackOffs (&Arg1.Expr, 0);
@@ -1153,7 +1153,7 @@ static void StdFunc_strcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
     }
 
     /* The function result is an rvalue in the primary register */
-    ED_MakeRValExpr (Expr);
+    ED_FinalizeRValLoad (Expr);
     Expr->Type = GetFuncReturn (Expr->Type);
 
 ExitPoint:
@@ -1250,7 +1250,7 @@ static void StdFunc_strlen (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
             AddCodeLine ("tya");
 
             /* The function result is an rvalue in the primary register */
-            ED_MakeRValExpr (Expr);
+            ED_FinalizeRValLoad (Expr);
             Expr->Type = type_size_t;
 
             /* Bail out, no need for further processing */
@@ -1279,7 +1279,7 @@ static void StdFunc_strlen (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
             AddCodeLine ("ldx #$00");
 
             /* The function result is an rvalue in the primary register */
-            ED_MakeRValExpr (Expr);
+            ED_FinalizeRValLoad (Expr);
             Expr->Type = type_size_t;
 
             /* Bail out, no need for further processing */
@@ -1304,7 +1304,7 @@ static void StdFunc_strlen (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
             AddCodeLine ("tya");
 
             /* The function result is an rvalue in the primary register */
-            ED_MakeRValExpr (Expr);
+            ED_FinalizeRValLoad (Expr);
             Expr->Type = type_size_t;
 
             /* Bail out, no need for further processing */
@@ -1333,7 +1333,7 @@ static void StdFunc_strlen (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
             AddCodeLine ("tya");
 
             /* The function result is an rvalue in the primary register */
-            ED_MakeRValExpr (Expr);
+            ED_FinalizeRValLoad (Expr);
             Expr->Type = type_size_t;
 
             /* Bail out, no need for further processing */
@@ -1348,7 +1348,7 @@ static void StdFunc_strlen (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
     AddCodeLine ("jsr _%s", Func_strlen);
 
     /* The function result is an rvalue in the primary register */
-    ED_MakeRValExpr (Expr);
+    ED_FinalizeRValLoad (Expr);
     Expr->Type = type_size_t;
 
 ExitPoint:


### PR DESCRIPTION
This PR contains fixes for Issues #1075 and #1077. There are also unpushed fixes for other issues that depend on this.

Brief on what's the matter:

- The compiler didn't have any status flags on whether an expression is to be used dereferenced or directly. It did very carefully everywhere in the code to handle the two cases correctly by separating the code flows and/or looking at some other known conditions, but it still had missed some parts, which resulted in the two issues reported. This PR keeps a track on this to fix the problem.

- There were also some confusions in the code with regards to "lvalue" and "rvalue". It seems the code was originally to use the concepts "lvalue" (as in "**l**ocation **value**", to be used dereferenced) and "rvalue" (as in "**r**egister **value**", to be used directly) to deal with the issue above, but they were overloaded also to mean "mutable" by "lvalue" and "const" by "rvalue". This PR divides by the meanings, uses "indirection"/"reference" and "address"/"immediate numeric" when talking about the former matter, leaves the "lvalue" (as in "**l**eft **value**") and "rvalue" (as in "**r**ight **value**") terms to be used in C's sense and deduces "constant-ness" according to various conditions.

- This PR also adds some tiny facility/utility stuff to be usable for other pending/future changes. They are bundled here since they are closely related to those needed for resolving the issues above. However, some of them might be eventually unused.

EDIT: Tidy up.