### PR TITLE
Add test cases for integral promotion of chars

### DIFF
--- a/test/val/char-promote.c
+++ b/test/val/char-promote.c
@@ -1,0 +1,127 @@
+/*
+  Copyright 2020 The cc65 Authors
+
+  This software is provided 'as-is', without any express or implied
+  warranty. In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+/*
+  Tests of promotions of character types.
+*/
+
+#include <stdio.h>
+
+typedef unsigned char u8;
+
+static unsigned char failures = 0;
+
+void test_sub (void)
+{
+    const u8 one = 1, two = 2;
+
+    /* For any unsigned type other than unsigned char, (T) 1 - (T) 2 > 0. */
+    if (1U - 2U < 0) {
+        fprintf (stderr, "Expected 1U - 2U > 0\n");
+        failures++;
+    }
+
+    /* The unsigned chars get promoted to int, so this is negative. */
+    if (one - two > 0) {
+        fprintf (stderr, "Expected one - two < 0\n");
+        failures++;
+    }
+
+    /* Test the constant expression code paths. */
+    if ((u8) 1 - (u8) 2 > 0) {
+        fprintf (stderr, "Expected (u8) 1 - (u8) 2 < 0\n");
+        failures++;
+    }
+}
+
+void test_mul (void)
+{
+    const u8 two_fifty_five = 255;
+
+    if (255U * 255U != 65025U) {
+        fprintf (stderr, "Expected 255U * 255U == 65025U\n");
+        failures++;
+    }
+#if 0
+    /* Disabled pending fix of #1310. */
+    if (255 * 255 != -511) {
+        fprintf (stderr, "Expected 255 * 255 == -511, got: %d\n", 255 * 255);
+        failures++;
+    }
+#endif
+
+    /* The unsigned chars get promoted to int, so this is -511.
+    ** We should also be able to observe that the generated code uses mul, not umul.
+    */
+    if (two_fifty_five * two_fifty_five != -511) {
+        fprintf (stderr, "Expected two_fifty_five * two_fifty_five == -511\n");
+        failures++;
+    }
+#if 0
+    /* Disabled pending fix of #1310. */
+    if ((u8) 255 * (u8) 255 != -511) {
+        fprintf (stderr, "Expected (u8) 255 * (u8) 255 == -511, got: %d\n",
+                 (u8) 255 * (u8) 255);
+        failures++;
+    }
+#endif
+}
+
+void test_div (void)
+{
+    const u8 seventeen = 17;
+    const u8 three = 3;
+
+    /* We should also be able to observe that the generated code uses div, not udiv. */
+    if (seventeen / three != 5) {
+        fprintf (stderr, "Expected seventeen / three == 5, got: %d\n", seventeen / three);
+        failures++;
+    }
+    if ((u8) 17 / (u8) 3 != 5) {
+        fprintf (stderr, "Expected (u8) 17 / (u8) 3 == 5, got: %d\n", (u8) 17 / (u8) 3);
+        failures++;
+    }
+}
+
+void test_shr (void)
+{
+    const unsigned int forty_two = 42;
+    const unsigned int two = 2;
+
+    /* We should also be able to observe that the generated code uses asr, not shr. */
+    if (forty_two >> two != 10) {
+        fprintf (stderr, "Expected forty_two / two == 10, got: %d\n", forty_two >> two);
+        failures++;
+    }
+    if ((u8) 42 >> (u8) 2 != 10) {
+        fprintf (stderr, "Expected (u8) 42 >> (u8) 2 == 10, got: %d\n", (u8) 42 >> (u8) 3);
+        failures++;
+    }
+}
+
+int main (void)
+{
+    test_sub ();
+    test_mul ();
+    test_div ();
+    test_shr ();
+    printf ("failures: %u\n", failures);
+    return failures;
+}


### PR DESCRIPTION
Both signed and unsigned chars are promoted to int by C's evaluation
rules.  It is more efficient to use unsigned operations when possible,
however.  These tests will help test the correctness of optimizations
doing that.  See #1308.