### PR TITLE
CS_MergeLabels: Keep labels referenced by data

### DIFF
--- a/src/cc65/codeent.h
+++ b/src/cc65/codeent.h
@@ -180,6 +180,16 @@ INLINE CodeLabel* CE_GetLabel (CodeEntry* E, unsigned Index)
 #  define CE_GetLabel(E, Index) CollAt (&(E)->Labels, (Index))
 #endif
 
+#if defined(HAVE_INLINE)
+INLINE void CE_ReplaceLabel (CodeEntry* E, CodeLabel* L, unsigned Index)
+/* Replace the code label at the specified index with L */
+{
+    return CollReplace (&E->Labels, L, Index);
+}
+#else
+#  define CE_ReplaceLabel(E, L, Index) CollReplace (&(E)->Labels, (L), (Index))
+#endif
+
 void CE_MoveLabel (CodeLabel* L, CodeEntry* E);
 /* Move the code label L from it's former owner to the code entry E. */
 

--- a/test/val/bug1211-ice-move-refs-1.c
+++ b/test/val/bug1211-ice-move-refs-1.c
@@ -21,7 +21,8 @@
 /*
   Test of indirect goto with label merge ICE.
   https://github.com/cc65/cc65/issues/1211
-  This should compile and should be moved to tests/val/ when the bug is fixed.
+  This test case works because CS_MergeLabels has a hack to keep the "unreferenced" label
+  (i.e. the one referenced in a data segment).
 */
 
 #include <stdio.h>


### PR DESCRIPTION
Partial fix for ICE in #1211.  This may fix enough to allow #1049 to be
fixed.

When merging labels, keep the first label with a ref that has no JumpTo;
this is a data segment label, used by computed gotos.

The real fix is to track and rewrite labels in data, but this is more
involved.