### PR TITLE
[cc65]Issue 1265 Fix

### DIFF
--- a/src/cc65/codeinfo.c
+++ b/src/cc65/codeinfo.c
@@ -493,22 +493,28 @@ fncls_t GetFuncInfo (const char* Name, unsigned int* Use, unsigned int* Chg)
                 ** registers.
                 */
                 *Use = REG_EAXY;
-            } else if (D->ParamCount > 0 &&
+            } else if ((D->ParamCount > 0 ||
+                       (D->Flags & FD_EMPTY) != 0) &&
                        (AutoCDecl ?
                         IsQualFastcall (E->Type) :
                         !IsQualCDecl (E->Type))) {
                 /* Will use registers depending on the last param. If the last
-                ** param has incomplete type, just assume __EAX__.
+                ** param has incomplete type, or if the function has not been
+                ** prototyped yet, just assume __EAX__.
                 */
-                switch (SizeOf (D->LastParam->Type)) {
-                    case 1u:
-                        *Use = REG_A;
-                        break;
-                    case 2u:
-                        *Use = REG_AX;
-                        break;
-                    default:
-                        *Use = REG_EAX;
+                if (D->LastParam != 0) {
+                    switch (SizeOf(D->LastParam->Type)) {
+                        case 1u:
+                            *Use = REG_A;
+                            break;
+                        case 2u:
+                            *Use = REG_AX;
+                            break;
+                        default:
+                            *Use = REG_EAX;
+                    }
+                } else {
+                    *Use = REG_EAX;
                 }
             } else {
                 /* Will not use any registers */

--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -462,7 +462,7 @@ Type* GetImplicitFuncType (void)
     Type* T = TypeAlloc (3);    /* func/returns int/terminator */
 
     /* Prepare the function descriptor */
-    F->Flags  = FD_EMPTY | FD_VARIADIC;
+    F->Flags  = FD_EMPTY;
     F->SymTab = &EmptySymTab;
     F->TagTab = &EmptySymTab;
 

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1171,16 +1171,16 @@ static void Primary (ExprDesc* E)
 
                 /* IDENT is either an auto-declared function or an undefined variable. */
                 if (CurTok.Tok == TOK_LPAREN) {
-                    /* C99 doesn't allow calls to undefined functions, so
+                    /* C99 doesn't allow calls to undeclared functions, so
                     ** generate an error and otherwise a warning. Declare a
                     ** function returning int. For that purpose, prepare a
                     ** function signature for a function having an empty param
                     ** list and returning int.
                     */
                     if (IS_Get (&Standard) >= STD_C99) {
-                        Error ("Call to undefined function '%s'", Ident);
+                        Error ("Call to undeclared function '%s'", Ident);
                     } else {
-                        Warning ("Call to undefined function '%s'", Ident);
+                        Warning ("Call to undeclared function '%s'", Ident);
                     }
                     Sym = AddGlobalSym (Ident, GetImplicitFuncType(), SC_EXTERN | SC_REF | SC_FUNC);
                     E->Type  = Sym->Type;

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -1159,12 +1159,13 @@ SymEntry* AddLocalSym (const char* Name, const Type* T, unsigned Flags, int Offs
 SymEntry* AddGlobalSym (const char* Name, const Type* T, unsigned Flags)
 /* Add an external or global symbol to the symbol table and return the entry */
 {
-    /* Use the global symbol table */
+    /* Start from the local symbol table */
     SymTable* Tab = SymTab;
 
     /* Do we have an entry with this name already? */
     SymEntry* Entry = FindSymInTree (Tab, Name);
     if (Entry) {
+
         /* We have a symbol with this name already */
         if (HandleSymRedefinition (Entry, T, Flags)) {
             Entry = 0;
@@ -1215,7 +1216,11 @@ SymEntry* AddGlobalSym (const char* Name, const Type* T, unsigned Flags)
             /* Use the fail-safe table for fictitious symbols */
             Tab = FailSafeTab;
         }
-    } 
+
+    } else if ((Flags & (SC_EXTERN | SC_FUNC)) != 0) {
+        /* Add the new declaration to the global symbol table instead */
+        Tab = SymTab0;
+    }
     
     if (Entry == 0 || Entry->Owner != Tab) {
 

--- a/test/misc/Makefile
+++ b/test/misc/Makefile
@@ -101,13 +101,12 @@ $(WORKDIR)/bug1263.$1.$2.prg: bug1263.c | $(WORKDIR)
 	$(NOT) $(CC65) -t sim$2 -$1 -o $$@ $$< $(NULLERR)
 
 # this one requires --std=c89, it fails with --std=c99
-# it fails currently at runtime
 $(WORKDIR)/bug1265.$1.$2.prg: bug1265.c | $(WORKDIR)
 	$(if $(QUIET),echo misc/bug1265.$1.$2.prg)
 	$(CC65) --standard c89 -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLERR)
 	$(CA65) -t sim$2 -o $$(@:.prg=.o) $$(@:.prg=.s) $(NULLERR)
 	$(LD65) -t sim$2 -o $$@ $$(@:.prg=.o) sim$2.lib $(NULLERR)
-	$(NOT) $(SIM65) $(SIM65FLAGS) $$@ $(NULLOUT) $(NULLERR)
+	$(SIM65) $(SIM65FLAGS) $$@ $(NULLOUT) $(NULLERR)
 
 # should compile, but then hangs in an endless loop
 $(WORKDIR)/endless.$1.$2.prg: endless.c | $(WORKDIR)

--- a/test/misc/bug1265.c
+++ b/test/misc/bug1265.c
@@ -14,11 +14,9 @@ int main (void) {
   int x, n;
 
   sprintf (str1, "%p\n", &x);
-  puts(str1);
   x = 1234;
   n = f1 (x);
   sprintf (str2, "%p\n", &x);
-  puts(str2);
   
   if (strcmp(str1, str2)) {
       puts("not equal");
@@ -30,11 +28,9 @@ int main (void) {
   }
 
   sprintf (str1, "%p\n", &x);
-  puts(str1);
   x = 2345;
   n = f2 (x);
   sprintf (str2, "%p\n", &x);
-  puts(str2);
   
   if (strcmp(str1, str2)) {
       puts("not equal");


### PR DESCRIPTION
- [X] Made `extern` declarations visible in the whole file scope.
- [X] Fixed a potential optimization bug regarding register usage with unprototyped function calls.
- [X] Fixed #1265: An undeclared function will be treated as if declared with `int` return type and an empty parameter list when first called. The bug was that it would also be errorneously treated as a variadic function, which could result in an unbalanced stack if the function is not really variadic.