### PR TITLE
[Telestrat] left and right joysticks mask are inverted : fix in telestrat.h

### DIFF
--- a/include/telestrat.h
+++ b/include/telestrat.h
@@ -100,8 +100,8 @@
 /* Masks for joy_read */
 #define JOY_UP_MASK     0x10
 #define JOY_DOWN_MASK   0x08
-#define JOY_LEFT_MASK   0x01
-#define JOY_RIGHT_MASK  0x02
+#define JOY_LEFT_MASK   0x02
+#define JOY_RIGHT_MASK  0x01
 #define JOY_BTN_1_MASK  0x04
 
 #define JOY_FIRE_MASK   JOY_BTN_1_MASK


### PR DESCRIPTION
There is a bug in joysticks Telestrat masks. Left and right were inverted. 

