### PR TITLE
Fix crashes when .BANK() or ld65/dbgsyms.c look for a nonexistent export.

### DIFF
--- a/src/ld65/expr.c
+++ b/src/ld65/expr.c
@@ -466,7 +466,6 @@ static void GetSegExprValInternal (ExprNode* Expr, SegExprDesc* D, int Sign)
 
     if (Expr == 0)
     {
-        D->TooComplex = 1;
         return;
     }
 

--- a/src/ld65/expr.c
+++ b/src/ld65/expr.c
@@ -464,6 +464,12 @@ static void GetSegExprValInternal (ExprNode* Expr, SegExprDesc* D, int Sign)
 {
     Export* E;
 
+    if (Expr == 0)
+    {
+        D->TooComplex = 1;
+        return;
+    }
+
     switch (Expr->Op) {
 
         case EXPR_LITERAL:

--- a/src/ld65/expr.c
+++ b/src/ld65/expr.c
@@ -464,8 +464,7 @@ static void GetSegExprValInternal (ExprNode* Expr, SegExprDesc* D, int Sign)
 {
     Export* E;
 
-    if (Expr == 0)
-    {
+    if (Expr == 0) {
         return;
     }
 


### PR DESCRIPTION
I had the following code, which caused a null reference crash when the symbols in question were not available for import.
```
.import checkpoint_init
.import checkpoint_tick
.assert .bank(checkpoint_init)=.bank(checkpoint_tick),error,"init/tick in different banks for: checkpoint"
```

So in GetSegExprValInternal there is a case EXPR_SYMBOL which checks for a circular reference, and then if it's not, marks the symbol and recurses into GetSegExprValInternal. It seems at this point, the GetExprExport used before the recursion returned an Export with a NULL Expr member for some reason. (Crash was on "switch (Expr->Op)" with a NULL Expr.)

I haven't dug into why GetExprExport can return an Export with a NULL Expr member, or whether this is a real problem, but it seems sufficient to just reject this case as "TooComplex" here. The resulting error is very understandable and points to the specific line causing it, so it seems safe to do this?

```
ld65.exe: Warning: Cannot evaluate assertion in module '...', line 62
Unresolved external 'ceiling_init' referenced in:
  ...(62)
```