### PR TITLE
[cc65] Fixed calling functions with parameters first declared with an empty parameter list

### DIFF
--- a/src/cc65/codeinfo.c
+++ b/src/cc65/codeinfo.c
@@ -392,7 +392,7 @@ fncls_t GetFuncInfo (const char* Name, unsigned short* Use, unsigned short* Chg)
 
         /* Did we find it in the top-level table? */
         if (E && IsTypeFunc (E->Type)) {
-            FuncDesc* D = GetFuncCompositeDesc (E);
+            FuncDesc* D = GetFuncDesc (E->Type);
 
             /* A variadic function will use the Y register (the parameter list
             ** size is passed there). A fastcall function will use the A or A/X

--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -77,6 +77,7 @@ static void Parse (void)
 {
     int comma;
     SymEntry* Entry;
+    FuncDesc* FuncDef = 0;
 
     /* Go... */
     NextToken ();
@@ -187,9 +188,9 @@ static void Parse (void)
                     /* Convert an empty parameter list into one accepting no
                     ** parameters (same as void) as required by the standard.
                     */
-                    FuncDesc* D = GetFuncDesc (Decl.Type);
-                    if (D->Flags & FD_EMPTY) {
-                        D->Flags = (D->Flags & ~FD_EMPTY) | FD_VOID_PARAM;
+                    FuncDef = GetFuncDesc (Decl.Type);
+                    if (FuncDef->Flags & FD_EMPTY) {
+                        FuncDef->Flags = (FuncDef->Flags & ~FD_EMPTY) | FD_VOID_PARAM;
                     }
                 } else {
                     /* Just a declaration */
@@ -315,7 +316,7 @@ SkipOneDecl:
                     NextToken ();
                 } else {
                     /* Parse the function body */
-                    NewFunc (Entry);
+                    NewFunc (Entry, FuncDef);
                 }
             }
 

--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -1115,28 +1115,6 @@ Type* GetFuncReturn (Type* T)
 
 
 
-Type* GetFuncCompositeType (SymEntry* Func)
-/* Get the composite function type */
-{
-    /* Be sure it's a function type */
-    CHECK (IsClassFunc (Func->Type));
-
-    return Func->V.F.Composite->Type;
-}
-
-
-
-FuncDesc* GetFuncCompositeDesc (SymEntry* Func)
-/* Get the composite function type descriptor */
-{
-    /* Be sure it's a function type */
-    CHECK (IsClassFunc (Func->Type));
-
-    return GetFuncDesc (Func->V.F.Composite->Type);
-}
-
-
-
 long GetElementCount (const Type* T)
 /* Get the element count of the array specified in T (which must be of
 ** array type).

--- a/src/cc65/datatype.h
+++ b/src/cc65/datatype.h
@@ -753,12 +753,6 @@ void SetFuncDesc (Type* T, FuncDesc* F);
 Type* GetFuncReturn (Type* T) attribute ((const));
 /* Return a pointer to the return type of a function or pointer-to-function type */
 
-Type* GetFuncCompositeType (struct SymEntry* Func);
-/* Get the composite function type */
-
-FuncDesc* GetFuncCompositeDesc (struct SymEntry* Func);
-/* Get the composite function type descriptor */
-
 long GetElementCount (const Type* T);
 /* Get the element count of the array specified in T (which must be of
 ** array type).

--- a/src/cc65/function.c
+++ b/src/cc65/function.c
@@ -72,7 +72,7 @@ Function* CurrentFunc = 0;
 
 
 
-static Function* NewFunction (struct SymEntry* Sym)
+static Function* NewFunction (struct SymEntry* Sym, FuncDesc* D)
 /* Create a new function activation structure and return it */
 {
     /* Allocate a new structure */
@@ -81,7 +81,7 @@ static Function* NewFunction (struct SymEntry* Sym)
     /* Initialize the fields */
     F->FuncEntry  = Sym;
     F->ReturnType = GetFuncReturn (Sym->Type);
-    F->Desc       = GetFuncDesc (Sym->Type);
+    F->Desc       = D;
     F->Reserved   = 0;
     F->RetLab     = GetLocalLabel ();
     F->TopLevelSP = 0;
@@ -295,7 +295,7 @@ static void F_RestoreRegVars (Function* F)
     }
 
     /* Get the first symbol from the function symbol table */
-    Sym = GetFuncDesc (F->FuncEntry->Type)->SymTab->SymHead;
+    Sym = F->Desc->SymTab->SymHead;
 
     /* Walk through all symbols checking for register variables */
     while (Sym) {
@@ -375,18 +375,15 @@ static void F_EmitDebugInfo (void)
 
 
 
-void NewFunc (SymEntry* Func)
+void NewFunc (SymEntry* Func, FuncDesc* D)
 /* Parse argument declarations and function body. */
 {
     int         C99MainFunc = 0;/* Flag for C99 main function returning int */
     SymEntry*   Param;
     const Type* RType;          /* Real type used for struct parameters */
 
-    /* Get the function descriptor from the function entry */
-    FuncDesc* D = GetFuncDesc (Func->Type);
-
     /* Allocate the function activation record for the function */
-    CurrentFunc = NewFunction (Func);
+    CurrentFunc = NewFunction (Func, D);
 
     /* Reenter the lexical level */
     ReenterFunctionLevel (D);

--- a/src/cc65/function.h
+++ b/src/cc65/function.h
@@ -67,6 +67,9 @@ struct Function {
 /* Structure that holds all data needed for function activation */
 typedef struct Function Function;
 
+/* Forward declaration */
+struct FuncDesc;
+
 /* Function activation data for current function (or NULL) */
 extern Function* CurrentFunc;
 
@@ -138,7 +141,7 @@ int F_AllocRegVar (Function* F, const Type* Type);
 ** bank (zero page storage). If there is no register space left, return -1.
 */
 
-void NewFunc (struct SymEntry* Func);
+void NewFunc (struct SymEntry* Func, struct FuncDesc* D);
 /* Parse argument declarations and function body. */
 
 

--- a/src/cc65/pragma.c
+++ b/src/cc65/pragma.c
@@ -527,7 +527,7 @@ static void WrappedCallPragma (StrBuf* B)
 
         PushWrappedCall(Entry, (unsigned char) Val);
         Entry->Flags |= SC_REF;
-        GetFuncCompositeDesc (Entry)->Flags |= FD_CALL_WRAPPER;
+        GetFuncDesc (Entry->Type)->Flags |= FD_CALL_WRAPPER;
 
     } else {
 

--- a/src/cc65/symentry.h
+++ b/src/cc65/symentry.h
@@ -191,7 +191,6 @@ struct SymEntry {
 
         /* Data for functions */
         struct {
-            SymEntry*           Composite;/* Entry to hold composite function type */
             struct Segments*    Seg;      /* Segments for this function */
             struct LiteralPool* LitPool;  /* Literal pool for this function */
         } F;

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -590,14 +590,14 @@ static int HandleSymRedefinition (SymEntry* Entry, const Type* T, unsigned Flags
                 Entry = 0;
             } else {
                 /* New type must be compatible with the composite prototype */
-                if (TypeCmp (GetFuncCompositeType (Entry), T) < TC_EQUAL) {
+                if (TypeCmp (Entry->Type, T) < TC_EQUAL) {
                     Error ("Conflicting function types for '%s'", Entry->Name);
                     Entry = 0;
                 } else {
                     /* Refine the existing composite prototype with this new
                     ** one.
                     */
-                    RefineFuncDesc (GetFuncCompositeType (Entry), T);
+                    RefineFuncDesc (Entry->Type, T);
                 }
             }
 
@@ -1159,14 +1159,6 @@ SymEntry* AddGlobalSym (const char* Name, const Type* T, unsigned Flags)
             }
 
             if (Entry) {
-                /* Update existing function type if this is a definition */
-                if (IsTypeFunc (Entry->Type)    &&
-                    !SymIsDef (Entry)           &&
-                    (Flags & SC_DEF) == SC_DEF) {
-                    TypeFree (Entry->Type);
-                    Entry->Type = TypeDup (T);
-                }
-
                 /* Add the new flags */
                 Entry->Flags |= Flags;
             }
@@ -1186,17 +1178,8 @@ SymEntry* AddGlobalSym (const char* Name, const Type* T, unsigned Flags)
         /* Set the symbol attributes */
         Entry->Type = TypeDup (T);
 
-        /* If this is a function, set the function composite typeand clear
-        ** additional fields.
-        */
+        /* If this is a function, clear additional fields */
         if (IsTypeFunc (T)) {
-            /* GitHub #1167 - Make a composite prototype */
-            ident Ident;
-            AnonName (Ident, "prototype");
-            Entry->V.F.Composite = NewSymEntry (Ident, SC_EXTERN | SC_DECL | SC_ALIAS | SC_FUNC);
-            Entry->V.F.Composite->Type = TypeDup (T);
-            AddSymEntry (SymTab0, Entry->V.F.Composite);
-
             Entry->V.F.Seg = 0;
         }
 


### PR DESCRIPTION
This fixes the regression in #1176:

```c
void f();
void f(int);

void g(void)
{
    f(0); /* BUG: this shouldn't fail */
}
```
(1/1) commit pushed in PR but see below.

---
Caveat: #1185 combined with this will output the "composite" version of function parameter lists instead of the "definition" version of function parameter lists. If the "definition" version is desired, either the implementation of this or some other part of the code base outside of #1185 need be modified.