### PR TITLE
docs: fix simple typo, paramater -> parameter

### DIFF
--- a/src/cc65/pragma.c
+++ b/src/cc65/pragma.c
@@ -677,7 +677,7 @@ static void WarnPragma (StrBuf* B)
 
 
 static void FlagPragma (StrBuf* B, IntStack* Stack)
-/* Handle a pragma that expects a boolean paramater */
+/* Handle a pragma that expects a boolean parameter */
 {
     StrBuf Ident = AUTO_STRBUF_INITIALIZER;
     long   Val;
@@ -727,7 +727,7 @@ ExitPoint:
 
 
 static void IntPragma (StrBuf* B, IntStack* Stack, long Low, long High)
-/* Handle a pragma that expects an int paramater */
+/* Handle a pragma that expects an int parameter */
 {
     long  Val;
     int   Push;


### PR DESCRIPTION
There is a small typo in src/cc65/pragma.c.

Should read `parameter` rather than `paramater`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md