### PR TITLE
[cc65] Fixes for multiple "redefinition" problems and labels with the same identiers as typedefs

### DIFF
--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -1256,11 +1256,23 @@ static void ParseTypeSpec (DeclSpec* D, long Default, TypeCode Qualifiers)
             break;
 
         case TOK_IDENT:
-            Entry = FindSym (CurTok.Ident);
-            if (Entry && SymIsTypeDef (Entry)) {
-                /* It's a typedef */
-                NextToken ();
-                TypeCopy (D->Type, Entry->Type);
+            /* This could be a label */
+            if (NextTok.Tok != TOK_COLON) {
+                Entry = FindSym (CurTok.Ident);
+                if (Entry && SymIsTypeDef (Entry)) {
+                    /* It's a typedef */
+                    NextToken ();
+                    TypeCopy (D->Type, Entry->Type);
+                    break;
+                }
+            } else {
+                /* This is a label. Use the default type flag to end the loop
+                ** in DeclareLocals. The type code used here doesn't matter as
+                ** long as it has no qualifiers.
+                */
+                D->Flags |= DS_DEF_TYPE;
+                D->Type[0].C = T_QUAL_NONE;
+                D->Type[1].C = T_END;
                 break;
             }
             /* FALL THROUGH */


### PR DESCRIPTION
Resolved Issues:
- #1113, no more crash.
- #1114, no more missing/spurious errors on the "redefinitions (true or false)". Also the labels are correctly recognized now.
- Generally more informative error messages about "redefinitions", though they could be improved even better.

Example `1114a.c`:
```c
typedef int UOP;
typedef int UOP;

void f(void);

struct S {
    int a;
} y;

struct S {
    int a;
} x;                      /* TODO: It would be better if the error were reported two lines earlier */

typedef enum E {
    A
} E;

typedef int I;
typedef unsigned int I;
typedef signed int I;
typedef signed I;         /* FIXED: This should NOT cause an error */

int I;
int f;

int main(void)
{
    extern int B;
    enum {
        A,                /* FIXED: This should NOT cause an error */
        B                 /* FIXED: This should cause an error */
    } a;
    int A;                /* FIXED: This should cause an error */
    typedef int A;

E:                        /* FIXED: This was wrongly interpreted as an enum declarator */
a:
A:
    f();                  /* FIXED: This should NOT crash the compiler */
    return 0;
}

/* TODO: the warning messages about unused symbols should tell the kind of the symbols */

/* TODO: in general, the diagnostic messages should point to the exact locations of the symbols */
```

Old compiler output (just aborted before crashing as seen in #1113):
```
1114.c(2): Error: Multiple definition for 'UOP'
1114.c(12): Error: Multiple definition for 'S'
1114.c(19): Error: Multiple definition for 'I'
1114.c(20): Error: Multiple definition for 'I'
1114.c(21): Error: Multiple definition for 'I'
1114.c(23): Error: Multiple definition for 'I'
1114.c(24): Error: Conflicting types for 'f'
1114.c(24): Error: Global variable 'f' already was defined in the '' segment.
1114.c(30): Error: Multiple definition for 'A'
1114.c(34): Error: Multiple definition for 'A'
1114.c(36): Error: Identifier expected
1114.c(36): Fatal: Too many errors
```

New compiler output:
```
1114.c(12): Error: Multiple definition for 'S'
1114.c(19): Error: Conflicting types for typedef 'I'
1114.c(23): Error: Redefinition of typedef 'I' as different kind of symbol
1114.c(24): Error: Redefinition of function 'f' as different kind of symbol
1114.c(32): Error: Symbol 'B' is already different kind
1114.c(33): Error: Redefinition of 'A' as different kind of symbol
1114.c(34): Error: Redefinition of 'A' as different kind of symbol
1114.c(41): Warning: 'a' is defined but never used
1114.c(41): Warning: 'E' is defined but never used
1114.c(41): Warning: 'a' is defined but never used
1114.c(41): Warning: 'A' is defined but never used
```