### PR TITLE
atarixl configs: make size of CHARGEN configurable

### DIFF
--- a/cfg/atarixl-largehimem.cfg
+++ b/cfg/atarixl-largehimem.cfg
@@ -8,39 +8,40 @@ FEATURES {
 }
 SYMBOLS {
     __EXEHDR__:       type = import;
-    __SYSTEM_CHECK__: type = import;  # force inclusion of "system check" load chunk
-    __AUTOSTART__:    type = import;  # force inclusion of autostart "trailer"
-    __STACKSIZE__:    type = weak, value = $0800; # 2k stack
+    __SYSTEM_CHECK__: type = import;                # force inclusion of "system check" load chunk
+    __AUTOSTART__:    type = import;                # force inclusion of autostart "trailer"
+    __STACKSIZE__:    type = weak,   value = $0800; # 2k stack
+    __CHARGENSIZE__:  type = weak,   value = $0400;
     __STARTADDRESS__: type = export, value = %S;
 }
 MEMORY {
-    ZP:         file = "", define = yes, start = $0082,                size = $007E;
+    ZP:         file = "", define = yes, start = $0082,                   size = $007E;
 
 # just $FFFF
-    HEADER:     file = %O,               start = $0000,                size = $0002;
+    HEADER:     file = %O,               start = $0000,                   size = $0002;
 
 # "system check" load chunk
-    SYSCHKHDR:  file = %O,               start = $0000,                size = $0004;
-    SYSCHKCHNK: file = %O,               start = $2E00,                size = $0300;
-    SYSCHKTRL:  file = %O,               start = $0000,                size = $0006;
+    SYSCHKHDR:  file = %O,               start = $0000,                   size = $0004;
+    SYSCHKCHNK: file = %O,               start = $2E00,                   size = $0300;
+    SYSCHKTRL:  file = %O,               start = $0000,                   size = $0006;
 
 # "shadow RAM preparation" load chunk
-    SRPREPHDR:  file = %O,               start = $0000,                size = $0004;
-    SRPREPCHNK: file = %O, define = yes, start = %S,                   size = $7C20 - %S - $07FF;  # $07FF: space for temp. chargen buffer, 1K aligned
-    SRPREPTRL:  file = %O,               start = $0000,                size = $0006;
+    SRPREPHDR:  file = %O,               start = $0000,                   size = $0004;
+    SRPREPCHNK: file = %O, define = yes, start = %S,                      size = $7C20 - %S - $07FF;  # $07FF: space for temp. chargen buffer, 1K aligned
+    SRPREPTRL:  file = %O,               start = $0000,                   size = $0006;
 
 # "main program" load chunk
-    MAINHDR:    file = %O,               start = $0000,                size = $0004;
-    MAIN:       file = %O, define = yes, start = %S + __LOWBSS_SIZE__, size = $D000 - __STACKSIZE__ - %S - __LOWBSS_SIZE__;
+    MAINHDR:    file = %O,               start = $0000,                   size = $0004;
+    MAIN:       file = %O, define = yes, start = %S + __LOWBSS_SIZE__,    size = $D000 - __STACKSIZE__ - %S - __LOWBSS_SIZE__;
 
 # defines entry point into program
-    TRAILER:    file = %O,               start = $0000,                size = $0006;
+    TRAILER:    file = %O,               start = $0000,                   size = $0006;
 
 # address of relocated character generator
-    CHARGEN:    file = "", define = yes, start = $D800,                size = $0400;
+    CHARGEN:    file = "", define = yes, start = $D800,                   size = __CHARGENSIZE__;
 
 # memory beneath the ROM
-    HIDDEN_RAM: file = "", define = yes, start = $DC00,                size = $FFFA - $DC00;
+    HIDDEN_RAM: file = "", define = yes, start = $D800 + __CHARGENSIZE__, size = $FFFA - $D800 - __CHARGENSIZE__;
 }
 SEGMENTS {
     ZEROPAGE:    load = ZP,                           type = zp;

--- a/cfg/atarixl-overlay.cfg
+++ b/cfg/atarixl-overlay.cfg
@@ -3,44 +3,45 @@ FEATURES {
 }
 SYMBOLS {
     __EXEHDR__:       type = import;
-    __SYSTEM_CHECK__: type = import;  # force inclusion of "system check" load chunk
-    __AUTOSTART__:    type = import;  # force inclusion of autostart "trailer"
-    __STACKSIZE__:    type = weak, value = $0800; # 2k stack
-    __OVERLAYSIZE__:  type = weak, value = $1000; # 4k overlay
+    __SYSTEM_CHECK__: type = import; # force inclusion of "system check" load chunk
+    __AUTOSTART__:    type = import; # force inclusion of autostart "trailer"
+    __STACKSIZE__:    type = weak,   value = $0800; # 2k stack
+    __CHARGENSIZE__:  type = weak,   value = $0400;
+    __OVERLAYSIZE__:  type = weak,   value = $1000; # 4k overlay
     __STARTADDRESS__: type = export, value = %S;
 }
 MEMORY {
-    ZP:          file = "", define = yes, start = $0082,                size = $007E;
+    ZP:          file = "", define = yes, start = $0082,                   size = $007E;
 
 # just $FFFF
-    HEADER:      file = %O,               start = $0000,                size = $0002;
+    HEADER:      file = %O,               start = $0000,                   size = $0002;
 
 # "system check" load chunk
-    SYSCHKHDR:   file = %O,               start = $0000,                size = $0004;
-    SYSCHKCHNK:  file = %O,               start = $2E00,                size = $0300;
-    SYSCHKTRL:   file = %O,               start = $0000,                size = $0006;
+    SYSCHKHDR:   file = %O,               start = $0000,                   size = $0004;
+    SYSCHKCHNK:  file = %O,               start = $2E00,                   size = $0300;
+    SYSCHKTRL:   file = %O,               start = $0000,                   size = $0006;
 
 # "shadow RAM preparation" load chunk
-    SRPREPHDR:   file = %O,               start = $0000,                size = $0004;
-    SRPREPCHNK:  file = %O, define = yes, start = %S + __OVERLAYSIZE__, size = $7C20 - %S - __OVERLAYSIZE__ - $07FF;  # $07FF: space for temp. chargen buffer, 1K aligned
-    SRPREPTRL:   file = %O,               start = $0000,                size = $0006;
+    SRPREPHDR:   file = %O,               start = $0000,                   size = $0004;
+    SRPREPCHNK:  file = %O, define = yes, start = %S + __OVERLAYSIZE__,    size = $7C20 - %S - __OVERLAYSIZE__ - $07FF;  # $07FF: space for temp. chargen buffer, 1K aligned
+    SRPREPTRL:   file = %O,               start = $0000,                   size = $0006;
 
 # "main program" load chunk
-    MAINHDR:     file = %O,               start = $0000,                size = $0004;
+    MAINHDR:     file = %O,               start = $0000,                   size = $0004;
     MAIN:        file = %O, define = yes, start = %S + __OVERLAYSIZE__ +
-                                                       __LOWBSS_SIZE__, size = $D000 - __STACKSIZE__ - %S - __OVERLAYSIZE__ - __LOWBSS_SIZE__;
+                                                       __LOWBSS_SIZE__,    size = $D000 - __STACKSIZE__ - %S - __OVERLAYSIZE__ - __LOWBSS_SIZE__;
 
 # defines entry point into program
-    TRAILER:     file = %O,               start = $0000,                size = $0006;
+    TRAILER:     file = %O,               start = $0000,                   size = $0006;
 
 # memory beneath the ROM preceeding the character generator
-    HIDDEN_RAM2: file = "", define = yes, start = $D800,                size = $0800;
+    HIDDEN_RAM2: file = "", define = yes, start = $D800,                   size = $0800;
 
 # address of relocated character generator (same addess as ROM version)
-    CHARGEN:     file = "", define = yes, start = $E000,                size = $0400;
+    CHARGEN:     file = "", define = yes, start = $E000,                   size = __CHARGENSIZE__;
 
 # memory beneath the ROM
-    HIDDEN_RAM:  file = "", define = yes, start = $E400,                size = $FFFA - $E400;
+    HIDDEN_RAM:  file = "", define = yes, start = $E000 + __CHARGENSIZE__, size = $FFFA - $E000 - __CHARGENSIZE__;
 
 # overlays
     OVL1:        file = "%O.1",           start = %S,                   size = __OVERLAYSIZE__;

--- a/cfg/atarixl-xex.cfg
+++ b/cfg/atarixl-xex.cfg
@@ -4,35 +4,36 @@ FEATURES {
     STARTADDRESS: default = $2400;
 }
 SYMBOLS {
-    __SYSTEM_CHECK__: type = import;  # force inclusion of "system check" load chunk
-    __STACKSIZE__:    type = weak, value = $0800; # 2k stack
+    __SYSTEM_CHECK__: type = import; # force inclusion of "system check" load chunk
+    __STACKSIZE__:    type = weak,   value = $0800; # 2k stack
     __STARTADDRESS__: type = export, value = %S;
+    __CHARGENSIZE__:  type = weak,   value = $0400;
     __SYSCHKHDR__:    type = export, value = 0; # Disable system check header
     __SYSCHKTRL__:    type = export, value = 0; # Disable system check trailer
 }
 MEMORY {
-    ZP:          file = "", define = yes, start = $0082,                size = $007E;
+    ZP:          file = "", define = yes, start = $0082,                   size = $007E;
 
 # "system check" load chunk
-    SYSCHKCHNK:  file = %O,               start = $2E00,                size = $0300;
+    SYSCHKCHNK:  file = %O,               start = $2E00,                   size = $0300;
 
 # "shadow RAM preparation" load chunk
-    SRPREPCHNK:  file = %O, define = yes, start = %S,                   size = $7C20 - %S - $07FF;  # $07FF: space for temp. chargen buffer, 1K aligned
+    SRPREPCHNK:  file = %O, define = yes, start = %S,                      size = $7C20 - %S - $07FF;  # $07FF: space for temp. chargen buffer, 1K aligned
 
 # "main program" load chunk
-    MAIN:        file = %O, define = yes, start = %S + __LOWBSS_SIZE__, size = $D000 - __STACKSIZE__ - %S - __LOWBSS_SIZE__;
+    MAIN:        file = %O, define = yes, start = %S + __LOWBSS_SIZE__,    size = $D000 - __STACKSIZE__ - %S - __LOWBSS_SIZE__;
 
 # memory beneath the ROM preceeding the character generator
-    HIDDEN_RAM2: file = "", define = yes, start = $D800,                size = $0800;
+    HIDDEN_RAM2: file = "", define = yes, start = $D800,                   size = $0800;
 
 # address of relocated character generator (same addess as ROM version)
-    CHARGEN:     file = "", define = yes, start = $E000,                size = $0400;
+    CHARGEN:     file = "", define = yes, start = $E000,                   size = __CHARGENSIZE__;
 
 # memory beneath the ROM
-    HIDDEN_RAM:  file = "", define = yes, start = $E400,                size = $FFFA - $E400;
+    HIDDEN_RAM:  file = "", define = yes, start = $E000 + __CHARGENSIZE__, size = $FFFA - $E000 - __CHARGENSIZE__;
 
 # UNUSED - hide
-    UNUSED:  file = "", start = $0,  size = $10;
+    UNUSED:      file = "",               start = $0,                      size = $10;
 }
 FILES {
     %O: format = atari;

--- a/cfg/atarixl.cfg
+++ b/cfg/atarixl.cfg
@@ -6,39 +6,40 @@ SYMBOLS {
     __SYSTEM_CHECK__: type = import;  # force inclusion of "system check" load chunk
     __AUTOSTART__:    type = import;  # force inclusion of autostart "trailer"
     __STACKSIZE__:    type = weak, value = $0800; # 2k stack
+    __CHARGENSIZE__:  type = weak, value = $0400;
     __STARTADDRESS__: type = export, value = %S;
 }
 MEMORY {
-    ZP:          file = "", define = yes, start = $0082,                size = $007E;
+    ZP:          file = "", define = yes, start = $0082,                   size = $007E;
 
 # just $FFFF
-    HEADER:      file = %O,               start = $0000,                size = $0002;
+    HEADER:      file = %O,               start = $0000,                   size = $0002;
 
 # "system check" load chunk
-    SYSCHKHDR:   file = %O,               start = $0000,                size = $0004;
-    SYSCHKCHNK:  file = %O,               start = $2E00,                size = $0300;
-    SYSCHKTRL:   file = %O,               start = $0000,                size = $0006;
+    SYSCHKHDR:   file = %O,               start = $0000,                   size = $0004;
+    SYSCHKCHNK:  file = %O,               start = $2E00,                   size = $0300;
+    SYSCHKTRL:   file = %O,               start = $0000,                   size = $0006;
 
 # "shadow RAM preparation" load chunk
-    SRPREPHDR:   file = %O,               start = $0000,                size = $0004;
-    SRPREPCHNK:  file = %O, define = yes, start = %S,                   size = $7C20 - %S - $07FF;  # $07FF: space for temp. chargen buffer, 1K aligned
-    SRPREPTRL:   file = %O,               start = $0000,                size = $0006;
+    SRPREPHDR:   file = %O,               start = $0000,                   size = $0004;
+    SRPREPCHNK:  file = %O, define = yes, start = %S,                      size = $7C20 - %S - $07FF;  # $07FF: space for temp. chargen buffer, 1K aligned
+    SRPREPTRL:   file = %O,               start = $0000,                   size = $0006;
 
 # "main program" load chunk
-    MAINHDR:     file = %O,               start = $0000,                size = $0004;
-    MAIN:        file = %O, define = yes, start = %S + __LOWBSS_SIZE__, size = $D000 - __STACKSIZE__ - %S - __LOWBSS_SIZE__;
+    MAINHDR:     file = %O,               start = $0000,                   size = $0004;
+    MAIN:        file = %O, define = yes, start = %S + __LOWBSS_SIZE__,    size = $D000 - __STACKSIZE__ - %S - __LOWBSS_SIZE__;
 
 # defines entry point into program
-    TRAILER:     file = %O,               start = $0000,                size = $0006;
+    TRAILER:     file = %O,               start = $0000,                   size = $0006;
 
 # memory beneath the ROM preceeding the character generator
-    HIDDEN_RAM2: file = "", define = yes, start = $D800,                size = $0800;
+    HIDDEN_RAM2: file = "", define = yes, start = $D800,                   size = $0800;
 
 # address of relocated character generator (same addess as ROM version)
-    CHARGEN:     file = "", define = yes, start = $E000,                size = $0400;
+    CHARGEN:     file = "", define = yes, start = $E000,                   size = __CHARGENSIZE__;
 
 # memory beneath the ROM
-    HIDDEN_RAM:  file = "", define = yes, start = $E400,                size = $FFFA - $E400;
+    HIDDEN_RAM:  file = "", define = yes, start = $E000 + __CHARGENSIZE__, size = $FFFA - $E000 - __CHARGENSIZE__;
 }
 SEGMENTS {
     ZEROPAGE:    load = ZP,                            type = zp;


### PR DESCRIPTION
If text mode is not used, its space can be reclaimed by setting __CHARGENSIZE__ to 0.
Following a suggestion from issue #1314.