### PR TITLE
[cc65] Forbid arrays/struct-fields/union-fields and assignment of incomplete types

### DIFF
--- a/src/cc65/assignment.c
+++ b/src/cc65/assignment.c
@@ -150,6 +150,11 @@ void Assignment (ExprDesc* Expr)
         Error ("Assignment to const");
     }
 
+    /* Check for assignment to incomplete type */
+    if (IsIncompleteESUType (ltype)) {
+        Error ("Assignment to incomplete type '%s'", GetFullTypeName (ltype));
+    }
+
     /* Skip the '=' token */
     NextToken ();
 

--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -140,19 +140,10 @@ static void Parse (void)
         comma = 0;
         while (1) {
 
-            Declaration         Decl;
+            Declaration Decl;
 
             /* Read the next declaration */
             ParseDecl (&Spec, &Decl, DM_NEED_IDENT);
-            if (Decl.Ident[0] == '\0') {
-                NextToken ();
-                break;
-            }
-
-            if ((Decl.StorageClass & SC_FICTITIOUS) == SC_FICTITIOUS) {
-                /* Failed parsing */
-                goto SkipOneDecl;
-            }
 
             /* Check if we must reserve storage for the variable. We do this,
             **
@@ -163,8 +154,9 @@ static void Parse (void)
             **
             ** This means that "extern int i;" will not get storage allocated.
             */
-            if ((Decl.StorageClass & SC_FUNC) != SC_FUNC          &&
-                (Decl.StorageClass & SC_TYPEMASK) != SC_TYPEDEF) {
+            if ((Decl.StorageClass & SC_FUNC) != SC_FUNC        &&
+                (Decl.StorageClass & SC_TYPEMASK) != SC_TYPEDEF &&
+                (Decl.StorageClass & SC_FICTITIOUS) != SC_FICTITIOUS) {
                 if ((Spec.Flags & DS_DEF_STORAGE) != 0                       ||
                     (Decl.StorageClass & (SC_EXTERN|SC_STATIC)) == SC_STATIC ||
                     ((Decl.StorageClass & SC_EXTERN) != 0 &&
@@ -296,7 +288,6 @@ static void Parse (void)
 
             }
 
-SkipOneDecl:
             /* Check for end of declaration list */
             if (CurTok.Tok == TOK_COMMA) {
                 NextToken ();
@@ -452,10 +443,6 @@ void Compile (const char* FileName)
                     }
 
                     Sym = GetSymType (GetElementType (Entry->Type));
-                    if (Size == 0 && Sym != 0 && SymIsDef (Sym)) {
-                        /* Array of 0-size elements */
-                        Warning ("Array '%s[]' has 0-sized elements", Entry->Name);
-                    }
                 }
 
                 /* For non-ESU types, Size != 0 */

--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -686,7 +686,10 @@ const Type* GetUnderlyingType (const Type* Type)
             Internal ("Enum tag type error in GetUnderlyingTypeCode");
         }
 
-        return ((SymEntry*)Type->A.P)->V.E.Type;
+        /* If incomplete enum type is used, just return its raw type */
+        if (((SymEntry*)Type->A.P)->V.E.Type != 0) {
+            return ((SymEntry*)Type->A.P)->V.E.Type;
+        }
     }
 
     return Type;
@@ -1246,9 +1249,14 @@ Type* IntPromotion (Type* T)
         ** to unsigned int.
         */
         return IsSignUnsigned (T) ? type_uint : type_int;
-    } else {
-        /* Otherwise, the type is not smaller than int, so leave it alone. */
+    } else if (!IsIncompleteESUType (T)) {
+        /* The type is a complete type not smaller than int, so leave it alone. */
         return T;
+    } else {
+        /* Otherwise, this is an incomplete enum, and there is expceted to be an error already.
+        ** Assume int to avoid further errors.
+        */
+        return type_int;
     }
 }
 

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -911,8 +911,15 @@ static SymEntry* ParseUnionDecl (const char* Name)
                 }
             }
 
+            /* Check for incomplete type */
+            if (IsIncompleteESUType (Decl.Type)) {
+                Error ("Field '%s' has incomplete type '%s'",
+                       Decl.Ident,
+                       GetFullTypeName (Decl.Type));
+            }
+
             /* Handle sizes */
-            FieldSize = CheckedSizeOf (Decl.Type);
+            FieldSize = SizeOf (Decl.Type);
             if (FieldSize > UnionSize) {
                 UnionSize = FieldSize;
             }
@@ -1095,6 +1102,13 @@ static SymEntry* ParseStructDecl (const char* Name)
                 }
             }
 
+            /* Check for incomplete type */
+            if (IsIncompleteESUType (Decl.Type)) {
+                Error ("Field '%s' has incomplete type '%s'",
+                       Decl.Ident,
+                       GetFullTypeName (Decl.Type));
+            }
+
             /* Add a field entry to the table */
             if (FieldWidth > 0) {
                 /* Full bytes have already been added to the StructSize,
@@ -1119,7 +1133,7 @@ static SymEntry* ParseStructDecl (const char* Name)
                     AddLocalSym (Decl.Ident, Decl.Type, SC_STRUCTFIELD, StructSize);
                 }
                 if (!FlexibleMember) {
-                    StructSize += CheckedSizeOf (Decl.Type);
+                    StructSize += SizeOf (Decl.Type);
                 }
             }
 

--- a/src/cc65/loadexpr.c
+++ b/src/cc65/loadexpr.c
@@ -142,6 +142,10 @@ void LoadExpr (unsigned Flags, struct ExprDesc* Expr)
                 BitFieldFullWidthFlags |= CF_UNSIGNED;
             }
         } else if ((Flags & CF_TYPEMASK) == 0) {
+            /* If Expr is an incomplete ESY type, bail out */
+            if (IsIncompleteESUType (Expr->Type)) {
+                return;
+            }
             Flags |= TypeOf (Expr->Type);
         }
 

--- a/src/cc65/locals.c
+++ b/src/cc65/locals.c
@@ -172,7 +172,11 @@ static void ParseRegisterDecl (Declaration* Decl, int Reg)
 
     /* Cannot allocate a variable of zero size */
     if (Size == 0) {
-        Error ("Variable '%s' has unknown size", Decl->Ident);
+        if (IsTypeArray (Decl->Type)) {
+            Error ("Array '%s' has unknown size", Decl->Ident);
+        } else {
+            Error ("Variable '%s' has unknown size", Decl->Ident);
+        }
     }
 }
 
@@ -357,7 +361,11 @@ static void ParseAutoDecl (Declaration* Decl)
 
     /* Cannot allocate a variable of zero size */
     if (Size == 0) {
-        Error ("Variable '%s' has unknown size", Decl->Ident);
+        if (IsTypeArray (Decl->Type)) {
+            Error ("Array '%s' has unknown size", Decl->Ident);
+        } else {
+            Error ("Variable '%s' has unknown size", Decl->Ident);
+        }
     }
 }
 
@@ -411,7 +419,11 @@ static void ParseStaticDecl (Declaration* Decl)
 
     /* Cannot allocate a variable of zero size */
     if (Size == 0) {
-        Error ("Variable '%s' has unknown size", Decl->Ident);
+        if (IsTypeArray (Decl->Type)) {
+            Error ("Array '%s' has unknown size", Decl->Ident);
+        } else {
+            Error ("Variable '%s' has unknown size", Decl->Ident);
+        }
     }
 }
 


### PR DESCRIPTION
(4/4)
- [x] Forbid struct/union fields of incomplete types.
- [x] Disallowed arrays of incomplete types.
- [x] Fixed CHECK failures on certain usage of incomplete enums.
- [x] Fixed checks on assignment to incomplete types.

```c
struct S {
    struct T a;   /* Error as struct T is incomplete */
};

struct T a[1];    /* Error as struct T is incomplete */

extern union U u; /* Extern declaration of incomplete type is OK */

void f()
{
    enum E e;     /* Error as as struct T is incomplete */
    u = u;        /* Error as union U is incomplete */
}
```
---
The `CHECK` failure happened when an incomplete enum (which has already raised an error) is used in expression:
```c
enum E e; /* Error */
e + 0;    /* CHECK failure*/
```
It is now fixed.