### PR TITLE
[cc65] More compile-time constant expressions regarding object addresses

### DIFF
--- a/src/cc65/codegen.c
+++ b/src/cc65/codegen.c
@@ -2112,29 +2112,38 @@ void g_addaddr_local (unsigned flags attribute ((unused)), int offs)
 
     /* Add the offset */
     offs -= StackPtr;
-    if (offs != 0) {
-        /* We cannot address more then 256 bytes of locals anyway */
-        L = GetLocalLabel();
-        CheckLocalOffs (offs);
-        AddCodeLine ("clc");
-        AddCodeLine ("adc #$%02X", offs & 0xFF);
-        /* Do also skip the CLC insn below */
-        AddCodeLine ("bcc %s", LocalLabelName (L));
-        AddCodeLine ("inx");
-    }
+    if (IS_Get (&CodeSizeFactor) <= 100) {
+        if (offs != 0) {
+            /* We cannot address more then 256 bytes of locals anyway */
+            g_inc (CF_INT | CF_CONST, offs);
+        }
+        /* Add the current stackpointer value */
+        AddCodeLine ("jsr leaaxsp");
+    } else {
+        if (offs != 0) {
+            /* We cannot address more then 256 bytes of locals anyway */
+            L = GetLocalLabel();
+            CheckLocalOffs (offs);
+            AddCodeLine ("clc");
+            AddCodeLine ("adc #$%02X", offs & 0xFF);
+            /* Do also skip the CLC insn below */
+            AddCodeLine ("bcc %s", LocalLabelName (L));
+            AddCodeLine ("inx");
+        }
 
-    /* Add the current stackpointer value */
-    AddCodeLine ("clc");
-    if (L != 0) {
-        /* Label was used above */
-        g_defcodelabel (L);
+        /* Add the current stackpointer value */
+        AddCodeLine ("clc");
+        if (L != 0) {
+            /* Label was used above */
+            g_defcodelabel (L);
+        }
+        AddCodeLine ("adc sp");
+        AddCodeLine ("tay");
+        AddCodeLine ("txa");
+        AddCodeLine ("adc sp+1");
+        AddCodeLine ("tax");
+        AddCodeLine ("tya");
     }
-    AddCodeLine ("adc sp");
-    AddCodeLine ("tay");
-    AddCodeLine ("txa");
-    AddCodeLine ("adc sp+1");
-    AddCodeLine ("tax");
-    AddCodeLine ("tya");
 }
 
 

--- a/src/cc65/exprdesc.c
+++ b/src/cc65/exprdesc.c
@@ -408,6 +408,15 @@ int ED_IsConst (const ExprDesc* Expr)
 
 
 
+int ED_IsQuasiConst (const ExprDesc* Expr)
+/* Return true if the expression denotes a quasi-constant of some sort. This
+** can be a numeric constant, a constant address or a stack variable address.
+*/
+{
+    return (Expr->Flags & E_MASK_LOC) == E_LOC_NONE || ED_IsQuasiConstAddr (Expr);
+}
+
+
 int ED_IsConstAddr (const ExprDesc* Expr)
 /* Return true if the expression denotes a constant address of some sort. This
 ** can be the address of a global variable (maybe with offset) or similar.

--- a/src/cc65/exprdesc.h
+++ b/src/cc65/exprdesc.h
@@ -649,6 +649,11 @@ int ED_IsConst (const ExprDesc* Expr);
 ** similar.
 */
 
+int ED_IsQuasiConst (const ExprDesc* Expr);
+/* Return true if the expression denotes a quasi-constant of some sort. This
+** can be a numeric constant, a constant address or a stack variable address.
+*/
+
 int ED_IsConstAddr (const ExprDesc* Expr);
 /* Return true if the expression denotes a constant address of some sort. This
 ** can be the address of a global variable (maybe with offset) or similar.


### PR DESCRIPTION
This enables most sensible cases discussed in Issue #1196, which are `Compile-Time-Known`.

Notable cases that _aren't_ supported:
```c
/* Taken from #1196 OP  */
int a;
int f() { return 1; }
extern int g();

a == a;         /* Pure: Yes; Static: Yes;  Immutable: Yes; Compile-Time-Known: Yes  */
f();            /* Pure: Yes; Static: Yes?; Immutable: Yes; Compile-Time-Known: Yes? */
g() * 0;        /* Pure: No;  Static: No;   Immutable: Yes; Compile-Time-Known: Yes  */
```
Notable cases that _are_ supported (https://github.com/cc65/cc65/issues/1196#issuecomment-675497430):
```c
/* Taken from #1196 reply */
struct S {
    int a;
    int b;
} s[2];

/* The compiler can be sure of: */
&s == &s[0];
&s[0] < &s[1];
&s[0].b > &s[0].a;
&s[0].b < &s[1].a;
```