### PR TITLE
[cc65] Use separate label pools for code, literals and static data

### DIFF
--- a/src/cc65/asmlabel.c
+++ b/src/cc65/asmlabel.c
@@ -98,3 +98,32 @@ int IsLocalLabelName (const char* Name)
     /* Local label name */
     return 1;
 }
+
+
+
+unsigned GetPooledLiteralLabel (void)
+/* Get an unused literal label. Will never return zero. */
+{
+    /* Number to generate unique labels */
+    static unsigned NextLabel = 0;
+
+    /* Check for an overflow */
+    if (NextLabel >= 0xFFFF) {
+        Internal ("Literal label overflow");
+    }
+
+    /* Return the next label */
+    return ++NextLabel;
+}
+
+
+
+const char* PooledLiteralLabelName (unsigned L)
+/* Make a litral label name from the given label number. The label name will be
+** created in static storage and overwritten when calling the function again.
+*/
+{
+    static char Buf[64];
+    sprintf (Buf, "S%04X", L);
+    return Buf;
+}

--- a/src/cc65/asmlabel.c
+++ b/src/cc65/asmlabel.c
@@ -101,6 +101,35 @@ int IsLocalLabelName (const char* Name)
 
 
 
+unsigned GetLocalDataLabel (void)
+/* Get an unused local data label. Will never return zero. */
+{
+    /* Number to generate unique labels */
+    static unsigned NextLabel = 0;
+
+    /* Check for an overflow */
+    if (NextLabel >= 0xFFFF) {
+        Internal ("Local data label overflow");
+    }
+
+    /* Return the next label */
+    return ++NextLabel;
+}
+
+
+
+const char* LocalDataLabelName (unsigned L)
+/* Make a label name from the given data label number. The label name will be
+** created in static storage and overwritten when calling the function again.
+*/
+{
+    static char Buf[64];
+    sprintf (Buf, "M%04X", L);
+    return Buf;
+}
+
+
+
 unsigned GetPooledLiteralLabel (void)
 /* Get an unused literal label. Will never return zero. */
 {

--- a/src/cc65/asmlabel.h
+++ b/src/cc65/asmlabel.h
@@ -56,6 +56,14 @@ const char* LocalLabelName (unsigned L);
 int IsLocalLabelName (const char* Name);
 /* Return true if Name is the name of a local label */
 
+unsigned GetLocalDataLabel (void);
+/* Get an unused local data label. Will never return zero. */
+
+const char* LocalDataLabelName (unsigned L);
+/* Make a label name from the given data label number. The label name will be
+** created in static storage and overwritten when calling the function again.
+*/
+
 unsigned GetPooledLiteralLabel (void);
 /* Get an unused literal label. Will never return zero. */
 

--- a/src/cc65/asmlabel.h
+++ b/src/cc65/asmlabel.h
@@ -56,6 +56,14 @@ const char* LocalLabelName (unsigned L);
 int IsLocalLabelName (const char* Name);
 /* Return true if Name is the name of a local label */
 
+unsigned GetPooledLiteralLabel (void);
+/* Get an unused literal label. Will never return zero. */
+
+const char* PooledLiteralLabelName (unsigned L);
+/* Make a litral label name from the given label number. The label name will be
+** created in static storage and overwritten when calling the function again.
+*/
+
 
 
 /* End of asmlabel.h */

--- a/src/cc65/asmstmt.c
+++ b/src/cc65/asmstmt.c
@@ -289,7 +289,7 @@ static void ParseLabelArg (StrBuf* T, unsigned Arg attribute ((unused)))
 
     } else {
 
-        /* Add a new label symbol if we don't have one until now */
+        /* Add a new C label symbol if we don't have one until now */
         SymEntry* Entry = AddLabelSym (CurTok.Ident, SC_REF);
 
         /* Append the label name to the buffer */

--- a/src/cc65/codegen.c
+++ b/src/cc65/codegen.c
@@ -107,11 +107,11 @@ static const char* GetLabelName (unsigned Flags, uintptr_t Label, long Offs)
             break;
 
         case CF_STATIC:
-            /* Static memory cell */
+            /* Local static memory cell */
             if (Offs) {
-                xsprintf (Buf, sizeof (Buf), "%s%+ld", LocalLabelName (Label), Offs);
+                xsprintf (Buf, sizeof (Buf), "%s%+ld", LocalDataLabelName (Label), Offs);
             } else {
-                xsprintf (Buf, sizeof (Buf), "%s", LocalLabelName (Label));
+                xsprintf (Buf, sizeof (Buf), "%s", LocalDataLabelName (Label));
             }
             break;
 
@@ -142,6 +142,15 @@ static const char* GetLabelName (unsigned Flags, uintptr_t Label, long Offs)
         case CF_REGVAR:
             /* Variable in register bank */
             xsprintf (Buf, sizeof (Buf), "regbank+%u", (unsigned)((Label+Offs) & 0xFFFF));
+            break;
+
+        case CF_CODE:
+            /* Code label location */
+            if (Offs) {
+                xsprintf (Buf, sizeof (Buf), "%s%+ld", LocalLabelName (Label), Offs);
+            } else {
+                xsprintf (Buf, sizeof (Buf), "%s", LocalLabelName (Label));
+            }
             break;
 
         default:
@@ -360,7 +369,7 @@ void g_defcodelabel (unsigned label)
 void g_defdatalabel (unsigned label)
 /* Define a local data label */
 {
-    AddDataLine ("%s:", LocalLabelName (label));
+    AddDataLine ("%s:", LocalDataLabelName (label));
 }
 
 
@@ -2453,11 +2462,11 @@ void g_lateadjustSP (unsigned label)
 /* Adjust stack based on non-immediate data */
 {
     AddCodeLine ("pha");
-    AddCodeLine ("lda %s", LocalLabelName (label));
+    AddCodeLine ("lda %s", LocalDataLabelName (label));
     AddCodeLine ("clc");
     AddCodeLine ("adc sp");
     AddCodeLine ("sta sp");
-    AddCodeLine ("lda %s+1", LocalLabelName (label));
+    AddCodeLine ("lda %s+1", LocalDataLabelName (label));
     AddCodeLine ("adc sp+1");
     AddCodeLine ("sta sp+1");
     AddCodeLine ("pla");

--- a/src/cc65/codegen.h
+++ b/src/cc65/codegen.h
@@ -148,9 +148,6 @@ void g_defcodelabel (unsigned label);
 void g_defdatalabel (unsigned label);
 /* Define a local data label */
 
-void g_aliasdatalabel (unsigned label, unsigned baselabel, long offs);
-/* Define label as a local alias for baselabel+offs */
-
 
 
 /*****************************************************************************/
@@ -161,6 +158,12 @@ void g_aliasdatalabel (unsigned label, unsigned baselabel, long offs);
 
 void g_defgloblabel (const char* Name);
 /* Define a global label with the given name */
+
+void g_defliterallabel (unsigned label);
+/* Define a literal data label */
+
+void g_aliasliterallabel (unsigned label, unsigned baselabel, long offs);
+/* Define label as an alias for baselabel+offs */
 
 void g_defexport (const char* Name, int ZP);
 /* Export the given label */

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -2157,9 +2157,13 @@ static void DefineData (ExprDesc* Expr)
             break;
 
         case E_LOC_STATIC:
-        case E_LOC_LITERAL:
-            /* Static variable or literal in the literal pool */
+            /* Static variable */
             g_defdata (CF_STATIC, Expr->Name, Expr->IVal);
+            break;
+
+        case E_LOC_LITERAL:
+            /* Literal in the literal pool */
+            g_defdata (CF_LITERAL, Expr->Name, Expr->IVal);
             break;
 
         case E_LOC_REGISTER:

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -2176,6 +2176,11 @@ static void DefineData (ExprDesc* Expr)
             g_defdata (CF_REGVAR, Expr->Name, Expr->IVal);
             break;
 
+        case E_LOC_CODE:
+            /* Code label location */
+            g_defdata (CF_CODE, Expr->Name, Expr->IVal);
+            break;
+
         case E_LOC_STACK:
         case E_LOC_PRIMARY:
         case E_LOC_EXPR:

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1519,19 +1519,13 @@ void Store (ExprDesc* Expr, const Type* StoreType)
             break;
 
         case E_LOC_GLOBAL:
-            /* Global variable */
-            g_putstatic (Flags, Expr->Name, Expr->IVal);
-            break;
-
         case E_LOC_STATIC:
+        case E_LOC_REGISTER:
         case E_LOC_LITERAL:
         case E_LOC_CODE:
-            /* Static variable, pooled literal or code label location */
-            g_putstatic (Flags, Expr->Name, Expr->IVal);
-            break;
-
-        case E_LOC_REGISTER:
-            /* Register variable */
+            /* Global variabl, static variable, register variable, pooled
+            ** literal or code label location.
+            */
             g_putstatic (Flags, Expr->Name, Expr->IVal);
             break;
 
@@ -1599,19 +1593,13 @@ static void PreInc (ExprDesc* Expr)
             break;
 
         case E_LOC_GLOBAL:
-            /* Global variable */
-            g_addeqstatic (Flags, Expr->Name, Expr->IVal, Val);
-            break;
-
         case E_LOC_STATIC:
+        case E_LOC_REGISTER:
         case E_LOC_LITERAL:
         case E_LOC_CODE:
-            /* Static variable, pooled literal or code label location */
-            g_addeqstatic (Flags, Expr->Name, Expr->IVal, Val);
-            break;
-
-        case E_LOC_REGISTER:
-            /* Register variable */
+            /* Global variabl, static variable, register variable, pooled
+            ** literal or code label location.
+            */
             g_addeqstatic (Flags, Expr->Name, Expr->IVal, Val);
             break;
 
@@ -1676,19 +1664,13 @@ static void PreDec (ExprDesc* Expr)
             break;
 
         case E_LOC_GLOBAL:
-            /* Global variable */
-            g_subeqstatic (Flags, Expr->Name, Expr->IVal, Val);
-            break;
-
         case E_LOC_STATIC:
+        case E_LOC_REGISTER:
         case E_LOC_LITERAL:
         case E_LOC_CODE:
-            /* Static variable, pooled literal or code label location */
-            g_subeqstatic (Flags, Expr->Name, Expr->IVal, Val);
-            break;
-
-        case E_LOC_REGISTER:
-            /* Register variable */
+            /* Global variabl, static variable, register variable, pooled
+            ** literal or code label location.
+            */
             g_subeqstatic (Flags, Expr->Name, Expr->IVal, Val);
             break;
 
@@ -3648,36 +3630,15 @@ static void addsubeq (const GenDesc* Gen, ExprDesc *Expr, const char* Op)
     switch (ED_GetLoc (Expr)) {
 
         case E_LOC_ABS:
-            /* Absolute numeric addressed variable */
-            if (Gen->Tok == TOK_PLUS_ASSIGN) {
-                g_addeqstatic (lflags, Expr->Name, Expr->IVal, Expr2.IVal);
-            } else {
-                g_subeqstatic (lflags, Expr->Name, Expr->IVal, Expr2.IVal);
-            }
-            break;
-
         case E_LOC_GLOBAL:
-            /* Global variable */
-            if (Gen->Tok == TOK_PLUS_ASSIGN) {
-                g_addeqstatic (lflags, Expr->Name, Expr->IVal, Expr2.IVal);
-            } else {
-                g_subeqstatic (lflags, Expr->Name, Expr->IVal, Expr2.IVal);
-            }
-            break;
-
         case E_LOC_STATIC:
+        case E_LOC_REGISTER:
         case E_LOC_LITERAL:
         case E_LOC_CODE:
-            /* Static variable, pooled literal or code label location */
-            if (Gen->Tok == TOK_PLUS_ASSIGN) {
-                g_addeqstatic (lflags, Expr->Name, Expr->IVal, Expr2.IVal);
-            } else {
-                g_subeqstatic (lflags, Expr->Name, Expr->IVal, Expr2.IVal);
-            }
-            break;
-
-        case E_LOC_REGISTER:
-            /* Register variable */
+            /* Absolute numeric addressed variable, global variable, local
+            ** static variable, register variable, pooled literal or code
+            ** label location.
+            */
             if (Gen->Tok == TOK_PLUS_ASSIGN) {
                 g_addeqstatic (lflags, Expr->Name, Expr->IVal, Expr2.IVal);
             } else {

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -92,6 +92,7 @@ static unsigned GlobalModeFlags (const ExprDesc* Expr)
         case E_LOC_PRIMARY:     return CF_PRIMARY;
         case E_LOC_EXPR:        return CF_EXPR;
         case E_LOC_LITERAL:     return CF_LITERAL;
+        case E_LOC_CODE:        return CF_CODE;
         default:
             Internal ("GlobalModeFlags: Invalid location flags value: 0x%04X", Expr->Flags);
             /* NOTREACHED */
@@ -786,7 +787,7 @@ static void Primary (ExprDesc* E)
                 NextToken ();
                 Entry = AddLabelSym (CurTok.Ident, SC_REF | SC_GOTO_IND);
                 /* output its label */
-                E->Flags = E_RTYPE_RVAL | E_LOC_STATIC | E_ADDRESS_OF;
+                E->Flags = E_RTYPE_RVAL | E_LOC_CODE | E_ADDRESS_OF;
                 E->Name = Entry->V.L.Label;
                 E->Type = PointerTo (type_void);
                 NextToken ();
@@ -1524,7 +1525,8 @@ void Store (ExprDesc* Expr, const Type* StoreType)
 
         case E_LOC_STATIC:
         case E_LOC_LITERAL:
-            /* Static variable or literal in the literal pool */
+        case E_LOC_CODE:
+            /* Static variable, pooled literal or code label location */
             g_putstatic (Flags, Expr->Name, Expr->IVal);
             break;
 
@@ -1603,7 +1605,8 @@ static void PreInc (ExprDesc* Expr)
 
         case E_LOC_STATIC:
         case E_LOC_LITERAL:
-            /* Static variable or literal in the literal pool */
+        case E_LOC_CODE:
+            /* Static variable, pooled literal or code label location */
             g_addeqstatic (Flags, Expr->Name, Expr->IVal, Val);
             break;
 
@@ -1679,7 +1682,8 @@ static void PreDec (ExprDesc* Expr)
 
         case E_LOC_STATIC:
         case E_LOC_LITERAL:
-            /* Static variable or literal in the literal pool */
+        case E_LOC_CODE:
+            /* Static variable, pooled literal or code label location */
             g_subeqstatic (Flags, Expr->Name, Expr->IVal, Val);
             break;
 
@@ -3663,7 +3667,8 @@ static void addsubeq (const GenDesc* Gen, ExprDesc *Expr, const char* Op)
 
         case E_LOC_STATIC:
         case E_LOC_LITERAL:
-            /* Static variable or literal in the literal pool */
+        case E_LOC_CODE:
+            /* Static variable, pooled literal or code label location */
             if (Gen->Tok == TOK_PLUS_ASSIGN) {
                 g_addeqstatic (lflags, Expr->Name, Expr->IVal, Expr2.IVal);
             } else {

--- a/src/cc65/exprdesc.c
+++ b/src/cc65/exprdesc.c
@@ -172,9 +172,9 @@ const char* ED_GetLabelName (const ExprDesc* Expr, long Offs)
         case E_LOC_LITERAL:
             /* Literal in the literal pool */
             if (Offs) {
-                SB_Printf (&Buf, "%s%+ld", LocalLabelName (Expr->Name), Offs);
+                SB_Printf (&Buf, "%s%+ld", PooledLiteralLabelName (Expr->Name), Offs);
             } else {
-                SB_Printf (&Buf, "%s", LocalLabelName (Expr->Name));
+                SB_Printf (&Buf, "%s", PooledLiteralLabelName (Expr->Name));
             }
             break;
 

--- a/src/cc65/exprdesc.c
+++ b/src/cc65/exprdesc.c
@@ -178,6 +178,15 @@ const char* ED_GetLabelName (const ExprDesc* Expr, long Offs)
             }
             break;
 
+        case E_LOC_CODE:
+            /* Code label location */
+            if (Offs) {
+                SB_Printf (&Buf, "%s%+ld", LocalLabelName (Expr->Name), Offs);
+            } else {
+                SB_Printf (&Buf, "%s", LocalLabelName (Expr->Name));
+            }
+            break;
+
         default:
             Internal ("Invalid location in ED_GetLabelName: 0x%04X", ED_GetLoc (Expr));
     }
@@ -470,9 +479,9 @@ void PrintExprDesc (FILE* F, ExprDesc* E)
         Flags &= ~E_LOC_LITERAL;
         Sep = ',';
     }
-    if (Flags & E_RTYPE_LVAL) {
-        fprintf (F, "%cE_RTYPE_LVAL", Sep);
-        Flags &= ~E_RTYPE_LVAL;
+    if (Flags & E_LOC_CODE) {
+        fprintf (F, "%cE_LOC_CODE", Sep);
+        Flags &= ~E_LOC_CODE;
         Sep = ',';
     }
     if (Flags & E_BITFIELD) {
@@ -488,6 +497,11 @@ void PrintExprDesc (FILE* F, ExprDesc* E)
     if (Flags & E_CC_SET) {
         fprintf (F, "%cE_CC_SET", Sep);
         Flags &= ~E_CC_SET;
+        Sep = ',';
+    }
+    if (Flags & E_RTYPE_LVAL) {
+        fprintf (F, "%cE_RTYPE_LVAL", Sep);
+        Flags &= ~E_RTYPE_LVAL;
         Sep = ',';
     }
     if (Flags & E_ADDRESS_OF) {

--- a/src/cc65/litpool.c
+++ b/src/cc65/litpool.c
@@ -99,7 +99,7 @@ static Literal* NewLiteral (const void* Buf, unsigned Len)
     Literal* L = xmalloc (sizeof (*L));
 
     /* Initialize the fields */
-    L->Label    = GetLocalLabel ();
+    L->Label    = GetPooledLiteralLabel ();
     L->RefCount = 0;
     L->Output   = 0;
     SB_Init (&L->Data);
@@ -130,7 +130,7 @@ static void OutputLiteral (Literal* L)
     TranslateLiteral (L);
 
     /* Define the label for the literal */
-    g_defdatalabel (L->Label);
+    g_defliterallabel (L->Label);
 
     /* Output the literal data */
     g_defbytes (SB_GetConstBuf (&L->Data), SB_GetLen (&L->Data));
@@ -423,12 +423,12 @@ static void OutputReadOnlyLiterals (Collection* Literals)
         if (C != 0) {
 
             /* This literal is part of a longer literal, merge them */
-            g_aliasdatalabel (L->Label, C->Label, GetLiteralSize (C) - GetLiteralSize (L));
+            g_aliasliterallabel (L->Label, C->Label, GetLiteralSize (C) - GetLiteralSize (L));
 
         } else {
 
             /* Define the label for the literal */
-            g_defdatalabel (L->Label);
+            g_defliterallabel (L->Label);
 
             /* Output the literal data */
             g_defbytes (SB_GetConstBuf (&L->Data), SB_GetLen (&L->Data));

--- a/src/cc65/loadexpr.c
+++ b/src/cc65/loadexpr.c
@@ -64,9 +64,13 @@ static void LoadAddress (unsigned Flags, ExprDesc* Expr)
             break;
 
         case E_LOC_STATIC:
-        case E_LOC_LITERAL:
-            /* Static symbol or literal, load address */
+            /* Static symbol, load address */
             g_getimmed ((Flags | CF_STATIC) & ~CF_CONST, Expr->Name, Expr->IVal);
+            break;
+
+        case E_LOC_LITERAL:
+            /* Literal, load address */
+            g_getimmed ((Flags | CF_LITERAL) & ~CF_CONST, Expr->Name, Expr->IVal);
             break;
 
         case E_LOC_REGISTER:
@@ -183,9 +187,13 @@ void LoadExpr (unsigned Flags, struct ExprDesc* Expr)
                 break;
 
             case E_LOC_STATIC:
-            case E_LOC_LITERAL:
-                /* Static variable or literal in the literal pool */
+                /* Static variable */
                 g_getstatic (Flags | CF_STATIC, Expr->Name, Expr->IVal);
+                break;
+
+            case E_LOC_LITERAL:
+                /* Literal in the literal pool */
+                g_getstatic (Flags | CF_LITERAL, Expr->Name, Expr->IVal);
                 break;
 
             case E_LOC_REGISTER:

--- a/src/cc65/loadexpr.c
+++ b/src/cc65/loadexpr.c
@@ -83,6 +83,11 @@ static void LoadAddress (unsigned Flags, ExprDesc* Expr)
             g_getimmed ((Flags | CF_REGVAR) & ~CF_CONST, Expr->Name, Expr->IVal);
             break;
 
+        case E_LOC_CODE:
+            /* Code label, load address */
+            g_getimmed ((Flags | CF_CODE) & ~CF_CONST, Expr->Name, Expr->IVal);
+            break;
+
         case E_LOC_STACK:
             g_leasp (Expr->IVal);
             break;
@@ -199,6 +204,11 @@ void LoadExpr (unsigned Flags, struct ExprDesc* Expr)
             case E_LOC_REGISTER:
                 /* Register variable */
                 g_getstatic (Flags | CF_REGVAR, Expr->Name, Expr->IVal);
+                break;
+
+            case E_LOC_CODE:
+                /* Code label location */
+                g_getstatic (Flags | CF_CODE, Expr->Name, Expr->IVal);
                 break;
 
             case E_LOC_STACK:

--- a/src/cc65/locals.c
+++ b/src/cc65/locals.c
@@ -64,31 +64,31 @@
 
 
 static unsigned AllocLabel (void (*UseSeg) ())
-/* Switch to a segment, define a local label and return it */
+/* Switch to a segment, define a local data label and return it */
 {
-    unsigned Label;
+    unsigned DataLabel;
 
     /* Switch to the segment */
     UseSeg ();
 
     /* Define the variable label */
-    Label = GetLocalLabel ();
-    g_defdatalabel (Label);
+    DataLabel = GetLocalDataLabel ();
+    g_defdatalabel (DataLabel);
 
     /* Return the label */
-    return Label;
+    return DataLabel;
 }
 
 
 
-static void AllocStorage (unsigned Label, void (*UseSeg) (), unsigned Size)
-/* Reserve Size bytes of BSS storage prefixed by a local label. */
+static void AllocStorage (unsigned DataLabel, void (*UseSeg) (), unsigned Size)
+/* Reserve Size bytes of BSS storage prefixed by a local data label. */
 {
     /* Switch to the segment */
     UseSeg ();
 
     /* Define the variable label */
-    g_defdatalabel (Label);
+    g_defdatalabel (DataLabel);
 
     /* Reserve space for the data */
     g_res (Size);
@@ -299,7 +299,7 @@ static void ParseAutoDecl (Declaration* Decl)
         Decl->StorageClass = (Decl->StorageClass & ~SC_AUTO) | SC_STATIC;
 
         /* Generate a label, but don't define it */
-        DataLabel = GetLocalLabel ();
+        DataLabel = GetLocalDataLabel ();
 
         /* Add the symbol to the symbol table. */
         Sym = AddLocalSym (Decl->Ident, Decl->Type, Decl->StorageClass, DataLabel);
@@ -377,7 +377,7 @@ static void ParseStaticDecl (Declaration* Decl)
     unsigned Size;
 
     /* Generate a label, but don't define it */
-    unsigned DataLabel = GetLocalLabel ();
+    unsigned DataLabel = GetLocalDataLabel ();
 
     /* Add the symbol to the symbol table. */
     SymEntry* Sym = AddLocalSym (Decl->Ident, Decl->Type,

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -905,7 +905,7 @@ DefOrRef* AddDefOrRef (SymEntry* E, unsigned Flags)
     DOR->Flags = Flags;
     DOR->StackPtr = StackPtr;
     DOR->Depth = CollCount (&CurrentFunc->LocalsBlockStack);
-    DOR->LateSP_Label = GetLocalLabel ();
+    DOR->LateSP_Label = GetLocalDataLabel ();
 
     return DOR;
 }
@@ -927,7 +927,7 @@ unsigned short FindSPAdjustment (const char* Name)
 
 
 SymEntry* AddLabelSym (const char* Name, unsigned Flags)
-/* Add a goto label to the label table */
+/* Add a C goto label to the label table */
 {
     unsigned i;
     DefOrRef *DOR, *NewDOR;
@@ -986,7 +986,7 @@ SymEntry* AddLabelSym (const char* Name, unsigned Flags)
                     /* Optimizer will need the information about the value of SP adjustment
                     ** later, so let's preserve it.
                     */
-                    E = NewSymEntry (LocalLabelName (DOR->LateSP_Label), SC_SPADJUSTMENT);
+                    E = NewSymEntry (LocalDataLabelName (DOR->LateSP_Label), SC_SPADJUSTMENT);
                     E->V.SPAdjustment = StackPtr - DOR->StackPtr;
                     AddSymEntry (SPAdjustTab, E);
                 }
@@ -1108,9 +1108,9 @@ SymEntry* AddLocalSym (const char* Name, const Type* T, unsigned Flags, int Offs
             Entry->V.L.Label = Offs;
             SymSetAsmName (Entry);
         } else if ((Flags & SC_STATIC) == SC_STATIC) {
-            /* Generate the assembler name from the label number */
+            /* Generate the assembler name from the data label number */
             Entry->V.L.Label = Offs;
-            Entry->AsmName = xstrdup (LocalLabelName (Entry->V.L.Label));
+            Entry->AsmName = xstrdup (LocalDataLabelName (Entry->V.L.Label));
         } else {
             Internal ("Invalid flags in AddLocalSym: %04X", Flags);
         }


### PR DESCRIPTION
Apparently the first commit from this branch was squashed with PR #1220 in order to get it to compile. So this now depends on it....
(3/3) commits.
- [x] Use a dedicated label pool for literals.
- [x] Made local static data use a separated label pool from the code label pool.
- [x] Merged some switch cases in code generation subroutines.
