### PR TITLE
Added generic way of defining CLOCKS_PER_SEC

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -84,8 +84,9 @@ extern struct _timezone {
 
 
 #if defined(__ATARI__)
-/* The clock depends on the video standard, so read it at runtime */
-unsigned _clocks_per_sec (void);
+   /* The clock depends on the video standard, so read it at runtime
+   */
+   unsigned _clocks_per_sec (void);   
 #  define CLK_TCK               _clocks_per_sec()
 #  define CLOCKS_PER_SEC        _clocks_per_sec()
 #elif defined(__ATARI5200__)
@@ -96,7 +97,8 @@ unsigned _clocks_per_sec (void);
 #  define CLOCKS_PER_SEC        100     /* ANSI */
 #elif defined(__CBM__)
 #  if defined(__CBM510__) || defined(__CBM610__)
-/* The 510/610 gets its clock from the AC current */
+     /* The 510/610 gets its clock from the AC current
+	 */
 #    define CLK_TCK             50      /* POSIX */
 #    define CLOCKS_PER_SEC      50      /* ANSI */
 #  else
@@ -116,12 +118,23 @@ unsigned _clocks_per_sec (void);
 #  define CLK_TCK               1       /* POSIX */
 #  define CLOCKS_PER_SEC        1       /* ANSI */
 #elif defined(__LYNX__)
-/* The clock-rate depends on the video scan-rate;
-** so, read it at run-time.
-*/
-extern clock_t _clk_tck (void);
+   /* The clock-rate depends on the video scan-rate;
+   ** so, read it at run-time.
+   */
+   extern clock_t _clk_tck (void);
+   
 #  define CLK_TCK               _clk_tck()
 #  define CLOCKS_PER_SEC        _clk_tck()
+#else
+   /* The clock-rate, if undefined, is provided in a separate user defined funtion.
+   */
+   extern clock_t _clk_tck (void);
+#  if !defined (CLK_TCK)
+#    define CLK_TCK             _clk_tck()
+#  endif
+#  if !defined (CLOCKS_PER_SEC)
+#    define CLOCKS_PER_SEC      _clk_tck()
+#  endif
 #endif
 #define CLOCK_REALTIME          0
 


### PR DESCRIPTION
Hi

I'm porting cc65 to a new target and I'm creating code for library functions in time.h for the new target.
For the purpose, I need to use CLOCKS_PER_SEC. I could use a separate header to define it, but then the user will have to always include <time.h> AND my header, which means I must adapt all existing code that uses time.h, this makes porting cumbersome.
My proposal here is to define an external function _clk_tck()  that is called, should CLOCKS_PER_SEC still be undefined. It has some speed drawbacks but will make porting of existing code easier.

I made minor formatting changes to the file.