### PR TITLE
[cc65] Fixed type mask usage

### DIFF
--- a/src/cc65/typecmp.c
+++ b/src/cc65/typecmp.c
@@ -215,8 +215,8 @@ static void DoCompare (const Type* lhs, const Type* rhs, typecmp_t* Result)
         }
 
         /* Get the left and right types, signs and qualifiers */
-        LeftType  = GetUnderlyingTypeCode (lhs);
-        RightType = GetUnderlyingTypeCode (rhs);
+        LeftType  = (GetUnderlyingTypeCode (lhs) & T_MASK_TYPE);
+        RightType = (GetUnderlyingTypeCode (rhs) & T_MASK_TYPE);
         LeftSign  = GetSignedness (lhs);
         RightSign = GetSignedness (rhs);
         LeftQual  = GetQualifier (lhs);


### PR DESCRIPTION
As it's said (https://github.com/cc65/cc65/pull/1121#issuecomment-664000221), the type system is unfortunately complicated, and I'll add in that it's error-prone. This bug was found with a test intended for #1114/#1133 (only the relevent part here, full at https://github.com/cc65/cc65/pull/1133#issuecomment-665628371):

```c
void f(void) {}
void f(int);    /* Should fail */
```
