### PR TITLE
Fixes Issue 479

### DIFF
--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -1143,6 +1143,11 @@ if you want to access the "other" symbol <tt/bar/, you would have to write:
         .endscope
 </verb></tscreen>
 
+The above example also shows that to search a scope that is not yet defined in
+the code above the usage, you must use the namespace token (<tt/::/) and
+specify the full scope name, to allow the assembler to create the scope at the
+correct place.
+
 
 <sect>Address sizes and memory models<label id="address-sizes"><p>
 

--- a/src/ca65/symbol.c
+++ b/src/ca65/symbol.c
@@ -136,10 +136,10 @@ SymTable* ParseScopedIdent (StrBuf* Name, StrBuf* FullName)
         SB_Append (FullName, Name);
 
         /* Search for the child scope */
-        Scope = SymFindScope (Scope, Name, SYM_FIND_EXISTING);
+        Scope = SymFindScope (Scope, Name, SYM_ALLOC_NEW);
         if (Scope == 0) {
             /* Scope not found */
-            Error ("No such scope: '%m%p'", FullName);
+            Error ("Can't create scope: '%m%p'", FullName);
             return 0;
         }
 


### PR DESCRIPTION
This fixes issue #479 , it probably needs more testing in corner cases, but at lease the example in the documentation now works.
Note that to actually reference a scope not yet defined you *must* begin the name with "::".
