### PR TITLE
Default PREFIX to /usr/local/.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,6 +2,8 @@ ifneq ($(shell echo),)
   CMD_EXE = 1
 endif
 
+PREFIX ?= /usr/local
+
 .PHONY: all mostlyclean clean install zip doc html info
 
 .SUFFIXES:
@@ -46,7 +48,6 @@ clean:
 	$(RM) -r ../html ../info
 
 install:
-	$(if $(PREFIX),,$(error variable "PREFIX" must be set))
 ifeq ($(wildcard ../html),../html)
 	$(INSTALL) -d $(DESTDIR)$(htmldir)
 	$(INSTALL) -m0644 ../html/*.* $(DESTDIR)$(htmldir)

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -2,6 +2,8 @@ ifneq ($(shell echo),)
   CMD_EXE = 1
 endif
 
+PREFIX ?= /usr/local
+
 CBMS = c128   \
        c16    \
        c64    \
@@ -94,7 +96,6 @@ INSTALL = install
 
 define INSTALL_recipe
 
-$(if $(PREFIX),,$(error variable "PREFIX" must be set))
 $(INSTALL) -d $(DESTDIR)$(datadir)/$(dir)
 $(INSTALL) -m0644 ../$(dir)/*.* $(DESTDIR)$(datadir)/$(dir)
 

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -4,6 +4,8 @@
 # This Makefile requires GNU make
 #
 
+PREFIX ?= /usr/local
+
 # Run 'make SYS=<target>'; or, set a SYS env.
 # var. to build for another target system.
 SYS ?= c64
@@ -332,7 +334,6 @@ INSTALL = install
 samplesdir = $(PREFIX)/share/cc65/samples
 
 install:
-	$(if $(PREFIX),,$(error variable "PREFIX" must be set))
 	$(INSTALL) -d $(DESTDIR)$(samplesdir)
 	$(INSTALL) -d $(DESTDIR)$(samplesdir)/geos
 	$(INSTALL) -d $(DESTDIR)$(samplesdir)/tutorial

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,6 +2,8 @@ ifneq ($(shell echo),)
   CMD_EXE = 1
 endif
 
+PREFIX ?= /usr/local
+
 PROGS = ar65     \
         ca65     \
         cc65     \
@@ -105,7 +107,6 @@ $(RM) /usr/local/bin/$(prog)
 endef # UNAVAIL_recipe
 
 install:
-	$(if $(PREFIX),,$(error variable "PREFIX" must be set))
 	$(INSTALL) -d $(DESTDIR)$(bindir)
 	$(INSTALL) ../bin/* $(DESTDIR)$(bindir)
 


### PR DESCRIPTION
This is the traditional path on unixoids for additional user
system resources – having to set it manually every time for the
install target is rather unusual.  See also
https://www.gnu.org/software/make/manual/html_node/Directory-Variables.html