### PR TITLE
[cc65] Several new/changed optimization steps 

### DIFF
--- a/src/cc65/codeopt.c
+++ b/src/cc65/codeopt.c
@@ -178,6 +178,7 @@ static OptFunc DOptShift3       = { OptShift3,       "OptShift3",        17, 0, 
 static OptFunc DOptShift4       = { OptShift4,       "OptShift4",       100, 0, 0, 0, 0, 0 };
 static OptFunc DOptShift5       = { OptShift5,       "OptShift5",       110, 0, 0, 0, 0, 0 };
 static OptFunc DOptShift6       = { OptShift6,       "OptShift6",       200, 0, 0, 0, 0, 0 };
+static OptFunc DOptSignExtended = { OptSignExtended, "OptSignExtended",   0, 0, 0, 0, 0, 0 };
 static OptFunc DOptSize1        = { OptSize1,        "OptSize1",        100, 0, 0, 0, 0, 0 };
 static OptFunc DOptSize2        = { OptSize2,        "OptSize2",        100, 0, 0, 0, 0, 0 };
 static OptFunc DOptStackOps     = { OptStackOps,     "OptStackOps",     100, 0, 0, 0, 0, 0 };
@@ -280,6 +281,7 @@ static OptFunc* OptFuncs[] = {
     &DOptShift4,
     &DOptShift5,
     &DOptShift6,
+    &DOptSignExtended,
     &DOptSize1,
     &DOptSize2,
     &DOptStackOps,
@@ -713,6 +715,7 @@ static unsigned RunOptGroup3 (CodeSeg* S)
         C += RunOptFunc (S, &DOptPushPop1, 1);
         C += RunOptFunc (S, &DOptPushPop2, 1);
         C += RunOptFunc (S, &DOptPrecalc, 1);
+        C += RunOptFunc (S, &DOptSignExtended, 1);
 
         Changes += C;
 

--- a/src/cc65/codeopt.c
+++ b/src/cc65/codeopt.c
@@ -167,7 +167,8 @@ static OptFunc DOptPtrStore2    = { OptPtrStore2,    "OptPtrStore2",     65, 0, 
 static OptFunc DOptPtrStore3    = { OptPtrStore3,    "OptPtrStore3",    100, 0, 0, 0, 0, 0 };
 static OptFunc DOptPush1        = { OptPush1,        "OptPush1",         65, 0, 0, 0, 0, 0 };
 static OptFunc DOptPush2        = { OptPush2,        "OptPush2",         50, 0, 0, 0, 0, 0 };
-static OptFunc DOptPushPop      = { OptPushPop,      "OptPushPop",        0, 0, 0, 0, 0, 0 };
+static OptFunc DOptPushPop1     = { OptPushPop1,     "OptPushPop1",       0, 0, 0, 0, 0, 0 };
+static OptFunc DOptPushPop2     = { OptPushPop2,     "OptPushPop2",       0, 0, 0, 0, 0, 0 };
 static OptFunc DOptRTS          = { OptRTS,          "OptRTS",          100, 0, 0, 0, 0, 0 };
 static OptFunc DOptRTSJumps1    = { OptRTSJumps1,    "OptRTSJumps1",    100, 0, 0, 0, 0, 0 };
 static OptFunc DOptRTSJumps2    = { OptRTSJumps2,    "OptRTSJumps2",    100, 0, 0, 0, 0, 0 };
@@ -269,7 +270,7 @@ static OptFunc* OptFuncs[] = {
     &DOptPtrStore3,
     &DOptPush1,
     &DOptPush2,
-    &DOptPushPop,
+    &DOptPushPop1,
     &DOptRTS,
     &DOptRTSJumps1,
     &DOptRTSJumps2,
@@ -709,7 +710,8 @@ static unsigned RunOptGroup3 (CodeSeg* S)
         C += RunOptFunc (S, &DOptTransfers4, 1);
         C += RunOptFunc (S, &DOptStore1, 1);
         C += RunOptFunc (S, &DOptStore5, 1);
-        C += RunOptFunc (S, &DOptPushPop, 1);
+        C += RunOptFunc (S, &DOptPushPop1, 1);
+        C += RunOptFunc (S, &DOptPushPop2, 1);
         C += RunOptFunc (S, &DOptPrecalc, 1);
 
         Changes += C;

--- a/src/cc65/codeopt.c
+++ b/src/cc65/codeopt.c
@@ -178,6 +178,7 @@ static OptFunc DOptShift3       = { OptShift3,       "OptShift3",        17, 0, 
 static OptFunc DOptShift4       = { OptShift4,       "OptShift4",       100, 0, 0, 0, 0, 0 };
 static OptFunc DOptShift5       = { OptShift5,       "OptShift5",       110, 0, 0, 0, 0, 0 };
 static OptFunc DOptShift6       = { OptShift6,       "OptShift6",       200, 0, 0, 0, 0, 0 };
+static OptFunc DOptShiftBack    = { OptShiftBack,    "OptShiftBack",      0, 0, 0, 0, 0, 0 };
 static OptFunc DOptSignExtended = { OptSignExtended, "OptSignExtended",   0, 0, 0, 0, 0, 0 };
 static OptFunc DOptSize1        = { OptSize1,        "OptSize1",        100, 0, 0, 0, 0, 0 };
 static OptFunc DOptSize2        = { OptSize2,        "OptSize2",        100, 0, 0, 0, 0, 0 };
@@ -281,6 +282,7 @@ static OptFunc* OptFuncs[] = {
     &DOptShift4,
     &DOptShift5,
     &DOptShift6,
+    &DOptShiftBack,
     &DOptSignExtended,
     &DOptSize1,
     &DOptSize2,
@@ -715,6 +717,7 @@ static unsigned RunOptGroup3 (CodeSeg* S)
         C += RunOptFunc (S, &DOptPushPop1, 1);
         C += RunOptFunc (S, &DOptPushPop2, 1);
         C += RunOptFunc (S, &DOptPrecalc, 1);
+        C += RunOptFunc (S, &DOptShiftBack, 1);
         C += RunOptFunc (S, &DOptSignExtended, 1);
 
         Changes += C;

--- a/src/cc65/coptind.c
+++ b/src/cc65/coptind.c
@@ -1474,3 +1474,95 @@ unsigned OptPrecalc (CodeSeg* S)
     /* Return the number of changes made */
     return Changes;
 }
+
+
+
+unsigned OptSignExtended (CodeSeg* S)
+/* Change
+**
+**      lda     xxx     ; X is 0
+**      bpl     L1
+**      dex/ldx #$FF
+**  L1: cpx     #$00
+**      bpl     L2
+**
+** or
+**
+**      lda     xxx     ; X is 0
+**      bpl     L1
+**      dex/ldx #$FF
+**  L1: cpx     #$80
+**      bcc/bmi L2
+**
+** into
+**      lda     xxx     ; X is 0
+**      bpl     L2
+**      dex/ldx #$FF
+**
+** provided the C flag isn't used later.
+*/
+{
+    unsigned Changes = 0;
+    CodeEntry* L[5];
+    CodeEntry* X;
+    unsigned CheckStates;
+
+    /* Walk over the entries */
+    unsigned I = 0;
+    while (I < CS_GetEntryCount (S)) {
+
+        /* Get next entry */
+        L[0] = CS_GetEntry (S, I);
+
+        /* Check if it's a register load or transfer insn */
+        if (L[0]->OPC == OP65_LDA                   &&
+            CS_GetEntries (S, L+1, I+1, 4)          &&
+            !CS_RangeHasLabel (S, I+1, 2)           &&
+            CE_GetLabelCount (L[3]) == 1            &&
+            L[1]->JumpTo == CE_GetLabel (L[3], 0)   &&
+            (L[1]->Info & OF_CBRA) != 0             &&
+            GetBranchCond (L[1]->OPC) == BC_PL      &&
+            RegValIsKnown (L[2]->RI->Out.RegX)      &&
+            L[2]->RI->Out.RegX == 0xFF              &&
+            L[2]->OPC != OP65_JSR                   &&
+            (L[2]->Chg & REG_AXY) == REG_X) {
+
+            /* We find a sign extention */
+            CheckStates = PSTATE_CZN;
+            if (L[3]->OPC == OP65_CPX                       &&
+                CE_IsConstImm (L[3])                        &&
+                (L[4]->Info & OF_CBRA) != 0                 &&
+                ((L[3]->Num == 0x00                     &&
+                  GetBranchCond (L[4]->OPC) == BC_PL)       ||
+                ((L[3]->Num == 0x80                     &&
+                  GetBranchCond (L[4]->OPC) == BC_CC &&
+                  GetBranchCond (L[4]->OPC) == BC_MI)))) {
+
+                /* Check if the processor states set by the CPX are unused later */
+                if ((GetRegInfo (S, I+5, CheckStates) & CheckStates) == 0) {
+
+                    /* Change the target of the sign extention branch */
+                    X = NewCodeEntry (OP65_JPL, L[4]->AM, L[4]->Arg, L[4]->JumpTo, L[4]->LI);
+                    CS_InsertEntry (S, X, I+1);
+                    CS_DelEntry (S, I+2);
+
+                    /* Remove the old conditional branch */
+                    CS_DelEntries (S, I+3, 2);
+
+                    /* Remember, we had changes */
+                    ++Changes;
+
+                    /* Continue with the current insn */
+                    continue;
+                }
+            }
+        }
+
+        /* Next entry */
+        ++I;
+
+    }
+
+    /* Return the number of changes made */
+    return Changes;
+}

--- a/src/cc65/coptind.h
+++ b/src/cc65/coptind.h
@@ -93,6 +93,31 @@ unsigned OptPrecalc (CodeSeg* S);
 ** known by a load of the final value.
 */
 
+unsigned OptSignExtended (CodeSeg* S);
+/* Change
+**
+**      lda     xxx     ; X is 0
+**      bpl     L1
+**      dex/ldx #$FF
+**  L1: cpx     #$00
+**      bpl     L2
+**
+** or
+**
+**      lda     xxx     ; X is 0
+**      bpl     L1
+**      dex/ldx #$FF
+**  L1: cpx     #$80
+**      bcc/bmi L2
+**
+** into
+**      lda     xxx     ; X is 0
+**      bpl     L2
+**      dex/ldx #$FF
+**
+** provided the C flag isn't used later.
+*/
+
 
 
 /* End of coptind.h */

--- a/src/cc65/coptind.h
+++ b/src/cc65/coptind.h
@@ -93,6 +93,11 @@ unsigned OptPrecalc (CodeSeg* S);
 ** known by a load of the final value.
 */
 
+unsigned OptShiftBack (CodeSeg* S);
+/* Remove a pair of shifts to the opposite directions if none of the bits of
+** the register A or the Z/N flags modified by these shifts are used later.
+*/
+
 unsigned OptSignExtended (CodeSeg* S);
 /* Change
 **

--- a/src/cc65/coptind.h
+++ b/src/cc65/coptind.h
@@ -82,8 +82,11 @@ unsigned OptTransfers4 (CodeSeg* S);
 ** by a load of the second register if possible.
 */
 
-unsigned OptPushPop (CodeSeg* S);
-/* Remove a PHA/PLA sequence were A is not used later */
+unsigned OptPushPop1 (CodeSeg* S);
+/* Remove a PHA/PLA sequence were A not used later */
+
+unsigned OptPushPop2 (CodeSeg* S);
+/* Remove a PHP/PLP sequence were no processor flags changed inside */
 
 unsigned OptPrecalc (CodeSeg* S);
 /* Replace immediate operations with the accu where the current contents are

--- a/src/cc65/coptneg.c
+++ b/src/cc65/coptneg.c
@@ -480,7 +480,7 @@ unsigned OptNegAX2 (CodeSeg* S)
 **      eor     #$FF
 **      clc
 **      adc     #$01
-**      bne     L1
+**      bcc     L1
 **      inx
 ** L1:
 **
@@ -528,8 +528,8 @@ unsigned OptNegAX2 (CodeSeg* S)
             /* Get the label attached to the insn following the call */
             L = CS_GenLabel (S, P);
 
-            /* bne L */
-            X = NewCodeEntry (OP65_BNE, AM65_BRA, L->Name, L, E->LI);
+            /* bcc L */
+            X = NewCodeEntry (OP65_BCC, AM65_BRA, L->Name, L, E->LI);
             CS_InsertEntry (S, X, I+5);
 
             /* inx */

--- a/src/cc65/coptneg.h
+++ b/src/cc65/coptneg.h
@@ -155,7 +155,7 @@ unsigned OptNegAX2 (CodeSeg* S);
 **      eor     #$FF
 **      clc
 **      adc     #$01
-**      bne     L1
+**      bcc     L1
 **      inx
 ** L1:
 **


### PR DESCRIPTION
- `OptSignExtended` and `OptShiftBack` are for optimizing code patterns that could be generated with #1070.
- `OpPushPop2` is for optimizing a code pattern that could be generated with #1285.
- `OptNegAX2` is changed to be more friendly to other optimization steps looking for addition patterns.