### PR TITLE
Move bit-field adjustment to codegen.c

### DIFF
--- a/src/cc65/codegen.h
+++ b/src/cc65/codegen.h
@@ -472,6 +472,17 @@ void g_initstatic (unsigned InitLabel, unsigned VarLabel, unsigned Size);
 
 
 /*****************************************************************************/
+/*                                Bit-fields                                 */
+/*****************************************************************************/
+
+void g_testbitfield (unsigned Flags, unsigned BitOffs, unsigned BitWidth);
+/* Test bit-field in ax. */
+
+void g_extractbitfield (unsigned Flags, unsigned FullWidthFlags,
+                        unsigned BitOffs, unsigned BitWidth);
+/* Extract bits from bit-field in ax. */
+
+/*****************************************************************************/
 /*                             Switch statement                              */
 /*****************************************************************************/
 


### PR DESCRIPTION
Extract functions `g_testbitfield` and `g_extractbitfield` from `LoadExpr`.

This helps prepare for #1192, since `g_extractbitfield` will get much
longer and call `AddCodeLine`.