### PR TITLE
[cc65] Fixed testing 'struct->field'

### DIFF
--- a/src/cc65/assignment.c
+++ b/src/cc65/assignment.c
@@ -77,7 +77,7 @@ static int CopyStruct (ExprDesc* LExpr, ExprDesc* RExpr)
     /* Get the expression on the right of the '=' */
     hie1 (RExpr);
 
-    /* Check for equality of the structs */
+    /* Check for equality of the structs/unions */
     if (TypeCmp (ltype, RExpr->Type) < TC_STRICT_COMPATIBLE) {
         TypeCompatibilityDiagnostic (ltype, RExpr->Type, 1,
             "Incompatible types in assignment to '%s' from '%s'");
@@ -114,6 +114,12 @@ static int CopyStruct (ExprDesc* LExpr, ExprDesc* RExpr)
 
         /* Restore the indirection level of lhs */
         ED_IndExpr (LExpr);
+
+        /* Clear the tested flag set during loading. This is not neccessary
+        ** currently (and probably ever) as a struct/union cannot be converted
+        ** to a boolean in C, but there is no harm to be future-proof.
+        */
+        ED_MarkAsUntested (LExpr);
     }
 
     return 1;

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1301,6 +1301,9 @@ static void StructRef (ExprDesc* Expr)
         LoadExpr (CF_NONE, Expr);
     }
 
+    /* Clear the tested flag set during loading */
+    ED_MarkAsUntested (Expr);
+
     /* The type is the field type plus any qualifiers from the struct/union */
     if (IsClassStruct (Expr->Type)) {
         Q = GetQualifier (Expr->Type);


### PR DESCRIPTION
- Fixed #1181.

Note: Usually, the C parser recursively parses expression reusing the same `ExprDesc` object for the result as well as for the "left-hand subexpression" if it is binary or ternary. This could lead to problems like this if the info to and from the subexpression is not handled carefully. It could be avoided in the future by separating the info of the two expressions (See https://github.com/cc65/cc65/issues/1123#issuecomment-664114740).