### PR TITLE
[cc65] Codegen fix for certain cases of object addresses as boolean

### DIFF
--- a/src/cc65/exprdesc.c
+++ b/src/cc65/exprdesc.c
@@ -397,6 +397,30 @@ int ED_IsConstBool (const ExprDesc* Expr)
 
 
 
+int ED_IsConstTrue (const ExprDesc* Expr)
+/* Return true if the constant expression can be evaluated as boolean true at
+** compile time.
+*/
+{
+    /* Non-zero arithmetics and objects addresses are boolean true */
+    return (ED_IsConstAbsInt (Expr) && Expr->IVal != 0) ||
+           (ED_IsAddrExpr (Expr));
+}
+
+
+
+int ED_IsConstFalse (const ExprDesc* Expr)
+/* Return true if the constant expression can be evaluated as boolean false at
+** compile time.
+*/
+{
+    /* Zero arithmetics and null pointers are boolean false */
+    return (ED_IsConstAbsInt (Expr) && Expr->IVal == 0) ||
+           ED_IsNullPtr (Expr);
+}
+
+
+
 int ED_IsConst (const ExprDesc* Expr)
 /* Return true if the expression denotes a constant of some sort. This can be a
 ** numeric constant, the address of a global variable (maybe with offset) or
@@ -440,7 +464,7 @@ int ED_IsNullPtr (const ExprDesc* Expr)
 
 
 int ED_IsBool (const ExprDesc* Expr)
-/* Return true of the expression can be treated as a boolean, that is, it can
+/* Return true if the expression can be treated as a boolean, that is, it can
 ** be an operand to a compare operation.
 */
 {

--- a/src/cc65/exprdesc.h
+++ b/src/cc65/exprdesc.h
@@ -643,6 +643,16 @@ int ED_IsConstAbsInt (const ExprDesc* Expr);
 int ED_IsConstBool (const ExprDesc* Expr);
 /* Return true if the expression can be constantly evaluated as a boolean. */
 
+int ED_IsConstTrue (const ExprDesc* Expr);
+/* Return true if the constant expression can be evaluated as boolean true at
+** compile time.
+*/
+
+int ED_IsConstFalse (const ExprDesc* Expr);
+/* Return true if the constant expression can be evaluated as boolean false at
+** compile time.
+*/
+
 int ED_IsConst (const ExprDesc* Expr);
 /* Return true if the expression denotes a constant of some sort. This can be a
 ** numeric constant, the address of a global variable (maybe with offset) or
@@ -663,7 +673,7 @@ int ED_IsNullPtr (const ExprDesc* Expr);
 /* Return true if the given expression is a NULL pointer constant */
 
 int ED_IsBool (const ExprDesc* Expr);
-/* Return true of the expression can be treated as a boolean, that is, it can
+/* Return true if the expression can be treated as a boolean, that is, it can
 ** be an operand to a compare operation with 0/NULL.
 */
 

--- a/src/cc65/testexpr.c
+++ b/src/cc65/testexpr.c
@@ -70,7 +70,7 @@ unsigned Test (unsigned Label, int Invert)
         DoDeferred (SQP_KEEP_NONE, &Expr);
 
         /* Result is constant, so we know the outcome */
-        Result = (Expr.IVal != 0);
+        Result = (Expr.IVal != 0) ? TESTEXPR_TRUE : TESTEXPR_FALSE;
 
         /* Constant rvalue */
         if (!Invert && Expr.IVal == 0) {
@@ -86,7 +86,12 @@ unsigned Test (unsigned Label, int Invert)
         DoDeferred (SQP_KEEP_NONE, &Expr);
 
         /* Object addresses are non-NULL */
-        Result = 1;
+        Result = TESTEXPR_TRUE;
+
+        /* Condition is always true */
+        if (Invert) {
+            g_jump (Label);
+        }
 
     } else {
 

--- a/src/cc65/testexpr.h
+++ b/src/cc65/testexpr.h
@@ -44,9 +44,9 @@
 
 
 
-#define TESTEXPR_UNKNOWN        0       /* Result of expression unknown */
+#define TESTEXPR_UNKNOWN        -1      /* Result of expression unknown */
 #define TESTEXPR_TRUE           1       /* Expression yields true */
-#define TESTEXPR_FALSE          2       /* Expression yields false */
+#define TESTEXPR_FALSE          0       /* Expression yields false */
 
 
 


### PR DESCRIPTION
Fixed code generation logic with certain cases of object addresses as boolean:

```c
#include <stdio.h>

int main(void)
{
    int a;
    while (&a) {
        return 0;
    }
    printf("Failure!\n");
    return -1;
}
```

Wrong with `while`, `do while` and `for` loops. This PR fixes them all.