### PR TITLE
[cc65] Corrected the error message about struct/union members not found

### DIFF
--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1219,7 +1219,7 @@ static void StructRef (ExprDesc* Expr)
     NextToken ();
     Field = FindStructField (Expr->Type, Ident);
     if (Field == 0) {
-        Error ("No field named '%s' found in %s", GetBasicTypeName (Expr->Type), Ident);
+        Error ("No field named '%s' found in %s", Ident, GetBasicTypeName (Expr->Type));
         /* Make the expression an integer at address zero */
         ED_MakeConstAbs (Expr, 0, type_int);
         return;


### PR DESCRIPTION
This is the missing part from PR #1102.