### PR TITLE
[cc65] Disabled applying 'sizeof' to a bit-field

### DIFF
--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1867,23 +1867,23 @@ void hie10 (ExprDesc* Expr)
             NextToken ();
             ExprWithCheck (hie10, Expr);
             /* The & operator may be applied to any lvalue, and it may be
-            ** applied to functions, even if they're no lvalues.
+            ** applied to functions and arrays, even if they're not lvalues.
             */
-            if (ED_IsRVal (Expr) && !IsTypeFunc (Expr->Type) && !IsTypeArray (Expr->Type)) {
-                Error ("Illegal address");
-            } else {
+            if (!IsTypeFunc (Expr->Type) && !IsTypeArray (Expr->Type)) {
+                if (ED_IsRVal (Expr)) {
+                    Error ("Illegal address");
+                    break;
+                }
+
                 if (ED_IsBitField (Expr)) {
                     Error ("Cannot take address of bit-field");
                     /* Do it anyway, just to avoid further warnings */
-                    Expr->Flags &= ~E_BITFIELD;
+                    ED_DisBitField (Expr);
                 }
-                /* It's allowed in C to take the address of an array this way */
-                if (!IsTypeFunc (Expr->Type) && !IsTypeArray (Expr->Type)) {
-                    /* The & operator yields an rvalue address */
-                    ED_AddrExpr (Expr);
-                }
-                Expr->Type = PointerTo (Expr->Type);
+                /* The & operator yields an rvalue address */
+                ED_AddrExpr (Expr);
             }
+            Expr->Type = PointerTo (Expr->Type);
             break;
 
         case TOK_SIZEOF:

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1898,14 +1898,19 @@ void hie10 (ExprDesc* Expr)
                 CodeMark Mark;
                 GetCodePos (&Mark);
                 hie10 (Expr);
-                /* If the expression is a literal string, release it, so it
-                ** won't be output as data if not used elsewhere.
-                */
-                if (ED_IsLocLiteral (Expr)) {
-                    ReleaseLiteral (Expr->LVal);
+                if (ED_IsBitField (Expr)) {
+                    Error ("Cannot apply 'sizeof' to bit-field");
+                    Size = 0;
+                } else {
+                    /* If the expression is a literal string, release it, so it
+                    ** won't be output as data if not used elsewhere.
+                    */
+                    if (ED_IsLocLiteral (Expr)) {
+                        ReleaseLiteral (Expr->LVal);
+                    }
+                    /* Calculate the size */
+                    Size = CheckedSizeOf (Expr->Type);
                 }
-                /* Calculate the size */
-                Size = CheckedSizeOf (Expr->Type);
                 /* Remove any generated code */
                 RemoveCode (&Mark);
             }

--- a/src/cc65/exprdesc.h
+++ b/src/cc65/exprdesc.h
@@ -278,6 +278,16 @@ INLINE int ED_IsBitField (const ExprDesc* Expr)
 #  define ED_IsBitField(Expr)   (((Expr)->Flags & E_BITFIELD) != 0)
 #endif
 
+#if defined(HAVE_INLINE)
+INLINE void ED_DisBitField (ExprDesc* Expr)
+/* Make the expression no longer a bit field */
+{
+    Expr->Flags &= ~E_BITFIELD;
+}
+#else
+#  define ED_DisBitField(Expr)  ((Expr)->Flags &= ~E_BITFIELD)
+#endif
+
 void ED_MakeBitField (ExprDesc* Expr, unsigned BitOffs, unsigned BitWidth);
 /* Make this expression a bit field expression */
 

--- a/src/cc65/typeconv.c
+++ b/src/cc65/typeconv.c
@@ -169,9 +169,7 @@ ExitPoint:
     ReplaceType (Expr, NewType);
 
     /* Bit-fields are converted to integers */
-    if (ED_IsBitField (Expr)) {
-        ED_DisBitField (Expr);
-    }
+    ED_DisBitField (Expr);
 }
 
 

--- a/src/cc65/typeconv.c
+++ b/src/cc65/typeconv.c
@@ -59,8 +59,8 @@ static void DoConversion (ExprDesc* Expr, const Type* NewType)
 /* Emit code to convert the given expression to a new type. */
 {
     Type*    OldType;
-    unsigned OldSize;
-    unsigned NewSize;
+    unsigned OldBits;
+    unsigned NewBits;
 
 
     /* Remember the old type */
@@ -83,8 +83,12 @@ static void DoConversion (ExprDesc* Expr, const Type* NewType)
     /* Get the sizes of the types. Since we've excluded void types, checking
     ** for known sizes makes sense here.
     */
-    OldSize = CheckedSizeOf (OldType);
-    NewSize = CheckedSizeOf (NewType);
+    if (ED_IsBitField (Expr)) {
+        OldBits = Expr->BitWidth;
+    } else {
+        OldBits = CheckedSizeOf (OldType) * CHAR_BITS;
+    }
+    NewBits = CheckedSizeOf (NewType) * CHAR_BITS;
 
     /* lvalue? */
     if (ED_IsLVal (Expr)) {
@@ -97,7 +101,7 @@ static void DoConversion (ExprDesc* Expr, const Type* NewType)
         ** If both sizes are equal, do also leave the value alone.
         ** If the new size is larger, we must convert the value.
         */
-        if (NewSize > OldSize) {
+        if (NewBits > OldBits) {
             /* Load the value into the primary */
             LoadExpr (CF_NONE, Expr);
 
@@ -113,10 +117,6 @@ static void DoConversion (ExprDesc* Expr, const Type* NewType)
         /* A cast of a constant numeric value to another type. Be sure
         ** to handle sign extension correctly.
         */
-
-        /* Get the current and new size of the value */
-        unsigned OldBits = OldSize * 8;
-        unsigned NewBits = NewSize * 8;
 
         /* Check if the new datatype will have a smaller range. If it
         ** has a larger range, things are OK, since the value is
@@ -151,7 +151,7 @@ static void DoConversion (ExprDesc* Expr, const Type* NewType)
         ** not equal, add conversion code. Be sure to convert chars
         ** correctly.
         */
-        if (OldSize != NewSize) {
+        if (OldBits != NewBits) {
 
             /* Load the value into the primary */
             LoadExpr (CF_NONE, Expr);
@@ -167,6 +167,11 @@ static void DoConversion (ExprDesc* Expr, const Type* NewType)
 ExitPoint:
     /* The expression has always the new type */
     ReplaceType (Expr, NewType);
+
+    /* Bit-fields are converted to integers */
+    if (ED_IsBitField (Expr)) {
+        ED_DisBitField (Expr);
+    }
 }
 
 


### PR DESCRIPTION
Fixes #1097, and partly fixed conversions from bit-fields to integers.

156ada3f552bc3e8e16238e3b10eb582a18ba277 is a required fix in order to make `sizeof ((int)s.bitfield)` not an error.

~~Nothing is done about `offsetof (struct S, bitfield)`, as the standard says it's UB and any outcome is literally allowed.~~

Nothing was wrong with  `offsetof (struct S, bitfield)`. It is working as expected by rejecting bit-fields correctly.