### PR TITLE
[cc65] Fixed StrBuf initialization in PreparseArg()

### DIFF
--- a/src/cc65/codeent.c
+++ b/src/cc65/codeent.c
@@ -585,8 +585,7 @@ const char* MakeHexArg (unsigned Num)
 void PreparseArg (CodeEntry* E)
 /* Parse the argument string and memorize the result for the code entry */
 {
-    StrBuf B;
-    SB_InitFromString (&B, xmalloc (strlen (E->Arg) + 1));
+    StrBuf B = AUTO_STRBUF_INITIALIZER;
 
     /* Parse the argument string */
     if (ParseOpcArgStr (E->Arg, &E->ArgInfo, &B, &E->ArgOff)) {


### PR DESCRIPTION
Just do the initialization as it is done everywhere else. Fixed #1277.