### PR TITLE
[cc65] Enhanced OptStackOps optimization

### DIFF
--- a/src/cc65/codeinfo.c
+++ b/src/cc65/codeinfo.c
@@ -64,6 +64,13 @@ static const char CmpSuffixTab [][4] = {
     "eq", "ne", "gt", "ge", "lt", "le", "ugt", "uge", "ult", "ule"
 };
 
+/* Table with the bool transformers */
+static const char BoolTransformerTab [][8] = {
+    "booleq", "boolne",
+    "boolgt", "boolge", "boollt", "boolle",
+    "boolugt", "booluge", "boolult", "boolule"
+};
+
 /* Table listing the function names and code info values for known internally
 ** used functions. This table should get auto-generated in the future.
 */
@@ -838,5 +845,57 @@ cmp_t FindTosCmpCond (const char* Name)
     } else {
         /* Not found */
         return CMP_INV;
+    }
+}
+
+
+
+const char* GetBoolTransformer (cmp_t Cond)
+/* Get the bool transformer corresponding to the given compare condition */
+{
+    if (Cond > CMP_INV && Cond < CMP_END) {
+        return BoolTransformerTab[Cond];
+    }
+
+    /* Not found */
+    return 0;
+}
+
+
+cmp_t GetNegatedCond (cmp_t Cond)
+/* Get the logically opposite compare condition */
+{
+    switch (Cond) {
+    case CMP_EQ: return CMP_NE;
+    case CMP_NE: return CMP_EQ;
+    case CMP_GT: return CMP_LE;
+    case CMP_GE: return CMP_LT;
+    case CMP_LT: return CMP_GE;
+    case CMP_LE: return CMP_GT;
+    case CMP_UGT: return CMP_ULE;
+    case CMP_UGE: return CMP_ULT;
+    case CMP_ULT: return CMP_UGE;
+    case CMP_ULE: return CMP_UGT;
+    default: return CMP_INV;
+    }
+}
+
+
+
+cmp_t GetRevertedCond (cmp_t Cond)
+/* Get the compare condition in reverted order of operands */
+{
+    switch (Cond) {
+    case CMP_EQ: return CMP_EQ;
+    case CMP_NE: return CMP_NE;
+    case CMP_GT: return CMP_LT;
+    case CMP_GE: return CMP_LE;
+    case CMP_LT: return CMP_GT;
+    case CMP_LE: return CMP_GE;
+    case CMP_UGT: return CMP_ULT;
+    case CMP_UGE: return CMP_ULE;
+    case CMP_ULT: return CMP_UGT;
+    case CMP_ULE: return CMP_UGE;
+    default: return CMP_INV;
     }
 }

--- a/src/cc65/codeinfo.h
+++ b/src/cc65/codeinfo.h
@@ -115,7 +115,10 @@ typedef enum {
     CMP_UGT,
     CMP_UGE,
     CMP_ULT,
-    CMP_ULE
+    CMP_ULE,
+
+    /* End of the enumeration */
+    CMP_END
 } cmp_t;
 
 
@@ -184,6 +187,15 @@ cmp_t FindTosCmpCond (const char* Name);
 /* Check if this is a call to one of the TOS compare functions (tosgtax).
 ** Return the condition code or CMP_INV on failure.
 */
+
+const char* GetBoolTransformer (cmp_t Cond);
+/* Get the bool transformer corresponding to the given compare condition */
+
+cmp_t GetNegatedCond (cmp_t Cond);
+/* Get the logically opposite compare condition */
+
+cmp_t GetRevertedCond (cmp_t Cond);
+/* Get the compare condition in reverted order of operands */
 
 
 

--- a/src/cc65/coptcmp.c
+++ b/src/cc65/coptcmp.c
@@ -448,11 +448,7 @@ unsigned OptCmp3 (CodeSeg* S)
                         Delete = 1;
                         break;
 
-                    case CMP_UGT:
-                    case CMP_UGE:
-                    case CMP_ULT:
-                    case CMP_ULE:
-                    case CMP_INV:
+                    default:
                         /* Leave it alone */
                         break;
                 }


### PR DESCRIPTION
(3/3) This was one of my oldest attempts on optimizer enhancements (refreshed once this year). It basically skips the comparison operations on the hi-bytes if they are equal. This is similar to _but not the same as_ that requested in Issue #1203 (which  would skip operations on the lo-bytes instead).

An enhanment to allow OptStack to optimize more cases on the stack is also stuffed in.

- [x] Utility functions about compare conditions.
- [x] Improved OptStackOps for optimizating further when operands have equal hi-bytes.
- [x] Extended support for more addressing modes in tos* optimizations.