### PR TITLE
[cc65] Improved diagnostics

### DIFF
--- a/src/cc65/assignment.c
+++ b/src/cc65/assignment.c
@@ -127,7 +127,13 @@ void Assignment (ExprDesc* Expr)
 
     /* We must have an lvalue for an assignment */
     if (ED_IsRVal (Expr)) {
-        Error ("Invalid lvalue in assignment");
+        if (IsTypeArray (Expr->Type)) {
+            Error ("Array type '%s' is not assignable", GetFullTypeName (Expr->Type));
+        } else if (IsTypeFunc (Expr->Type)) {
+            Error ("Function type '%s' is not assignable", GetFullTypeName (Expr->Type));
+        } else {
+            Error ("Assignment to rvalue");
+        }
     }
 
     /* Check for assignment to const */

--- a/src/cc65/codegen.c
+++ b/src/cc65/codegen.c
@@ -3642,7 +3642,7 @@ void g_lt (unsigned flags, unsigned long val)
 
             /* Give a warning in some special cases */
             if (val == 0) {
-                Warning ("Condition is never true");
+                Warning ("Comparison of unsigned type < 0 is always false");
                 AddCodeLine ("jsr return0");
                 return;
             }

--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -903,7 +903,7 @@ unsigned CheckedSizeOf (const Type* T)
 {
     unsigned Size = SizeOf (T);
     if (Size == 0) {
-        Error ("Size of data type is unknown");
+        Error ("Size of type '%s' is unknown", GetFullTypeName (T));
         Size = SIZEOF_CHAR;     /* Don't return zero */
     }
     return Size;
@@ -919,7 +919,7 @@ unsigned CheckedPSizeOf (const Type* T)
 {
     unsigned Size = PSizeOf (T);
     if (Size == 0) {
-        Error ("Size of data type is unknown");
+        Error ("Size of type '%s' is unknown", GetFullTypeName (T));
         Size = SIZEOF_CHAR;     /* Don't return zero */
     }
     return Size;

--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -974,6 +974,11 @@ unsigned TypeOf (const Type* T)
             /* Address of ... */
             return CF_INT | CF_UNSIGNED;
 
+        case T_ENUM:
+            /* Incomplete enum type */
+            Error ("Incomplete enum type");
+            return CF_INT;
+
         default:
             Error ("Illegal type %04lX", T->C);
             return CF_INT;

--- a/src/cc65/error.c
+++ b/src/cc65/error.c
@@ -325,7 +325,8 @@ void ListWarnings (FILE* F)
 void ErrorReport (void)
 /* Report errors (called at end of compile) */
 {
-    Print (stdout, 1, "%u errors, %u warnings\n", ErrorCount, WarningCount);
+    unsigned int V = (ErrorCount != 0 ? 0 : 1);
+    Print (stdout, V, "%u errors and %u warnings generated.\n", ErrorCount, WarningCount);
 }
 
 

--- a/src/cc65/error.c
+++ b/src/cc65/error.c
@@ -184,7 +184,7 @@ static void IntError (const char* Filename, unsigned LineNo, const char* Msg, va
         Print (stderr, 1, "Input: %.*s\n", (int) SB_GetLen (Line), SB_GetConstBuf (Line));
     }
     ++ErrorCount;
-    if (ErrorCount > 10) {
+    if (ErrorCount > 20) {
         Fatal ("Too many errors");
     }
 }

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1218,7 +1218,7 @@ static void StructRef (ExprDesc* Expr)
     NextToken ();
     const SymEntry Field = FindStructField (Expr->Type, Ident);
     if (Field.Type == 0) {
-        Error ("No field named '%s' found in %s", Ident, GetBasicTypeName (Expr->Type));
+        Error ("No field named '%s' found in '%s'", Ident, GetFullTypeName (Expr->Type));
         /* Make the expression an integer at address zero */
         ED_MakeConstAbs (Expr, 0, type_int);
         return;
@@ -1296,7 +1296,7 @@ static void StructRef (ExprDesc* Expr)
                 Flags = CF_LONG | CF_UNSIGNED | CF_CONST;
                 break;
             default:
-                Internal ("Invalid %s size: %u", GetBasicTypeName (Expr->Type), StructSize);
+                Internal ("Invalid '%s' size: %u", GetFullTypeName (Expr->Type), StructSize);
                 break;
         }
 

--- a/src/cc65/function.c
+++ b/src/cc65/function.c
@@ -513,7 +513,7 @@ void NewFunc (SymEntry* Func)
             ** We don't currently support this case.
             */
             if (RType == Param->Type) {
-                Error ("Passing %s of this size by value is not supported", GetBasicTypeName (Param->Type));
+                Error ("Passing '%s' of this size by value is not supported", GetFullTypeName (Param->Type));
             }
         }
 

--- a/src/cc65/shiftexpr.c
+++ b/src/cc65/shiftexpr.c
@@ -139,9 +139,14 @@ void ShiftExpr (struct ExprDesc* Expr)
             ** the operand, the behaviour is undefined according to the
             ** standard.
             */
-            if (Expr2.IVal < 0 || Expr2.IVal >= (long) ExprBits) {
+            if (Expr2.IVal < 0) {
 
-                Warning ("Shift count too large for operand type");
+                Warning ("Shift count '%ld' is negative", Expr2.IVal);
+                Expr2.IVal &= ExprBits - 1;
+
+            } else if (Expr2.IVal >= (long) ExprBits) {
+
+                Warning ("Shift count '%ld' >= width of type", Expr2.IVal);
                 Expr2.IVal &= ExprBits - 1;
 
             }

--- a/src/cc65/stmt.c
+++ b/src/cc65/stmt.c
@@ -333,7 +333,7 @@ static void ReturnStatement (void)
                 /* Handle struct/union specially */
                 ReturnType = GetStructReplacementType (Expr.Type);
                 if (ReturnType == Expr.Type) {
-                    Error ("Returning %s of this size by value is not supported", GetBasicTypeName (Expr.Type));
+                    Error ("Returning '%s' of this size by value is not supported", GetFullTypeName (Expr.Type));
                 }
                 LoadExpr (TypeOf (ReturnType), &Expr);
 

--- a/src/cc65/stmt.c
+++ b/src/cc65/stmt.c
@@ -581,6 +581,7 @@ int Statement (int* PendingToken)
     ExprDesc Expr;
     int GotBreak;
     CodeMark Start, End;
+    unsigned PrevErrorCount = ErrorCount;
 
     /* Assume no pending token */
     if (PendingToken) {
@@ -681,7 +682,8 @@ int Statement (int* PendingToken)
             GetCodePos (&End);
             if (CodeRangeIsEmpty (&Start, &End) &&
                 !IsTypeVoid (Expr.Type)         &&
-                IS_Get (&WarnNoEffect)) {
+                IS_Get (&WarnNoEffect)          &&
+                PrevErrorCount == ErrorCount) {
                 Warning ("Statement has no effect");
             }
             CheckSemi (PendingToken);

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -801,7 +801,7 @@ SymEntry* AddBitField (const char* Name, unsigned Offs, unsigned BitOffs, unsign
     if (Entry) {
 
         /* We have a symbol with this name already */
-        Error ("Multiple definition for '%s'", Name);
+        Error ("Multiple definition for bit-field '%s'", Name);
 
     } else {
 
@@ -834,7 +834,7 @@ SymEntry* AddConstSym (const char* Name, const Type* T, unsigned Flags, long Val
         if ((Entry->Flags & SC_CONST) != SC_CONST) {
             Error ("Symbol '%s' is already different kind", Name);
         } else {
-            Error ("Multiple definition for '%s'", Name);
+            Error ("Multiple definition for constant '%s'", Name);
         }
         return Entry;
     }

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -549,7 +549,8 @@ SymEntry FindStructField (const Type* T, const char* Name)
 
 static int HandleSymRedefinition (SymEntry* Entry, const Type* T, unsigned Flags)
 /* Check and handle redefinition of existing symbols.
-** Return ture if there *is* an error.
+** Complete array sizes and function descriptors as well.
+** Return true if there *is* an error.
 */
 {
     /* Get the type info of the existing symbol */
@@ -594,8 +595,8 @@ static int HandleSymRedefinition (SymEntry* Entry, const Type* T, unsigned Flags
             */
             if (IsTypeFunc (T)) {
 
-                /* New type must be identical */
-                if (TypeCmp (Entry->Type, T) < TC_EQUAL) {
+                /* New type must be equivalent */
+                if (TypeCmp (E_Type, T) < TC_EQUAL) {
                     Error ("Conflicting function types for '%s'", Entry->Name);
                     Entry = 0;
                 } else {
@@ -614,6 +615,7 @@ static int HandleSymRedefinition (SymEntry* Entry, const Type* T, unsigned Flags
                 Error ("Redefinition of function '%s' as different kind of symbol", Entry->Name);
                 Entry = 0;
             }
+
         } else if (E_SCType == SC_TYPEDEF) {
 
             if (SCType == SC_TYPEDEF) {
@@ -622,9 +624,7 @@ static int HandleSymRedefinition (SymEntry* Entry, const Type* T, unsigned Flags
                     Error ("Conflicting types for typedef '%s'", Entry->Name);
                     Entry = 0;
                 }
-
             } else {
-
                 Error ("Redefinition of typedef '%s' as different kind of symbol", Entry->Name);
                 Entry = 0;
             }
@@ -639,7 +639,10 @@ static int HandleSymRedefinition (SymEntry* Entry, const Type* T, unsigned Flags
                 Error ("Conflicting types for '%s'", Entry->Name);
                 Entry = 0;
             } else if (E_SCType == SC_ENUMERATOR) {
-                /* Current code logic won't reach here, but still... */
+                /* Enumerators aren't allowed to be redeclared at all, even if
+                ** all occurences are identical. The current code logic won't
+                ** get here, but let's just do it.
+                */
                 Error ("Redeclaration of enumerator constant '%s'", Entry->Name);
                 Entry = 0;
             }

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -172,7 +172,7 @@ static void CheckSymTable (SymTable* Tab)
                         }
                     } else {
                         if (IS_Get (&WarnUnusedVar)) {
-                            Warning ("'%s' is defined but never used", Entry->Name);
+                            Warning ("Variable '%s' is defined but never used", Entry->Name);
                         }
                     }
                 }
@@ -186,7 +186,7 @@ static void CheckSymTable (SymTable* Tab)
                 } else if (!SymIsRef (Entry)) {
                     /* Defined but not used */
                     if (IS_Get (&WarnUnusedLabel)) {
-                        Warning ("'%s' is defined but never used", Entry->Name);
+                        Warning ("Label '%s' is defined but never used", Entry->Name);
                     }
                 }
             }

--- a/test/misc/goto.ref
+++ b/test/misc/goto.ref
@@ -1,7 +1,7 @@
 goto.c(8): Warning: Goto at line 8 to label start jumps into a block with initialization of an object that has automatic storage duration
-goto.c(97): Warning: 'a' is defined but never used
-goto.c(117): Warning: 'a' is defined but never used
-goto.c(137): Warning: 'a' is defined but never used
+goto.c(97): Warning: Variable 'a' is defined but never used
+goto.c(117): Warning: Variable 'a' is defined but never used
+goto.c(137): Warning: Variable 'a' is defined but never used
 goto.c(159): Warning: Goto at line 23 to label l8 jumps into a block with initialization of an object that has automatic storage duration
 goto.c(159): Warning: Goto at line 44 to label l8 jumps into a block with initialization of an object that has automatic storage duration
 goto.c(159): Warning: Goto at line 65 to label l8 jumps into a block with initialization of an object that has automatic storage duration


### PR DESCRIPTION
- Increased upper limit of allowed errors before aborting from 10 to 20.
- Always show the count of errors/warnings if there are any errors.
- Tell what is the matter with certain errors.
- Show detailed types of the symbols that caused errors.
- Suppress "Statement has no effect" warnings on stuff that already caused errors.

Most of the changes are just in text (messages).