### PR TITLE
[cc65] Fixes for some optimization steps

### DIFF
--- a/src/cc65/coptind.c
+++ b/src/cc65/coptind.c
@@ -1147,8 +1147,9 @@ unsigned OptDupLoads (CodeSeg* S)
         /* Get next entry */
         CodeEntry* E = CS_GetEntry (S, I);
 
-        /* Assume we won't delete the entry */
+        /* Assume we won't delete or replace the entry */
         int Delete = 0;
+        opc_t NewOPC = OP65_INVALID;
 
         /* Get a pointer to the input registers of the insn */
         const RegContents* In  = &E->RI->In;
@@ -1218,7 +1219,7 @@ unsigned OptDupLoads (CodeSeg* S)
                            E->AM != AM65_ABSY         &&
                            E->AM != AM65_ZPY) {
                     /* Use the A register instead */
-                    CE_ReplaceOPC (E, OP65_STA);
+                    NewOPC = OP65_STA;
                 }
                 break;
 
@@ -1242,11 +1243,11 @@ unsigned OptDupLoads (CodeSeg* S)
                 */
                 } else if (RegValIsKnown (In->RegY)) {
                     if (In->RegY == In->RegA) {
-                        CE_ReplaceOPC (E, OP65_STA);
+                        NewOPC = OP65_STA;
                     } else if (In->RegY == In->RegX   &&
                                E->AM != AM65_ABSX     &&
                                E->AM != AM65_ZPX) {
-                        CE_ReplaceOPC (E, OP65_STX);
+                        NewOPC = OP65_STX;
                     }
                 }
                 break;
@@ -1318,6 +1319,14 @@ unsigned OptDupLoads (CodeSeg* S)
             ++Changes;
 
         } else {
+
+            if (NewOPC != OP65_INVALID) {
+                /* Replace the opcode */
+                CE_ReplaceOPC (E, NewOPC);
+
+                /* Remember, we had changes */
+                ++Changes;
+            }
 
             /* Next entry */
             ++I;

--- a/src/cc65/coptpush.h
+++ b/src/cc65/coptpush.h
@@ -52,16 +52,16 @@
 unsigned OptPush1 (CodeSeg* S);
 /* Given a sequence
 **
-**     ldy     #xx
 **     jsr     ldaxysp
 **     jsr     pushax
 **
-** If a/x are not used later, replace that by
+** If a/x are not used later, and Y is known, replace that by
 **
 **     ldy     #xx+2
 **     jsr     pushwysp
+**     ldy     #$00     ; present if later code expects Y = 0
 **
-** saving 3 bytes and several cycles.
+** saving several cycles.
 */
 
 unsigned OptPush2 (CodeSeg* S);

--- a/src/cc65/opcodes.h
+++ b/src/cc65/opcodes.h
@@ -128,7 +128,10 @@ typedef enum {
     OP65_TYA,
 
     /* Number of opcodes available */
-    OP65_COUNT
+    OP65_COUNT,
+
+    /* Invalid opcode */
+    OP65_INVALID = OP65_COUNT,
 } opc_t;
 
 /* 65XX addressing modes */


### PR DESCRIPTION
(2/2)
- [x] Fixed OptPush1 in case later code would rely on that pushax zeroes register Y.
There was the possibility that code following a `pushax` would rely on that register Y is set to `0` by it, whilst the opimization result `pushwysp` wouldn't set Y to 0. This fix checks for such cases and keeps the invariant on Y.
- [x] OptDupLoads shouldn't silently do optimizations.
`OptDupLoads` not only deletes code entries but also replaces the opcode at times, which was not correctly reported with `--debug-opt-output`. This PR fixes that.