### PR TITLE
Add operating system symbols for the Atari 5200 target

### DIFF
--- a/doc/atari5200.sgml
+++ b/doc/atari5200.sgml
@@ -81,7 +81,8 @@ The names are the usual ones you can find in system reference manuals. Example:
 ...
     OS.sdmctl = 0x00;                       // screen off
     OS.color4 = 14;                         // white frame
-... tics = OS.rtclok[1]                     // get ticks
+    tics = OS.rtclok[1]                     // get ticks
+...
 </verb></tscreen>
  
 <sect1>Atari 5200 specific functions<p>

--- a/doc/atari5200.sgml
+++ b/doc/atari5200.sgml
@@ -73,7 +73,17 @@ Special locations:
 
 Programs containing Atari 5200 specific code may use the <tt/atari5200.h/ header file.
 
+This also includes access to operating system locations (e.g. hardware shadow registers) by a structure called
+"<tt/OS/".
+The names are the usual ones you can find in system reference manuals. Example:
 
+<tscreen><verb>
+...
+    OS.sdmctl = 0x00;                       // screen off
+    OS.color4 = 14;                         // white frame
+... tics = OS.rtclok[1]                     // get ticks
+</verb></tscreen>
+ 
 <sect1>Atari 5200 specific functions<p>
 
 <itemize>

--- a/include/_atari5200os.h
+++ b/include/_atari5200os.h
@@ -49,12 +49,12 @@ struct __os {
     unsigned char pcolr1;            // = $09       PM color 1
     unsigned char pcolr2;            // = $0A       PM color 2
     unsigned char pcolr3;            // = $0B       PM color 3
-    unsigned char color0;            // = $0C       PF Color 0
-    unsigned char color1;            // = $0D       PF Color 1
-    unsigned char color2;            // = $0E       PF Color 2
-    unsigned char color3;            // = $0F       PF Color 3
-    unsigned char color4;            // = $10       PF Color 4
-    unsigned char __filler[0xEF];    // = $11-$FF   Filler
+    unsigned char color0;            // = $0C       PF color 0
+    unsigned char color1;            // = $0D       PF color 1
+    unsigned char color2;            // = $0E       PF color 2
+    unsigned char color3;            // = $0F       PF color 3
+    unsigned char color4;            // = $10       PF color 4
+    unsigned char _free_1[0xEF];     // = $11-$FF   User space
     
     /*Stack*/
     unsigned char stack[0x100];      // = $100-$1FF Stack
@@ -65,9 +65,9 @@ struct __os {
     void (*vvblkd)(void);            // = $204      Deferred VBI vector
     void (*vdslst)(void);            // = $206      DLI vector
     void (*vkeybd)(void);            // = $208      Keyboard IRQ vector
-    void (*vkeypd)(void);            // = $20A      Keypad continue vector
+    void (*vkeypd)(void);            // = $20A      Keyboard continuation vector
     void (*vbrkky)(void);            // = $20C      Break key interrupt vector
-    void (*vbreak)(void);            // = $20E      Break instruction interrupt vector
+    void (*vbreak)(void);            // = $20E      BRK instruction interrupt vector
     void (*vserin)(void);            // = $210      Serial input ready vector
     void (*vseror)(void);            // = $212      Serial output data needed vector
     void (*vseroc)(void);            // = $214      Serial output completed vector

--- a/include/_atari5200os.h
+++ b/include/_atari5200os.h
@@ -1,0 +1,80 @@
+/*****************************************************************************/
+/*                                                                           */
+/*                  _atari5200os.h                                           */
+/*                                                                           */
+/*            Internal include file, do not use directly                     */
+/*                                                                           */
+/*                                                                           */
+/* This software is provided 'as-is', without any expressed or implied       */
+/* warranty.  In no event will the authors be held liable for any damages    */
+/* arising from the use of this software.                                    */
+/*                                                                           */
+/* Permission is granted to anyone to use this software for any purpose,     */
+/* including commercial applications, and to alter it and redistribute it    */
+/* freely, subject to the following restrictions:                            */
+/*                                                                           */
+/* 1. The origin of this software must not be misrepresented; you must not   */
+/*    claim that you wrote the original software. If you use this software   */
+/*    in a product, an acknowledgment in the product documentation would be  */
+/*    appreciated but is not required.                                       */
+/* 2. Altered source versions must be plainly marked as such, and must not   */
+/*    be misrepresented as being the original software.                      */
+/* 3. This notice may not be removed or altered from any source              */
+/*    distribution.                                                          */
+/*                                                                           */
+/*****************************************************************************/
+
+#ifndef __ATARI5200OS_H
+#define __ATARI5200OS_H
+
+
+struct __os {
+
+    /*Page zero*/
+    unsigned char pokmsk;            // = $00       System mask for POKEY IRQ enable 
+    unsigned char rtclok[2];         // = $01,$02   Real time clock
+    unsigned char critic;            // = $03       Critical section flag 
+    unsigned char atract;            // = $04       Attract mode counter
+    
+    union {
+        struct {
+            unsigned char sdlstl;    // = $05       Save display list LO
+            unsigned char sdlsth;    // = $06       Save display list HI
+        };
+        void*   sdlst;               // = $05,$06   Display list shadow
+    };  
+    
+    unsigned char sdmctl;            // = $07       DMACTL shadow
+    unsigned char pcolr0;            // = $08       PM color 0
+    unsigned char pcolr1;            // = $09       PM color 1
+    unsigned char pcolr2;            // = $0A       PM color 2
+    unsigned char pcolr3;            // = $0B       PM color 3
+    unsigned char color0;            // = $0C       PF Color 0
+    unsigned char color1;            // = $0D       PF Color 1
+    unsigned char color2;            // = $0E       PF Color 2
+    unsigned char color3;            // = $0F       PF Color 3
+    unsigned char color4;            // = $10       PF Color 4
+    unsigned char __filler[0xEF];    // = $11-$FF   Filler
+    
+    /*Stack*/
+    unsigned char stack[0x100];      // = $100-$1FF Stack
+    
+    /*Page 2 OS variables*/
+    void (*vinter)(void);            // = $200      Immediate IRQ vector
+    void (*vvblki)(void);            // = $202      Immediate VBI vector
+    void (*vvblkd)(void);            // = $204      Deferred VBI vector
+    void (*vdslst)(void);            // = $206      DLI vector
+    void (*vkeybd)(void);            // = $208      Keyboard IRQ vector
+    void (*vkeypd)(void);            // = $20A      Keypad continue vector
+    void (*vbrkky)(void);            // = $20C      Break key interrupt vector
+    void (*vbreak)(void);            // = $20E      Break instruction interrupt vector
+    void (*vserin)(void);            // = $210      Serial input ready vector
+    void (*vseror)(void);            // = $212      Serial output data needed vector
+    void (*vseroc)(void);            // = $214      Serial output completed vector
+    void (*vtimr1)(void);            // = $216      POKEY timer 1 IRQ vector
+    void (*vtimr2)(void);            // = $218      POKEY timer 2 IRQ vector
+    void (*vtimr4)(void);            // = $21A      POKEY timer 4 IRQ vector
+    
+};
+
+#endif

--- a/include/atari5200.h
+++ b/include/atari5200.h
@@ -65,6 +65,10 @@ extern void atr5200std_joy[];        /* referred to by joy_static_stddrv[] */
 #define AT_NTSC     0
 #define AT_PAL      1
 
+/* Define variables used by the OS*/
+#include <_atari5200os.h>
+#define OS (*(struct __os*)0x0000)
+
 /* define hardware */
 #include <_gtia.h>
 #define GTIA_READ  (*(struct __gtia_read*)0xC000)


### PR DESCRIPTION
The atari and atarixl targets have the _atarios.h include file with definitions for operating system structures and variables.
This pull request adds the same for the atari5200 target.  Atari 5200 has a simplistic OS, therefore the _atari5200os.h is much smaller. This will make development for Atari 5200 more convenient.
