### PR TITLE
Support C2X _Static_assert(expr) syntax

### DIFF
--- a/src/cc65/staticassert.c
+++ b/src/cc65/staticassert.c
@@ -49,6 +49,7 @@ void ParseStaticAssert ()
 {
     /*
     ** static_assert-declaration ::=
+    **     _Static_assert ( constant-expression ) ;
     **     _Static_assert ( constant-expression , string-literal ) ;
     */
     ExprDesc Expr;
@@ -67,27 +68,35 @@ void ParseStaticAssert ()
     ConstAbsIntExpr (hie1, &Expr);
     failed = !Expr.IVal;
 
-    /* We expect a comma */
-    if (!ConsumeComma ()) {
-        return;
-    }
-
-    /* String literal */
-    if (CurTok.Tok != TOK_SCONST) {
-        Error ("String literal expected for static_assert message");
-        return;
-    }
-
-    /* Issue an error including the message if the static_assert failed. */
-    if (failed) {
-        Error ("static_assert failed '%s'", GetLiteralStr (CurTok.SVal));
-    }
-
-    /* Consume the string constant, now that we don't need it anymore.
-    ** This should never fail since we checked the token type above.
+    /* If there is a comma, we also have an error message.  The message is optional because we
+    ** support the C2X syntax with only an expression.
     */
-    if (!Consume (TOK_SCONST, "String literal expected")) {
-        return;
+    if (CurTok.Tok == TOK_COMMA) {
+        /* Skip the comma. */
+        NextToken ();
+
+        /* String literal */
+        if (CurTok.Tok != TOK_SCONST) {
+            Error ("String literal expected for static_assert message");
+            return;
+        }
+
+        /* Issue an error including the message if the static_assert failed. */
+        if (failed) {
+            Error ("static_assert failed '%s'", GetLiteralStr (CurTok.SVal));
+        }
+
+        /* Consume the string constant, now that we don't need it anymore.
+        ** This should never fail since we checked the token type above.
+        */
+        if (!Consume (TOK_SCONST, "String literal expected")) {
+            return;
+        }
+    } else {
+        /* No message. */
+        if (failed) {
+            Error ("static_assert failed");
+        }
     }
 
     /* Closing paren and semi-colon needed */

--- a/test/val/staticassert.c
+++ b/test/val/staticassert.c
@@ -27,6 +27,7 @@
 #include <assert.h>
 
 _Static_assert (1, "1 should be true.");
+_Static_assert (1);  /* Support C2x syntax with no message. */
 _Static_assert (!0, "!0 should be true.");
 _Static_assert (1 == 1, "1 == 1 should be true.");
 _Static_assert (1 == 1L, "1 == 1L should be true.");
@@ -46,6 +47,7 @@ _Static_assert (k == 1, "k should be 1.");
 
 /* Just test the macro version once. */
 static_assert (1, "1 should be true.");
+static_assert (1);
 
 /* _Static_assert can appear anywhere a declaration can. */
 void f (void)


### PR DESCRIPTION
This makes the message in _Static_assert(expr, message) optional.

Fixes #1188.