### PR TITLE
[cc65] Fixes for type comparisons

### DIFF
--- a/src/cc65/typecmp.c
+++ b/src/cc65/typecmp.c
@@ -190,6 +190,7 @@ static void DoCompare (const Type* lhs, const Type* rhs, typecmp_t* Result)
         */
         if (LeftType == T_TYPE_PTR && RightType == T_TYPE_ARRAY) {
             RightType = T_TYPE_PTR;
+            SetResult (Result, TC_STRICT_COMPATIBLE);
         }
 
         /* If the underlying types are not identical, the types are incompatible */
@@ -350,12 +351,14 @@ static void DoCompare (const Type* lhs, const Type* rhs, typecmp_t* Result)
                 /* Check member count */
                 LeftCount  = GetElementCount (lhs);
                 RightCount = GetElementCount (rhs);
-                if (LeftCount  != UNSPECIFIED &&
-                    RightCount != UNSPECIFIED &&
-                    LeftCount  != RightCount) {
-                    /* Member count given but different */
-                    SetResult (Result, TC_INCOMPATIBLE);
-                    return;
+                if (LeftCount != RightCount) {
+                    if (LeftCount  != UNSPECIFIED &&
+                        RightCount != UNSPECIFIED) {
+                        /* Member count given but different */
+                        SetResult (Result, TC_INCOMPATIBLE);
+                        return;
+                    }
+                    SetResult (Result, TC_EQUAL);
                 }
                 break;
 

--- a/src/cc65/typecmp.h
+++ b/src/cc65/typecmp.h
@@ -55,7 +55,7 @@ typedef enum {
     TC_COMPATIBLE = TC_SIGN_DIFF, /* Compatible types */
     TC_QUAL_DIFF,                 /* Types differ in qualifier of pointer */
     TC_STRICT_COMPATIBLE,         /* Strict compatibility */
-    TC_EQUAL,                     /* Types are equal */
+    TC_EQUAL,                     /* Types are equivalent */
     TC_IDENTICAL                  /* Types are identical */
 } typecmp_t;
 


### PR DESCRIPTION
- Fixed potential problems with type comparison with different enum types.
- Fixed #1168.
- Fixed typedefs related to arrays/pointers:
```c
typedef int P[];
typedef int P[1]; /* Should be an error */
typedef int *P;   /* Should be an error */
```