### PR TITLE
Move -Werror from .travis.yml to src/Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ install:
   - sudo apt-get update
   - sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass
 script:
-  - make bin USER_CFLAGS=-Werror
+  - make bin
   - make lib QUIET=1
   - make -C test QUIET=1
   - make -C src clean
-  - make bin USER_CFLAGS=-Werror CROSS_COMPILE=i686-w64-mingw32-
+  - make bin CROSS_COMPILE=i686-w64-mingw32-
   - make doc zip
 after_success:
   - make -f Makefile.travis

--- a/src/Makefile
+++ b/src/Makefile
@@ -61,7 +61,7 @@ endif
 $(info BUILD_ID: $(BUILD_ID))
 
 CFLAGS += -MMD -MP -O3 -I common \
-          -Wall -Wextra -Wno-char-subscripts $(USER_CFLAGS) \
+          -Wall -Wextra -Wno-char-subscripts -Werror $(USER_CFLAGS) \
           -DCA65_INC="$(CA65_INC)" -DCC65_INC="$(CC65_INC)" -DCL65_TGT="$(CL65_TGT)" \
           -DLD65_LIB="$(LD65_LIB)" -DLD65_OBJ="$(LD65_OBJ)" -DLD65_CFG="$(LD65_CFG)" \
           -DBUILD_ID="$(BUILD_ID)"


### PR DESCRIPTION
This prevents warnings from being missed and breaking the CI.