### PR TITLE
[cc65] Fixed function declarations with parameters of incomplete types

### DIFF
--- a/src/cc65/codeinfo.c
+++ b/src/cc65/codeinfo.c
@@ -410,8 +410,10 @@ fncls_t GetFuncInfo (const char* Name, unsigned short* Use, unsigned short* Chg)
                        (AutoCDecl ?
                         IsQualFastcall (E->Type) :
                         !IsQualCDecl (E->Type))) {
-                /* Will use registers depending on the last param. */
-                switch (CheckedSizeOf (D->LastParam->Type)) {
+                /* Will use registers depending on the last param. If the last
+                ** param has incomplete type, just assume __EAX__.
+                */
+                switch (SizeOf (D->LastParam->Type)) {
                     case 1u:
                         *Use = REG_A;
                         break;

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -1691,6 +1691,7 @@ static FuncDesc* ParseFuncDecl (void)
     /* It is allowed to use incomplete types in function prototypes, so we
     ** won't always get to know the parameter sizes here and may do that later.
     */
+    F->Flags |= FD_INCOMPLETE_PARAM;
  
     /* Leave the lexical level remembering the symbol tables */
     RememberFunctionLevel (F);

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -1642,7 +1642,6 @@ static void ParseAnsiParamList (FuncDesc* F)
 static FuncDesc* ParseFuncDecl (void)
 /* Parse the argument list of a function. */
 {
-    unsigned Offs;
     SymEntry* Sym;
     SymEntry* WrappedCall;
     unsigned char WrappedCallData;
@@ -1689,23 +1688,10 @@ static FuncDesc* ParseFuncDecl (void)
     */
     F->LastParam = GetSymTab()->SymTail;
 
-    /* Assign offsets. If the function has a variable parameter list,
-    ** there's one additional byte (the arg size).
+    /* It is allowed to use incomplete types in function prototypes, so we
+    ** won't always get to know the parameter sizes here and may do that later.
     */
-    Offs = (F->Flags & FD_VARIADIC)? 1 : 0;
-    Sym = F->LastParam;
-    while (Sym) {
-        unsigned Size = CheckedSizeOf (Sym->Type);
-        if (SymIsRegVar (Sym)) {
-            Sym->V.R.SaveOffs = Offs;
-        } else {
-            Sym->V.Offs = Offs;
-        }
-        Offs += Size;
-        F->ParamSize += Size;
-        Sym = Sym->PrevSym;
-    }
-
+ 
     /* Leave the lexical level remembering the symbol tables */
     RememberFunctionLevel (F);
 

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -1430,13 +1430,27 @@ static void ParseTypeSpec (DeclSpec* D, long Default, TypeCode Qualifiers,
 
 
 static Type* ParamTypeCvt (Type* T)
-/* If T is an array, convert it to a pointer else do nothing. Return the
-** resulting type.
+/* If T is an array or a function, convert it to a pointer else do nothing.
+** Return the resulting type.
 */
 {
+    Type* Tmp = 0;
+
     if (IsTypeArray (T)) {
-        T->C = T_PTR;
+        Tmp = ArrayToPtr (T);
+    } else if (IsTypeFunc (T)) {
+        Tmp = PointerTo (T);
     }
+    
+    if (Tmp != 0) {
+        /* Do several fixes on qualifiers */
+        FixQualifiers (Tmp);
+
+        /* Replace the type */
+        TypeCopy (T, Tmp);
+        TypeFree (Tmp);
+    }
+
     return T;
 }
 

--- a/src/cc65/declare.h
+++ b/src/cc65/declare.h
@@ -57,6 +57,9 @@
 #define DS_DEF_STORAGE          0x0001U /* Default storage class used   */
 #define DS_DEF_TYPE             0x0002U /* Default type used            */
 #define DS_EXTRA_TYPE           0x0004U /* Extra type declared          */
+#define DS_NEW_TYPE_DECL        0x0010U /* New type declared            */
+#define DS_NEW_TYPE_DEF         0x0020U /* New type defined             */
+#define DS_NEW_TYPE             (DS_NEW_TYPE_DECL | DS_NEW_TYPE_DEF)
 
 /* Result of ParseDeclSpec */
 typedef struct DeclSpec DeclSpec;

--- a/src/cc65/funcdesc.h
+++ b/src/cc65/funcdesc.h
@@ -49,13 +49,14 @@
 #define FD_EMPTY                0x0001U /* Function with empty param list    */
 #define FD_VOID_PARAM           0x0002U /* Function with a void param list   */
 #define FD_VARIADIC             0x0004U /* Function with variable param list */
+#define FD_INCOMPLETE_PARAM     0x0008U /* Function with param of unknown size */
 #define FD_OLDSTYLE             0x0010U /* Old style (K&R) function          */
 #define FD_OLDSTYLE_INTRET      0x0020U /* K&R func has implicit int return  */
 #define FD_UNNAMED_PARAMS       0x0040U /* Function has unnamed params       */
 #define FD_CALL_WRAPPER         0x0080U /* This function is used as a wrapper */
 
 /* Bits that must be ignored when comparing funcs */
-#define FD_IGNORE       (FD_OLDSTYLE | FD_OLDSTYLE_INTRET | FD_UNNAMED_PARAMS | FD_CALL_WRAPPER)
+#define FD_IGNORE   (FD_INCOMPLETE_PARAM | FD_OLDSTYLE | FD_OLDSTYLE_INTRET | FD_UNNAMED_PARAMS | FD_CALL_WRAPPER)
 
 
 

--- a/src/cc65/function.c
+++ b/src/cc65/function.c
@@ -117,6 +117,11 @@ int F_CheckParamList (FuncDesc* D, int RequireAll)
     unsigned    ParamSize = 0;
     unsigned    IncompleteCount = 0;
 
+    /* Don't bother to check unnecessarily */
+    if ((D->Flags & FD_INCOMPLETE_PARAM) == 0) {
+        return 1;
+    }
+
     /* Assign offsets. If the function has a variable parameter list,
     ** there's one additional byte (the arg size).
     */
@@ -147,11 +152,12 @@ int F_CheckParamList (FuncDesc* D, int RequireAll)
         ++I;
     }
 
-    /* If all parameters have complete types, set the total size description
-    ** and return true.
+    /* If all parameters have complete types, set the total size description,
+    ** clear the FD_INCOMPLETE_PARAM flag and return true.
     */
     if (IncompleteCount == 0) {
         D->ParamSize = ParamSize;
+        D->Flags &= ~FD_INCOMPLETE_PARAM;
         return 1;
     }
 

--- a/src/cc65/function.h
+++ b/src/cc65/function.h
@@ -81,6 +81,12 @@ extern Function* CurrentFunc;
 
 
 
+int F_CheckParamList (FuncDesc* D, int RequireAll);
+/* Check and set the parameter sizes.
+** If RequireAll is true, emit errors on parameters of incomplete types.
+** Return true if all parameters have complete types.
+*/
+
 const char* F_GetFuncName (const Function* F);
 /* Return the name of the current function */
 

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -686,7 +686,7 @@ static void AddSymEntry (SymTable* T, SymEntry* S)
 
 
 
-SymEntry* AddEnumSym (const char* Name, unsigned Flags, const Type* Type, SymTable* Tab)
+SymEntry* AddEnumSym (const char* Name, unsigned Flags, const Type* Type, SymTable* Tab, unsigned* DSFlags)
 /* Add an enum entry and return it */
 {
     SymTable* CurTagTab = TagTab;
@@ -719,6 +719,11 @@ SymEntry* AddEnumSym (const char* Name, unsigned Flags, const Type* Type, SymTab
                 Entry->V.E.Type   = Type;
                 Entry->Flags     &= ~SC_DECL;
                 Entry->Flags     |= SC_DEF;
+
+                /* Remember this is the first definition of this type */
+                if (DSFlags != 0) {
+                    *DSFlags |= DS_NEW_TYPE_DEF;
+                }
             }
         }
 
@@ -741,6 +746,14 @@ SymEntry* AddEnumSym (const char* Name, unsigned Flags, const Type* Type, SymTab
             Entry->Flags |= SC_DEF;
         }
 
+        /* Remember this is the first definition of this type */
+        if (CurTagTab != FailSafeTab && DSFlags != 0) {
+            if ((Entry->Flags & SC_DEF) != 0) {
+                *DSFlags |= DS_NEW_TYPE_DEF;
+            }
+            *DSFlags |= DS_NEW_TYPE_DECL;
+        }
+
         /* Add it to the current table */
         AddSymEntry (CurTagTab, Entry);
     }
@@ -751,7 +764,7 @@ SymEntry* AddEnumSym (const char* Name, unsigned Flags, const Type* Type, SymTab
 
 
 
-SymEntry* AddStructSym (const char* Name, unsigned Flags, unsigned Size, SymTable* Tab)
+SymEntry* AddStructSym (const char* Name, unsigned Flags, unsigned Size, SymTable* Tab, unsigned* DSFlags)
 /* Add a struct/union entry and return it */
 {
     SymTable* CurTagTab = TagTab;
@@ -791,6 +804,11 @@ SymEntry* AddStructSym (const char* Name, unsigned Flags, unsigned Size, SymTabl
                 Entry->Flags      = Flags;
                 Entry->V.S.SymTab = Tab;
                 Entry->V.S.Size   = Size;
+
+                /* Remember this is the first definition of this type */
+                if (DSFlags != 0) {
+                    *DSFlags |= DS_NEW_TYPE_DEF;
+                }
             }
         }
 
@@ -808,6 +826,14 @@ SymEntry* AddStructSym (const char* Name, unsigned Flags, unsigned Size, SymTabl
         /* Set the struct data */
         Entry->V.S.SymTab = Tab;
         Entry->V.S.Size   = Size;
+
+        /* Remember this is the first definition of this type */
+        if (CurTagTab != FailSafeTab && DSFlags != 0) {
+            if ((Entry->Flags & SC_DEF) != 0) {
+                *DSFlags |= DS_NEW_TYPE_DEF;
+            }
+            *DSFlags |= DS_NEW_TYPE_DECL;
+        }
 
         /* Add it to the current tag table */
         AddSymEntry (CurTagTab, Entry);

--- a/src/cc65/symtab.h
+++ b/src/cc65/symtab.h
@@ -149,10 +149,10 @@ unsigned short FindSPAdjustment (const char* Name);
 
 
 
-SymEntry* AddEnumSym (const char* Name, unsigned Flags, const Type* Type, SymTable* Tab);
+SymEntry* AddEnumSym (const char* Name, unsigned Flags, const Type* Type, SymTable* Tab, unsigned* DSFlags);
 /* Add an enum entry and return it */
 
-SymEntry* AddStructSym (const char* Name, unsigned Flags, unsigned Size, SymTable* Tab);
+SymEntry* AddStructSym (const char* Name, unsigned Flags, unsigned Size, SymTable* Tab, unsigned* DSFlags);
 /* Add a struct/union entry and return it */
 
 SymEntry* AddBitField (const char* Name, const Type* Type, unsigned Offs,


### PR DESCRIPTION
- Fixed #1167. Functions may have incomplete types in their declarations (https://github.com/cc65/cc65/issues/1167#issuecomment-670254608).
- Now it warns on type declarations in the parameter lists that are invisible out of the function declarations (to help avoid problems as in #1216).

(4/4) Pushed.

---
1167b (https://github.com/cc65/cc65/issues/1167#issuecomment-670254608) example:
```c
/* Note: new types declared inside a parameter list are local to the function and not visible outside */
struct S;
void foo(struct S);            /* BUG: should be OK, not "Size of type 'struct S' is unknown" */
void foo(struct S { int a; }); /* BUG: should be error *due to function type conflict* (#1168) */
void foo(struct S);            /* BUG: should be OK, not "Size of type 'struct S' is unknown" */
void bar(struct T);            /* BUG: should be OK, not "Size of type 'struct T' is unknown" */
void bar(struct T);            /* BUG: should conflict with the above (#1168), not be "Size of type 'struct T' is unknown" */
```

Before:
```
1167b.c(3): Error: Size of type 'struct S' is unknown
1167b.c(4): Error: Conflicting function types for 'foo'
1167b.c(5): Error: Size of type 'struct S' is unknown
1167b.c(6): Error: Size of type 'struct T' is unknown
1167b.c(7): Error: Size of type 'struct T' is unknown
1167b.c(7): Error: Conflicting function types for 'bar'
6 errors and 0 warnings generated.
```

After:
```
1167b.c(4): Warning: 'struct S' will be invisible out of this function
1167b.c(4): Error: Conflicting function types for 'foo'
1167b.c(6): Warning: 'struct T' will be invisible out of this function
1167b.c(7): Warning: 'struct T' will be invisible out of this function
1167b.c(7): Error: Conflicting function types for 'bar'
2 errors and 3 warnings generated.
```