### PR TITLE
Fix vacuous comparison warning from 0df45fe

### DIFF
--- a/src/cc65/symentry.c
+++ b/src/cc65/symentry.c
@@ -303,7 +303,8 @@ const char* GetSymTypeName (const Type* T)
     if (Sym == 0) {
         return GetBasicTypeName (T);
     }
-    sprintf (TypeName, "%s %s", GetBasicTypeName (T), Sym->Name ? Sym->Name : "<unknown>");
+    sprintf (TypeName, "%s %s", GetBasicTypeName (T),
+             Sym->Name[0] != '\0' ? Sym->Name : "<unknown>");
 
     return TypeName;
 }


### PR DESCRIPTION
```
cc65/symentry.c:306:60: warning: address of array 'Sym->Name' will always evaluate to 'true' [-Wpointer-bool-conversion]
    sprintf (TypeName, "%s %s", GetBasicTypeName (T), Sym->Name ? Sym->Name : "<unknown>");
                                                      ~~~~~^~~~ ~
```