### PR TITLE
Treat signed int bit-fields as signed

### DIFF
--- a/src/cc65/codegen.h
+++ b/src/cc65/codegen.h
@@ -478,7 +478,7 @@ void g_initstatic (unsigned InitLabel, unsigned VarLabel, unsigned Size);
 void g_testbitfield (unsigned Flags, unsigned BitOffs, unsigned BitWidth);
 /* Test bit-field in ax. */
 
-void g_extractbitfield (unsigned Flags, unsigned FullWidthFlags,
+void g_extractbitfield (unsigned Flags, unsigned FullWidthFlags, int IsSigned,
                         unsigned BitOffs, unsigned BitWidth);
 /* Extract bits from bit-field in ax. */
 

--- a/src/cc65/symtab.h
+++ b/src/cc65/symtab.h
@@ -155,7 +155,8 @@ SymEntry* AddEnumSym (const char* Name, unsigned Flags, const Type* Type, SymTab
 SymEntry* AddStructSym (const char* Name, unsigned Flags, unsigned Size, SymTable* Tab);
 /* Add a struct/union entry and return it */
 
-SymEntry* AddBitField (const char* Name, unsigned Offs, unsigned BitOffs, unsigned BitWidth);
+SymEntry* AddBitField (const char* Name, const Type* Type, unsigned Offs,
+                       unsigned BitOffs, unsigned BitWidth, int SignednessSpecified);
 /* Add a bit field to the local symbol table and return the symbol entry */
 
 SymEntry* AddConstSym (const char* Name, const Type* T, unsigned Flags, long Val);

--- a/test/val/bug1095.c
+++ b/test/val/bug1095.c
@@ -31,7 +31,10 @@ static struct signed_ints {
     signed int b : 3;
     signed int c : 3;
     signed int d : 10;
-} si = {-4, -1, 3, -500};
+    signed int : 0;
+    signed int e : 8;
+    signed int f : 16;
+} si = {-4, -1, 3, -500, -100, -5000};
 
 static void test_signed_bitfield(void)
 {
@@ -53,7 +56,7 @@ static void test_signed_bitfield(void)
         failures++;
     }
 
-    if (si.b <= 0) {
+    if (si.c <= 0) {
         printf("Got si.c = %d, expected positive.\n", si.c);
         failures++;
     }
@@ -71,10 +74,30 @@ static void test_signed_bitfield(void)
         failures++;
     }
 
+    if (si.e >= 0) {
+        printf("Got si.e = %d, expected negative.\n", si.e);
+        failures++;
+    }
+    if (si.e != -100) {
+        printf("Got si.e = %d, expected -100.\n", si.e);
+        failures++;
+    }
+
+    if (si.f >= 0) {
+        printf("Got si.f = %d, expected negative.\n", si.f);
+        failures++;
+    }
+    if (si.f != -5000) {
+        printf("Got si.f = %d, expected -5000.\n", si.f);
+        failures++;
+    }
+
     si.a = -3;
     si.b = 1;
     si.c = -2;
     si.d = 500;
+    si.e = 100;
+    si.f = 5000;
 
     if (si.a >= 0) {
         printf("Got si.a = %d, expected negative.\n", si.a);
@@ -94,7 +117,7 @@ static void test_signed_bitfield(void)
         failures++;
     }
 
-    if (si.b >= 0) {
+    if (si.c >= 0) {
         printf("Got si.c = %d, expected negative.\n", si.c);
         failures++;
     }
@@ -109,6 +132,24 @@ static void test_signed_bitfield(void)
     }
     if (si.d != 500) {
         printf("Got si.d = %d, expected 500.\n", si.d);
+        failures++;
+    }
+
+    if (si.e <= 0) {
+        printf("Got si.e = %d, expected positive.\n", si.e);
+        failures++;
+    }
+    if (si.e != 100) {
+        printf("Got si.e = %d, expected 100.\n", si.e);
+        failures++;
+    }
+
+    if (si.f <= 0) {
+        printf("Got si.f = %d, expected positive.\n", si.f);
+        failures++;
+    }
+    if (si.f != 5000) {
+        printf("Got si.f = %d, expected 5000.\n", si.f);
         failures++;
     }
 }


### PR DESCRIPTION
Prior to this PR, `int`, `signed int`, and `unsigned int`
bitfields are all treated as `unsigned int`.

With this PR, `signed int` will be treated as `signed int`,
and the others remain unsigned.

Since `Type` does not distinguish between `int` and `signed int`,
add an extra `int* SignenessSpecified` param to `ParseTypeSpec`
so we can tell these apart for bit-fields and treat plain `int : N`
as `unsigned int : N` since it is more efficient to zero-extend
than sign-extend.

Fixes #1095