### PR TITLE
[cc65] Improved ESU declaration failure handling

### DIFF
--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -682,13 +682,21 @@ static void AddSymEntry (SymTable* T, SymEntry* S)
 
 
 
-SymEntry* AddEnumSym (const char* Name, const Type* Type, SymTable* Tab)
+SymEntry* AddEnumSym (const char* Name, unsigned Flags, const Type* Type, SymTable* Tab)
 /* Add an enum entry and return it */
 {
     SymTable* CurTagTab = TagTab;
+    SymEntry* Entry;
 
-    /* Do we have an entry with this name already? */
-    SymEntry* Entry = FindSymInTable (CurTagTab, Name, HashStr (Name));
+    if ((Flags & SC_FICTITIOUS) == 0) {
+        /* Do we have an entry with this name already? */
+        Entry = FindSymInTable (CurTagTab, Name, HashStr (Name));
+    } else {
+        /* Add a fictitious symbol in the fail-safe table */
+        Entry = 0;
+        CurTagTab = FailSafeTab;
+    }
+
     if (Entry) {
 
         /* We do have an entry. This may be a forward, so check it. */
@@ -749,8 +757,15 @@ SymEntry* AddStructSym (const char* Name, unsigned Flags, unsigned Size, SymTabl
     /* Type must be struct or union */
     PRECONDITION (Type == SC_STRUCT || Type == SC_UNION);
 
-    /* Do we have an entry with this name already? */
-    Entry = FindSymInTable (CurTagTab, Name, HashStr (Name));
+    if ((Flags & SC_FICTITIOUS) == 0) {
+        /* Do we have an entry with this name already? */
+        Entry = FindSymInTable (CurTagTab, Name, HashStr (Name));
+    } else {
+        /* Add a fictitious symbol in the fail-safe table */
+        Entry = 0;
+        CurTagTab = FailSafeTab;
+    }
+
     if (Entry) {
 
         /* We do have an entry. This may be a forward, so check it. */

--- a/src/cc65/symtab.h
+++ b/src/cc65/symtab.h
@@ -149,10 +149,10 @@ unsigned short FindSPAdjustment (const char* Name);
 
 
 
-SymEntry* AddEnumSym (const char* Name, const Type* Type, SymTable* Tab);
+SymEntry* AddEnumSym (const char* Name, unsigned Flags, const Type* Type, SymTable* Tab);
 /* Add an enum entry and return it */
 
-SymEntry* AddStructSym (const char* Name, unsigned Type, unsigned Size, SymTable* Tab);
+SymEntry* AddStructSym (const char* Name, unsigned Flags, unsigned Size, SymTable* Tab);
 /* Add a struct/union entry and return it */
 
 SymEntry* AddBitField (const char* Name, unsigned Offs, unsigned BitOffs, unsigned BitWidth);


### PR DESCRIPTION
This makes failed declarations of ESU tags operate on fictitious symbols to avoid potential issues like #1113, though I haven't found any instances.

It depends on two of the previous PRs (#1169 and #1171). So I waited until now.