### PR TITLE
[cc65] Fixed #1096 and #1164 and more

### DIFF
--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -449,7 +449,7 @@ void Compile (const char* FileName)
                         /* Assume array size of 1 */
                         SetElementCount (Entry->Type, 1);
                         Size = SizeOf (Entry->Type);
-                        Warning ("Tentative array '%s[]' assumed to have one element", Entry->Name);
+                        Warning ("Incomplete array '%s[]' assumed to have one element", Entry->Name);
                     }
 
                     Sym = GetSymType (GetElementType (Entry->Type));
@@ -474,7 +474,7 @@ void Compile (const char* FileName)
                     Entry->Flags |= SC_DEF;
                 } else {
                     /* Tentative declared variable is still of incomplete type */
-                    Error ("Tentative definition of '%s' of type '%s' is incomplete",
+                    Error ("Definition of '%s' has type '%s' that is never completed",
                            Entry->Name,
                            GetFullTypeName (Entry->Type));
                 }

--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -148,6 +148,11 @@ static void Parse (void)
                 break;
             }
 
+            if ((Decl.StorageClass & SC_ALIAS) == SC_ALIAS) {
+                /* Failed parsing */
+                goto SkipOneDecl;
+            }
+
             /* Check if we must reserve storage for the variable. We do this,
             **
             **   - if it is not a typedef or function,
@@ -276,6 +281,7 @@ static void Parse (void)
 
             }
 
+SkipOneDecl:
             /* Check for end of declaration list */
             if (CurTok.Tok == TOK_COMMA) {
                 NextToken ();

--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -276,6 +276,15 @@ static void Parse (void)
                                    Entry->Name, Entry->V.BssName);
                         }
                         Entry->V.BssName = xstrdup (bssName);
+
+                        /* Check for enum forward declaration.
+                        ** Warn about it when extensions are not allowed.
+                        */
+                        if (Size == 0 && IsTypeEnum (Decl.Type)) {
+                            if (IS_Get (&Standard) != STD_CC65) {
+                                Warning ("ISO C forbids forward references to 'enum' types");
+                            }
+                        }
                     }
                 }
 

--- a/src/cc65/compile.h
+++ b/src/cc65/compile.h
@@ -48,7 +48,7 @@ void Compile (const char* FileName);
 /* Top level compile routine. Will setup things and call the parser. */
 
 void FinishCompile (void);
-/* Emit literals, externals, do cleanup and optimizations */
+/* Emit literals, debug info, do cleanup and optimizations */
 
 
 

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -920,7 +920,7 @@ NextMember: if (CurTok.Tok != TOK_COMMA) {
     LeaveStructLevel ();
 
     /* Make a real entry from the forward decl and return it */
-    return AddStructSym (Name, SC_UNION, UnionSize, FieldTab);
+    return AddStructSym (Name, SC_UNION | SC_DEF, UnionSize, FieldTab);
 }
 
 
@@ -1102,7 +1102,7 @@ NextMember: if (CurTok.Tok != TOK_COMMA) {
     LeaveStructLevel ();
 
     /* Make a real entry from the forward decl and return it */
-    return AddStructSym (Name, SC_STRUCT, StructSize, FieldTab);
+    return AddStructSym (Name, SC_STRUCT | SC_DEF, StructSize, FieldTab);
 }
 
 

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -1814,6 +1814,9 @@ Type* ParseType (Type* T)
 void ParseDecl (const DeclSpec* Spec, Declaration* D, declmode_t Mode)
 /* Parse a variable, type or function declaration */
 {
+    /* Used to check if we have any errors during parsing this */
+    unsigned PrevErrorCount = ErrorCount;
+
     /* Initialize the Declaration struct */
     InitDeclaration (D);
 
@@ -1891,8 +1894,8 @@ void ParseDecl (const DeclSpec* Spec, Declaration* D, declmode_t Mode)
         }
     }
 
-    /* Check the size of the generated type */
     if (!IsTypeFunc (D->Type) && !IsTypeVoid (D->Type)) {
+        /* Check the size of the generated type */
         unsigned Size = SizeOf (D->Type);
         if (Size >= 0x10000) {
             if (D->Ident[0] != '\0') {
@@ -1901,8 +1904,12 @@ void ParseDecl (const DeclSpec* Spec, Declaration* D, declmode_t Mode)
                 Error ("Invalid size in declaration (0x%06X)", Size);
             }
         }
-    }
 
+        if (PrevErrorCount != ErrorCount) {
+            /* Don't give storage if the declaration is not parsed correctly */
+            D->StorageClass |= SC_DECL | SC_ALIAS;
+        }
+    }
 }
 
 

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -244,6 +244,23 @@ static int TypeSpecAhead (void)
 
 
 
+static unsigned ExprCheckedSizeOf (const Type* T)
+/* Specially checked SizeOf() used in 'sizeof' expressions */
+{
+    unsigned Size = SizeOf (T);
+    SymEntry* Sym;
+
+    if (Size == 0) {
+        Sym = GetSymType (T);
+        if (Sym == 0 || !SymIsDef (Sym)) {
+            Error ("Cannot apply 'sizeof' to incomplete type '%s'", GetFullTypeName (T));
+        }
+    }
+    return Size;
+}
+
+
+
 void PushAddr (const ExprDesc* Expr)
 /* If the expression contains an address that was somehow evaluated,
 ** push this address on the stack. This is a helper function for all
@@ -1890,7 +1907,7 @@ void hie10 (ExprDesc* Expr)
             if (TypeSpecAhead ()) {
                 Type T[MAXTYPELEN];
                 NextToken ();
-                Size = CheckedSizeOf (ParseType (T));
+                Size = ExprCheckedSizeOf (ParseType (T));
                 ConsumeRParen ();
             } else {
                 /* Remember the output queue pointer */
@@ -1908,7 +1925,7 @@ void hie10 (ExprDesc* Expr)
                         ReleaseLiteral (Expr->LVal);
                     }
                     /* Calculate the size */
-                    Size = CheckedSizeOf (Expr->Type);
+                    Size = ExprCheckedSizeOf (Expr->Type);
                 }
                 /* Remove any generated code */
                 RemoveCode (&Mark);

--- a/src/cc65/locals.c
+++ b/src/cc65/locals.c
@@ -443,13 +443,14 @@ static void ParseOneDecl (const DeclSpec* Spec)
     }
 
     /* If the symbol is not marked as external, it will be defined now */
-    if ((Decl.StorageClass & SC_EXTERN) == 0) {
+    if ((Decl.StorageClass & SC_ALIAS) == 0 &&
+        (Decl.StorageClass & SC_EXTERN) == 0) {
         Decl.StorageClass |= SC_DEF;
     }
 
     /* Handle anything that needs storage (no functions, no typdefs) */
-    if ((Decl.StorageClass & SC_FUNC) != SC_FUNC &&
-         (Decl.StorageClass & SC_TYPEMASK) != SC_TYPEDEF) {
+    if ((Decl.StorageClass & SC_DEF) == SC_DEF &&
+        (Decl.StorageClass & SC_TYPEMASK) != SC_TYPEDEF) {
 
         /* If we have a register variable, try to allocate a register and
         ** convert the declaration to "auto" if this is not possible.
@@ -468,13 +469,6 @@ static void ParseOneDecl (const DeclSpec* Spec)
         } else if ((Decl.StorageClass & SC_AUTO) == SC_AUTO) {
             /* Auto variable */
             ParseAutoDecl (&Decl);
-        } else if ((Decl.StorageClass & SC_EXTERN) == SC_EXTERN) {
-            /* External identifier - may not get initialized */
-            if (CurTok.Tok == TOK_ASSIGN) {
-                Error ("Cannot initialize externals");
-            }
-            /* Add the external symbol to the symbol table */
-            AddLocalSym (Decl.Ident, Decl.Type, Decl.StorageClass, 0);
         } else if ((Decl.StorageClass & SC_STATIC) == SC_STATIC) {
             /* Static variable */
             ParseStaticDecl (&Decl);
@@ -483,6 +477,13 @@ static void ParseOneDecl (const DeclSpec* Spec)
         }
 
     } else {
+
+        if ((Decl.StorageClass & SC_EXTERN) == SC_EXTERN) {
+            /* External identifier - may not get initialized */
+            if (CurTok.Tok == TOK_ASSIGN) {
+                Error ("Cannot initialize externals");
+            }
+        }
 
         /* Add the symbol to the symbol table */
         AddLocalSym (Decl.Ident, Decl.Type, Decl.StorageClass, 0);

--- a/src/cc65/locals.c
+++ b/src/cc65/locals.c
@@ -426,13 +426,25 @@ static void ParseOneDecl (const DeclSpec* Spec)
     /* Read the declaration */
     ParseDecl (Spec, &Decl, DM_NEED_IDENT);
 
-    /* Set the correct storage class for functions */
+    /* Check if there are any non-extern storage classes set for function
+    ** declarations. The only valid storage class for function declarations
+    ** inside functions is 'extern'.
+    */
     if ((Decl.StorageClass & SC_FUNC) == SC_FUNC) {
-        /* Function prototypes are always external */
-        if ((Decl.StorageClass & SC_EXTERN) == 0) {
-            Warning ("Function must be extern");
+
+        /* Check if there are explicitly specified non-external storage classes */
+        if ((Spec->Flags & DS_DEF_STORAGE) != DS_DEF_STORAGE    &&
+            (Decl.StorageClass & SC_EXTERN) == 0                &&
+            (Decl.StorageClass & SC_STORAGEMASK) != 0) {
+            Error ("Illegal storage class on function");
         }
+
+        /* The default storage class could be wrong. Just use 'extern' in all
+        ** cases.
+        */
+        Decl.StorageClass &= ~SC_STORAGEMASK;
         Decl.StorageClass |= SC_EXTERN;
+
     }
 
     /* If we don't have a name, this was flagged as an error earlier.

--- a/src/cc65/main.c
+++ b/src/cc65/main.c
@@ -1069,7 +1069,7 @@ int main (int argc, char* argv[])
     /* Create the output file if we didn't had any errors */
     if (PreprocessOnly == 0 && (ErrorCount == 0 || Debug)) {
 
-        /* Emit literals, externals, do cleanup and optimizations */
+        /* Emit literals, do cleanup and optimizations */
         FinishCompile ();
 
         /* Open the file */


### PR DESCRIPTION
Resolved issues:

- #1096, the "definitons of 0-size structs/unions are treated as pure declarations" part as in the title, not the "support for empty structs/unions" part.
- Closes #1118 and fixes #1164, see below.
- Clearer error info on applying `sizeof` to incomplete arrays.
- Warning message about arrays of unspecified lengths assumed to have one element in the end.
- Enabled cc65 to output the diagnostic info about variables delayed in bss segments when there are already errors.

The output of cc65 when compiling the example code from #1164, before this PR:
```
1164.c(3): Error: Variable 's' has unknown size
1164.c(9): Error: Variable 't' has unknown size
1164.c(15): Error: Size of type 'int[]' is unknown
3 errors and 0 warnings generated.
```
After:
```
1164.c(15): Error: Cannot apply 'sizeof' to incomplete type 'int[]'
1164.c(21): Error: Definition of 't' has type 'enum E' that is never completed
1164.c(21): Warning: Incomplete array 'm[]' assumed to have one element
2 errors and 1 warnings generated.
```
The two bugs reported in #1164 are fixed.