### PR TITLE
[cc65] Avoided unnecessarily boosting the code label numbers with boolean AND

### DIFF
--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -3237,8 +3237,8 @@ static int hieAnd (ExprDesc* Expr, unsigned* TrueLab, int* TrueLabAllocated)
     int HasFalseJump = 0, HasTrueJump = 0;
     CodeMark Start;
 
-    /* Get a label that we will use for false expressions */
-    int FalseLab = GetLocalLabel ();
+    /* The label that we will use for false expressions */
+    int FalseLab = 0;
 
     /* Get lhs */
     GetCodePos (&Start);
@@ -3266,8 +3266,12 @@ static int hieAnd (ExprDesc* Expr, unsigned* TrueLab, int* TrueLabAllocated)
                 /* Clear the test flag */
                 ED_RequireNoTest (Expr);
 
-                /* Remember that the jump is used */
-                HasFalseJump = 1;
+                if (HasFalseJump == 0) {
+                    /* Remember that the jump is used */
+                    HasFalseJump = 1;
+                    /* Get a label for false expressions */
+                    FalseLab = GetLocalLabel ();
+                }
 
                 /* Generate the jump */
                 g_falsejump (CF_NONE, FalseLab);
@@ -3304,7 +3308,12 @@ static int hieAnd (ExprDesc* Expr, unsigned* TrueLab, int* TrueLabAllocated)
 
                     /* Do short circuit evaluation */
                     if (CurTok.Tok == TOK_BOOL_AND) {
-                        HasFalseJump = 1;
+                        if (HasFalseJump == 0) {
+                            /* Remember that the jump is used */
+                            HasFalseJump = 1;
+                            /* Get a label for false expressions */
+                            FalseLab = GetLocalLabel ();
+                        }
                         g_falsejump (CF_NONE, FalseLab);
                     } else {
                         /* We need the true label for the last expression */


### PR DESCRIPTION
Greatly reduced the label numbers when `&&` is involved, to ease the label overflow number concern in PR #1220:
> It might be worth mentioning that despite that 1d7fcc67a498f65a4687099b87a40d402c039c78 saves nearly half of the labels, the new testcase d4025efaba798c652302bb49fb45506f8504b5c0 still easily reaches a big label number (>= L1141).

... as well as the problems described in Issue #301.