### PR TITLE
[cc65] Fixed error message of CheckedPSizeOf()

### DIFF
--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -919,7 +919,7 @@ unsigned CheckedPSizeOf (const Type* T)
 {
     unsigned Size = PSizeOf (T);
     if (Size == 0) {
-        Error ("Size of type '%s' is unknown", GetFullTypeName (T));
+        Error ("Size of type '%s' is unknown", GetFullTypeName (T + 1));
         Size = SIZEOF_CHAR;     /* Don't return zero */
     }
     return Size;


### PR DESCRIPTION
It was mistakenly getting the pointer type name instead of the expected pointed type name  in the error message.