### PR TITLE
[cc65] Sizeof fixes and optimizations

### DIFF
--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -593,7 +593,7 @@ static void FunctionCall (ExprDesc* Expr)
         }
 
         /* Check for known standard functions and inline them */
-        if (Expr->Name != 0) {
+        if (Expr->Name != 0 && !ED_IsUneval (Expr)) {
             int StdFunc = FindStdFunc ((const char*) Expr->Name);
             if (StdFunc >= 0) {
                 /* Inline this function */

--- a/src/cc65/exprdesc.h
+++ b/src/cc65/exprdesc.h
@@ -474,13 +474,13 @@ void ED_MarkForUneval (ExprDesc* Expr);
 /* Mark the expression as not to be evaluated */
 
 #if defined(HAVE_INLINE)
-INLINE int ED_MayBeUneval (const ExprDesc* Expr)
-/* Check if the expression may be uevaluated */
+INLINE int ED_IsUneval (const ExprDesc* Expr)
+/* Check if the expression is not to be evaluated */
 {
     return (Expr->Flags & E_EVAL_UNEVAL) == E_EVAL_UNEVAL;
 }
 #else
-#  define ED_MayBeUneval(Expr)  (((Expr)->Flags & E_EVAL_UNEVAL) == E_EVAL_UNEVAL)
+#  define ED_IsUneval(Expr)     (((Expr)->Flags & E_EVAL_UNEVAL) == E_EVAL_UNEVAL)
 #endif
 
 #if defined(HAVE_INLINE)


### PR DESCRIPTION
(2/2) Resolved #1222.
- [x] Std-functions are no longer inlined if they are unevaluated.
- [x] Avoided referencing string literals with sizeof so that they are not output if unused elsewhere.