### PR TITLE
Add "return-type" warning suppression type.

### DIFF
--- a/doc/cc65.sgml
+++ b/doc/cc65.sgml
@@ -731,10 +731,7 @@ This cc65 version has some extensions to the ISO C standard.
 <item>  There is pseudo variable named <tt/__A__/ that indicates accumulator register. 
         It can be used to highlight the returned variable in non-void
         function where result is hidden in the <tt/asm/ section.
-        every other variable. They are most useful together with short
-        sequences of assembler code. 
-
-    For example, in the function below
+        For example, in the function below
 
         <tscreen><verb>
         BYTE get_key_via_atarixl_romcall_device_k(void)      \

--- a/doc/cc65.sgml
+++ b/doc/cc65.sgml
@@ -739,7 +739,7 @@ This cc65 version has some extensions to the ISO C standard.
             asm("PHA");         \
             asm("LDA $E424");   \
             asm("PHA");         \
-            asm("RTA");         \
+            asm("RTS");         \
             return __A__;
         </verb></tscreen>
 

--- a/doc/cc65.sgml
+++ b/doc/cc65.sgml
@@ -549,6 +549,8 @@ Here is a description of all the command line options:
   <tag><tt/remap-zero/</tag>
         Warn about a <tt/<ref id="pragma-charmap" name="#pragma charmap()">/
         that changes a character's code number from/to 0x00.
+  <tag><tt/return-type/</tag>
+        Warn about no return statement in function returning non-void..
   <tag><tt/struct-param/</tag>
         Warn when passing structs by value.
   <tag><tt/unknown-pragma/</tag>
@@ -724,6 +726,29 @@ This cc65 version has some extensions to the ISO C standard.
         </verb></tscreen>
 
         will give the high byte of any unsigned value.
+        <p>
+
+<item>  There is pseudo variable named <tt/__A__/ that indicates accumulator register. 
+        It can be used to highlight the returned variable in non-void
+        function where result is hidden in the <tt/asm/ section.
+        every other variable. They are most useful together with short
+        sequences of assembler code. 
+
+    For example, in the function below
+
+        <tscreen><verb>
+        BYTE get_key_via_atarixl_romcall_device_k(void)      \
+            asm("LDA $E425");   \
+            asm("PHA");         \
+            asm("LDA $E424");   \
+            asm("PHA");         \
+            asm("RTA");         \
+            return __A__;
+        </verb></tscreen>
+
+        <tt/return __A__;/ will indicate that result is stored in the accumulator
+        and suppress warning that function has no return statement. Instead, you can
+        also use <tt/#pragma warn (return-type, off) ... pragma warn (return-type, on)/
         <p>
 
 <item>  Inside a function, the identifier <tt/__func__/ gives the name of the

--- a/doc/cc65.sgml
+++ b/doc/cc65.sgml
@@ -709,7 +709,7 @@ This cc65 version has some extensions to the ISO C standard.
         places.
         <p>
 
-<item>  There are two pseudo variables named <tt/__AX__/ and <tt/__EAX__/.
+<item>  There are two pseudo variables named <tt/__A__, __AX__/ and <tt/__EAX__/.
         Both refer to the primary register that is used by the compiler to
         evaluate expressions or return function results. <tt/__AX__/ is of
         type <tt/unsigned int/ and <tt/__EAX__/ of type <tt/long unsigned int/
@@ -726,26 +726,6 @@ This cc65 version has some extensions to the ISO C standard.
         </verb></tscreen>
 
         will give the high byte of any unsigned value.
-        <p>
-
-<item>  There is pseudo variable named <tt/__A__/ that indicates accumulator register. 
-        It can be used to highlight the returned variable in non-void
-        function where result is hidden in the <tt/asm/ section.
-        For example, in the function below
-
-        <tscreen><verb>
-        BYTE get_key_via_atarixl_romcall_device_k(void)      \
-            asm("LDA $E425");   \
-            asm("PHA");         \
-            asm("LDA $E424");   \
-            asm("PHA");         \
-            asm("RTS");         \
-            return __A__;
-        </verb></tscreen>
-
-        <tt/return __A__;/ will indicate that result is stored in the accumulator
-        and suppress warning that function has no return statement. Instead, you can
-        also use <tt/#pragma warn (return-type, off) ... pragma warn (return-type, on)/
         <p>
 
 <item>  Inside a function, the identifier <tt/__func__/ gives the name of the

--- a/doc/cc65.sgml
+++ b/doc/cc65.sgml
@@ -550,7 +550,7 @@ Here is a description of all the command line options:
         Warn about a <tt/<ref id="pragma-charmap" name="#pragma charmap()">/
         that changes a character's code number from/to 0x00.
   <tag><tt/return-type/</tag>
-        Warn about no return statement in function returning non-void..
+        Warn about no return statement in function returning non-void.
   <tag><tt/struct-param/</tag>
         Warn when passing structs by value.
   <tag><tt/unknown-pragma/</tag>

--- a/src/cc65/error.c
+++ b/src/cc65/error.c
@@ -74,6 +74,7 @@ IntStack WarnUnknownPragma  = INTSTACK(1);  /* - unknown #pragmas */
 IntStack WarnUnusedLabel    = INTSTACK(1);  /* - unused labels */
 IntStack WarnUnusedParam    = INTSTACK(1);  /* - unused parameters */
 IntStack WarnUnusedVar      = INTSTACK(1);  /* - unused variables */
+IntStack WarnReturnType     = INTSTACK(1);  /* - control reaches end of non-void function */
 
 /* Map the name of a warning to the intstack that holds its state */
 typedef struct WarnMapEntry WarnMapEntry;
@@ -92,6 +93,7 @@ static WarnMapEntry WarnMap[] = {
     { &WarnUnusedLabel,         "unused-label"          },
     { &WarnUnusedParam,         "unused-param"          },
     { &WarnUnusedVar,           "unused-var"            },
+    { &WarnReturnType,          "return-type"           },
 };
 
 Collection DiagnosticStrBufs;

--- a/src/cc65/error.h
+++ b/src/cc65/error.h
@@ -71,6 +71,7 @@ extern IntStack WarnUnknownPragma;      /* - unknown #pragmas */
 extern IntStack WarnUnusedLabel;        /* - unused labels */
 extern IntStack WarnUnusedParam;        /* - unused parameters */
 extern IntStack WarnUnusedVar;          /* - unused variables */
+extern IntStack WarnReturnType;         /* - control reaches end of non-void function */
 
 /* Forward */
 struct StrBuf;

--- a/src/cc65/function.c
+++ b/src/cc65/function.c
@@ -654,8 +654,8 @@ void NewFunc (SymEntry* Func, FuncDesc* D)
     ** environment returning int, output a warning if we didn't see a return
     ** statement.
     */
-    if (!F_HasVoidReturn (CurrentFunc) && !F_HasReturn (CurrentFunc) && !C99MainFunc) {
-        Warning ("Control reaches end of non-void function");
+    if (!F_HasVoidReturn (CurrentFunc) && !F_HasReturn (CurrentFunc) && !C99MainFunc && IS_Get (&WarnReturnType)) {
+        Warning ("Control reaches end of non-void function [-Wreturn-type]");
     }
 
     /* If this is the main function in a C99 environment returning an int, let


### PR DESCRIPTION
Now, it is possible to write:
```c
#pragma warn (return-type, off)
BYTE get_key() {
  asm("LDA $E425");
  asm("PHA");
  asm("LDA $E424");
  asm("PHA");
  asm("RTS");
}
#pragma warn (return-type, on)
```
that follows:
https://atariwiki.org/wiki/Wiki.jsp?page=How%20to%20read%20a%20Key%20from%20Keyboard%20with%20ATARI%20ROM%20Routines
```asm
...
JSR GETKEY
...

00010 ------------------------------
00020 *  READ CHAR FROM KEYBOARD   *
00030 *  CHAR WILL BE IN THE       *
00040 *  <A> REGISTER              *
00050 *  <X>,<Y> will be destroyed *
00060 ------------------------------
00070 *
00080 GETKEY   LDA $E425   GET ADDRESS-VECTOR
00090          PHA         FROM ROM HANDLER TABLE
00100          LDA $E424   PLACE ADDRESS AS
00110          PHA         RETURN ADDRESS TO STACK
00120          RTS         JUMP TO ROM-ROUTINE
00130 *
```
Options for cc65:
a) cc65 -Wreturn-type
b) cc65 -W-return-type
c) cc65 --list-warnings