### PR TITLE
[cc65] Fixed logical-NOT in constant context.

### DIFF
--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1907,14 +1907,19 @@ void hie10 (ExprDesc* Expr)
 
         case TOK_BOOL_NOT:
             NextToken ();
-            if (evalexpr (CF_NONE, hie10, Expr) == 0) {
+            BoolExpr (hie10, Expr);
+            if (ED_IsConstAbs (Expr)) {
                 /* Constant expression */
                 Expr->IVal = !Expr->IVal;
             } else {
+                /* Not constant, load into the primary */
+                LoadExpr (CF_NONE, Expr);
                 g_bneg (TypeOf (Expr->Type));
                 ED_FinalizeRValLoad (Expr);
                 ED_TestDone (Expr);             /* bneg will set cc */
             }
+            /* The result type is always boolean */
+            Expr->Type = type_bool;
             break;
 
         case TOK_STAR:
@@ -3969,29 +3974,6 @@ void hie0 (ExprDesc *Expr)
         Expr->Flags = Flags;
         NextToken ();
         hie1 (Expr);
-    }
-}
-
-
-
-int evalexpr (unsigned Flags, void (*Func) (ExprDesc*), ExprDesc* Expr)
-/* Will evaluate an expression via the given function. If the result is a
-** constant, 0 is returned and the value is put in the Expr struct. If the
-** result is not constant, LoadExpr is called to bring the value into the
-** primary register and 1 is returned.
-*/
-{
-    /* Evaluate */
-    ExprWithCheck (Func, Expr);
-
-    /* Check for a constant expression */
-    if (ED_IsConstAbs (Expr)) {
-        /* Constant expression */
-        return 0;
-    } else {
-        /* Not constant, load into the primary */
-        LoadExpr (Flags, Expr);
-        return 1;
     }
 }
 

--- a/src/cc65/exprdesc.c
+++ b/src/cc65/exprdesc.c
@@ -389,6 +389,14 @@ int ED_IsConstAbsInt (const ExprDesc* Expr)
 
 
 
+int ED_IsConstBool (const ExprDesc* Expr)
+/* Return true if the expression can be constantly evaluated as a boolean. */
+{
+    return ED_IsConstAbsInt (Expr) || ED_IsAddrExpr (Expr);
+}
+
+
+
 int ED_IsConst (const ExprDesc* Expr)
 /* Return true if the expression denotes a constant of some sort. This can be a
 ** numeric constant, the address of a global variable (maybe with offset) or

--- a/src/cc65/exprdesc.h
+++ b/src/cc65/exprdesc.h
@@ -630,6 +630,9 @@ int ED_IsConstAbs (const ExprDesc* Expr);
 int ED_IsConstAbsInt (const ExprDesc* Expr);
 /* Return true if the expression is a constant (numeric) integer. */
 
+int ED_IsConstBool (const ExprDesc* Expr);
+/* Return true if the expression can be constantly evaluated as a boolean. */
+
 int ED_IsConst (const ExprDesc* Expr);
 /* Return true if the expression denotes a constant of some sort. This can be a
 ** numeric constant, the address of a global variable (maybe with offset) or

--- a/src/cc65/testexpr.c
+++ b/src/cc65/testexpr.c
@@ -77,6 +77,11 @@ unsigned Test (unsigned Label, int Invert)
             g_jump (Label);
         }
 
+    } else if (ED_IsAddrExpr (&Expr)) {
+
+        /* Object addresses are non-NULL */
+        Result = 1;
+
     } else {
 
         /* Result is unknown */


### PR DESCRIPTION
(3/3) See also Issue #1196.
- [x] Fixed usage of logical-NOT in constant context.
- [x] Object addresses as non-NULL pointers in constant context.
This PR makes `&object != NULL` as a true constant value.