### PR TITLE
[cc65] Deferred postfix inc/dec operations till sequence points

### DIFF
--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -320,6 +320,9 @@ static void Parse (void)
                 } else {
                     /* Parse the function body */
                     NewFunc (Entry, FuncDef);
+
+                    /* Make sure we aren't omitting any work */
+                    CheckDeferredOpAllDone ();
                 }
             }
 
@@ -394,6 +397,8 @@ void Compile (const char* FileName)
     /* Other standard macros */
     /* DefineNumericMacro ("__STDC__", 1);      <- not now */
     DefineNumericMacro ("__STDC_HOSTED__", 1);
+
+    InitDeferredOps ();
 
     /* Create the base lexical level */
     EnterGlobalLevel ();
@@ -485,6 +490,8 @@ void Compile (const char* FileName)
             }
         }
     }
+
+    DoneDeferredOps ();
 
     if (Debug) {
         PrintMacroStats (stdout);

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -2302,6 +2302,9 @@ static unsigned ParseScalarInit (Type* T)
     /* Output the data */
     DefineData (&ED);
 
+    /* Do this anyways for safety */
+    DoDeferred (SQP_KEEP_NONE, &ED);
+
     /* Done */
     return SizeOf (T);
 }
@@ -2320,6 +2323,9 @@ static unsigned ParsePointerInit (Type* T)
 
     /* Output the data */
     DefineData (&ED);
+
+    /* Do this anyways for safety */
+    DoDeferred (SQP_KEEP_NONE, &ED);
 
     /* Close eventually opening braces */
     ClosingCurlyBraces (BraceCount);

--- a/src/cc65/expr.h
+++ b/src/cc65/expr.h
@@ -18,6 +18,19 @@
 
 
 /*****************************************************************************/
+/*                                   data                                    */
+/*****************************************************************************/
+
+
+
+#define SQP_KEEP_NONE	0x00
+#define SQP_KEEP_TEST	0x01U
+#define SQP_KEEP_EAX	0x02U
+#define SQP_KEEP_EXPR	0x03U	/* SQP_KEEP_TEST | SQP_KEEP_EAX */
+
+
+
+/*****************************************************************************/
 /*                                   code                                    */
 /*****************************************************************************/
 
@@ -38,6 +51,23 @@ void PushAddr (const ExprDesc* Expr);
 ** must be saved if it's not constant, before evaluating the rhs.
 */
 
+void InitDeferredOps (void);
+/* Init the collection for storing deferred ops */
+
+void DoneDeferredOps (void);
+/* Deinit the collection for storing deferred ops */
+
+int GetDeferredOpCount (void);
+/* Return how many deferred operations are still waiting in the queque */
+
+void CheckDeferredOpAllDone (void);
+/* Check if all deferred operations are done at sequence points.
+** Die off if check fails.
+*/
+
+void DoDeferred (unsigned Flags, ExprDesc* Expr);
+/* Do deferred operations such as post-inc/dec at sequence points */
+
 void Store (ExprDesc* Expr, const Type* StoreType);
 /* Store the primary register into the location denoted by lval. If StoreType
 ** is given, use this type when storing instead of lval->Type. If StoreType
@@ -52,7 +82,9 @@ int evalexpr (unsigned flags, void (*Func) (ExprDesc*), ExprDesc* Expr);
 */
 
 void Expression0 (ExprDesc* Expr);
-/* Evaluate an expression via hie0 and put the result into the primary register */
+/* Evaluate an expression via hie0 and put the result into the primary register.
+** The expression is completely evaluated and all side effects complete.
+*/
 
 void BoolExpr (void (*Func) (ExprDesc*), ExprDesc* Expr);
 /* Will evaluate an expression via the given function. If the result is not

--- a/src/cc65/goto.c
+++ b/src/cc65/goto.c
@@ -105,6 +105,9 @@ void GotoStatement (void)
                 val = (unsigned char)CurTok.IVal;
                 NextToken ();
 
+                /* Append deferred inc/dec at sequence point */
+                DoDeferred (SQP_KEEP_NONE, &desc);
+
                 if (CPUIsets[CPU] & CPU_ISET_65SC02) {
                     AddCodeLine ("ldx #$%02X", val * 2);
                     AddCodeLine ("jmp (.loword(%s),x)", arr->AsmName);
@@ -118,6 +121,10 @@ void GotoStatement (void)
                        (idx = FindSym (CurTok.Ident))) {
                 hie10 (&desc);
                 LoadExpr (CF_NONE, &desc);
+
+                /* Append deferred inc/dec at sequence point */
+                DoDeferred (SQP_KEEP_EAX, &desc);
+
                 AddCodeLine ("asl a");
 
                 if (CPUIsets[CPU] & CPU_ISET_65SC02) {

--- a/src/cc65/locals.c
+++ b/src/cc65/locals.c
@@ -165,6 +165,8 @@ static void ParseRegisterDecl (Declaration* Decl, int Reg)
             /* Store the value into the variable */
             g_putstatic (CF_REGVAR | TypeOf (Sym->Type), Reg, 0);
 
+            /* This has to be done at sequence point */
+            DoDeferred (SQP_KEEP_NONE, &Expr);
         }
 
         /* Mark the variable as referenced */
@@ -273,6 +275,8 @@ static void ParseAutoDecl (Declaration* Decl)
                 /* Push the value */
                 g_push (Flags | TypeOf (Sym->Type), Expr.IVal);
 
+                /* This has to be done at sequence point */
+                DoDeferred (SQP_KEEP_NONE, &Expr);
             }
 
             /* Mark the variable as referenced */
@@ -349,6 +353,9 @@ static void ParseAutoDecl (Declaration* Decl)
 
                 /* Store the value into the variable */
                 g_putstatic (CF_STATIC | TypeOf (Sym->Type), DataLabel, 0);
+
+                /* This has to be done at sequence point */
+                DoDeferred (SQP_KEEP_NONE, &Expr);
             }
 
             /* Mark the variable as referenced */
@@ -525,6 +532,9 @@ static void ParseOneDecl (const DeclSpec* Spec)
         }
 
     }
+
+    /* Make sure we aren't missing some work */
+    CheckDeferredOpAllDone ();
 }
 
 

--- a/src/cc65/stdfunc.c
+++ b/src/cc65/stdfunc.c
@@ -245,6 +245,9 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
         LoadExpr (CF_NONE, &Arg3.Expr);
     }
 
+    /* We still need to append deferred inc/dec before calling into the function */
+    DoDeferred (SQP_KEEP_EAX, &Arg3.Expr);
+
     /* Emit the actual function call. This will also cleanup the stack. */
     g_call (CF_FIXARGC, Func_memcpy, ParamSize);
 
@@ -594,6 +597,9 @@ static void StdFunc_memset (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
         LoadExpr (CF_NONE, &Arg3.Expr);
     }
 
+    /* We still need to append deferred inc/dec before calling into the function */
+    DoDeferred (SQP_KEEP_EAX, &Arg3.Expr);
+
     /* Emit the actual function call. This will also cleanup the stack. */
     g_call (CF_FIXARGC, MemSet? Func_memset : Func__bzero, ParamSize);
 
@@ -808,6 +814,9 @@ static void StdFunc_strcmp (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
         LoadExpr (CF_NONE, &Arg2.Expr);
     }
 
+    /* We still need to append deferred inc/dec before calling into the function */
+    DoDeferred (SQP_KEEP_EAX, &Arg2.Expr);
+
     /* Emit the actual function call. This will also cleanup the stack. */
     g_call (CF_FIXARGC, Func_strcmp, ParamSize);
 
@@ -1007,6 +1016,9 @@ static void StdFunc_strcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
         LoadExpr (CF_NONE, &Arg2.Expr);
     }
 
+    /* We still need to append deferred inc/dec before calling into the function */
+    DoDeferred (SQP_KEEP_EAX, &Arg2.Expr);
+
     /* Emit the actual function call. This will also cleanup the stack. */
     g_call (CF_FIXARGC, Func_strcpy, ParamSize);
 
@@ -1192,6 +1204,9 @@ static void StdFunc_strlen (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
 
     /* Evaluate the parameter */
     hie1 (&Arg);
+
+    /* We still need to append deferred inc/dec before calling into the function */
+    DoDeferred (SQP_KEEP_EAX, &Arg);
 
     /* Check if the argument is an array. If so, remember the element count.
     ** Otherwise set the element count to undefined.

--- a/src/cc65/stmt.c
+++ b/src/cc65/stmt.c
@@ -352,6 +352,9 @@ static void ReturnStatement (void)
                     LoadExpr (CF_NONE, &Expr);
                 }
             }
+
+            /* Append deferred inc/dec at sequence point */
+            DoDeferred (SQP_KEEP_EAX, &Expr);
         }
 
     } else if (!F_HasVoidReturn (CurrentFunc) && !F_HasOldStyleIntRet (CurrentFunc)) {

--- a/src/cc65/testexpr.c
+++ b/src/cc65/testexpr.c
@@ -66,6 +66,9 @@ unsigned Test (unsigned Label, int Invert)
     /* Check for a constant expression */
     if (ED_IsConstAbs (&Expr)) {
 
+        /* Append deferred inc/dec at sequence point */
+        DoDeferred (SQP_KEEP_NONE, &Expr);
+
         /* Result is constant, so we know the outcome */
         Result = (Expr.IVal != 0);
 
@@ -78,6 +81,9 @@ unsigned Test (unsigned Label, int Invert)
         }
 
     } else if (ED_IsAddrExpr (&Expr)) {
+
+        /* Append deferred inc/dec at sequence point */
+        DoDeferred (SQP_KEEP_NONE, &Expr);
 
         /* Object addresses are non-NULL */
         Result = 1;
@@ -92,6 +98,9 @@ unsigned Test (unsigned Label, int Invert)
 
         /* Load the value into the primary register */
         LoadExpr (CF_FORCECHAR, &Expr);
+
+        /* Append deferred inc/dec at sequence point */
+        DoDeferred (SQP_KEEP_TEST, &Expr);
 
         /* Generate the jump */
         if (Invert) {


### PR DESCRIPTION
...since the C standard allows that. Resolves #1229.

Basically, cc65 has been doing post-inc/dec mostly like this (pseudo-code):
```asm
; use expr++;             // or expr--;
load expr into primary
backup expr in regsave
inc expr                  ; or dec expr
load regsave into primary
use expr
```
This PR instead (only if `expr` is not complicated that it needs much code to be loaded):
```asm
; use expr++;             // or expr--;
load expr into primary
use expr
backup expr in regsave    ; only if the original value of expr must still be kept in primary
inc expr                  ; or dec expr
load regsave into primary ; only if the original value of expr must still be kept in primary
```
This usually allows faster & smaller code. It is more complicated than a simple solution that like 63506b05cdad1960a2e702037b58674c4ecd4809 from https://github.com/cc65/cc65/issues/1229#issuecomment-683707744, but gives better results when the value of the post-inc/dec is used.

Note that deferred operations must still be called at sequence points even if the whole expressions containing them had constant values.

PS: This is a merge of several old patches and I hope nothing got wrong or missed out.