### PR TITLE
Reduce stack size to 256B for unexpanded VICs.

### DIFF
--- a/cfg/vic20.cfg
+++ b/cfg/vic20.cfg
@@ -1,7 +1,7 @@
 SYMBOLS {
     __LOADADDR__:  type = import;
     __EXEHDR__:    type = import;
-    __STACKSIZE__: type = weak, value = $0400; # 1k stack
+    __STACKSIZE__: type = weak, value = $0100
 }
 MEMORY {
     ZP:       file = "", define = yes, start = $0002, size = $001A;


### PR DESCRIPTION
Unless someone goes for recursion this is still quite a lot.