### PR TITLE
[cc65] Turned incompatible pointer assignments from errors to warnings with correct type info.

### DIFF
--- a/src/cc65/assignment.c
+++ b/src/cc65/assignment.c
@@ -78,7 +78,8 @@ static int CopyStruct (ExprDesc* LExpr, ExprDesc* RExpr)
 
     /* Check for equality of the structs */
     if (TypeCmp (ltype, RExpr->Type) < TC_STRICT_COMPATIBLE) {
-        Error ("Incompatible types");
+        TypeCompatibilityDiagnostic (ltype, RExpr->Type, 1,
+            "Incompatible types in assignment to '%s' from '%s'");
     }
 
     /* Do we copy using the primary? */

--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -78,6 +78,144 @@ Type type_double[]      = { TYPE(T_DOUBLE), TYPE(T_END) };
 
 
 
+static struct StrBuf* GetFullTypeNameWestEast (struct StrBuf* West, struct StrBuf* East, const Type* T)
+/* Return the name string of the given type split into a western part and an
+** eastern part.
+*/
+{
+    struct StrBuf Buf = STATIC_STRBUF_INITIALIZER;
+
+    if (IsTypeArray (T)) {
+
+        long Count = GetElementCount (T);
+        if (!SB_IsEmpty (East)) {
+            if (Count > 0) {
+                SB_Printf (&Buf, "[%ld]", Count);
+            } else {
+                SB_Printf (&Buf, "[]");
+            }
+            SB_Append (East, &Buf);
+            SB_Terminate (East);
+
+        } else {
+            if (Count > 0) {
+                SB_Printf (East, "[%ld]", Count);
+            } else {
+                SB_Printf (East, "[]");
+            }
+
+            if (!SB_IsEmpty (West)) {
+                /* Add parentheses to West */
+                SB_Printf (&Buf, "(%s)", SB_GetConstBuf (West));
+                SB_Copy (West, &Buf);
+                SB_Terminate (West);
+            }
+        }
+
+        /* Get element type */
+        GetFullTypeNameWestEast (West, East, T + 1);
+
+    } else if (IsTypeFunc (T)) {
+
+        FuncDesc* F             = GetFuncDesc (T);
+        struct StrBuf ParamList = STATIC_STRBUF_INITIALIZER;
+
+        /* First argument */
+        SymEntry* Param = F->SymTab->SymHead;
+        for (unsigned I = 1; I < F->ParamCount; ++I) {
+            CHECK (Param->NextSym != 0 && (Param->Flags & SC_PARAM) != 0);
+            SB_AppendStr (&ParamList, SB_GetConstBuf (GetFullTypeNameBuf (&Buf, Param->Type)));
+            SB_AppendStr (&ParamList, ", ");
+            SB_Clear (&Buf);
+            /* Next argument */
+            Param = Param->NextSym;
+        }
+        if ((F->Flags & FD_VARIADIC) == 0) {
+            if (F->ParamCount > 0) {
+                SB_AppendStr (&ParamList, SB_GetConstBuf (GetFullTypeNameBuf (&Buf, Param->Type)));
+            } else {
+                SB_AppendStr (&ParamList, "void");
+            }
+        } else {
+            if (F->ParamCount > 0) {
+                SB_AppendStr (&ParamList, SB_GetConstBuf (GetFullTypeNameBuf (&Buf, Param->Type)));
+                SB_AppendStr (&ParamList, ", ...");
+            } else {
+                SB_AppendStr (&ParamList, "...");
+            }
+        }
+        SB_Terminate (&ParamList);
+
+        /* Join the existing West and East together */
+        if (!SB_IsEmpty (East)) {
+            SB_Append (West, East);
+            SB_Terminate (West);
+            SB_Clear (East);
+        }
+
+        if (SB_IsEmpty (West)) {
+            /* Just use the param list */
+            SB_Printf (West, "(%s)", SB_GetConstBuf (&ParamList));
+        } else {
+            /* Append the param list to the existing West */
+            SB_Printf (&Buf, "(%s)(%s)", SB_GetConstBuf (West), SB_GetConstBuf (&ParamList));
+            SB_Printf (West, "%s", SB_GetConstBuf (&Buf));
+        }
+        SB_Done (&ParamList);
+
+        /* Return type */
+        GetFullTypeNameWestEast (West, East, T + 1);
+
+    } else if (IsTypePtr (T)) {
+
+        int QualCount = 0;
+
+        SB_Printf (&Buf, "*");
+
+        /* Add qualifiers */
+        if ((GetQualifier (T) & ~T_QUAL_NEAR) != T_QUAL_NONE) {
+            QualCount = GetQualifierTypeCodeNameBuf (&Buf, T->C, T_QUAL_NEAR);
+        }
+
+        if (!SB_IsEmpty (West)) {
+            if (QualCount > 0) {
+                SB_AppendChar (&Buf, ' ');
+            }
+            SB_Append (&Buf, West);
+        }
+
+        SB_Copy (West, &Buf);
+        SB_Terminate (West);
+
+        /* Get indirection type */
+        GetFullTypeNameWestEast (West, East, T + 1);
+
+    } else {
+
+        /* Add qualifiers */
+        if ((GetQualifier (T) & ~T_QUAL_NEAR) != 0) {
+            if (GetQualifierTypeCodeNameBuf (&Buf, T->C, T_QUAL_NEAR) > 0) {
+                SB_AppendChar (&Buf, ' ');
+            }
+        }
+
+        SB_AppendStr (&Buf, GetSymTypeName (T));
+
+        if (!SB_IsEmpty (West)) {
+            SB_AppendChar (&Buf, ' ');
+            SB_Append (&Buf, West);
+        }
+
+        SB_Copy (West, &Buf);
+        SB_Terminate (West);
+    }
+
+    SB_Done (&Buf);
+    return West;
+}
+
+
+
 const char* GetBasicTypeName (const Type* T)
 /* Return a const name string of the basic type.
 ** Return "type" for unknown basic types.
@@ -130,6 +268,101 @@ const char* GetBasicTypeName (const Type* T)
         }
     }
     return "type";
+}
+
+
+
+const char* GetFullTypeName (const Type* T)
+/* Return the full name string of the given type.
+** Note: This may use a static buffer that could be overwritten by other calls.
+*/
+{
+    static struct StrBuf Buf = STATIC_STRBUF_INITIALIZER;
+    SB_Clear (&Buf);
+    GetFullTypeNameBuf (&Buf, T);
+
+    return SB_GetConstBuf (&Buf);
+}
+
+
+
+struct StrBuf* GetFullTypeNameBuf (struct StrBuf* S, const Type* T)
+/* Return the full name string of the given type */
+{
+    struct StrBuf East = STATIC_STRBUF_INITIALIZER;
+    GetFullTypeNameWestEast (S, &East, T);
+
+    /* Join West and East */
+    SB_Append (S, &East);
+    SB_Terminate (S);
+    SB_Done (&East);
+
+    return S;
+}
+
+
+
+int GetQualifierTypeCodeNameBuf (struct StrBuf* S, TypeCode Qual, TypeCode IgnoredQual)
+/* Return the names of the qualifiers of the type.
+** Qualifiers to be ignored can be specified with the IgnoredQual flags.
+** Return the count of added qualifier names.
+*/
+{
+    int Count = 0;
+
+    Qual &= T_MASK_QUAL & ~IgnoredQual;
+    if (Qual & T_QUAL_CONST) {
+        if (!SB_IsEmpty (S)) {
+            SB_AppendChar (S, ' ');
+        }
+        SB_AppendStr (S, "const");
+        ++Count;
+    }
+    if (Qual & T_QUAL_VOLATILE) {
+        if (Count > 0) {
+            SB_AppendChar (S, ' ');
+        }
+        SB_AppendStr (S, "volatile");
+        ++Count;
+    }
+    if (Qual & T_QUAL_RESTRICT) {
+        if (Count > 0) {
+            SB_AppendChar (S, ' ');
+        }
+        SB_AppendStr (S, "restrict");
+        ++Count;
+    }
+    if (Qual & T_QUAL_NEAR) {
+        if (Count > 0) {
+            SB_AppendChar (S, ' ');
+        }
+        SB_AppendStr (S, "__near__");
+        ++Count;
+    }
+    if (Qual & T_QUAL_FAR) {
+        SB_AppendStr (S, "__far__");
+        ++Count;
+    }
+    if (Qual & T_QUAL_FASTCALL) {
+        if (Count > 0) {
+            SB_AppendChar (S, ' ');
+        }
+        SB_AppendStr (S, "__fastcall__");
+        ++Count;
+    }
+    if (Qual & T_QUAL_CDECL) {
+        if (Count > 0) {
+            SB_AppendChar (S, ' ');
+        }
+        SB_AppendStr (S, "__cdecl__");
+        ++Count;
+    }
+
+    if (Count > 0) {
+        SB_Terminate (S);
+    }
+
+    return Count;
 }
 
 

--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -273,15 +273,12 @@ const char* GetBasicTypeName (const Type* T)
 
 
 const char* GetFullTypeName (const Type* T)
-/* Return the full name string of the given type.
-** Note: This may use a static buffer that could be overwritten by other calls.
-*/
+/* Return the full name string of the given type */
 {
-    static struct StrBuf Buf = STATIC_STRBUF_INITIALIZER;
-    SB_Clear (&Buf);
-    GetFullTypeNameBuf (&Buf, T);
+    struct StrBuf* Buf = NewDiagnosticStrBuf ();
+    GetFullTypeNameBuf (Buf, T);
 
-    return SB_GetConstBuf (&Buf);
+    return SB_GetConstBuf (Buf);
 }
 
 

--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -1009,6 +1009,20 @@ Type* Indirect (Type* T)
 
 
 
+const Type* IndirectConst (const Type* T)
+/* Do one indirection for the given type, that is, return the type where the
+** given type points to.
+*/
+{
+    /* We are expecting a pointer expression */
+    CHECK (IsClassPtr (T));
+
+    /* Skip the pointer or array token itself */
+    return T + 1;
+}
+
+
+
 Type* ArrayToPtr (Type* T)
 /* Convert an array to a pointer to it's first element */
 {

--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -895,8 +895,8 @@ Type* GetBaseElementType (Type* T)
 
 
 
-SymEntry* GetSymEntry (const Type* T)
-/* Return a SymEntry pointer from a type */
+SymEntry* GetESUSymEntry (const Type* T)
+/* Return a SymEntry pointer from an enum/struct/union type */
 {
     /* Only enums, structs or unions have a SymEntry attribute */
     CHECK (IsClassStruct (T) || IsTypeEnum (T));
@@ -907,8 +907,8 @@ SymEntry* GetSymEntry (const Type* T)
 
 
 
-void SetSymEntry (Type* T, SymEntry* S)
-/* Set the SymEntry pointer for a type */
+void SetESUSymEntry (Type* T, SymEntry* S)
+/* Set the SymEntry pointer for an enum/struct/union type */
 {
     /* Only enums, structs or unions have a SymEntry attribute */
     CHECK (IsClassStruct (T) || IsTypeEnum (T));

--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -1018,6 +1018,22 @@ Type* ArrayToPtr (Type* T)
 
 
 
+int IsClassArithmetic (const Type* T)
+/* Return true if this is an arithmetic type */
+{
+    return IsClassInt (T) || IsClassFloat (T);
+}
+
+
+
+int IsCastType (const Type* T)
+/* Return true if this type can be used for casting */
+{
+    return IsClassArithmetic (T) || IsClassPtr (T) || IsTypeVoid (T);
+}
+
+
+
 int IsVariadicFunc (const Type* T)
 /* Return true if this is a function type or pointer to function type with
 ** variable parameter list

--- a/src/cc65/datatype.h
+++ b/src/cc65/datatype.h
@@ -578,6 +578,12 @@ INLINE int IsClassFunc (const Type* T)
 #  define IsClassFunc(T)        (GetClass (T) == T_CLASS_FUNC)
 #endif
 
+int IsClassArithmetic (const Type* T);
+/* Return true if this is an arithmetic type */
+
+int IsCastType (const Type* T);
+/* Return true if this type can be used for casting */
+
 #if defined(HAVE_INLINE)
 INLINE TypeCode GetRawSignedness (const Type* T)
 /* Get the raw signedness of a type */

--- a/src/cc65/datatype.h
+++ b/src/cc65/datatype.h
@@ -747,11 +747,11 @@ Type* GetBaseElementType (Type* T);
 ** the element type that is not an array.
 */
 
-struct SymEntry* GetSymEntry (const Type* T) attribute ((const));
-/* Return a SymEntry pointer from a type */
+struct SymEntry* GetESUSymEntry (const Type* T) attribute ((const));
+/* Return a SymEntry pointer from an enum/struct/union type */
 
-void SetSymEntry (Type* T, struct SymEntry* S);
-/* Set the SymEntry pointer for a type */
+void SetESUSymEntry (Type* T, struct SymEntry* S);
+/* Set the SymEntry pointer for an enum/struct/union type */
 
 Type* IntPromotion (Type* T);
 /* Apply the integer promotions to T and return the result. The returned type

--- a/src/cc65/datatype.h
+++ b/src/cc65/datatype.h
@@ -203,6 +203,8 @@ extern Type type_double[];
 /* Forward for the SymEntry struct */
 struct SymEntry;
 
+/* Forward for the StrBuf struct */
+struct StrBuf;
 
 
 /*****************************************************************************/
@@ -214,6 +216,20 @@ struct SymEntry;
 const char* GetBasicTypeName (const Type* T);
 /* Return a const name string of the basic type.
 ** Return "type" for unknown basic types.
+*/
+
+const char* GetFullTypeName (const Type* T);
+/* Return the full name string of the given type.
+** Note: This may use a static buffer that could be overwritten by other calls.
+*/
+
+struct StrBuf* GetFullTypeNameBuf (struct StrBuf* S, const Type* T);
+/* Return the full name string of the given type */
+
+int GetQualifierTypeCodeNameBuf (struct StrBuf* S, TypeCode Qual, TypeCode IgnoredQual);
+/* Return the names of the qualifiers of the type.
+** Qualifiers to be ignored can be specified with the IgnoredQual flags.
+** Return the count of added qualifier names.
 */
 
 unsigned TypeLen (const Type* T);

--- a/src/cc65/datatype.h
+++ b/src/cc65/datatype.h
@@ -345,6 +345,11 @@ Type* Indirect (Type* T);
 ** given type points to.
 */
 
+const Type* IndirectConst (const Type* T);
+/* Do one indirection for the given type, that is, return the type where the
+** given type points to.
+*/
+
 Type* ArrayToPtr (Type* T);
 /* Convert an array to a pointer to it's first element */
 

--- a/src/cc65/datatype.h
+++ b/src/cc65/datatype.h
@@ -219,9 +219,7 @@ const char* GetBasicTypeName (const Type* T);
 */
 
 const char* GetFullTypeName (const Type* T);
-/* Return the full name string of the given type.
-** Note: This may use a static buffer that could be overwritten by other calls.
-*/
+/* Return the full name string of the given type */
 
 struct StrBuf* GetFullTypeNameBuf (struct StrBuf* S, const Type* T);
 /* Return the full name string of the given type */

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -766,6 +766,7 @@ static unsigned PadWithBitField (unsigned StructSize, unsigned BitOffs)
 }
 
 
+
 static unsigned AliasAnonStructFields (const Declaration* Decl, SymEntry* Anon)
 /* Create alias fields from an anon union/struct in the current lexical level.
 ** The function returns the count of created aliases.
@@ -775,7 +776,7 @@ static unsigned AliasAnonStructFields (const Declaration* Decl, SymEntry* Anon)
     SymEntry* Alias;
 
     /* Get the pointer to the symbol table entry of the anon struct */
-    SymEntry* Entry = GetSymEntry (Decl->Type);
+    SymEntry* Entry = GetESUSymEntry (Decl->Type);
 
     /* Get the symbol table containing the fields. If it is empty, there has
     ** been an error before, so bail out.
@@ -1267,7 +1268,7 @@ static void ParseTypeSpec (DeclSpec* D, long Default, TypeCode Qualifiers)
             Entry = ParseUnionDecl (Ident);
             /* Encode the union entry into the type */
             D->Type[0].C = T_UNION;
-            SetSymEntry (D->Type, Entry);
+            SetESUSymEntry (D->Type, Entry);
             D->Type[1].C = T_END;
             break;
 
@@ -1286,7 +1287,7 @@ static void ParseTypeSpec (DeclSpec* D, long Default, TypeCode Qualifiers)
             Entry = ParseStructDecl (Ident);
             /* Encode the struct entry into the type */
             D->Type[0].C = T_STRUCT;
-            SetSymEntry (D->Type, Entry);
+            SetESUSymEntry (D->Type, Entry);
             D->Type[1].C = T_END;
             break;
 
@@ -1308,7 +1309,7 @@ static void ParseTypeSpec (DeclSpec* D, long Default, TypeCode Qualifiers)
             /* Parse the enum decl */
             Entry = ParseEnumDecl (Ident);
             D->Type[0].C |= T_ENUM;
-            SetSymEntry (D->Type, Entry);
+            SetESUSymEntry (D->Type, Entry);
             D->Type[1].C = T_END;
             break;
 
@@ -2258,7 +2259,7 @@ static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
     }
 
     /* Get a pointer to the struct entry from the type */
-    Entry = GetSymEntry (T);
+    Entry = GetESUSymEntry (T);
 
     /* Get the size of the struct from the symbol table entry */
     SI.Size = Entry->V.S.Size;

--- a/src/cc65/error.c
+++ b/src/cc65/error.c
@@ -38,7 +38,9 @@
 #include <stdarg.h>
 
 /* common */
+#include "coll.h"
 #include "print.h"
+#include "strbuf.h"
 
 /* cc65 */
 #include "global.h"
@@ -91,6 +93,8 @@ static WarnMapEntry WarnMap[] = {
     { &WarnUnusedParam,         "unused-param"          },
     { &WarnUnusedVar,           "unused-var"            },
 };
+
+Collection DiagnosticStrBufs;
 
 
 
@@ -322,4 +326,51 @@ void ErrorReport (void)
 /* Report errors (called at end of compile) */
 {
     Print (stdout, 1, "%u errors, %u warnings\n", ErrorCount, WarningCount);
+}
+
+
+
+/*****************************************************************************/
+/*                              Tracked StrBufs                              */
+/*****************************************************************************/
+
+
+
+void InitDiagnosticStrBufs (void)
+/* Init tracking string buffers used for diagnostics */
+{
+    InitCollection (&DiagnosticStrBufs);
+}
+
+
+
+void DoneDiagnosticStrBufs (void)
+/* Done with tracked string buffers used for diagnostics */
+{
+    ClearDiagnosticStrBufs ();
+    DoneCollection (&DiagnosticStrBufs);
+}
+
+
+
+void ClearDiagnosticStrBufs (void)
+/* Free all tracked string buffers */
+{
+    unsigned I;
+
+    for (I = 0; I < CollCount (&DiagnosticStrBufs); ++I) {
+        SB_Done (CollAtUnchecked (&DiagnosticStrBufs, I));
+    }
+
+    CollDeleteAll (&DiagnosticStrBufs);
+}
+
+
+
+struct StrBuf* NewDiagnosticStrBuf (void)
+/* Get a new tracked string buffer */
+{
+    StrBuf *Buf = NewStrBuf ();
+    CollAppend (&DiagnosticStrBufs, Buf);
+    return Buf;
 }

--- a/src/cc65/error.h
+++ b/src/cc65/error.h
@@ -72,6 +72,9 @@ extern IntStack WarnUnusedLabel;        /* - unused labels */
 extern IntStack WarnUnusedParam;        /* - unused parameters */
 extern IntStack WarnUnusedVar;          /* - unused variables */
 
+/* Forward */
+struct StrBuf;
+
 
 
 /*****************************************************************************/
@@ -114,6 +117,18 @@ void ListWarnings (FILE* F);
 
 void ErrorReport (void);
 /* Report errors (called at end of compile) */
+
+void InitDiagnosticStrBufs (void);
+/* Init tracking string buffers used for diagnostics */
+
+void DoneDiagnosticStrBufs (void);
+/* Done with tracked string buffers used for diagnostics */
+
+void ClearDiagnosticStrBufs (void);
+/* Free all tracked string buffers */
+
+struct StrBuf* NewDiagnosticStrBuf (void);
+/* Get a new tracked string buffer */
 
 
 

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -2242,7 +2242,8 @@ static void hie_compare (const GenDesc* Ops,    /* List of generators */
         /* Make sure, the types are compatible */
         if (IsClassInt (Expr->Type)) {
             if (!IsClassInt (Expr2.Type) && !(IsClassPtr(Expr2.Type) && ED_IsNullPtr(Expr))) {
-                Error ("Incompatible types");
+                TypeCompatibilityDiagnostic (Expr->Type, Expr2.Type, 1,
+                    "Incompatible types comparing '%s' with '%s'");
             }
         } else if (IsClassPtr (Expr->Type)) {
             if (IsClassPtr (Expr2.Type)) {
@@ -2253,10 +2254,12 @@ static void hie_compare (const GenDesc* Ops,    /* List of generators */
                 Type* right = Indirect (Expr2.Type);
                 if (TypeCmp (left, right) < TC_QUAL_DIFF && left->C != T_VOID && right->C != T_VOID) {
                     /* Incompatible pointers */
-                    Error ("Incompatible types");
+                    TypeCompatibilityDiagnostic (Expr->Type, Expr2.Type, 1,
+                        "Incompatible pointer types comparing '%s' with '%s'");
                 }
             } else if (!ED_IsNullPtr (&Expr2)) {
-                Error ("Incompatible types");
+                TypeCompatibilityDiagnostic (Expr->Type, Expr2.Type, 1,
+                    "Comparing pointer type '%s' with '%s'");
             }
         }
 
@@ -3324,7 +3327,8 @@ static void hieQuest (ExprDesc* Expr)
             /* Result type is void */
             ResultType = Expr3.Type;
         } else {
-            Error ("Incompatible types");
+            TypeCompatibilityDiagnostic (Expr2.Type, Expr3.Type, 1,
+                "Incompatible types in ternary '%s' with '%s'");
             ResultType = Expr2.Type;            /* Doesn't matter here */
         }
 

--- a/src/cc65/main.c
+++ b/src/cc65/main.c
@@ -1060,6 +1060,9 @@ int main (int argc, char* argv[])
         IS_Set (&Standard, STD_DEFAULT);
     }
 
+    /* Track string buffer allocation */
+    InitDiagnosticStrBufs ();
+
     /* Go! */
     Compile (InputFile);
 
@@ -1082,6 +1085,9 @@ int main (int argc, char* argv[])
         /* Create dependencies if requested */
         CreateDependencies ();
     }
+
+    /* Done with tracked string buffer allocation */
+    DoneDiagnosticStrBufs ();
 
     /* Return an apropriate exit code */
     return (ErrorCount > 0)? EXIT_FAILURE : EXIT_SUCCESS;

--- a/src/cc65/symentry.c
+++ b/src/cc65/symentry.c
@@ -278,6 +278,38 @@ void CvtRegVarToAuto (SymEntry* Sym)
 
 
 
+SymEntry* GetSymType (const Type* T)
+/* Get the symbol entry of the enum/struct/union type
+** Return 0 if it is not an enum/struct/union.
+*/
+{
+    if ((IsClassStruct (T) || IsTypeEnum (T))) {
+        return T->A.P;
+    }
+    return 0;
+}
+
+
+
+const char* GetSymTypeName (const Type* T)
+/* Return a name string of the type or the symbol name if it is an ESU type.
+** Note: This may use a static buffer that could be overwritten by other calls.
+*/
+{
+    static char TypeName [IDENTSIZE + 16];
+    SymEntry* Sym;
+
+    Sym = GetSymType (T);
+    if (Sym == 0) {
+        return GetBasicTypeName (T);
+    }
+    sprintf (TypeName, "%s %s", GetBasicTypeName (T), Sym->Name ? Sym->Name : "<unknown>");
+
+    return TypeName;
+}
+
+
+
 void ChangeSymType (SymEntry* Entry, Type* T)
 /* Change the type of the given symbol */
 {

--- a/src/cc65/symentry.h
+++ b/src/cc65/symentry.h
@@ -304,6 +304,16 @@ void SymSetAsmName (SymEntry* Sym);
 void CvtRegVarToAuto (SymEntry* Sym);
 /* Convert a register variable to an auto variable */
 
+SymEntry* GetSymType (const Type* T);
+/* Get the symbol entry of the enum/struct/union type
+** Return 0 if it is not an enum/struct/union.
+*/
+
+const char* GetSymTypeName (const Type* T);
+/* Return a name string of the type or the symbol name if it is an ESU type.
+** Note: This may use a static buffer that could be overwritten by other calls.
+*/
+
 void ChangeSymType (SymEntry* Entry, Type* T);
 /* Change the type of the given symbol */
 

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -509,7 +509,7 @@ SymEntry FindStructField (const Type* T, const char* Name)
     if (IsClassStruct (T)) {
 
         /* Get a pointer to the struct/union type */
-        const SymEntry* Struct = GetSymEntry (T);
+        const SymEntry* Struct = GetESUSymEntry (T);
         CHECK (Struct != 0);
 
         /* Now search in the struct/union symbol table. Beware: The table may

--- a/src/cc65/typecmp.c
+++ b/src/cc65/typecmp.c
@@ -368,8 +368,8 @@ static void DoCompare (const Type* lhs, const Type* rhs, typecmp_t* Result)
                 ** pointer to the struct definition from the type, and compare
                 ** the fields.
                 */
-                Sym1 = GetSymEntry (lhs);
-                Sym2 = GetSymEntry (rhs);
+                Sym1 = GetESUSymEntry (lhs);
+                Sym2 = GetESUSymEntry (rhs);
 
                 /* If one symbol has a name, the names must be identical */
                 if (!HasAnonName (Sym1) || !HasAnonName (Sym2)) {

--- a/src/cc65/typeconv.c
+++ b/src/cc65/typeconv.c
@@ -192,7 +192,7 @@ ExitPoint:
 
 
 
-void TypeConversion (ExprDesc* Expr, Type* NewType)
+void TypeConversion (ExprDesc* Expr, const Type* NewType)
 /* Do an automatic conversion of the given expression to the new type. Output
 ** warnings or errors where this automatic conversion is suspicious or
 ** impossible.
@@ -264,7 +264,7 @@ void TypeConversion (ExprDesc* Expr, Type* NewType)
             **   - the rhs pointer is a void pointer, or
             **   - the lhs pointer is a void pointer.
             */
-            if (!IsTypeVoid (Indirect (NewType)) && !IsTypeVoid (Indirect (Expr->Type))) {
+            if (!IsTypeVoid (IndirectConst (NewType)) && !IsTypeVoid (Indirect (Expr->Type))) {
                 /* Compare the types */
                 switch (TypeCmp (NewType, Expr->Type)) {
 

--- a/src/cc65/typeconv.h
+++ b/src/cc65/typeconv.h
@@ -52,7 +52,7 @@
 void TypeCompatibilityDiagnostic (const Type* NewType, const Type* OldType, int IsError, const char* Msg);
 /* Print error or warning message about type conversion with proper type names */
 
-void TypeConversion (ExprDesc* Expr, Type* NewType);
+void TypeConversion (ExprDesc* Expr, const Type* NewType);
 /* Do an automatic conversion of the given expression to the new type. Output
 ** warnings or errors where this automatic conversion is suspicious or
 ** impossible.

--- a/src/cc65/typeconv.h
+++ b/src/cc65/typeconv.h
@@ -49,6 +49,9 @@
 
 
 
+void TypeCompatibilityDiagnostic (const Type* NewType, const Type* OldType, int IsError, const char* Msg);
+/* Print error or warning message about type conversion with proper type names */
+
 void TypeConversion (ExprDesc* Expr, Type* NewType);
 /* Do an automatic conversion of the given expression to the new type. Output
 ** warnings or errors where this automatic conversion is suspicious or


### PR DESCRIPTION
Resolved Issue #1089.

The "full type names" are reconstructed from the parsed type info. It could also be implemented by using the original source code text, but that would require recording the exact source locations of the symbols which has its own complexity (though that might be simpler than this).

Example code:
```c
typedef int (*(*PF[1])(unsigned))[];
int (* const(* pf[1])(unsigned))[];
int (*(*(*qf)(PF[]))[])(const int, ...);

typedef void QF();

const volatile int*pp;

int main(void)
{
    int*qq = pp;
    int m[1];
    int**p;
    char**q;
    const char(**r)[3];

    pf[0] = m;
    p = *p;
    *p = p;
    q = *q;
    *q = q;
    q = r;
    qf = r;
    pf[0] = qf;
    p = (*pf)(0);

    return 0;
}
```
Before:
```
1089.c(11): Error: Pointer types differ in type qualifiers
1089.c(17): Error: Incompatible pointer types at 'm'
1089.c(18): Error: Incompatible pointer types at 'Unknown'
1089.c(19): Error: Incompatible pointer types at 'p'
1089.c(20): Error: Incompatible pointer types at 'Unknown'
1089.c(21): Error: Incompatible pointer types at 'q'
1089.c(22): Error: Incompatible pointer types at 'r'
1089.c(23): Error: Incompatible pointer types at 'r'
1089.c(24): Error: Incompatible pointer types at 'qf'
```
After:
```
1089.c(11): Warning: Pointer assignment to 'int *' from 'const volatile int *' discards qualifiers
1089.c(17): Warning: Incompatible pointer assignment to 'int (* const (*)(unsigned int))[]' from 'int[1]'
1089.c(18): Warning: Incompatible pointer assignment to 'int **' from 'int *'
1089.c(19): Warning: Incompatible pointer assignment to 'int *' from 'int **'
1089.c(20): Warning: Incompatible pointer assignment to 'unsigned char **' from 'unsigned char *' 
1089.c(21): Warning: Incompatible pointer assignment to 'unsigned char *' from 'unsigned char **'
1089.c(22): Warning: Incompatible pointer assignment to 'unsigned char **' from 'const unsigned char (**)[3]'
1089.c(23): Warning: Incompatible pointer assignment to 'int (*(*(*)(int (*(*(*)[1])(unsigned int))[]))[])(const int, ...)' from 'const unsigned char (**)[3]'
1089.c(24): Warning: Incompatible pointer assignment to 'int (* const (*)(unsigned int))[]' from 'int (*(*(*)(int (*(*(*)[1])(unsigned int))[]))[])(const int, ...)'
```