### PR TITLE
[cc65]  Fixed composition of a function declaration with an empty parameter list and an old-style function definition

### DIFF
--- a/test/val/bug1263.c
+++ b/test/val/bug1263.c
@@ -1,9 +1,16 @@
 /* bug #1263 - erroneous error for K & R function declaration */
 
 enum E { I = 0 };
-extern int f(enum E);
 
+extern int f();
 int f(e)
+  enum E e;
+{
+  return e;
+}
+
+extern int g(int);
+int g(e)
   enum E e;
 {
   return e;
@@ -11,5 +18,5 @@ int f(e)
 
 int main(void)
 {
-    return f(I);
+    return f(I) + g(I);
 }


### PR DESCRIPTION
Fixed #1263.
Note: only the one in https://github.com/cc65/cc65/issues/1263#issuecomment-698869640 was a bug. The one in the [OP](https://github.com/cc65/cc65/issues/1263#issue-707625858)  was not, for the reason that the underlying type of the `enum` is `unsigned char` instead of `int` in cc65.