### PR TITLE
[cc65] Processor state tracking

### DIFF
--- a/src/cc65/codeent.c
+++ b/src/cc65/codeent.c
@@ -1418,10 +1418,10 @@ void CE_GenRegInfo (CodeEntry* E, RegContents* InputRegs)
                     Out->RegX = (In->RegX ^ 0xFF);
                 }
             } else if (strcmp (E->Arg, "tosandax") == 0) {
-                if (In->RegA == 0) {
+                if (RegValIsKnown (In->RegA) && In->RegA == 0) {
                     Out->RegA = 0;
                 }
-                if (In->RegX == 0) {
+                if (RegValIsKnown (In->RegX) && In->RegX == 0) {
                     Out->RegX = 0;
                 }
             } else if (strcmp (E->Arg, "tosaslax") == 0) {
@@ -1430,15 +1430,19 @@ void CE_GenRegInfo (CodeEntry* E, RegContents* InputRegs)
                     Out->RegA = 0;
                 }
             } else if (strcmp (E->Arg, "tosorax") == 0) {
-                if (In->RegA == 0xFF) {
+                if (RegValIsKnown (In->RegA) && In->RegA == 0xFF) {
                     Out->RegA = 0xFF;
                 }
-                if (In->RegX == 0xFF) {
+                if (RegValIsKnown (In->RegX) && In->RegX == 0xFF) {
                     Out->RegX = 0xFF;
                 }
             } else if (strcmp (E->Arg, "tosshlax") == 0) {
-                if ((In->RegA & 0x0F) >= 8) {
+                if (RegValIsKnown (In->RegA) && (In->RegA & 0x0F) >= 8) {
                     Out->RegA = 0;
+                }
+            } else if (strcmp (E->Arg, "tosshrax") == 0) {
+                if (RegValIsKnown (In->RegA) && (In->RegA & 0x0F) >= 8) {
+                    Out->RegX = 0;
                 }
             } else if (strcmp (E->Arg, "bcastax") == 0     ||
                        strcmp (E->Arg, "bnegax") == 0      ||

--- a/src/cc65/codeent.c
+++ b/src/cc65/codeent.c
@@ -206,6 +206,145 @@ static void SetUseChgInfo (CodeEntry* E, const OPCDesc* D)
                 /* Keep gcc silent */
                 break;
         }
+
+        /* Append processor flags as well as special usages */
+        switch (E->OPC) {
+
+            case OP65_ADC:
+            case OP65_SBC:
+                E->Use |= PSTATE_C;
+                E->Chg |= PSTATE_CZVN;
+                break;
+            case OP65_ROL:
+            case OP65_ROR:
+                E->Use |= PSTATE_C;
+                E->Chg |= PSTATE_CZN;
+                break;
+            case OP65_ASL:
+            case OP65_LSR:
+                E->Chg |= PSTATE_CZN;
+                break;
+            case OP65_CMP:
+            case OP65_CPX:
+            case OP65_CPY:
+                E->Chg |= PSTATE_CZN;
+                break;
+            case OP65_BIT:
+                E->Chg |= PSTATE_ZVN;
+                if (E->AM != AM65_IMM) {
+                    E->Chg &= ~(PSTATE_V | PSTATE_N);
+                }
+                break;
+            case OP65_BRK:
+                E->Chg |= PSTATE_B;
+                break;
+            case OP65_CLC:
+            case OP65_SEC:
+                E->Chg |= PSTATE_C;
+                break;
+            case OP65_CLD:
+            case OP65_SED:
+                E->Chg |= PSTATE_D;
+                break;
+            case OP65_CLI:
+            case OP65_SEI:
+                E->Chg |= PSTATE_I;
+                break;
+            case OP65_CLV:
+                E->Chg |= PSTATE_V;
+                break;
+            case OP65_TRB:
+            case OP65_TSB:
+                E->Chg |= PSTATE_Z;
+                break;
+            case OP65_BCC:
+            case OP65_BCS:
+            case OP65_JCC:
+            case OP65_JCS:
+                E->Use |= PSTATE_C;
+                break;
+            case OP65_BEQ:
+            case OP65_BNE:
+            case OP65_JEQ:
+            case OP65_JNE:
+                E->Use |= PSTATE_Z;
+                break;
+            case OP65_BMI:
+            case OP65_BPL:
+            case OP65_JMI:
+            case OP65_JPL:
+                E->Use |= PSTATE_N;
+                break;
+            case OP65_BVC:
+            case OP65_BVS:
+            case OP65_JVC:
+            case OP65_JVS:
+                E->Use |= PSTATE_V;
+                break;
+            case OP65_BRA:
+            case OP65_JMP:
+                break;
+            case OP65_AND:
+            case OP65_EOR:
+            case OP65_ORA:
+            case OP65_DEA:
+            case OP65_DEC:
+            case OP65_DEX:
+            case OP65_DEY:
+            case OP65_INA:
+            case OP65_INC:
+            case OP65_INX:
+            case OP65_INY:
+            case OP65_LDA:
+            case OP65_LDX:
+            case OP65_LDY:
+            case OP65_TAX:
+            case OP65_TAY:
+            case OP65_TXA:
+            case OP65_TYA:
+                E->Chg |= PSTATE_ZN;
+                break;
+            case OP65_TSX:
+                E->Use |= SLV_SP65;
+                E->Chg |= PSTATE_ZN;
+                break;
+            case OP65_TXS:
+                E->Chg |= SLV_SP65;
+                break;
+            case OP65_PLA:
+            case OP65_PLX:
+            case OP65_PLY:
+                E->Use |= SLV_SP65;
+                E->Chg |= SLV_PL65 | PSTATE_ZN;
+                break;
+            case OP65_PLP:
+                E->Use |= SLV_SP65;
+                E->Chg |= SLV_PL65 | PSTATE_ALL;
+                break;
+            case OP65_PHA:
+            case OP65_PHX:
+            case OP65_PHY:
+                E->Use |= SLV_SP65;
+                E->Chg |= SLV_PH65;
+                break;
+            case OP65_PHP:
+                E->Use |= SLV_SP65 | PSTATE_ALL;
+                E->Chg |= SLV_PH65;
+                break;
+            case OP65_RTI:
+                E->Chg |= PSTATE_ALL;
+                break;
+            case OP65_RTS:
+                break;
+            case OP65_STA:
+            case OP65_STX:
+            case OP65_STY:
+            case OP65_STZ:
+            case OP65_JSR:
+            case OP65_NOP:
+            default:
+                break;
+        }
     }
 }
 

--- a/src/cc65/copttest.c
+++ b/src/cc65/copttest.c
@@ -153,7 +153,7 @@ unsigned OptTest2 (CodeSeg* S)
             (L[2]->Info & OF_FBRA) != 0                         &&
             L[1]->AM == L[0]->AM                                &&
             strcmp (L[0]->Arg, L[1]->Arg) == 0                  &&
-            (GetRegInfo (S, I+2, L[1]->Chg) & L[1]->Chg) == 0) {
+            (GetRegInfo (S, I+2, L[1]->Chg & ~PSTATE_ZN) & L[1]->Chg & ~PSTATE_ZN) == 0) {
 
             /* Remove the load */
             CS_DelEntry (S, I+1);

--- a/src/cc65/opcodes.c
+++ b/src/cc65/opcodes.c
@@ -61,394 +61,394 @@ const OPCDesc OPCTable[OP65_COUNT] = {
     {   OP65_ADC,                               /* opcode */
         "adc",                                  /* mnemonic */
         0,                                      /* size */
-        REG_A,                                  /* use */
-        REG_A,                                  /* chg */
-        OF_SETF | OF_READ                       /* flags */
+        OF_SETF | OF_READ,                      /* flags */
+        REG_A | PSTATE_C,                       /* use */
+        REG_A | PSTATE_CZVN                     /* chg */
     },
     {   OP65_AND,                               /* opcode */
         "and",                                  /* mnemonic */
         0,                                      /* size */
+        OF_SETF | OF_READ,                      /* flags */
         REG_A,                                  /* use */
-        REG_A,                                  /* chg */
-        OF_SETF | OF_READ                       /* flags */
+        REG_A | PSTATE_ZN                       /* chg */
     },
     {   OP65_ASL,                               /* opcode */
         "asl",                                  /* mnemonic */
         0,                                      /* size */
+        OF_SETF | OF_NOIMP | OF_RMW,            /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_SETF | OF_NOIMP | OF_RMW             /* flags */
+        PSTATE_CZN                              /* chg */
     },
     {   OP65_BCC,                               /* opcode */
         "bcc",                                  /* mnemonic */
         2,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA                                 /* flags */
+        OF_CBRA,                                /* flags */
+        PSTATE_C,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_BCS,                               /* opcode */
         "bcs",                                  /* mnemonic */
         2,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA                                 /* flags */
+        OF_CBRA,                                /* flags */
+        PSTATE_C,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_BEQ,                               /* opcode */
         "beq",                                  /* mnemonic */
         2,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA | OF_ZBRA | OF_FBRA             /* flags */
+        OF_CBRA | OF_ZBRA | OF_FBRA,            /* flags */
+        PSTATE_Z,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_BIT,                               /* opcode */
         "bit",                                  /* mnemonic */
         0,                                      /* size */
+        OF_READ,                                /* flags */
         REG_A,                                  /* use */
-        REG_NONE,                               /* chg */
-        OF_READ                                 /* flags */
+        PSTATE_ZVN                              /* chg */
     },
     {   OP65_BMI,                               /* opcode */
         "bmi",                                  /* mnemonic */
         2,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA | OF_FBRA                       /* flags */
+        OF_CBRA | OF_FBRA,                      /* flags */
+        PSTATE_N,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_BNE,                               /* opcode */
         "bne",                                  /* mnemonic */
         2,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA | OF_ZBRA | OF_FBRA             /* flags */
+        OF_CBRA | OF_ZBRA | OF_FBRA,            /* flags */
+        PSTATE_Z,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_BPL,                               /* opcode */
         "bpl",                                  /* mnemonic */
         2,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA | OF_FBRA                       /* flags */
+        OF_CBRA | OF_FBRA,                      /* flags */
+        PSTATE_N,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_BRA,                               /* opcode */
         "bra",                                  /* mnemonic */
         2,                                      /* size */
+        OF_UBRA,                                /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_UBRA                                 /* flags */
+        REG_NONE                                /* chg */
     },
     {   OP65_BRK,                               /* opcode */
         "brk",                                  /* mnemonic */
         1,                                      /* size */
+        OF_NONE,                                /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        PSTATE_B                                /* chg */
     },
     {   OP65_BVC,                               /* opcode */
         "bvc",                                  /* mnemonic */
         2,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA                                 /* flags */
+        OF_CBRA,                                /* flags */
+        PSTATE_V,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_BVS,                               /* opcode */
         "bvs",                                  /* mnemonic */
         2,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA                                 /* flags */
+        OF_CBRA,                                /* flags */
+        PSTATE_V,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_CLC,                               /* opcode */
         "clc",                                  /* mnemonic */
         1,                                      /* size */
+        OF_NONE,                                /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        PSTATE_C                                /* chg */
     },
     {   OP65_CLD,                               /* opcode */
         "cld",                                  /* mnemonic */
         1,                                      /* size */
+        OF_NONE,                                /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        PSTATE_D                                /* chg */
     },
     {   OP65_CLI,                               /* opcode */
         "cli",                                  /* mnemonic */
         1,                                      /* size */
+        OF_NONE,                                /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        PSTATE_I                                /* chg */
     },
     {   OP65_CLV,                               /* opcode */
         "clv",                                  /* mnemonic */
         1,                                      /* size */
+        OF_NONE,                                /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        PSTATE_V                                /* chg */
     },
     {   OP65_CMP,                               /* opcode */
         "cmp",                                  /* mnemonic */
         0,                                      /* size */
+        OF_SETF | OF_CMP | OF_READ,             /* flags */
         REG_A,                                  /* use */
-        REG_NONE,                               /* chg */
-        OF_SETF | OF_CMP | OF_READ              /* flags */
+        PSTATE_CZN                              /* chg */
     },
     {   OP65_CPX,                               /* opcode */
         "cpx",                                  /* mnemonic */
         0,                                      /* size */
+        OF_SETF | OF_CMP | OF_READ,             /* flags */
         REG_X,                                  /* use */
-        REG_NONE,                               /* chg */
-        OF_SETF | OF_CMP | OF_READ              /* flags */
+        PSTATE_CZN                              /* chg */
     },
     {   OP65_CPY,                               /* opcode */
         "cpy",                                  /* mnemonic */
         0,                                      /* size */
+        OF_SETF | OF_CMP | OF_READ,             /* flags */
         REG_Y,                                  /* use */
-        REG_NONE,                               /* chg */
-        OF_SETF | OF_CMP | OF_READ              /* flags */
+        PSTATE_CZN                              /* chg */
     },
     {   OP65_DEA,                               /* opcode */
         "dea",                                  /* mnemonic */
         1,                                      /* size */
+        OF_REG_INCDEC | OF_SETF,                /* flags */
         REG_A,                                  /* use */
-        REG_A,                                  /* chg */
-        OF_REG_INCDEC | OF_SETF                 /* flags */
+        REG_A | PSTATE_ZN                       /* chg */
     },
     {   OP65_DEC,                               /* opcode */
         "dec",                                  /* mnemonic */
         0,                                      /* size */
+        OF_SETF | OF_NOIMP | OF_RMW,            /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_SETF | OF_NOIMP | OF_RMW             /* flags */
+        PSTATE_ZN                               /* chg */
     },
     {   OP65_DEX,                               /* opcode */
         "dex",                                  /* mnemonic */
         1,                                      /* size */
+        OF_REG_INCDEC | OF_SETF,                /* flags */
         REG_X,                                  /* use */
-        REG_X,                                  /* chg */
-        OF_REG_INCDEC | OF_SETF                 /* flags */
+        REG_X | PSTATE_ZN                       /* chg */
     },
     {   OP65_DEY,                               /* opcode */
         "dey",                                  /* mnemonic */
         1,                                      /* size */
+        OF_REG_INCDEC | OF_SETF,                /* flags */
         REG_Y,                                  /* use */
-        REG_Y,                                  /* chg */
-        OF_REG_INCDEC | OF_SETF                 /* flags */
+        REG_Y | PSTATE_ZN                       /* chg */
     },
     {   OP65_EOR,                               /* opcode */
         "eor",                                  /* mnemonic */
         0,                                      /* size */
+        OF_SETF | OF_READ,                      /* flags */
         REG_A,                                  /* use */
-        REG_A,                                  /* chg */
-        OF_SETF | OF_READ                       /* flags */
+        REG_A | PSTATE_ZN                       /* chg */
     },
     {   OP65_INA,                               /* opcode */
         "ina",                                  /* mnemonic */
         1,                                      /* size */
+        OF_REG_INCDEC | OF_SETF,                /* flags */
         REG_A,                                  /* use */
-        REG_A,                                  /* chg */
-        OF_REG_INCDEC | OF_SETF                 /* flags */
+        REG_A | PSTATE_ZN                       /* chg */
     },
     {   OP65_INC,                               /* opcode */
         "inc",                                  /* mnemonic */
         0,                                      /* size */
+        OF_SETF | OF_NOIMP | OF_RMW,            /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_SETF | OF_NOIMP | OF_RMW             /* flags */
+        PSTATE_ZN                               /* chg */
     },
     {   OP65_INX,                               /* opcode */
         "inx",                                  /* mnemonic */
         1,                                      /* size */
+        OF_REG_INCDEC | OF_SETF,                /* flags */
         REG_X,                                  /* use */
-        REG_X,                                  /* chg */
-        OF_REG_INCDEC | OF_SETF                 /* flags */
+        REG_X | PSTATE_ZN                       /* chg */
     },
     {   OP65_INY,                               /* opcode */
         "iny",                                  /* mnemonic */
         1,                                      /* size */
+        OF_REG_INCDEC | OF_SETF,                /* flags */
         REG_Y,                                  /* use */
-        REG_Y,                                  /* chg */
-        OF_REG_INCDEC | OF_SETF                 /* flags */
+        REG_Y | PSTATE_ZN                       /* chg */
     },
     {   OP65_JCC,                               /* opcode */
         "jcc",                                  /* mnemonic */
         5,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA | OF_LBRA                       /* flags */
+        OF_CBRA | OF_LBRA,                      /* flags */
+        PSTATE_C,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_JCS,                               /* opcode */
         "jcs",                                  /* mnemonic */
         5,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA | OF_LBRA                       /* flags */
+        OF_CBRA | OF_LBRA,                      /* flags */
+        PSTATE_C,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_JEQ,                               /* opcode */
         "jeq",                                  /* mnemonic */
         5,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA | OF_LBRA | OF_ZBRA | OF_FBRA   /* flags */
+        OF_CBRA | OF_LBRA | OF_ZBRA | OF_FBRA,  /* flags */
+        PSTATE_Z,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_JMI,                               /* opcode */
         "jmi",                                  /* mnemonic */
         5,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA | OF_LBRA | OF_FBRA             /* flags */
+        OF_CBRA | OF_LBRA | OF_FBRA,            /* flags */
+        PSTATE_N,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_JMP,                               /* opcode */
         "jmp",                                  /* mnemonic */
         3,                                      /* size */
+        OF_UBRA | OF_LBRA | OF_READ,            /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_UBRA | OF_LBRA | OF_READ             /* flags */
+        REG_NONE                                /* chg */
     },
     {   OP65_JNE,                               /* opcode */
         "jne",                                  /* mnemonic */
         5,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA | OF_LBRA | OF_ZBRA | OF_FBRA   /* flags */
+        OF_CBRA | OF_LBRA | OF_ZBRA | OF_FBRA,  /* flags */
+        PSTATE_Z,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_JPL,                               /* opcode */
         "jpl",                                  /* mnemonic */
         5,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA | OF_LBRA | OF_FBRA             /* flags */
+        OF_CBRA | OF_LBRA | OF_FBRA,            /* flags */
+        PSTATE_N,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_JSR,                               /* opcode */
         "jsr",                                  /* mnemonic */
         3,                                      /* size */
+        OF_CALL | OF_READ,                      /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CALL | OF_READ                       /* flags */
+        REG_NONE                                /* chg */
     },
     {   OP65_JVC,                               /* opcode */
         "jvc",                                  /* mnemonic */
         5,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA | OF_LBRA                       /* flags */
+        OF_CBRA | OF_LBRA,                      /* flags */
+        PSTATE_V,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_JVS,                               /* opcode */
         "jvs",                                  /* mnemonic */
         5,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_CBRA | OF_LBRA                       /* flags */
+        OF_CBRA | OF_LBRA,                      /* flags */
+        PSTATE_V,                               /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_LDA,                               /* opcode */
         "lda",                                  /* mnemonic */
         0,                                      /* size */
+        OF_LOAD | OF_SETF | OF_READ,            /* flags */
         REG_NONE,                               /* use */
-        REG_A,                                  /* chg */
-        OF_LOAD | OF_SETF | OF_READ             /* flags */
+        REG_A | PSTATE_ZN                       /* chg */
     },
     {   OP65_LDX,                               /* opcode */
         "ldx",                                  /* mnemonic */
         0,                                      /* size */
+        OF_LOAD | OF_SETF | OF_READ,            /* flags */
         REG_NONE,                               /* use */
-        REG_X,                                  /* chg */
-        OF_LOAD | OF_SETF | OF_READ             /* flags */
+        REG_X | PSTATE_ZN                       /* chg */
     },
     {   OP65_LDY,                               /* opcode */
         "ldy",                                  /* mnemonic */
         0,                                      /* size */
+        OF_LOAD | OF_SETF | OF_READ,            /* flags */
         REG_NONE,                               /* use */
-        REG_Y,                                  /* chg */
-        OF_LOAD | OF_SETF | OF_READ             /* flags */
+        REG_Y | PSTATE_ZN                       /* chg */
     },
     {   OP65_LSR,                               /* opcode */
         "lsr",                                  /* mnemonic */
         0,                                      /* size */
+        OF_SETF | OF_NOIMP | OF_RMW,            /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_SETF | OF_NOIMP | OF_RMW             /* flags */
+        PSTATE_CZN                              /* chg */
     },
     {   OP65_NOP,                               /* opcode */
         "nop",                                  /* mnemonic */
         1,                                      /* size */
+        OF_NONE,                                /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        REG_NONE                                /* chg */
     },
     {   OP65_ORA,                               /* opcode */
         "ora",                                  /* mnemonic */
         0,                                      /* size */
+        OF_SETF | OF_READ,                      /* flags */
         REG_A,                                  /* use */
-        REG_A,                                  /* chg */
-        OF_SETF | OF_READ                       /* flags */
+        REG_A | PSTATE_ZN                       /* chg */
     },
     {   OP65_PHA,                               /* opcode */
         "pha",                                  /* mnemonic */
         1,                                      /* size */
+        OF_NONE,                                /* flags */
         REG_A,                                  /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        REG_NONE                                /* chg */
     },
     {   OP65_PHP,                               /* opcode */
         "php",                                  /* mnemonic */
         1,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        OF_NONE,                                /* flags */
+        PSTATE_ALL,                             /* use */
+        REG_NONE                                /* chg */
     },
     {   OP65_PHX,                               /* opcode */
         "phx",                                  /* mnemonic */
         1,                                      /* size */
+        OF_NONE,                                /* flags */
         REG_X,                                  /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        REG_NONE                                /* chg */
     },
     {   OP65_PHY,                               /* opcode */
         "phy",                                  /* mnemonic */
         1,                                      /* size */
+        OF_NONE,                                /* flags */
         REG_Y,                                  /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        REG_NONE                                /* chg */
     },
     {   OP65_PLA,                               /* opcode */
         "pla",                                  /* mnemonic */
         1,                                      /* size */
+        OF_SETF,                                /* flags */
         REG_NONE,                               /* use */
-        REG_A,                                  /* chg */
-        OF_SETF                                 /* flags */
+        REG_A | PSTATE_ZN                       /* chg */
     },
     {   OP65_PLP,                               /* opcode */
         "plp",                                  /* mnemonic */
         1,                                      /* size */
+        OF_NONE,                                /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        PSTATE_ALL                              /* chg */
     },
     {   OP65_PLX,                               /* opcode */
         "plx",                                  /* mnemonic */
         1,                                      /* size */
+        OF_SETF,                                /* flags */
         REG_NONE,                               /* use */
-        REG_X,                                  /* chg */
-        OF_SETF                                 /* flags */
+        REG_X | PSTATE_ZN                       /* chg */
     },
     {   OP65_PLY,                               /* opcode */
         "ply",                                  /* mnemonic */
         1,                                      /* size */
+        OF_SETF,                                /* flags */
         REG_NONE,                               /* use */
-        REG_Y,                                  /* chg */
-        OF_SETF                                 /* flags */
+        REG_Y | PSTATE_ZN                       /* chg */
     },
     {   OP65_ROL,                               /* opcode */
         "rol",                                  /* mnemonic */
         0,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_SETF | OF_NOIMP | OF_RMW             /* flags */
+        OF_SETF | OF_NOIMP | OF_RMW,            /* flags */
+        PSTATE_C,                               /* use */
+        PSTATE_CZN                              /* chg */
     },
     {   OP65_ROR,                               /* opcode */
         "ror",                                  /* mnemonic */
         0,                                      /* size */
-        REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_SETF | OF_NOIMP | OF_RMW             /* flags */
+        OF_SETF | OF_NOIMP | OF_RMW,            /* flags */
+        PSTATE_C,                               /* use */
+        PSTATE_CZN                              /* chg */
     },
     /* Mark RTI as "uses all registers but doesn't change them", so the
     ** optimizer won't remove preceeding loads.
@@ -456,135 +456,135 @@ const OPCDesc OPCTable[OP65_COUNT] = {
     {   OP65_RTI,                               /* opcode */
         "rti",                                  /* mnemonic */
         1,                                      /* size */
+        OF_RET,                                 /* flags */
         REG_AXY,                                /* use */
-        REG_NONE,                               /* chg */
-        OF_RET                                  /* flags */
+        PSTATE_ALL                              /* chg */
     },
     {   OP65_RTS,                               /* opcode */
         "rts",                                  /* mnemonic */
         1,                                      /* size */
+        OF_RET,                                 /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_RET                                  /* flags */
+        REG_NONE                                /* chg */
     },
     {   OP65_SBC,                               /* opcode */
         "sbc",                                  /* mnemonic */
         0,                                      /* size */
-        REG_A,                                  /* use */
-        REG_A,                                  /* chg */
-        OF_SETF | OF_READ                       /* flags */
+        OF_SETF | OF_READ,                      /* flags */
+        REG_A | PSTATE_C,                       /* use */
+        REG_A | PSTATE_CZVN                     /* chg */
     },
     {   OP65_SEC,                               /* opcode */
         "sec",                                  /* mnemonic */
         1,                                      /* size */
+        OF_NONE,                                /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        PSTATE_C                                /* chg */
     },
     {   OP65_SED,                               /* opcode */
         "sed",                                  /* mnemonic */
         1,                                      /* size */
+        OF_NONE,                                /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        PSTATE_D                                /* chg */
     },
     {   OP65_SEI,                               /* opcode */
         "sei",                                  /* mnemonic */
         1,                                      /* size */
+        OF_NONE,                                /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        PSTATE_I                                /* chg */
     },
     {   OP65_STA,                               /* opcode */
         "sta",                                  /* mnemonic */
         0,                                      /* size */
+        OF_STORE | OF_WRITE,                    /* flags */
         REG_A,                                  /* use */
-        REG_NONE,                               /* chg */
-        OF_STORE | OF_WRITE                     /* flags */
+        REG_NONE                                /* chg */
     },
     {   OP65_STP,                               /* opcode */
         "stp",                                  /* mnemonic */
         1,                                      /* size */
+        OF_NONE,                                /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_NONE                                 /* flags */
+        REG_NONE                                /* chg */
     },
     {   OP65_STX,                               /* opcode */
         "stx",                                  /* mnemonic */
         0,                                      /* size */
+        OF_STORE | OF_WRITE,                    /* flags */
         REG_X,                                  /* use */
-        REG_NONE,                               /* chg */
-        OF_STORE | OF_WRITE                     /* flags */
+        REG_NONE                                /* chg */
     },
     {   OP65_STY,                               /* opcode */
         "sty",                                  /* mnemonic */
         0,                                      /* size */
+        OF_STORE | OF_WRITE,                    /* flags */
         REG_Y,                                  /* use */
-        REG_NONE,                               /* chg */
-        OF_STORE | OF_WRITE                     /* flags */
+        REG_NONE                                /* chg */
     },
     {   OP65_STZ,                               /* opcode */
         "stz",                                  /* mnemonic */
         0,                                      /* size */
+        OF_STORE | OF_WRITE,                    /* flags */
         REG_NONE,                               /* use */
-        REG_NONE,                               /* chg */
-        OF_STORE | OF_WRITE                     /* flags */
+        REG_NONE                                /* chg */
     },
     {   OP65_TAX,                               /* opcode */
         "tax",                                  /* mnemonic */
         1,                                      /* size */
+        OF_XFR | OF_SETF,                       /* flags */
         REG_A,                                  /* use */
-        REG_X,                                  /* chg */
-        OF_XFR | OF_SETF                        /* flags */
+        REG_X | PSTATE_ZN                       /* chg */
     },
     {   OP65_TAY,                               /* opcode */
         "tay",                                  /* mnemonic */
         1,                                      /* size */
+        OF_XFR | OF_SETF,                       /* flags */
         REG_A,                                  /* use */
-        REG_Y,                                  /* chg */
-        OF_XFR | OF_SETF                        /* flags */
+        REG_Y | PSTATE_ZN                       /* chg */
     },
     {   OP65_TRB,                               /* opcode */
         "trb",                                  /* mnemonic */
         0,                                      /* size */
+        OF_RMW,                                 /* flags */
         REG_A,                                  /* use */
-        REG_NONE,                               /* chg */
-        OF_RMW                                  /* flags */
+        PSTATE_Z                                /* chg */
     },
     {   OP65_TSB,                               /* opcode */
         "tsb",                                  /* mnemonic */
         0,                                      /* size */
+        OF_RMW,                                 /* flags */
         REG_A,                                  /* use */
-        REG_NONE,                               /* chg */
-        OF_RMW                                  /* flags */
+        PSTATE_Z                                /* chg */
     },
     {   OP65_TSX,                               /* opcode */
         "tsx",                                  /* mnemonic */
         1,                                      /* size */
+        OF_XFR | OF_SETF,                       /* flags */
         REG_NONE,                               /* use */
-        REG_X,                                  /* chg */
-        OF_XFR | OF_SETF                        /* flags */
+        REG_X | PSTATE_ZN                       /* chg */
     },
     {   OP65_TXA,                               /* opcode */
         "txa",                                  /* mnemonic */
         1,                                      /* size */
+        OF_XFR | OF_SETF,                       /* flags */
         REG_X,                                  /* use */
-        REG_A,                                  /* chg */
-        OF_XFR | OF_SETF                        /* flags */
+        REG_A | PSTATE_ZN                       /* chg */
     },
     {   OP65_TXS,                               /* opcode */
         "txs",                                  /* mnemonic */
         1,                                      /* size */
+        OF_XFR,                                 /* flags */
         REG_X,                                  /* use */
-        REG_NONE,                               /* chg */
-        OF_XFR                                  /* flags */
+        REG_NONE                                /* chg */
     },
     {   OP65_TYA,                               /* opcode */
         "tya",                                  /* mnemonic */
         1,                                      /* size */
+        OF_XFR | OF_SETF,                       /* flags */
         REG_Y,                                  /* use */
-        REG_A,                                  /* chg */
-        OF_XFR | OF_SETF                        /* flags */
+        REG_A | PSTATE_ZN                       /* chg */
     },
 };
 

--- a/src/cc65/opcodes.h
+++ b/src/cc65/opcodes.h
@@ -192,9 +192,9 @@ typedef struct {
     opc_t           OPC;                /* Opcode */
     char            Mnemo[9];           /* Mnemonic */
     unsigned char   Size;               /* Size, 0 = check addressing mode */
-    unsigned short  Use;                /* Registers used by this insn */
-    unsigned short  Chg;                /* Registers changed by this insn */
     unsigned short  Info;               /* Additional information */
+    unsigned int    Use;                /* Registers used by this insn */
+    unsigned int    Chg;                /* Registers changed by this insn */
 } OPCDesc;
 
 /* Opcode description table */


### PR DESCRIPTION
(3/3) commits.
- [x] Added processor flag usage/change-tracking for non-JSR/RTS code entries.
  - [x] Fixed and improved `OptPrecalc`. Now it respects the C/V/Z/N flags.
  - [x] Fixed optimizations impacted by added support of tracking processor flags.
- [x] Added processor state info to the `OPCDesc` table. However, since some opcodes are affected by the addressing mode, this info is unused in codegen/optimizer but just as quick in-code documentation/hints. The real processor state info used for optimizer instead of this is deduced elsewhere.
- [x] Fixed quick hack for known registers after calling certain runtime functions, and new quick hack for `tosshrax`.

This is the second half of the changeset (see also #1254) to add processor state tracking. It has a few fixes to the optimizer in order to work again.