### PR TITLE
[cc65] Fixed deferred post-inc and post-dec in unevaluated context

### DIFF
--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -376,6 +376,9 @@ void DoneDeferredOps (void)
 static void DeferInc (const ExprDesc* Expr)
 /* Defer the post-inc and put it in a queue */
 {
+    if (ED_IsUneval (Expr)) {
+        return;
+    }
     DeferredOp* Op = xmalloc (sizeof (DeferredOp));
     memcpy (&Op->Expr, Expr, sizeof (ExprDesc));
     Op->OpType = DOT_INC;
@@ -387,6 +390,9 @@ static void DeferInc (const ExprDesc* Expr)
 static void DeferDec (const ExprDesc* Expr)
 /* Defer the post-dec and put it in a queue */
 {
+    if (ED_IsUneval (Expr)) {
+        return;
+    }
     DeferredOp* Op = xmalloc (sizeof (DeferredOp));
     memcpy (&Op->Expr, Expr, sizeof (ExprDesc));
     Op->OpType = DOT_DEC;

--- a/test/val/uneval.c
+++ b/test/val/uneval.c
@@ -1,0 +1,46 @@
+/*
+  Copyright 2021, The cc65 Authors
+
+  This software is provided "as-is", without any express or implied
+  warranty. In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications; and, to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated, but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+/*
+  Test of deferred operations in unevaluated context resulted from 'sizeof' and
+  short-circuited code-paths in AND, OR and tenary operations.
+
+  https://github.com/cc65/cc65/issues/1406
+*/
+
+#include <stdio.h>
+
+int main(void)
+{
+    int i = 0;
+    int j = 0;
+
+    sizeof(i++ | j--);
+    0 && (i++ | j--);
+    1 || (i++ | j--);
+    0 ? i++ | j-- : 0;
+    1 ? 0 : i++ | j--;
+
+    if (i != 0 || j != 0) {
+        printf("i = %d, j = %d\n", i, j);
+        printf("Failures: %d\n", i - j);
+    }
+    return i - j;
+}


### PR DESCRIPTION
This fixes the bug:
```c
#include <stdio.h>

int main(void)
{
    char i = 0;
    sizeof(i++);
    0 && i++;
    1 || i++;
    printf("%d\n", i);
    return i;
}
```
Expected output: `0`
Revision 131f96eb1eda192623b1b3e323a2a0739645b641 output: `3`