### PR TITLE
[cc65] Preferred parameter lists from function definition in asm output

### DIFF
--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -596,8 +596,8 @@ void PrintFuncSig (FILE* F, const char* Name, Type* T)
     StrBuf East      = AUTO_STRBUF_INITIALIZER;
     StrBuf West      = AUTO_STRBUF_INITIALIZER;
 
-    /* Get the function descriptor */
-    const FuncDesc* D = GetFuncDesc (T);
+    /* Get the function descriptor used in definition */
+    const FuncDesc* D = GetFuncDefinitionDesc (T);
 
     /* Get the parameter list string. Start from the first parameter */
     SymEntry* Param = D->SymTab->SymHead;
@@ -1133,6 +1133,20 @@ Type* GetFuncReturn (Type* T)
 
     /* Return a pointer to the return type */
     return T + 1;
+}
+
+
+
+FuncDesc* GetFuncDefinitionDesc (Type* T)
+/* Get the function descriptor of the function definition */
+{
+    FuncDesc* D;
+
+    /* Be sure it's a function type */
+    CHECK (IsClassFunc (T));
+
+    D = GetFuncDesc (T);
+    return D->FuncDef != 0 ? D->FuncDef : D;
 }
 
 

--- a/src/cc65/datatype.h
+++ b/src/cc65/datatype.h
@@ -836,6 +836,9 @@ void SetFuncDesc (Type* T, FuncDesc* F);
 Type* GetFuncReturn (Type* T) attribute ((const));
 /* Return a pointer to the return type of a function or pointer-to-function type */
 
+FuncDesc* GetFuncDefinitionDesc (struct Type* T);
+/* Get the function descriptor of the function definition */
+
 long GetElementCount (const Type* T);
 /* Get the element count of the array specified in T (which must be of
 ** array type).

--- a/src/cc65/funcdesc.c
+++ b/src/cc65/funcdesc.c
@@ -60,6 +60,7 @@ FuncDesc* NewFuncDesc (void)
     F->ParamCount = 0;
     F->ParamSize  = 0;
     F->LastParam  = 0;
+    F->FuncDef    = 0;
     F->WrappedCall = 0;
     F->WrappedCallData = 0;
 

--- a/src/cc65/funcdesc.h
+++ b/src/cc65/funcdesc.h
@@ -68,6 +68,7 @@ struct FuncDesc {
     unsigned            ParamCount;     /* Number of parameters              */
     unsigned            ParamSize;      /* Size of the parameters            */
     struct SymEntry*    LastParam;      /* Pointer to last parameter         */
+    struct FuncDesc*    FuncDef;        /* Descriptor used in definition     */
     struct SymEntry*    WrappedCall;    /* Pointer to the WrappedCall        */
     unsigned char       WrappedCallData;/* The WrappedCall's user data       */
 };

--- a/src/cc65/function.c
+++ b/src/cc65/function.c
@@ -382,6 +382,9 @@ void NewFunc (SymEntry* Func, FuncDesc* D)
     SymEntry*   Param;
     const Type* RType;          /* Real type used for struct parameters */
 
+    /* Remember this function descriptor used for definition */
+    GetFuncDesc (Func->Type)->FuncDef = D;
+
     /* Allocate the function activation record for the function */
     CurrentFunc = NewFunction (Func, D);
 


### PR DESCRIPTION
(1/1) Resolved the comments from #1185 and #1187.

Example code:
```c
void hg(int (*p)[1]);
void hg(int (*a)[])
{
    void hg(int (*q)[]);
}
```
instead of previously:
```asm
; ---------------------------------------------------------------
; int __near__ hg (int (*p)[1])
; ---------------------------------------------------------------
```
the function signature of `hg()` is now printed in the output asm with `--add-source` as:
```asm
; ---------------------------------------------------------------
; void __near__ hg (int (*a)[])
; ---------------------------------------------------------------
```