### PR TITLE
[cc65] 'void' extension fixes

### DIFF
--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -979,7 +979,7 @@ int IsClassIncomplete (const Type* T)
 /* Return true if this is an object type lacking size info */
 {
     if (IsTypeArray (T)) {
-        return GetElementCount (T) == UNSPECIFIED;
+        return GetElementCount (T) == UNSPECIFIED || IsClassIncomplete (T + 1);
     }
     return IsTypeVoid (T) || IsIncompleteESUType (T);
 }
@@ -1072,7 +1072,7 @@ int HasUnknownSize (const Type* T)
 /* Return true if this is an incomplete ESU type or an array of unknown size */
 {
     if (IsTypeArray (T)) {
-        return GetElementCount (T) == UNSPECIFIED;
+        return GetElementCount (T) == UNSPECIFIED || HasUnknownSize (T + 1);
     }
     return IsIncompleteESUType (T);
 }

--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -903,6 +903,7 @@ unsigned TypeOf (const Type* T)
             /* Address of ... */
             return CF_INT | CF_UNSIGNED;
 
+        case T_VOID:
         case T_ENUM:
             /* Incomplete enum type */
             Error ("Incomplete type '%s'", GetFullTypeName (T));

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -942,8 +942,8 @@ static SymEntry* ParseUnionDecl (const char* Name, unsigned* DSFlags)
                 }
             }
 
-            /* Check for incomplete type */
-            if (IsIncompleteESUType (Decl.Type)) {
+            /* Check for incomplete types including 'void' */
+            if (IsClassIncomplete (Decl.Type)) {
                 Error ("Field '%s' has incomplete type '%s'",
                        Decl.Ident,
                        GetFullTypeName (Decl.Type));
@@ -1142,8 +1142,8 @@ static SymEntry* ParseStructDecl (const char* Name, unsigned* DSFlags)
                 }
             }
 
-            /* Check for incomplete type */
-            if (IsIncompleteESUType (Decl.Type)) {
+            /* Check for incomplete types including 'void' */
+            if (IsClassIncomplete (Decl.Type)) {
                 Error ("Field '%s' has incomplete type '%s'",
                        Decl.Ident,
                        GetFullTypeName (Decl.Type));

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -2389,6 +2389,11 @@ static unsigned ParseArrayInit (Type* T, int* Braces, int AllowFlexibleMembers)
         }
     }
 
+    /* Size of 'void' elements are determined after initialization */
+    if (ElementSize == 0) {
+        ElementSize = SizeOf (ElementType);
+    }
+
     if (ElementCount == UNSPECIFIED) {
         /* Number of elements determined by initializer */
         SetElementCount (T, Count);
@@ -2695,7 +2700,11 @@ static unsigned ParseVoidInit (Type* T)
     ConsumeRCurly ();
 
     /* Number of bytes determined by initializer */
-    T->A.U = Size;
+    if (T->A.U != 0 && T->A.U != Size) {
+        Error ("'void' array initialized with elements of variant sizes");
+    } else {
+        T->A.U = Size;
+    }
 
     /* Return the number of bytes initialized */
     return Size;


### PR DESCRIPTION
(4/4) It's easier to leave `void` arrays supported than to forbid them while keep supporting `extern void` arrays....
- [x] Disallowed void arrays of elements of variant sizes.
- [x] Improved diagnostic info on assignment to void types.
- [x] Recursively checking for incomplete/unknown-sized types.
- [x] Disabled struct/union fields of 'void' type.

Resolved #1144.

```c
extern void v[];                            /* OK */
void ex      = { 12, (char)34 };            /* OK */
void ex1[1]  = { {12, (char)34} };          /* OK */
void ex2a[2] = { {12, (char)34}, {(char)56, (char)78, (char)90} };  /* OK - each "row" is 3 bytes in size */
void ex2b[2] = { {12, (char)34}, { 56 }, }; /* Error: 'void' array initialized with elements of variant sizes */
void ex3[3]  = { {12, (char)34}, };         /* OK - the last two "rows" will each be 3 bytes in size and zero-filled */

void x[][2] = { { { 1 } , { 2 }} };

struct S {
    int a;
    void v[1];                              /* Error: Field 'v' has incomplete type 'void[1]' */
};

union U {
    int a;
    void v;                                 /* Error: Field 'v' has incomplete type 'void' */
};
```
