### PR TITLE
Fix build problem for apple2enh on parallel builds

### DIFF
--- a/libsrc/geos-apple/targetutil/Makefile.inc
+++ b/libsrc/geos-apple/targetutil/Makefile.inc
@@ -5,8 +5,7 @@ DEPS += ../libwrk/$(TARGET)/convert.d
 ../libwrk/$(TARGET)/convert.o: $(SRCDIR)/targetutil/convert.c | ../libwrk/$(TARGET)
 	$(COMPILE_recipe)
 
-../lib/apple2enh.lib:
-	@$(MAKE) --no-print-directory apple2enh
+../lib/apple2enh.lib: apple2enh
 
 ../target/$(TARGET)/util/convert.system: ../libwrk/$(TARGET)/convert.o ../lib/apple2enh.lib | ../target/$(TARGET)/util
 	$(LD65) -o $@ -C apple2enh-system.cfg $^


### PR DESCRIPTION
For parallel builds, the apple2enh library failed very often. This
fixes it. Fixes #1080.