### PR TITLE
[cc65] Reduced exess errors on wrong initializations with curly braces

### DIFF
--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -959,7 +959,16 @@ static void Primary (ExprDesc* E)
             /* Illegal primary. Be sure to skip the token to avoid endless
             ** error loops.
             */
-            {
+            if (CurTok.Tok == TOK_LCURLY) {
+                /* Statement block */
+                NextToken ();
+                Error ("Expression expected");
+                hie0 (E);
+                if (CurTok.Tok == TOK_RCURLY) {
+                    NextToken ();
+                }
+                break;
+            } else {
                 /* Let's see if this is a C99-style declaration */
                 DeclSpec    Spec;
                 InitDeclSpec (&Spec);


### PR DESCRIPTION
(1/1) As cc65 doesn't support initializing scalar typed objects with extra stuff enclosed in curly braces, it's desired to avoid unwanted error messages resulted from them.

Example:
```c
int f(int x)
{
    int a = { 1, 2 };
    if (a) { return a * 2; }
    return a + x;
}

int y;
```
Before:
```
<source>(3): Error: Expression expected
<source>(3): Error: ';' expected
<source>(3): Warning: Expression result unused
<source>(3): Warning: Expression result unused
<source>(3): Error: ';' expected
<source>(3): Warning: Control reaches end of non-void functi
<source>(3): Warning: Parameter 'x' is never used
<source>(4): Error: Identifier expected
<source>(4): Warning: Implicit 'int' is an obsolete feature
<source>(4): Error: ';' expected
<source>(4): Warning: Implicit 'int' is an obsolete feature
<source>(4): Error: ';' expected
<source>(4): Error: Identifier expected
<source>(4): Warning: Implicit 'int' is an obsolete feature
<source>(4): Error: ';' expected
<source>(4): Error: Identifier expected
<source>(4): Warning: Implicit 'int' is an obsolete feature
<source>(4): Error: ';' expected
<source>(4): Warning: Implicit 'int' is an obsolete feature
<source>(4): Error: ';' expected
<source>(4): Error: Identifier expected
<source>(4): Warning: Implicit 'int' is an obsolete feature
<source>(4): Error: Identifier expected
<source>(4): Warning: Implicit 'int' is an obsolete feature
<source>(5): Error: ';' expected
<source>(5): Error: Identifier expected
<source>(5): Warning: Implicit 'int' is an obsolete feature
<source>(5): Error: ';' expected
<source>(5): Warning: Implicit 'int' is an obsolete feature
<source>(5): Error: ';' expected
<source>(5): Error: Identifier expected
<source>(5): Warning: Implicit 'int' is an obsolete feature
<source>(5): Error: ';' expected
<source>(5): Warning: Implicit 'int' is an obsolete feature
<source>(6): Error: Identifier expected
<source>(6): Warning: Implicit 'int' is an obsolete feature
<source>(8): Error: ';' expected
<source>(8): Fatal: Too many errors
```
After:
```
<source>(3): Error: Expression expected
1 errors and 0 warnings generated.
```
