### PR TITLE
Fix bit-field truncation warning message

### DIFF
--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -2567,9 +2567,9 @@ static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
                 long RestoredVal = asr_l(asl_l (Val, ShiftBits), ShiftBits);
                 if (ED.IVal != RestoredVal) {
                     Warning ("Implicit truncation from '%s' to '%s : %u' in bit-field initializer "
-                             "changes value from %ld to %d",
+                             "changes value from %ld to %ld",
                              GetFullTypeName (ED.Type), GetFullTypeName (Entry->Type),
-                             Entry->V.B.BitWidth, ED.IVal, Val);
+                             Entry->V.B.BitWidth, ED.IVal, RestoredVal);
                 }
             }
 


### PR DESCRIPTION
Fix copy & paste bug with warning message.

```
struct X {
      signed int a : 3;
};
struct X g = { 5 };
```

Before:
```
s.c(4): Warning: Implicit truncation from 'int' to 'int : 3' in bit-field initializer changes value from 5 to 5
```

After:
```
s.c(4): Warning: Implicit truncation from 'int' to 'int : 3' in bit-field initializer changes value from 5 to -3
```

Fixes #1268