### PR TITLE
[cc65] Fixed evaluation flags propagation

### DIFF
--- a/src/cc65/assignment.c
+++ b/src/cc65/assignment.c
@@ -136,10 +136,11 @@ static int CopyStruct (ExprDesc* LExpr, ExprDesc* RExpr)
 void Assignment (ExprDesc* Expr)
 /* Parse an assignment */
 {
-    ExprDesc Expr2;
     Type* ltype = Expr->Type;
 
+    ExprDesc Expr2;
     ED_Init (&Expr2);
+    Expr2.Flags |= Expr->Flags & E_MASK_KEEP_SUBEXPR;
 
     /* We must have an lvalue for an assignment */
     if (ED_IsRVal (Expr)) {

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -332,7 +332,7 @@ static void WarnConstCompareResult (const ExprDesc* Expr)
 
 
 
-static unsigned FunctionParamList (FuncDesc* Func, int IsFastcall)
+static unsigned FunctionParamList (FuncDesc* Func, int IsFastcall, ExprDesc* ED)
 /* Parse a function parameter list, and pass the arguments to the called
 ** function. Depending on several criteria, this may be done by just pushing
 ** into each parameter separately, or creating the parameter frame once, and
@@ -391,9 +391,10 @@ static unsigned FunctionParamList (FuncDesc* Func, int IsFastcall)
     /* Parse the actual argument list */
     while (CurTok.Tok != TOK_RPAREN) {
 
-        unsigned Flags;
+        unsigned Flags;     /* Code generator flags, not expression flags */
         ExprDesc Expr;
         ED_Init (&Expr);
+        Expr.Flags |= ED->Flags & E_MASK_KEEP_SUBEXPR;
 
         /* Count arguments */
         ++PushedCount;
@@ -609,7 +610,7 @@ static void FunctionCall (ExprDesc* Expr)
     }
 
     /* Parse the parameter list */
-    ParamSize = FunctionParamList (Func, IsFastcall);
+    ParamSize = FunctionParamList (Func, IsFastcall, Expr);
 
     /* We need the closing paren here */
     ConsumeRParen ();

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -3223,6 +3223,9 @@ static int hieAnd (ExprDesc* Expr, unsigned* TrueLab, int* TrueLabAllocated)
                 /* Load the value */
                 LoadExpr (CF_FORCECHAR, Expr);
 
+                /* Clear the test flag */
+                ED_RequireNoTest (Expr);
+
                 /* Remember that the jump is used */
                 HasFalseJump = 1;
 
@@ -3355,6 +3358,9 @@ static void hieOr (ExprDesc *Expr)
 
                     /* Get first expr */
                     LoadExpr (CF_FORCECHAR, Expr);
+
+                    /* Clear the test flag */
+                    ED_RequireNoTest (Expr);
 
                     if (HasTrueJump == 0) {
                         /* Get a label that we will use for true expressions */

--- a/src/cc65/exprdesc.h
+++ b/src/cc65/exprdesc.h
@@ -365,6 +365,16 @@ INLINE void ED_RequireTest (ExprDesc* Expr)
 #endif
 
 #if defined(HAVE_INLINE)
+INLINE void ED_RequireNoTest (ExprDesc* Expr)
+/* Mark the expression not for a test. */
+{
+    Expr->Flags &= ~E_NEED_TEST;
+}
+#else
+#  define ED_RequireNoTest(Expr)    do { (Expr)->Flags &= ~E_NEED_TEST; } while (0)
+#endif
+
+#if defined(HAVE_INLINE)
 INLINE int ED_GetNeeds (const ExprDesc* Expr)
 /* Get flags about what the expression needs. */
 {

--- a/test/ref/pr1220.c
+++ b/test/ref/pr1220.c
@@ -10,14 +10,14 @@
 
 /* test AND/OR in ternary context */
 #define CONTEXT_B(x)    do {\
-                        s = 0, flags = 0,\
-                        (x ? printf("%3d %2X: 1\n", s, flags) : printf("%3d %2X: 0\n", s, flags));\
+                        s = 0, flags = 0, t = (x ? 42 : -42),\
+                        printf("%3d %2X: %d\n", s, flags, t);\
                         } while (0)
 
 int s, t;
 unsigned flags;
 
-int f(x)
+int f(int x)
 /* The call to this function should be and only be skipped strictly according to
 ** the short-circuit evaluation rule.
 */
@@ -31,8 +31,8 @@ int f(x)
 #define _B f(b)
 #define _C f(c)
 #define _D f(d)
-#define _T (f(0), -1)
-#define _F (f(-1), 0)
+#define _T (f(0), 256)
+#define _F (f(256), 0)
 
 void f0()
 /* constant short-circuit */
@@ -176,7 +176,7 @@ void f5(int a, int b, int c, int d)
 void f0_B()
 /* constant short-circuit */
 {
-    printf("f0()\n");
+    printf("f0_B()\n");
 
     CONTEXT_B(_T && _T && _T);
     CONTEXT_B(_F && _F && _F);
@@ -205,7 +205,7 @@ void f0_B()
 void f1_B(int a, int b, int c)
 /* AND */
 {
-    printf("f1(%d, %d, %d)\n", a, b, c);
+    printf("f1_B(%d, %d, %d)\n", a, b, c);
 
     CONTEXT_B(_A && _B && _C);
 
@@ -227,7 +227,7 @@ void f1_B(int a, int b, int c)
 void f2_B(int a, int b, int c)
 /* OR */
 {
-    printf("f2(%d, %d, %d)\n", a, b, c);
+    printf("f2_B(%d, %d, %d)\n", a, b, c);
 
     CONTEXT_B(_A || _B || _C);
 
@@ -249,7 +249,7 @@ void f2_B(int a, int b, int c)
 void f3_B(int a, int b, int c, int d)
 /* AND and OR */
 {
-    printf("f3(%d, %d, %d, %d)\n", a, b, c, d);
+    printf("f3_B(%d, %d, %d, %d)\n", a, b, c, d);
 
     CONTEXT_B(_A && _B || _C && _D);
     CONTEXT_B(_T && _T || _C && _D);
@@ -271,7 +271,7 @@ void f3_B(int a, int b, int c, int d)
 void f4_B(int a, int b, int c, int d)
 /* AND as top-level expression inside OR context */
 {
-    printf("f4(%d, %d, %d, %d)\n", a, b, c, d);
+    printf("f4_B(%d, %d, %d, %d)\n", a, b, c, d);
 
     CONTEXT_B((_A && _B) || (_C && _D));
     CONTEXT_B((_T && _T) || (_C && _D));
@@ -293,7 +293,7 @@ void f4_B(int a, int b, int c, int d)
 void f5_B(int a, int b, int c, int d)
 /* OR as top-level expression inside AND context */
 {
-    printf("f5(%d, %d, %d, %d)\n", a, b, c, d);
+    printf("f5_B(%d, %d, %d, %d)\n", a, b, c, d);
 
     CONTEXT_B((_A || _B) && (_C || _D));
     CONTEXT_B((_F || _F) && (_C || _D));


### PR DESCRIPTION
(3/3)
- [x] Fixed AND/OR in certain cases where the 'E_NEED_TEST' flag set for usage only in subexpressions should be cleared.
Still the same old "reused subexpression" bug. Sigh.
- [x] Fixed evaluation flags propagation to subexpressions in assignments and function calls.
- [x] Updated `test/ref/pr1220.c` for testing this.
