### PR TITLE
[cc65] Made local code/data labels really local to the functions where they live in

### DIFF
--- a/src/cc65/asmlabel.c
+++ b/src/cc65/asmlabel.c
@@ -42,6 +42,17 @@
 /* cc65 */
 #include "asmlabel.h"
 #include "error.h"
+#include "segments.h"
+
+
+
+/*****************************************************************************/
+/*                                   Data                                    */
+/*****************************************************************************/
+
+
+
+static struct Segments* CurrentFunctionSegment;
 
 
 
@@ -51,19 +62,26 @@
 
 
 
-unsigned GetLocalLabel (void)
-/* Get an unused label. Will never return zero. */
+void UseLabelPoolFromSegments (struct Segments* Seg)
+/* Use the info in segments for generating new label numbers */
 {
-    /* Number to generate unique labels */
-    static unsigned NextLabel = 0;
+    CurrentFunctionSegment = Seg;
+}
+
+
+
+unsigned GetLocalLabel (void)
+/* Get an unused assembler label for the function. Will never return zero. */
+{
+    PRECONDITION (CurrentFunctionSegment != 0);
 
     /* Check for an overflow */
-    if (NextLabel >= 0xFFFF) {
+    if (CurrentFunctionSegment->NextLabel >= 0xFFFF) {
         Internal ("Local label overflow");
     }
 
     /* Return the next label */
-    return ++NextLabel;
+    return ++CurrentFunctionSegment->NextLabel;
 }
 
 
@@ -104,16 +122,15 @@ int IsLocalLabelName (const char* Name)
 unsigned GetLocalDataLabel (void)
 /* Get an unused local data label. Will never return zero. */
 {
-    /* Number to generate unique labels */
-    static unsigned NextLabel = 0;
+    PRECONDITION (CurrentFunctionSegment != 0);
 
     /* Check for an overflow */
-    if (NextLabel >= 0xFFFF) {
+    if (CurrentFunctionSegment->NextDataLabel >= 0xFFFF) {
         Internal ("Local data label overflow");
     }
 
     /* Return the next label */
-    return ++NextLabel;
+    return ++CurrentFunctionSegment->NextDataLabel;
 }
 
 

--- a/src/cc65/asmlabel.h
+++ b/src/cc65/asmlabel.h
@@ -39,13 +39,26 @@
 
 
 /*****************************************************************************/
+/*                                 Forwards                                  */
+/*****************************************************************************/
+
+
+
+struct Segments;
+
+
+
+/*****************************************************************************/
 /*                                   Code                                    */
 /*****************************************************************************/
 
 
 
+void UseLabelPoolFromSegments (struct Segments* Seg);
+/* Use the info in segments for generating new label numbers */
+
 unsigned GetLocalLabel (void);
-/* Get an unused assembler label. Will never return zero. */
+/* Get an unused assembler label for the function. Will never return zero. */
 
 const char* LocalLabelName (unsigned L);
 /* Make a label name from the given label number. The label name will be

--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -389,6 +389,12 @@ void Compile (const char* FileName)
     /* Create the global code and data segments */
     CreateGlobalSegments ();
 
+    /* There shouldn't be needs for local labels outside a function, but the
+    ** current code generator still tries to get some at times even though the
+    ** code were ill-formed. So just set it up with the global segment list.
+    */
+    UseLabelPoolFromSegments (GS);
+
     /* Initialize the literal pool */
     InitLiteralPool ();
 
@@ -488,6 +494,9 @@ void FinishCompile (void)
     */
     for (Entry = GetGlobalSymTab ()->SymHead; Entry; Entry = Entry->NextSym) {
         if (SymIsOutputFunc (Entry)) {
+            /* Continue with previous label numbers */
+            UseLabelPoolFromSegments (Entry->V.F.Seg);
+
             /* Function which is defined and referenced or extern */
             MoveLiteralPool (Entry->V.F.LitPool);
             CS_MergeLabels (Entry->V.F.Seg->Code);

--- a/src/cc65/function.h
+++ b/src/cc65/function.h
@@ -120,6 +120,9 @@ int F_IsOldStyle (const Function* F);
 int F_HasOldStyleIntRet (const Function* F);
 /* Return true if this is an old style (K&R) function with an implicit int return */
 
+void F_SetRetLab (Function* F, unsigned NewRetLab);
+/* Change the return jump label */
+
 unsigned F_GetRetLab (const Function* F);
 /* Return the return jump label */
 

--- a/src/cc65/segments.c
+++ b/src/cc65/segments.c
@@ -143,12 +143,14 @@ static Segments* NewSegments (SymEntry* Func)
     Segments* S = xmalloc (sizeof (Segments));
 
     /* Initialize the fields */
-    S->Text     = NewTextSeg (Func);
-    S->Code     = NewCodeSeg (GetSegName (SEG_CODE), Func);
-    S->Data     = NewDataSeg (GetSegName (SEG_DATA), Func);
-    S->ROData   = NewDataSeg (GetSegName (SEG_RODATA), Func);
-    S->BSS      = NewDataSeg (GetSegName (SEG_BSS), Func);
-    S->CurDSeg  = SEG_DATA;
+    S->Text    = NewTextSeg (Func);
+    S->Code    = NewCodeSeg (GetSegName (SEG_CODE), Func);
+    S->Data    = NewDataSeg (GetSegName (SEG_DATA), Func);
+    S->ROData  = NewDataSeg (GetSegName (SEG_RODATA), Func);
+    S->BSS     = NewDataSeg (GetSegName (SEG_BSS), Func);
+    S->CurDSeg = SEG_DATA;
+    S->NextLabel     = 0;
+    S->NextDataLabel = 0;
 
     /* Return the new struct */
     return S;

--- a/src/cc65/segments.h
+++ b/src/cc65/segments.h
@@ -86,6 +86,8 @@ struct Segments {
     struct DataSeg*     ROData;         /* Readonly data segment */
     struct DataSeg*     BSS;            /* Segment for uninitialized data */
     segment_t           CurDSeg;        /* Current data segment */
+    unsigned            NextLabel;      /* Number to generate unique code labels */
+    unsigned            NextDataLabel;  /* Number to generate unique data labels */
 };
 
 /* Pointer to the current segment list. Output goes here. */


### PR DESCRIPTION
Reset the code/data label numbers in every function to ease with the problem described in #301. 

Also greatly reduced the label numbers when `&&` is invloved to ease the label overflow number concern in PR #1220:
> It might be worth mentioning that despite [1d7fcc6](https://github.com/cc65/cc65/commit/1d7fcc67a498f65a4687099b87a40d402c039c78) saves nearly half of the labels, the new testcase [d4025ef](https://github.com/cc65/cc65/commit/d4025efaba798c652302bb49fb45506f8504b5c0) still easily reaches a big label number (>= L1131).

Note: String literals still have global data label numbers even though they were compiled with `--local-strings`.