### PR TITLE
[cc65] Fixed check for processor flags usage in case of PHP

### DIFF
--- a/src/cc65/codeent.c
+++ b/src/cc65/codeent.c
@@ -476,6 +476,11 @@ int CE_UseLoadFlags (CodeEntry* E)
         }
     }
 
+    /* PHP will use all flags */
+    if (E->OPC == OP65_PHP) {
+        return 1;
+    }
+
     /* Anything else */
     return 0;
 }


### PR DESCRIPTION
(1/1) Opcode `php` uses the Z/N flags. Although this opcode isn't being generated by cc65 at the moment, it may appear in asm().