### PR TITLE
[cc65] Storage classes/types fix and #975

### DIFF
--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -112,7 +112,7 @@ static void Parse (void)
         ParseDeclSpec (&Spec, SC_EXTERN | SC_STATIC, T_INT);
 
         /* Don't accept illegal storage classes */
-        if ((Spec.StorageClass & SC_TYPE) == 0) {
+        if ((Spec.StorageClass & SC_TYPEMASK) == 0) {
             if ((Spec.StorageClass & SC_AUTO) != 0 ||
                 (Spec.StorageClass & SC_REGISTER) != 0) {
                 Error ("Illegal storage class");

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -490,7 +490,7 @@ static void ParseEnumDecl (void)
         }
 
         /* Add an entry to the symbol table */
-        AddConstSym (Ident, type_int, SC_ENUMERATOR|SC_CONST, EnumVal++);
+        AddConstSym (Ident, type_int, SC_ENUMERATOR | SC_CONST, EnumVal++);
 
         /* Check for end of definition */
         if (CurTok.Tok != TOK_COMMA)

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -490,7 +490,7 @@ static void ParseEnumDecl (void)
         }
 
         /* Add an entry to the symbol table */
-        AddConstSym (Ident, type_int, SC_ENUM, EnumVal++);
+        AddConstSym (Ident, type_int, SC_ENUM|SC_CONST, EnumVal++);
 
         /* Check for end of definition */
         if (CurTok.Tok != TOK_COMMA)

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -490,7 +490,7 @@ static void ParseEnumDecl (void)
         }
 
         /* Add an entry to the symbol table */
-        AddConstSym (Ident, type_int, SC_ENUM|SC_CONST, EnumVal++);
+        AddConstSym (Ident, type_int, SC_ENUMERATOR|SC_CONST, EnumVal++);
 
         /* Check for end of definition */
         if (CurTok.Tok != TOK_COMMA)

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -758,7 +758,7 @@ static void Primary (ExprDesc* E)
 
                 /* Check for illegal symbol types */
                 CHECK ((Sym->Flags & SC_LABEL) != SC_LABEL);
-                if (Sym->Flags & SC_TYPE) {
+                if (Sym->Flags & SC_ESUTYPEMASK) {
                     /* Cannot use type symbols */
                     Error ("Variable identifier expected");
                     /* Assume an int type to make E valid */

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -802,7 +802,7 @@ static void Primary (ExprDesc* E)
                     E->Name  = Sym->V.R.RegOffs;
                 } else if ((Sym->Flags & SC_STATIC) == SC_STATIC) {
                     /* Static variable */
-                    if (Sym->Flags & (SC_EXTERN | SC_STORAGE)) {
+                    if (Sym->Flags & (SC_EXTERN | SC_STORAGE | SC_DECL)) {
                         E->Flags = E_LOC_GLOBAL | E_RTYPE_LVAL;
                         E->Name = (uintptr_t) Sym->Name;
                     } else {

--- a/src/cc65/pragma.c
+++ b/src/cc65/pragma.c
@@ -523,7 +523,7 @@ static void WrappedCallPragma (StrBuf* B)
     Entry = FindSym(Name);
 
     /* Check if the name is valid */
-    if (Entry && Entry->Flags & SC_FUNC) {
+    if (Entry && (Entry->Flags & SC_FUNC) == SC_FUNC) {
 
         PushWrappedCall(Entry, (unsigned char) Val);
         Entry->Flags |= SC_REF;

--- a/src/cc65/symentry.c
+++ b/src/cc65/symentry.c
@@ -113,26 +113,29 @@ void DumpSymEntry (FILE* F, const SymEntry* E)
         { "SC_TYPEDEF",     SC_TYPEDEF          },
         { "SC_UNION",       SC_UNION            },
         { "SC_STRUCT",      SC_STRUCT           },
+        { "SC_ENUM",        SC_ENUM             },
     };
 
-    static SCFlagTable Flags[] = {
-        /* Beware: Order is important! */
+    static SCFlagTable Types[] = {
         { "SC_BITFIELD",    SC_BITFIELD         },
         { "SC_STRUCTFIELD", SC_STRUCTFIELD      },
-        { "SC_AUTO",        SC_AUTO             },
-        { "SC_REGISTER",    SC_REGISTER         },
-        { "SC_STATIC",      SC_STATIC           },
-        { "SC_EXTERN",      SC_EXTERN           },
-        { "SC_ENUM",        SC_ENUM             },
+        { "SC_ENUMERATOR",  SC_ENUMERATOR       },
         { "SC_CONST",       SC_CONST            },
         { "SC_LABEL",       SC_LABEL            },
         { "SC_PARAM",       SC_PARAM            },
         { "SC_FUNC",        SC_FUNC             },
+    };
+
+    static SCFlagTable Storages[] = {
+        { "SC_AUTO",        SC_AUTO             },
+        { "SC_REGISTER",    SC_REGISTER         },
+        { "SC_STATIC",      SC_STATIC           },
+        { "SC_EXTERN",      SC_EXTERN           },
         { "SC_STORAGE",     SC_STORAGE          },
+        { "SC_ZEROPAGE",    SC_ZEROPAGE         },
         { "SC_DECL",        SC_DECL             },
         { "SC_DEF",         SC_DEF              },
         { "SC_REF",         SC_REF              },
-        { "SC_ZEROPAGE",    SC_ZEROPAGE         },
     };
 
     unsigned I;
@@ -149,18 +152,28 @@ void DumpSymEntry (FILE* F, const SymEntry* E)
     /* Print the flags */
     SymFlags = E->Flags;
     fprintf (F, "    Flags:");
+    /* Enum, struct, union and typedefs */
     if ((SymFlags & SC_ESUTYPEMASK) != 0) {
         for (I = 0; I < sizeof (ESUTypes) / sizeof (ESUTypes[0]); ++I) {
             if ((SymFlags & SC_ESUTYPEMASK) == ESUTypes[I].Val) {
                 SymFlags &= ~SC_ESUTYPEMASK;
                 fprintf (F, " %s", ESUTypes[I].Name);
+                break;
             }
         }
     }
-    for (I = 0; I < sizeof (Flags) / sizeof (Flags[0]) && SymFlags != 0; ++I) {
-        if ((SymFlags & Flags[I].Val) == Flags[I].Val) {
-            SymFlags &= ~Flags[I].Val;
-            fprintf (F, " %s", Flags[I].Name);
+    /* Other type flags */
+    for (I = 0; I < sizeof (Types) / sizeof (Types[0]) && SymFlags != 0; ++I) {
+        if ((SymFlags & Types[I].Val) == Types[I].Val) {
+            SymFlags &= ~Types[I].Val;
+            fprintf (F, " %s", Types[I].Name);
+        }
+    }
+    /* Storage flags */
+    for (I = 0; I < sizeof (Storages) / sizeof (Storages[0]) && SymFlags != 0; ++I) {
+        if ((SymFlags & Storages[I].Val) == Storages[I].Val) {
+            SymFlags &= ~Storages[I].Val;
+            fprintf (F, " %s", Storages[I].Name);
         }
     }
     if (SymFlags != 0) {

--- a/src/cc65/symentry.c
+++ b/src/cc65/symentry.c
@@ -104,16 +104,21 @@ void FreeSymEntry (SymEntry* E)
 void DumpSymEntry (FILE* F, const SymEntry* E)
 /* Dump the given symbol table entry to the file in readable form */
 {
-    static const struct {
+    typedef const struct {
         const char*         Name;
         unsigned            Val;
-    } Flags [] = {
-        /* Beware: Order is important! */
+    } SCFlagTable;
+
+    static SCFlagTable ESUTypes[] = {
         { "SC_TYPEDEF",     SC_TYPEDEF          },
-        { "SC_BITFIELD",    SC_BITFIELD         },
-        { "SC_STRUCTFIELD", SC_STRUCTFIELD      },
         { "SC_UNION",       SC_UNION            },
         { "SC_STRUCT",      SC_STRUCT           },
+    };
+
+    static SCFlagTable Flags[] = {
+        /* Beware: Order is important! */
+        { "SC_BITFIELD",    SC_BITFIELD         },
+        { "SC_STRUCTFIELD", SC_STRUCTFIELD      },
         { "SC_AUTO",        SC_AUTO             },
         { "SC_REGISTER",    SC_REGISTER         },
         { "SC_STATIC",      SC_STATIC           },
@@ -124,6 +129,7 @@ void DumpSymEntry (FILE* F, const SymEntry* E)
         { "SC_PARAM",       SC_PARAM            },
         { "SC_FUNC",        SC_FUNC             },
         { "SC_STORAGE",     SC_STORAGE          },
+        { "SC_DECL",        SC_DECL             },
         { "SC_DEF",         SC_DEF              },
         { "SC_REF",         SC_REF              },
         { "SC_ZEROPAGE",    SC_ZEROPAGE         },
@@ -143,6 +149,14 @@ void DumpSymEntry (FILE* F, const SymEntry* E)
     /* Print the flags */
     SymFlags = E->Flags;
     fprintf (F, "    Flags:");
+    if ((SymFlags & SC_ESUTYPEMASK) != 0) {
+        for (I = 0; I < sizeof (ESUTypes) / sizeof (ESUTypes[0]); ++I) {
+            if ((SymFlags & SC_ESUTYPEMASK) == ESUTypes[I].Val) {
+                SymFlags &= ~SC_ESUTYPEMASK;
+                fprintf (F, " %s", ESUTypes[I].Name);
+            }
+        }
+    }
     for (I = 0; I < sizeof (Flags) / sizeof (Flags[0]) && SymFlags != 0; ++I) {
         if ((SymFlags & Flags[I].Val) == Flags[I].Val) {
             SymFlags &= ~Flags[I].Val;

--- a/src/cc65/symentry.h
+++ b/src/cc65/symentry.h
@@ -69,39 +69,42 @@ struct CodeEntry;
 
 
 /* Storage classes and flags */
-#define SC_AUTO         0x0001U         /* Auto variable */
-#define SC_REGISTER     0x0002U         /* Register variable */
-#define SC_STATIC       0x0004U         /* Static */
-#define SC_EXTERN       0x0008U         /* Extern linkage */
+#define SC_NONE         0x0000U         /* Nothing */
+#define SC_STRUCT       0x0001U         /* Struct */
+#define SC_UNION        0x0002U         /* Union */
+#define SC_TYPEDEF      0x0004U         /* A typedef */
+#define SC_ESUTYPEMASK  0x0007U         /* Mask for above types */
+#define SC_ENUM         0x0008U         /* An enum */
+#define SC_BITFIELD     0x0010U         /* A bit-field inside a struct or union */
+#define SC_TYPEMASK     0x001FU         /* Mask for above types */
 
-#define SC_ENUM         0x0030U         /* An enum */
 #define SC_CONST        0x0020U         /* A numeric constant with a type */
-#define SC_LABEL        0x0040U         /* A goto label */
+#define SC_LABEL        0x0040U         /* A goto code label */
 #define SC_PARAM        0x0080U         /* A function parameter */
 #define SC_FUNC         0x0100U         /* A function */
-
 #define SC_DEFTYPE      0x0200U         /* Parameter has default type (=int, old style) */
-#define SC_STORAGE      0x0400U         /* Symbol with associated storage */
-#define SC_DEFAULT      0x0800U         /* Flag: default storage class was used */
+#define SC_STRUCTFIELD  0x0400U         /* Struct or union field */
+
+#define SC_DECL         0x0800U         /* Symbol is declared in global scope */
 
 #define SC_DEF          0x1000U         /* Symbol is defined */
 #define SC_REF          0x2000U         /* Symbol is referenced */
 
-#define SC_TYPE         0x4000U         /* This is a type, struct, typedef, etc. */
-#define SC_STRUCT       0x4001U         /* Struct */
-#define SC_UNION        0x4002U         /* Union */
-#define SC_STRUCTFIELD  0x4003U         /* Struct or union field */
-#define SC_BITFIELD     0x4004U         /* A bit-field inside a struct or union */
-#define SC_TYPEDEF      0x4005U         /* A typedef */
-#define SC_TYPEMASK     0x400FU         /* Mask for above types */
+#define SC_ZEROPAGE     0x4000U         /* Symbol marked as zeropage */
 
-#define SC_ZEROPAGE     0x8000U         /* Symbol marked as zeropage */
+#define SC_STORAGE      0x8000U         /* Symbol with associated storage */
 
-#define SC_HAVEATTR     0x10000U        /* Symbol has attributes */
+#define SC_AUTO         0x010000U       /* Auto variable */
+#define SC_REGISTER     0x020000U       /* Register variable */
+#define SC_STATIC       0x040000U       /* Static - not to be confused with other *_STATIC */
+#define SC_EXTERN       0x080000U       /* Extern linkage */
+#define SC_STORAGEMASK  0x0F0000U       /* Storage type mask */
 
-#define SC_GOTO         0x20000U
-#define SC_SPADJUSTMENT 0x40000U
-#define SC_GOTO_IND     0x80000U        /* Indirect goto */
+#define SC_HAVEATTR     0x100000U       /* Symbol has attributes */
+
+#define SC_GOTO         0x200000U
+#define SC_SPADJUSTMENT 0x400000U
+#define SC_GOTO_IND     0x800000U       /* Indirect goto */
 
 
 
@@ -245,10 +248,10 @@ INLINE int SymIsRegVar (const SymEntry* Sym)
 /* Return true if the given entry is a register variable */
 /* ### HACK! Fix the ugly type flags! */
 {
-    return ((Sym->Flags & (SC_REGISTER|SC_TYPE)) == SC_REGISTER);
+    return ((Sym->Flags & (SC_REGISTER|SC_TYPEMASK)) == SC_REGISTER);
 }
 #else
-#  define SymIsRegVar(Sym)      (((Sym)->Flags & (SC_REGISTER|SC_TYPE)) == SC_REGISTER)
+#  define SymIsRegVar(Sym)  (((Sym)->Flags & (SC_REGISTER|SC_ESUTYPEMASK)) == SC_REGISTER)
 #endif
 
 int SymIsOutputFunc (const SymEntry* Sym);

--- a/src/cc65/symentry.h
+++ b/src/cc65/symentry.h
@@ -247,10 +247,10 @@ INLINE int SymIsRegVar (const SymEntry* Sym)
 /* Return true if the given entry is a register variable */
 /* ### HACK! Fix the ugly type flags! */
 {
-    return ((Sym->Flags & (SC_REGISTER|SC_TYPEMASK)) == SC_REGISTER);
+    return ((Sym->Flags & (SC_REGISTER | SC_TYPEMASK)) == SC_REGISTER);
 }
 #else
-#  define SymIsRegVar(Sym)  (((Sym)->Flags & (SC_REGISTER|SC_TYPEMASK)) == SC_REGISTER)
+#  define SymIsRegVar(Sym)  (((Sym)->Flags & (SC_REGISTER | SC_TYPEMASK)) == SC_REGISTER)
 #endif
 
 int SymIsOutputFunc (const SymEntry* Sym);

--- a/src/cc65/symentry.h
+++ b/src/cc65/symentry.h
@@ -74,24 +74,22 @@ struct CodeEntry;
 #define SC_UNION        0x0002U         /* Union */
 #define SC_TYPEDEF      0x0004U         /* A typedef */
 #define SC_ESUTYPEMASK  0x0007U         /* Mask for above types */
-#define SC_ENUM         0x0008U         /* An enum */
+#define SC_ENUM         0x0008U         /* An enumerator */
 #define SC_BITFIELD     0x0010U         /* A bit-field inside a struct or union */
 #define SC_TYPEMASK     0x001FU         /* Mask for above types */
 
-#define SC_CONST        0x0020U         /* A numeric constant with a type */
+#define SC_FUNC         0x0020U         /* A function */
 #define SC_LABEL        0x0040U         /* A goto code label */
-#define SC_PARAM        0x0080U         /* A function parameter */
-#define SC_FUNC         0x0100U         /* A function */
+#define SC_CONST        0x0080U         /* A numeric constant with a type */
+#define SC_PARAM        0x0100U         /* A function parameter */
 #define SC_DEFTYPE      0x0200U         /* Parameter has default type (=int, old style) */
 #define SC_STRUCTFIELD  0x0400U         /* Struct or union field */
 
-#define SC_DECL         0x0800U         /* Symbol is declared in global scope */
+#define SC_ZEROPAGE     0x0800U         /* Symbol marked as zeropage */
 
 #define SC_DEF          0x1000U         /* Symbol is defined */
 #define SC_REF          0x2000U         /* Symbol is referenced */
-
-#define SC_ZEROPAGE     0x4000U         /* Symbol marked as zeropage */
-
+#define SC_DECL         0x4000U         /* Symbol is declared in global scope */
 #define SC_STORAGE      0x8000U         /* Symbol with associated storage */
 
 #define SC_AUTO         0x010000U       /* Auto variable */
@@ -217,10 +215,10 @@ INLINE int SymIsBitField (const SymEntry* Sym)
 INLINE int SymIsTypeDef (const SymEntry* Sym)
 /* Return true if the given entry is a typedef entry */
 {
-    return ((Sym->Flags & SC_TYPEDEF) == SC_TYPEDEF);
+    return ((Sym->Flags & SC_TYPEMASK) == SC_TYPEDEF);
 }
 #else
-#  define SymIsTypeDef(Sym)     (((Sym)->Flags & SC_TYPEDEF) == SC_TYPEDEF)
+#  define SymIsTypeDef(Sym)     (((Sym)->Flags & SC_TYPEMASK) == SC_TYPEDEF)
 #endif
 
 #if defined(HAVE_INLINE)
@@ -251,7 +249,7 @@ INLINE int SymIsRegVar (const SymEntry* Sym)
     return ((Sym->Flags & (SC_REGISTER|SC_TYPEMASK)) == SC_REGISTER);
 }
 #else
-#  define SymIsRegVar(Sym)  (((Sym)->Flags & (SC_REGISTER|SC_ESUTYPEMASK)) == SC_REGISTER)
+#  define SymIsRegVar(Sym)  (((Sym)->Flags & (SC_REGISTER|SC_TYPEMASK)) == SC_REGISTER)
 #endif
 
 int SymIsOutputFunc (const SymEntry* Sym);

--- a/src/cc65/symentry.h
+++ b/src/cc65/symentry.h
@@ -72,9 +72,10 @@ struct CodeEntry;
 #define SC_NONE         0x0000U         /* Nothing */
 #define SC_STRUCT       0x0001U         /* Struct */
 #define SC_UNION        0x0002U         /* Union */
-#define SC_TYPEDEF      0x0004U         /* A typedef */
+#define SC_ENUM         0x0003U         /* Enum */
+#define SC_TYPEDEF      0x0004U         /* Typedef */
 #define SC_ESUTYPEMASK  0x0007U         /* Mask for above types */
-#define SC_ENUM         0x0008U         /* An enumerator */
+#define SC_ENUMERATOR   0x0008U         /* An enumerator */
 #define SC_BITFIELD     0x0010U         /* A bit-field inside a struct or union */
 #define SC_TYPEMASK     0x001FU         /* Mask for above types */
 

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -821,7 +821,7 @@ SymEntry* AddLocalSym (const char* Name, const Type* T, unsigned Flags, int Offs
 
         /* Set the symbol attributes */
         Entry->Type = TypeDup (T);
-        if ((Flags & SC_AUTO) == SC_AUTO) {
+        if ((Flags & SC_AUTO) == SC_AUTO || (Flags & SC_TYPEDEF) == SC_TYPEDEF) {
             Entry->V.Offs = Offs;
         } else if ((Flags & SC_REGISTER) == SC_REGISTER) {
             Entry->V.R.RegOffs  = Offs;
@@ -872,7 +872,7 @@ SymEntry* AddGlobalSym (const char* Name, const Type* T, unsigned Flags)
         }
 
         /* We have a symbol with this name already */
-        if (Entry->Flags & SC_TYPE) {
+        if (Entry->Flags & SC_TYPEMASK) {
             Error ("Multiple definition for '%s'", Name);
             return Entry;
         }
@@ -1109,7 +1109,7 @@ void EmitDebugInfo (void)
         }
         Sym = SymTab->SymHead;
         while (Sym) {
-            if ((Sym->Flags & (SC_CONST|SC_TYPE)) == 0) {
+            if ((Sym->Flags & (SC_CONST|SC_TYPEMASK)) == 0) {
                 if (Sym->Flags & SC_AUTO) {
                     AddTextLine ("%s, \"%s\", \"00\", auto, %d",
                                  Head, Sym->Name, Sym->V.Offs);

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -633,7 +633,7 @@ SymEntry* AddConstSym (const char* Name, const Type* T, unsigned Flags, long Val
 /* Add an constant symbol to the symbol table and return it */
 {
     /* Enums must be inserted in the global symbol table */
-    SymTable* Tab = ((Flags & SC_ENUM) == SC_ENUM)? SymTab0 : SymTab;
+    SymTable* Tab = ((Flags & SC_ENUMERATOR) == SC_ENUMERATOR) ? SymTab0 : SymTab;
 
     /* Do we have an entry with this name already? */
     SymEntry* Entry = FindSymInTable (Tab, Name, HashStr (Name));
@@ -867,8 +867,8 @@ SymEntry* AddGlobalSym (const char* Name, const Type* T, unsigned Flags)
         /* If the existing symbol is an enumerated constant,
         ** then avoid a compiler crash.  See GitHub issue #728.
         */
-        if (Entry->Flags & SC_ENUM) {
-            Fatal ("Can't redeclare enum constant '%s' as global variable", Name);
+        if (Entry->Flags & SC_ENUMERATOR) {
+            Fatal ("Can't redeclare enumerator constant '%s' as global variable", Name);
         }
 
         /* We have a symbol with this name already */

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -717,7 +717,7 @@ SymEntry* AddLabelSym (const char* Name, unsigned Flags)
         for (i = 0; i < CollCount (Entry->V.L.DefsOrRefs); i++) {
             DOR = CollAt (Entry->V.L.DefsOrRefs, i);
 
-            if ((DOR->Flags & SC_DEF) && (Flags & SC_REF) && (Flags & (SC_GOTO|SC_GOTO_IND))) {
+            if ((DOR->Flags & SC_DEF) && (Flags & SC_REF) && (Flags & (SC_GOTO | SC_GOTO_IND))) {
                 /* We're processing a goto and here is its destination label.
                 ** This means the difference between SP values is already known,
                 ** so we simply emit the SP adjustment code.
@@ -739,7 +739,7 @@ SymEntry* AddLabelSym (const char* Name, unsigned Flags)
             }
 
 
-            if ((DOR->Flags & SC_REF) && (DOR->Flags & (SC_GOTO|SC_GOTO_IND)) && (Flags & SC_DEF)) {
+            if ((DOR->Flags & SC_REF) && (DOR->Flags & (SC_GOTO | SC_GOTO_IND)) && (Flags & SC_DEF)) {
                 /* We're processing a label, let's update all gotos encountered
                 ** so far
                 */
@@ -1109,7 +1109,7 @@ void EmitDebugInfo (void)
         }
         Sym = SymTab->SymHead;
         while (Sym) {
-            if ((Sym->Flags & (SC_CONST|SC_TYPEMASK)) == 0) {
+            if ((Sym->Flags & (SC_CONST | SC_TYPEMASK)) == 0) {
                 if (Sym->Flags & SC_AUTO) {
                     AddTextLine ("%s, \"%s\", \"00\", auto, %d",
                                  Head, Sym->Name, Sym->V.Offs);

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -821,7 +821,7 @@ SymEntry* AddLocalSym (const char* Name, const Type* T, unsigned Flags, int Offs
 
         /* Set the symbol attributes */
         Entry->Type = TypeDup (T);
-        if ((Flags & SC_AUTO) == SC_AUTO || (Flags & SC_TYPEDEF) == SC_TYPEDEF) {
+        if ((Flags & SC_AUTO) == SC_AUTO || (Flags & SC_TYPEMASK) == SC_TYPEDEF) {
             Entry->V.Offs = Offs;
         } else if ((Flags & SC_REGISTER) == SC_REGISTER) {
             Entry->V.R.RegOffs  = Offs;


### PR DESCRIPTION
The "storage classes flags" were buggy as they were not bitwise-exclusive but often checked simply with bitwise-and. It was pure coincidence that most of them (including `SC_TYPEDEF`) worked as expected. Nevertheless, they have to be fixed up in this PR before they could get in the way sooner or later.

Note: the "SC_**ESU_**" types are now used in a more "value-ish" way rather than as bit flags, so that they needn't be bitwise-exclusive to each other.

---

This PR also fixed Issue #975 by recognizing and tracking the incomplete (unknown-size) array declarations.

Note: not only should the current test case for #975 compile and work, but also the code piece below fail to compile and generate errors like commented:

```c
static const unsigned char array[3];                /* OK */
static const unsigned char array[] = { 0, 1, 2 };   /* OK - complete definition*/
static const unsigned char array[3];                /* OK */
static const unsigned char array[];                 /* OK */
static const unsigned char array[] = { 1, 2, 3 };   /* Error - redefinition */
static const unsigned char array[4];                /* Error - conflicting size */
```
