### PR TITLE
Simplify Gamate tile redefinition (as already done for PCE)

### DIFF
--- a/libsrc/gamate/conio.s
+++ b/libsrc/gamate/conio.s
@@ -1,6 +1,7 @@
         .include        "gamate.inc"
         .include        "extzp.inc"
 
+        .import         fontdata
         .import         colors
         .importzp       ptr1, tmp1
 
@@ -24,8 +25,3 @@ initconio:
         sta     BGCOLOR
         rts
 
-        .segment        "RODATA"
-
-        .export         fontdata
-fontdata:
-        .include        "vga.inc"

--- a/libsrc/gamate/vga.s
+++ b/libsrc/gamate/vga.s
@@ -1,8 +1,8 @@
 ; VGA charset for the Gamate conio implementation
 
-.export fontdata
+        .export fontdata
 
-.rodata
+        .rodata
 
 fontdata:
 

--- a/libsrc/gamate/vga.s
+++ b/libsrc/gamate/vga.s
@@ -1,5 +1,10 @@
-
 ; VGA charset for the Gamate conio implementation
+
+.export fontdata
+
+.rodata
+
+fontdata:
 
         .byte   $00, $00, $00, $00, $00, $00, $00, $00
 


### PR DESCRIPTION
This pull request greatly simplifies the (re)-definition of tiles for the gamate target by using an Assembly file for the tile data instead of a .inc file.

This is very similar to what has already been done by @greg-king5 for the pce target in
https://github.com/cc65/cc65/commit/ba0ef5938d267dc47ca6d30af18b596190b4f932

