### PR TITLE
Update to correct prerequisite for GEOS calcblksfree() (issue #1318)

### DIFF
--- a/libsrc/geos-common/disk/calcblksfree.s
+++ b/libsrc/geos-common/disk/calcblksfree.s
@@ -13,6 +13,10 @@
             .include "geossym.inc"
         
 _CalcBlksFree:
+        lda #>curDirHead
+        sta r5H
+        lda #<curDirHead
+        sta r5L
         jsr CalcBlksFree
         stx __oserror
         lda r4L


### PR DESCRIPTION
Fixes #1318.