### PR TITLE
Default PREFIX to /usr/local/.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,6 +2,8 @@ ifneq ($(shell echo),)
   CMD_EXE = 1
 endif
 
+PREFIX ?= /usr/local
+
 .PHONY: all mostlyclean clean install zip doc html info
 
 .SUFFIXES:
@@ -46,7 +48,6 @@ clean:
 	$(RM) -r ../html ../info
 
 install:
-	$(if $(PREFIX),,$(error variable "PREFIX" must be set))
 ifeq ($(wildcard ../html),../html)
 	$(INSTALL) -d $(DESTDIR)$(htmldir)
 	$(INSTALL) -m0644 ../html/*.* $(DESTDIR)$(htmldir)

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -2,6 +2,8 @@ ifneq ($(shell echo),)
   CMD_EXE = 1
 endif
 
+PREFIX ?= /usr/local
+
 CBMS = c128   \
        c16    \
        c64    \
@@ -94,7 +96,6 @@ INSTALL = install
 
 define INSTALL_recipe
 
-$(if $(PREFIX),,$(error variable "PREFIX" must be set))
 $(INSTALL) -d $(DESTDIR)$(datadir)/$(dir)
 $(INSTALL) -m0644 ../$(dir)/*.* $(DESTDIR)$(datadir)/$(dir)
 

--- a/libsrc/cbm/cbm_read.s
+++ b/libsrc/cbm/cbm_read.s
@@ -45,11 +45,11 @@
 
 
 _cbm_read:
-        eor     #$FF
-        sta     ptr1
-        txa
-        eor     #$FF
-        sta     ptr1+1          ; Save -size-1
+        inx
+        stx     ptr1+1
+        tax
+        inx
+        stx     ptr1            ; Save size with each byte incremented.
 
         jsr     popax
         sta     ptr2
@@ -92,9 +92,9 @@ _cbm_read:
         bne     @L3
         inc     ptr3+1          ; ++bytesread;
 
-@L3:    inc     ptr1
+@L3:    dec     ptr1
         bne     @L1
-        inc     ptr1+1
+        dec     ptr1+1
         bne     @L1
 
 @L4:    jsr     CLRCH

--- a/libsrc/cbm/cbm_write.s
+++ b/libsrc/cbm/cbm_write.s
@@ -39,11 +39,11 @@
 _cbm_write:
         sta     ptr3
         stx     ptr3+1          ; Save size
-        eor     #$FF
-        sta     ptr1
-        txa
-        eor     #$FF
-        sta     ptr1+1          ; Save -size-1
+        inx
+        stx     ptr1+1
+        tax
+        inx
+        stx     ptr1            ; Save size with each byte incremented
 
         jsr     popax
         sta     ptr2
@@ -69,9 +69,9 @@ _cbm_write:
 
 @L2:    jsr     BSOUT           ; cbm_k_bsout (A);
 
-@L3:    inc     ptr1            ; --size;
+@L3:    dec     ptr1            ; --size;
         bne     @L1
-        inc     ptr1+1
+        dec     ptr1+1
         bne     @L1
 
         jsr     CLRCH

--- a/libsrc/common/getcwd.s
+++ b/libsrc/common/getcwd.s
@@ -17,22 +17,22 @@
 
 .proc   _getcwd
 
-; Remember -size-1 because this simplifies the following loop
+; Remember size with each byte incremented because this simplifies the following loop
 
-        eor     #$FF
-        sta     ptr2
-        txa
-        eor     #$FF
-        sta     ptr2+1
+        inx
+        stx     ptr2+1
+        tax
+        inx
+        stx     ptr2
 
         jsr     popptr1         ; Get buf to ptr1
 
 ; Copy __cwd to the given buffer checking the length
 
         ; ldy     #$00          is guaranteed by popptr1
-loop:   inc     ptr2
+loop:   dec     ptr2
         bne     @L1
-        inc     ptr2+1
+        dec     ptr2+1
         beq     overflow
 
 ; Copy one character, end the loop if the zero terminator is reached. We

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -4,6 +4,8 @@
 # This Makefile requires GNU make
 #
 
+PREFIX ?= /usr/local
+
 # Run 'make SYS=<target>'; or, set a SYS env.
 # var. to build for another target system.
 SYS ?= c64
@@ -332,7 +334,6 @@ INSTALL = install
 samplesdir = $(PREFIX)/share/cc65/samples
 
 install:
-	$(if $(PREFIX),,$(error variable "PREFIX" must be set))
 	$(INSTALL) -d $(DESTDIR)$(samplesdir)
 	$(INSTALL) -d $(DESTDIR)$(samplesdir)/geos
 	$(INSTALL) -d $(DESTDIR)$(samplesdir)/tutorial

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,6 +2,8 @@ ifneq ($(shell echo),)
   CMD_EXE = 1
 endif
 
+PREFIX ?= /usr/local
+
 PROGS = ar65     \
         ca65     \
         cc65     \
@@ -105,7 +107,6 @@ $(RM) /usr/local/bin/$(prog)
 endef # UNAVAIL_recipe
 
 install:
-	$(if $(PREFIX),,$(error variable "PREFIX" must be set))
 	$(INSTALL) -d $(DESTDIR)$(bindir)
 	$(INSTALL) ../bin/* $(DESTDIR)$(bindir)
 


### PR DESCRIPTION
This is the traditional path on unixoids for additional user
system resources – having to set it manually every time for the
install target is rather unusual.  See also
https://www.gnu.org/software/make/manual/html_node/Directory-Variables.html