### PR TITLE
[cc65] Fixed missing "multiple definition" of local variables

### DIFF
--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -697,18 +697,17 @@ SymEntry* AddEnumSym (const char* Name, const Type* Type, SymTable* Tab)
             /* Existing symbol is not an enum */
             Error ("Symbol '%s' is already different kind", Name);
             Entry = 0;
-        } else {
+        } else if (Type != 0) {
             /* Define the struct size if the underlying type is given. */
-            if (Type != 0) {
-                if (Type !=0 && Entry->V.E.Type != 0) {
-                    /* Both are definitions. */
-                    Error ("Multiple definition for enum '%s'", Name);
-                    Entry = 0;
-                } else {
-                    Entry->Type       = 0;
-                    Entry->V.E.SymTab = Tab;
-                    Entry->V.E.Type   = Type;
-                }
+            if (Entry->V.E.Type != 0) {
+                /* Both are definitions. */
+                Error ("Multiple definition for 'enum %s'", Name);
+                Entry = 0;
+            } else {
+                Entry->V.E.SymTab = Tab;
+                Entry->V.E.Type   = Type;
+                Entry->Flags     &= ~SC_DECL;
+                Entry->Flags     |= SC_DEF;
             }
         }
 
@@ -724,7 +723,6 @@ SymEntry* AddEnumSym (const char* Name, const Type* Type, SymTable* Tab)
         Entry = NewSymEntry (Name, SC_ENUM);
 
         /* Set the enum type data */
-        Entry->Type       = 0;
         Entry->V.E.SymTab = Tab;
         Entry->V.E.Type   = Type;
 

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -1019,9 +1019,18 @@ SymEntry* AddLocalSym (const char* Name, const Type* T, unsigned Flags, int Offs
 
         /* We have a symbol with this name already */
         if (HandleSymRedefinition (Entry, T, Flags)) {
-            /* Use the fail-safe table for fictitious symbols */
-            Tab   = FailSafeTab;
             Entry = 0;
+        } else if ((Flags & SC_ESUTYPEMASK) != SC_TYPEDEF) {
+            /* Redefinitions are not allowed */
+            if (SymIsDef (Entry) && (Flags & SC_DEF) == SC_DEF) {
+                Error ("Multiple definition of '%s'", Entry->Name);
+                Entry = 0;
+            }
+        }
+
+        if (Entry == 0) {
+            /* Use the fail-safe table for fictitious symbols */
+            Tab = FailSafeTab;
         }
     }
     
@@ -1033,7 +1042,7 @@ SymEntry* AddLocalSym (const char* Name, const Type* T, unsigned Flags, int Offs
         Entry->Type = TypeDup (T);
 
         if ((Flags & SC_STRUCTFIELD) == SC_STRUCTFIELD ||
-            (Flags & SC_TYPEDEF) == SC_TYPEDEF) {
+            (Flags & SC_ESUTYPEMASK) == SC_TYPEDEF) {
             if ((Flags & SC_ALIAS) != SC_ALIAS) {
                 Entry->V.Offs = Offs;
             }


### PR DESCRIPTION
This fixed the missing check for multiple definitions of local variables in functions.
```c
void f()
{
    int i, i; /* BUG: Should be a "multiple definition" error */
}
```
