### PR TITLE
[cc65] Fixed internal representation of calculated constant results

### DIFF
--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -3347,7 +3347,7 @@ static void parsesub (ExprDesc* Expr)
                     Error ("Incompatible pointer types");
                 } else {
                     Expr->IVal = (Expr->IVal - Expr2.IVal) /
-                                      CheckedPSizeOf (lhst);
+                                      (long)CheckedPSizeOf (lhst);
                 }
                 /* Operate on pointers, result type is an integer */
                 Expr->Type = type_int;

--- a/src/cc65/testexpr.c
+++ b/src/cc65/testexpr.c
@@ -63,7 +63,7 @@ unsigned Test (unsigned Label, int Invert)
     /* Read a boolean expression */
     BoolExpr (hie0, &Expr);
 
-    /* Check for a constant expression */
+    /* Check for a constant numeric expression */
     if (ED_IsConstAbs (&Expr)) {
 
         /* Append deferred inc/dec at sequence point */

--- a/test/val/bug1310.c
+++ b/test/val/bug1310.c
@@ -68,6 +68,14 @@ int main (void)
         failures++;
     }
 
+    if (-32768U != 32768U) {
+        fprintf (stderr, "Expected -32768U == 32768U, got: %ld\n", (long)-32768U);
+        failures++;
+    }
+    if (~32767U != 32768U) {
+        fprintf (stderr, "Expected ~32767U == 32768U, got: %ld\n", (long)~32767U);
+        failures++;
+    }
     printf ("failures: %u\n", failures);
     return failures;
 }

--- a/test/val/bug1310.c
+++ b/test/val/bug1310.c
@@ -76,6 +76,12 @@ int main (void)
         fprintf (stderr, "Expected ~32767U == 32768U, got: %ld\n", (long)~32767U);
         failures++;
     }
+
+    if ((long*)0x1000 - (long*)0x2000 >= 0) {
+        fprintf (stderr, "Expected (long*)0x1000 - (long*)0x2000 < 0, got: %ld\n", (long*)0x1000 - (long*)0x2000);
+        failures++;
+    }
     printf ("failures: %u\n", failures);
+
     return failures;
 }


### PR DESCRIPTION
- [X] Fixed #1310 as well as some more cases.
Note: The numeric constant results of unary and binary calculations are stored inside `Expr->IVal`, which are as expected to be mathematically correct after being converted to its type. On the other hand, the offsets of expressions are not converted.
- [X] Fixed a bug that pointer subtraction results from two absolute addresses are calculated as `unsigned long`.
- [X] Test cases for the issues above.