### PR TITLE
Add support for static_assert

### DIFF
--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -61,6 +61,7 @@
 #include "pragma.h"
 #include "preproc.h"
 #include "standard.h"
+#include "staticassert.h"
 #include "symtab.h"
 
 
@@ -105,6 +106,12 @@ static void Parse (void)
         /* Check for a #pragma */
         if (CurTok.Tok == TOK_PRAGMA) {
             DoPragma ();
+            continue;
+        }
+
+        /* Check for a _Static_assert */
+        if (CurTok.Tok == TOK_STATIC_ASSERT) {
+            ParseStaticAssert ();
             continue;
         }
 

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -58,6 +58,7 @@
 #include "pragma.h"
 #include "scanner.h"
 #include "standard.h"
+#include "staticassert.h"
 #include "symtab.h"
 #include "wrappedcall.h"
 #include "typeconv.h"
@@ -742,6 +743,13 @@ static SymEntry* ParseStructDecl (const char* Name)
 
         /* Get the type of the entry */
         DeclSpec Spec;
+
+        /* Check for a _Static_assert */
+        if (CurTok.Tok == TOK_STATIC_ASSERT) {
+            ParseStaticAssert ();
+            continue;
+        }
+
         InitDeclSpec (&Spec);
         ParseTypeSpec (&Spec, -1, T_QUAL_NONE);
 

--- a/src/cc65/locals.c
+++ b/src/cc65/locals.c
@@ -50,6 +50,7 @@
 #include "locals.h"
 #include "stackptr.h"
 #include "standard.h"
+#include "staticassert.h"
 #include "symtab.h"
 #include "typeconv.h"
 #include "input.h"
@@ -511,6 +512,13 @@ void DeclareLocals (void)
         ** declarations.
         */
         DeclSpec Spec;
+
+        /* Check for a _Static_assert */
+        if (CurTok.Tok == TOK_STATIC_ASSERT) {
+            ParseStaticAssert ();
+            continue;
+        }
+
         ParseDeclSpec (&Spec, SC_AUTO, T_INT);
         if ((Spec.Flags & DS_DEF_STORAGE) != 0 &&       /* No storage spec */
             (Spec.Flags & DS_DEF_TYPE) != 0    &&       /* No type given */

--- a/src/cc65/scanner.c
+++ b/src/cc65/scanner.c
@@ -86,6 +86,7 @@ static const struct Keyword {
     unsigned char   Std;        /* Token supported in which standards? */
 } Keywords [] = {
     { "_Pragma",        TOK_PRAGMA,     TT_C89 | TT_C99 | TT_CC65  },   /* !! */
+    { "_Static_assert", TOK_STATIC_ASSERT,                TT_CC65  },   /* C11 */
     { "__AX__",         TOK_AX,         TT_C89 | TT_C99 | TT_CC65  },
     { "__A__",          TOK_A,          TT_C89 | TT_C99 | TT_CC65  },
     { "__EAX__",        TOK_EAX,        TT_C89 | TT_C99 | TT_CC65  },

--- a/src/cc65/scanner.h
+++ b/src/cc65/scanner.h
@@ -173,6 +173,7 @@ typedef enum token_t {
     TOK_WCSCONST,
 
     TOK_ATTRIBUTE,
+    TOK_STATIC_ASSERT,
     TOK_FAR,
     TOK_NEAR,
     TOK_A,

--- a/src/cc65/staticassert.c
+++ b/src/cc65/staticassert.c
@@ -6,7 +6,7 @@
 /*                                                                           */
 /*                                                                           */
 /*                                                                           */
-/* Copyright 2020 Google LLC                                                 */
+/* Copyright 2020 The cc65 Authors                                           */
 /*                                                                           */
 /*                                                                           */
 /* This software is provided 'as-is', without any expressed or implied       */

--- a/src/cc65/staticassert.h
+++ b/src/cc65/staticassert.h
@@ -1,15 +1,12 @@
 /*****************************************************************************/
 /*                                                                           */
-/*                                 assert.h                                  */
+/*                               staticassert.h                              */
 /*                                                                           */
-/*                                Diagnostics                                */
+/*          _Static_assert handling for the cc65 C compiler                  */
 /*                                                                           */
 /*                                                                           */
 /*                                                                           */
-/* (C) 1998-2015, Ullrich von Bassewitz                                      */
-/*                Roemerstrasse 52                                           */
-/*                D-70794 Filderstadt                                        */
-/* EMail:         uz@cc65.org                                                */
+/* Copyright 2020 Google LLC                                                 */
 /*                                                                           */
 /*                                                                           */
 /* This software is provided 'as-is', without any expressed or implied       */
@@ -33,29 +30,22 @@
 
 
 
-#ifndef _ASSERT_H
-#define _ASSERT_H
+#ifndef STATICASSERT_H
+#define STATICASSERT_H
 
 
 
-#undef assert
-#ifdef NDEBUG
-#  define assert(expr)
-#else
-extern void __fastcall__ _afailed (const char*, unsigned);
-#  define assert(expr)  ((expr)? (void)0 : _afailed(__FILE__, __LINE__))
+/*****************************************************************************/
+/*                                   Code                                    */
+/*****************************************************************************/
+
+
+
+void ParseStaticAssert (void);
+/* Handle _Static_assert. These are a C11 feature. */
+
+
+
+/* End of staticassert.h */
+
 #endif
-
-/*
-** TODO: Guard with #if __STDC_VERSION__ >= 201112L or similar when there
-** is a C11 mode.
-*/
-#define static_assert _Static_assert
-
-
-
-/* End of assert.h */
-#endif
-
-
-

--- a/src/cc65/staticassert.h
+++ b/src/cc65/staticassert.h
@@ -6,7 +6,7 @@
 /*                                                                           */
 /*                                                                           */
 /*                                                                           */
-/* Copyright 2020 Google LLC                                                 */
+/* Copyright 2020 The cc65 Authors                                           */
 /*                                                                           */
 /*                                                                           */
 /* This software is provided 'as-is', without any expressed or implied       */

--- a/test/err/staticassert.c
+++ b/test/err/staticassert.c
@@ -1,0 +1,26 @@
+/*
+  Copyright 2020 Google LLC
+
+  This software is provided 'as-is', without any express or implied
+  warranty. In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+/*
+** Test of failing _Static_assert.
+**/
+
+
+_Static_assert(0, "0 should be false.");

--- a/test/val/staticassert.c
+++ b/test/val/staticassert.c
@@ -1,0 +1,70 @@
+/*
+  Copyright 2020 Google LLC
+
+  This software is provided 'as-is', without any express or implied
+  warranty. In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+/*
+** Tests of passing _Static_asserts.
+**/
+
+
+
+#include <assert.h>
+
+_Static_assert (1, "1 should be true.");
+_Static_assert (!0, "!0 should be true.");
+_Static_assert (1 == 1, "1 == 1 should be true.");
+_Static_assert (1 == 1L, "1 == 1L should be true.");
+_Static_assert (1 != 0, "1 != 0 should be true.");
+_Static_assert (sizeof (char) == 1, "sizeof (char) should be 1.");
+_Static_assert (sizeof (int) == 2, "sizeof (int) should be 2.");
+
+/* Make sure we can also do structs. */
+struct sc { char a; };
+_Static_assert (sizeof (struct sc) == 1, "sizeof (struct sc) should be 1.");
+struct si { int a; };
+_Static_assert (sizeof (struct si) == 2, "sizeof (struct si) should be 2.");
+
+/* Try enums. */
+enum { k = 1 };
+_Static_assert (k == 1, "k should be 1.");
+
+/* Just test the macro version once. */
+static_assert (1, "1 should be true.");
+
+/* _Static_assert can appear anywhere a declaration can. */
+void f (void)
+{
+    _Static_assert (1, "1 should still be true.");
+    if (1) {
+        _Static_assert (1, "1 should still be true.");
+    }
+}
+
+/* _Static_assert can also appear in structs. */
+struct S {
+    int a;
+    _Static_assert (1, "1 should still be true.");
+    int b;
+};
+
+
+int main (void)
+{
+    return 0;
+}


### PR DESCRIPTION
Add C11's `_Static_assert` and static_assert macro.

This is like `#error`, but is handled at a later stage
of translation, so it is possible to check sizes of
types, values of enums, etc.

https://en.cppreference.com/w/c/language/_Static_assert
https://port70.net/~nsz/c/c11/n1570.html#6.7.10