### PR TITLE
Fix build on systems without <stdint.h>

### DIFF
--- a/src/common/inttypes.h
+++ b/src/common/inttypes.h
@@ -38,7 +38,8 @@
 
 
 
-/* If we have <stdint.h>, include it; otherwise, adapt types from <stddef.h>.
+/* If we have <stdint.h>, include it; otherwise, adapt types from <stddef.h>
+** and define integer boundary constants.
 ** gcc and msvc don't define __STDC_VERSION__ without special flags, so check
 ** for them explicitly.  Undefined symbols are replaced by zero; so, checks for
 ** defined(__GNUC__) and defined(_MSC_VER) aren't necessary.

--- a/src/common/inttypes.h
+++ b/src/common/inttypes.h
@@ -57,6 +57,16 @@ typedef size_t uintptr_t;
 typedef ptrdiff_t intmax_t;
 typedef size_t uintmax_t;
 
+#define INT8_MAX (0x7F)
+#define INT16_MAX (0x7FFF)
+#define INT32_MAX (0x7FFFFFFF)
+
+#define INT8_MIN (-INT8_MAX - 1)
+#define INT16_MIN (-INT16_MAX - 1)
+
+#define UINT8_MAX (0xFF)
+#define UINT16_MAX (0xFFFF)
+
 #endif
 
 


### PR DESCRIPTION
While porting cc65 over to Plan 9, I noticed that the compiler would not build when `<stdint.h>` was not included (due to certain macros not being defined by default, in my case), complaining about the missing `INT*_{MIN,MAX}` macros used on `src/cc65/declare.c`. Since there already is a compile-time branch for cases where the header is (supposedly) missing and the fact that given values don't vary between systems (I'd be surprised to see otherwise), I found it reasonable to just `#define` the missing constants. I just included the ones used in the code, but it might be desirable add the missing ones as well, for proofing against possible future use of the macros. 