### PR TITLE
[cc65] Fixed function signatures in asm output

### DIFF
--- a/src/cc65/datatype.h
+++ b/src/cc65/datatype.h
@@ -278,13 +278,13 @@ Type* PointerTo (const Type* T);
 */
 
 void PrintType (FILE* F, const Type* T);
-/* Output translation of type array. */
-
-void PrintRawType (FILE* F, const Type* T);
-/* Print a type string in raw format (for debugging) */
+/* Print fulle name of the type */
 
 void PrintFuncSig (FILE* F, const char* Name, Type* T);
-/* Print a function signature. */
+/* Print a function signature */
+
+void PrintRawType (FILE* F, const Type* T);
+/* Print a type string in raw hex format (for debugging) */
 
 int TypeHasAttr (const Type* T);
 /* Return true if the given type has attribute data */


### PR DESCRIPTION
- Fixed function signatures in asm output.
- Improved full type name production.

(1/1) commit pushed in PR but see below.

---
Caveat: this combined with #1187 will output the "composite" version of function parameter lists instead of the "definition" version of function parameter lists. If the "definition" version is desired, either the implementation of #1187 or some other part of the code base outside of this need be modified.