### PR TITLE
[cc65] Better support for putting stuff on the zeropage

### DIFF
--- a/src/cc65/codegen.c
+++ b/src/cc65/codegen.c
@@ -39,6 +39,7 @@
 #include <stdarg.h>
 
 /* common */
+#include "addrsize.h"
 #include "check.h"
 #include "cpu.h"
 #include "inttypes.h"
@@ -260,6 +261,9 @@ void g_usebss (void)
 void g_segname (segment_t Seg)
 /* Emit the name of a segment if necessary */
 {
+    unsigned char AddrSize;
+    const char* Name;
+
     /* Emit a segment directive for the data style segments */
     DataSeg* S;
     switch (Seg) {
@@ -269,7 +273,13 @@ void g_segname (segment_t Seg)
         default:         S = 0;          break;
     }
     if (S) {
-        DS_AddLine (S, ".segment\t\"%s\"", GetSegName (Seg));
+        Name = GetSegName (Seg);
+        AddrSize = GetSegAddrSize (Name);
+        if (AddrSize != ADDR_SIZE_INVALID) {
+            DS_AddLine (S, ".segment\t\"%s\": %s", Name, AddrSizeToStr (AddrSize));
+        } else {
+            DS_AddLine (S, ".segment\t\"%s\"", Name);
+        }
     }
 }
 

--- a/src/cc65/codeinfo.h
+++ b/src/cc65/codeinfo.h
@@ -119,7 +119,8 @@ struct RegContents;
 typedef struct ZPInfo ZPInfo;
 struct ZPInfo {
     unsigned char  Len;         /* Length of the following string */
-    char           Name[11];    /* Name of zero page symbol */
+    char           Name[10];    /* Name of zero page symbol */
+    unsigned char  Size;        /* Maximum buffer size of this register */
     unsigned short ByteUse;     /* Register info for this symbol */
     unsigned short WordUse;     /* Register info for 16 bit access */
 };
@@ -161,6 +162,9 @@ typedef enum {
 /*****************************************************************************/
 
 
+
+int IsZPArg (const char* Arg);
+/* Exam if the main part of the arg string indicates a ZP loc */
 
 fncls_t GetFuncInfo (const char* Name, unsigned int* Use, unsigned int* Chg);
 /* For the given function, lookup register information and store it into

--- a/src/cc65/codeseg.c
+++ b/src/cc65/codeseg.c
@@ -372,7 +372,7 @@ static CodeEntry* ParseInsn (CodeSeg* S, LineInfo* LI, const char* L)
                 if ((OPC->Info & OF_BRA) != 0) {
                     /* Branch */
                     AM = AM65_BRA;
-                } else if (GetZPInfo(Arg) != 0) {
+                } else if (IsZPArg (Arg)) {
                     AM = AM65_ZP;
                 } else {
                     /* Check for subroutine call to local label */
@@ -393,12 +393,15 @@ static CodeEntry* ParseInsn (CodeSeg* S, LineInfo* LI, const char* L)
                     Reg = toupper (*L);
                     L = SkipSpace (L+1);
                     if (Reg == 'X') {
-                        if (GetZPInfo(Arg) != 0) {
+                        if (IsZPArg (Arg)) {
                             AM = AM65_ZPX;
                         } else {
                             AM = AM65_ABSX;
                         }
                     } else if (Reg == 'Y') {
+                        /* On 6502 only LDX and STX support AM65_ZPY.
+                        ** We just play it simple and safe for now.
+                        */
                         AM = AM65_ABSY;
                     } else {
                         Error ("ASM code error: syntax error");

--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -37,6 +37,7 @@
 #include <time.h>
 
 /* common */
+#include "addrsize.h"
 #include "debugflag.h"
 #include "segnames.h"
 #include "version.h"
@@ -275,6 +276,17 @@ static void Parse (void)
                         }
                         Entry->V.BssName = xstrdup (bssName);
 
+                        /* This is to make the automatical zeropage setting of the symbol
+                        ** work right.
+                        */
+                        g_usebss ();
+                    }
+                }
+
+                /* Make the symbol zeropage according to the segment address size */
+                if ((Entry->Flags & SC_EXTERN) != 0) {
+                    if (GetSegAddrSize (GetSegName (CS->CurDSeg)) == ADDR_SIZE_ZP) {
+                        Entry->Flags |= SC_ZEROPAGE;
                         /* Check for enum forward declaration.
                         ** Warn about it when extensions are not allowed.
                         */

--- a/src/cc65/main.c
+++ b/src/cc65/main.c
@@ -897,6 +897,9 @@ int main (int argc, char* argv[])
     /* Initialize the default segment names */
     InitSegNames ();
 
+    /* Initialize the segment address sizes table */
+    InitSegAddrSizes ();
+
     /* Initialize the include search paths */
     InitIncludePaths ();
 
@@ -1088,6 +1091,9 @@ int main (int argc, char* argv[])
 
     /* Done with tracked string buffer allocation */
     DoneDiagnosticStrBufs ();
+
+    /* Free up the segment address sizes table */
+    DoneSegAddrSizes ();
 
     /* Return an apropriate exit code */
     return (ErrorCount > 0)? EXIT_FAILURE : EXIT_SUCCESS;

--- a/src/cc65/opcodes.c
+++ b/src/cc65/opcodes.c
@@ -649,6 +649,7 @@ unsigned GetInsnSize (opc_t OPC, am_t AM)
         case AM65_IMM:     return 2;
         case AM65_ZP:      return 2;
         case AM65_ZPX:     return 2;
+        case AM65_ZPY:     return 2;
         case AM65_ABS:     return 3;
         case AM65_ABSX:    return 3;
         case AM65_ABSY:    return 3;

--- a/src/cc65/segments.c
+++ b/src/cc65/segments.c
@@ -37,6 +37,7 @@
 #include <string.h>
 
 /* common */
+#include "addrsize.h"
 #include "chartype.h"
 #include "check.h"
 #include "coll.h"
@@ -61,6 +62,13 @@
 
 
 
+/* Table struct for address sizes of segments */
+typedef struct {
+    StrBuf Name;
+    unsigned char AddrSize;
+} SegAddrSize_t;
+
+
 /* Pointer to the current segment list. Output goes here. */
 Segments* CS = 0;
 
@@ -69,6 +77,9 @@ Segments* GS = 0;
 
 /* Actual names for the segments */
 static StrStack SegmentNames[SEG_COUNT];
+
+/* Address size for the segments */
+static Collection SegmentAddrSizes;
 
 /* We're using a collection for the stack instead of a linked list. Since
 ** functions may not be nested (at least in the current implementation), the
@@ -82,6 +93,85 @@ static Collection SegmentStack = STATIC_COLLECTION_INITIALIZER;
 /*****************************************************************************/
 /*                                   Code                                    */
 /*****************************************************************************/
+
+
+
+void InitSegAddrSizes (void)
+/* Initialize the segment address sizes */
+{
+    InitCollection (&SegmentAddrSizes);
+}
+
+
+
+void DoneSegAddrSizes (void)
+/* Free the segment address sizes */
+{
+    SegAddrSize_t* A;
+    int I;
+    for (I = 0; I < (int)CollCount (&SegmentAddrSizes); ++I) {
+        A = CollAtUnchecked (&SegmentAddrSizes, I);
+        SB_Done (&A->Name);
+        xfree (A);
+    }
+    DoneCollection (&SegmentAddrSizes);
+}
+
+
+
+static SegAddrSize_t* FindSegAddrSize (const char* Name)
+/* Find already specified address size for a segment by name.
+** Return the found struct or 0 if not found.
+*/
+{
+    SegAddrSize_t* A;
+    int I;
+    for (I = 0; I < (int)CollCount (&SegmentAddrSizes); ++I) {
+        A = CollAtUnchecked (&SegmentAddrSizes, I);
+        if (A && strcmp (SB_GetConstBuf (&A->Name), Name) == 0) {
+            return A;
+        }
+    }
+    return 0;
+}
+
+
+
+void SetSegAddrSize (const char* Name, unsigned char AddrSize)
+/* Set the address size for a segment */
+{
+    SegAddrSize_t* A = FindSegAddrSize (Name);
+    if (!A) {
+        /* New one */
+        A = xmalloc (sizeof (SegAddrSize_t));
+        SB_Init (&A->Name);
+        SB_CopyStr (&A->Name, Name);
+        SB_Terminate (&A->Name);
+        CollAppend (&SegmentAddrSizes, A);
+    } else {
+        /* Check for mismatching address sizes */
+        if (A->AddrSize != AddrSize) {
+            Warning ("Segment address size changed from last time!");
+        }
+    }
+
+    /* Set the address size anyway */
+    A->AddrSize = AddrSize;
+}
+
+
+
+unsigned char GetSegAddrSize (const char* Name)
+/* Get the address size of the given segment.
+** Return ADDR_SIZE_INVALID if not found.
+*/
+{
+    SegAddrSize_t* A = FindSegAddrSize (Name);
+    if (A) {
+        return A->AddrSize;
+    }
+    return ADDR_SIZE_INVALID;
+}
 
 
 

--- a/src/cc65/segments.h
+++ b/src/cc65/segments.h
@@ -103,6 +103,19 @@ extern Segments* GS;
 /*****************************************************************************/
 
 
+void InitSegAddrSizes (void);
+/* Initialize the segment address sizes */
+
+void DoneSegAddrSizes (void);
+/* Free the segment address sizes */
+
+void SetSegAddrSize (const char* Name, unsigned char AddrSize);
+/* Set the address size for a segment */
+
+unsigned char GetSegAddrSize (const char* Name);
+/* Get the address size of the given segment.
+** Return ADDR_SIZE_INVALID if not found.
+*/
 
 void InitSegNames (void);
 /* Initialize the segment names */


### PR DESCRIPTION
- [X] The instruction parser can now recognize ZP locations and set the addressing mode for them.
- [X] Support for optionally specifying address size for segments with:
`#pragma ***-name([push,] "name"[, "addrsize"])`
where "addrsize" is any addressing size supported in ca65.
- [X] Symbols in ZP segments will use '.exportzp' instead of '.export' if exported.

This resolves #261 and resolves #917 with the new features. It could be considered that this also "almost resolves" #243 (as in the OP) since this opens a path to the expected optimizations, although there are still some other factors that could prevent the optimizations from happening.

The new optional parameter of `#pragma ***-name`
---
`#pragma ***-name([push,] "name"[, "addrsize"])`

Example: https://github.com/cc65/cc65/issues/917#issuecomment-647326244.

The new optional "addrsize" string is to add an address size string for a segment in asm output and in theory can be anything, but only those recognized by ca65 make sense.

- Absolute address size strings
  - "abs"
  - "absolute"
  - "near"
- Default address size strings
  - "default"
- Far address size strings
  - "far"
- Long address size strings
  - "dword"
  - "long"
- Zeropage address size strings
  - "direct"
  - "zeropage"
  - "zp"

Moreover, symbols put on a zeropage specified with this pragma will be exported with `.exportzp` instead of `.export`.

