### PR TITLE
Make $WORKDIR for tests/err

### DIFF
--- a/test/err/Makefile
+++ b/test/err/Makefile
@@ -34,7 +34,10 @@ TESTS = $(patsubst %.c,$(WORKDIR)/%.s,$(SOURCES))
 
 all: $(TESTS)
 
-$(WORKDIR)/%.s: %.c
+$(WORKDIR):
+	$(call MKDIR,$(WORKDIR))
+
+$(WORKDIR)/%.s: %.c | $(WORKDIR)
 	$(if $(QUIET),echo err/$*.s)
 	$(NOT) $(CC65) -o $@ $< $(NULLERR)
 


### PR DESCRIPTION
Without this, if there is a test that can compile,
it will still fail because the `WORKDIR` does not exist:

```
pass.c(1): Fatal: Cannot open output file '../../testwrk/err/pass.s': No such file or directory
```