### PR TITLE
Remove special-case bit-field width code

### DIFF
--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -688,15 +688,15 @@ static int ParseFieldWidth (Declaration* Decl)
         return -1;
     }
 
-    /* Read the width */
-    NextToken ();
-    ConstAbsIntExpr (hie1, &Expr);
-
     if (SizeOf (Decl->Type) != SizeOf (type_uint)) {
         /* Only int sized types may be used for bit-fields for now */
         Error ("cc65 currently only supports unsigned int bit-fields");
         return -1;
     }
+
+    /* Read the width */
+    NextToken ();
+    ConstAbsIntExpr (hie1, &Expr);
 
     if (Expr.IVal < 0) {
         Error ("Negative width in bit-field");

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -681,14 +681,16 @@ static int ParseFieldWidth (Declaration* Decl)
         return -1;
     }
 
+    if (!IsClassInt (Decl->Type)) {
+        /* Only integer types may be used for bit-fields */
+        Error ("Bit-field has invalid type '%s', must be integral",
+               GetBasicTypeName (Decl->Type));
+        return -1;
+    }
+
     /* Read the width */
     NextToken ();
     ConstAbsIntExpr (hie1, &Expr);
-    if (!IsClassInt (Decl->Type)) {
-        /* Only integer types may be used for bit-fields */
-        Error ("Bit-field has invalid type '%s'", GetBasicTypeName (Decl->Type));
-        return -1;
-    }
 
     if (SizeOf (Decl->Type) != SizeOf (type_uint)) {
         /* Only int sized types may be used for bit-fields for now */
@@ -700,20 +702,10 @@ static int ParseFieldWidth (Declaration* Decl)
         Error ("Negative width in bit-field");
         return -1;
     }
-    /* FIXME: We should compare with the width of the specified type */
-#if 0
-    /* Use is when we really support non-uint16_t bit-fields */
     if (Expr.IVal > (long)(SizeOf (Decl->Type) * CHAR_BITS)) {
         Error ("Width of bit-field exceeds its type");
         return -1;
     }
-#else
-    /* This is what we currenty do */
-    if (Expr.IVal > (long)(SizeOf (type_uint) * CHAR_BITS)) {
-        Error ("Width of bit-field exceeds 16");
-        return -1;
-    }
-#endif
     if (Expr.IVal == 0 && Decl->Ident[0] != '\0') {
         Error ("Zero width for named bit-field");
         return -1;

--- a/test/err/bitfield-named-zero-width.c
+++ b/test/err/bitfield-named-zero-width.c
@@ -1,0 +1,29 @@
+/*
+  Copyright 2020 Google LLC
+
+  This software is provided 'as-is', without any express or implied
+  warranty. In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+/*
+  Test of bit-field with zero-width named field
+*/
+
+struct s {
+    unsigned int x : 4;
+    unsigned int y : 0;
+    unsigned int z : 4;
+};

--- a/test/err/bitfield-negative-width.c
+++ b/test/err/bitfield-negative-width.c
@@ -1,0 +1,27 @@
+/*
+  Copyright 2020 Google LLC
+
+  This software is provided 'as-is', without any express or implied
+  warranty. In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+/*
+  Test of bit-field with negative width.
+*/
+
+struct s {
+    unsigned int x : -1;
+};

--- a/test/err/bitfield-too-wide.c
+++ b/test/err/bitfield-too-wide.c
@@ -1,0 +1,27 @@
+/*
+  Copyright 2020 Google LLC
+
+  This software is provided 'as-is', without any express or implied
+  warranty. In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+/*
+  Test of bit-field with too large width.
+*/
+
+struct s {
+    unsigned int x : 17;
+};


### PR DESCRIPTION
cbb33f8 restricted allowed bit-field types to int,
so this is equivalent for now, but forward-compatible.

Fixes FIXME

Also move the int type check before parsing the colon.