### PR TITLE
Add .REFERTO control command

### DIFF
--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -3765,7 +3765,7 @@ See: <tt><ref id=".ASCIIZ" name=".ASCIIZ"></tt>,<tt><ref id=".BYTE" name=".BYTE"
   See: <tt><ref id=".POPSEG" name=".POPSEG"></tt>
 
 
-<sect1><tt>.REFERTO</tt><label id=".REFERTO"><p>
+<sect1><tt>.REFERTO, .REFTO</tt><label id=".REFERTO"><p>
 
   Mark a symbol as referenced.
 
@@ -3779,11 +3779,24 @@ See: <tt><ref id=".ASCIIZ" name=".ASCIIZ"></tt>,<tt><ref id=".BYTE" name=".BYTE"
   Example:
 
   <tscreen><verb>
+        .ifref NegateValue              ; If this subroutine is used
+        NegateValue:                    ; Define it
+                lda     #0
+                sec
+                sbc     Value
+            .ifref ResetValue           ; If the ResetValue is also used
+                jmp     SetValue        ; Jump over it
+            .else
+                .refto  SetValue        ; Ensure that SetValue will be included
+            .endif
+        .endif
+
         .ifref ResetValue               ; If this subroutine is used
         ResetValue:                     ; Define it
                 lda     #0              ; Set a default value
-                .referto SetValue       ; Ensure that SetValue will be included
+                .refto  SetValue        ; Ensure that SetValue will be included
         .endif
+
         .ifref SetValue                 ; If this or previous subroutine is used
         SetValue:
                 sta     Value

--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -3213,7 +3213,8 @@ See: <tt><ref id=".ASCIIZ" name=".ASCIIZ"></tt>,<tt><ref id=".CHARMAP" name=".CH
         .endif
   </verb></tscreen>
 
-  See also: <tt><ref id=".REFERENCED" name=".REFERENCED"></tt>
+  See also: <tt><ref id=".REFERENCED" name=".REFERENCED"></tt>, and
+  <tt><ref id=".REFERTO" name=".REFERTO"></tt>
 
 
 <sect1><tt>.IMPORT</tt><label id=".IMPORT"><p>
@@ -3762,6 +3763,33 @@ See: <tt><ref id=".ASCIIZ" name=".ASCIIZ"></tt>,<tt><ref id=".BYTE" name=".BYTE"
   full, when this command is issued.
 
   See: <tt><ref id=".POPSEG" name=".POPSEG"></tt>
+
+
+<sect1><tt>.REFERTO</tt><label id=".REFERTO"><p>
+
+  Mark a symbol as referenced.
+
+  It is useful in combination with the <tt><ref id=".IFREF" name=".IFREF"></tt>
+  command. A subroutine with two entry points can be created. When the first
+  entry point is called, it sets some default value as an argument, and falls
+  through into the second entry point. <tt>.REFERTO</tt> helps to ensure that
+  the second part is included into binary when only the first entry point is
+  actually used from the code.
+
+  Example:
+
+  <tscreen><verb>
+        .ifref ResetValue               ; If this subroutine is used
+        ResetValue:                     ; Define it
+                lda     #0              ; Set a default value
+                .referto SetValue       ; Ensure that SetValue will be included
+        .endif
+        .ifref SetValue                 ; If this or previous subroutine is used
+        SetValue:
+                sta     Value
+                rts
+        .endif
+  </verb></tscreen>
 
 
 <sect1><tt>.RELOC</tt><label id=".RELOC"><p>

--- a/src/ca65/pseudo.c
+++ b/src/ca65/pseudo.c
@@ -1730,7 +1730,7 @@ static void DoPushSeg (void)
 
 
 
-static void DoReferenced (void)
+static void DoReferTo (void)
 /* Mark given symbol as referenced */
 {
     SymEntry* Sym = ParseAnySymName (SYM_ALLOC_NEW);
@@ -2165,7 +2165,8 @@ static CtrlDesc CtrlCmdTab [] = {
     { ccNone,           DoPushCharmap   },
     { ccNone,           DoPushCPU       },
     { ccNone,           DoPushSeg       },
-    { ccNone,           DoReferenced    },      /* .REFERENCED */
+    { ccNone,           DoUnexpected    },      /* .REFERENCED */
+    { ccNone,           DoReferTo       },      /* .REFERTO */
     { ccNone,           DoReloc         },
     { ccNone,           DoRepeat        },
     { ccNone,           DoRes           },

--- a/src/ca65/pseudo.c
+++ b/src/ca65/pseudo.c
@@ -1730,6 +1730,18 @@ static void DoPushSeg (void)
 
 
 
+static void DoReferenced (void)
+/* Mark given symbol as referenced */
+{
+    SymEntry* Sym = ParseAnySymName (SYM_ALLOC_NEW);
+    if (Sym)
+    {
+        SymRef (Sym);
+    }
+}
+
+
+
 static void DoReloc (void)
 /* Enter relocatable mode */
 {
@@ -2153,7 +2165,7 @@ static CtrlDesc CtrlCmdTab [] = {
     { ccNone,           DoPushCharmap   },
     { ccNone,           DoPushCPU       },
     { ccNone,           DoPushSeg       },
-    { ccNone,           DoUnexpected    },      /* .REFERENCED */
+    { ccNone,           DoReferenced    },      /* .REFERENCED */
     { ccNone,           DoReloc         },
     { ccNone,           DoRepeat        },
     { ccNone,           DoRes           },

--- a/src/ca65/pseudo.c
+++ b/src/ca65/pseudo.c
@@ -1734,8 +1734,7 @@ static void DoReferTo (void)
 /* Mark given symbol as referenced */
 {
     SymEntry* Sym = ParseAnySymName (SYM_ALLOC_NEW);
-    if (Sym)
-    {
+    if (Sym) {
         SymRef (Sym);
     }
 }

--- a/src/ca65/scanner.c
+++ b/src/ca65/scanner.c
@@ -271,6 +271,7 @@ struct DotKeyword {
     { ".PUSHSEG",       TOK_PUSHSEG             },
     { ".REF",           TOK_REFERENCED          },
     { ".REFERENCED",    TOK_REFERENCED          },
+    { ".REFERTO",       TOK_REFERTO             },
     { ".RELOC",         TOK_RELOC               },
     { ".REPEAT",        TOK_REPEAT              },
     { ".RES",           TOK_RES                 },

--- a/src/ca65/scanner.c
+++ b/src/ca65/scanner.c
@@ -272,6 +272,7 @@ struct DotKeyword {
     { ".REF",           TOK_REFERENCED          },
     { ".REFERENCED",    TOK_REFERENCED          },
     { ".REFERTO",       TOK_REFERTO             },
+    { ".REFTO",         TOK_REFERTO             },
     { ".RELOC",         TOK_RELOC               },
     { ".REPEAT",        TOK_REPEAT              },
     { ".RES",           TOK_RES                 },

--- a/src/ca65/token.h
+++ b/src/ca65/token.h
@@ -241,6 +241,7 @@ typedef enum token_t {
     TOK_PUSHCPU,
     TOK_PUSHSEG,
     TOK_REFERENCED,
+    TOK_REFERTO,
     TOK_RELOC,
     TOK_REPEAT,
     TOK_RES,


### PR DESCRIPTION
I propose to add new `.REF` control command which just marks a symbol as referenced and does nothing else. It is useful when a subroutine has a couple of entry points, and we want to include these pieces of code when they are used only. Example:
```
.DEFINE REF .REF

.ENUM
	ppu_mask
	ppu_ctrl        ; + ppu_scroll_base
	ppu_scroll_x    ; from 0 to 255
	ppu_scroll_y    ; from 0 to 239
.ENDENUM

test:

	LDA #10
	JSR ppu_scroll_set_b0_x
	RTS

.IFREF ppu_scroll_set_b0_x

ppu_scroll_set_b0_x:

	STA ppu_scroll_x
	CLC
	REF ppu_scroll_select_base0_x

.ENDIF
.IFREF ppu_scroll_select_base0_x

ppu_scroll_select_base0_x:

	LDA ppu_ctrl
	AND #%11111110
	STA ppu_ctrl
	RTS

.ENDIF
```

The `ppu_scroll_set_b0_x` should fall through into the `ppu_scroll_select_base0_x`, which itself is a separate usable function. If you remove the `REF ppu_scroll_select_base0_x`, the `ppu_scroll_select_base0_x` won't be included into the binary and it will cause an error. So, we need somehow explicitly reference the `ppu_scroll_select_base0_x` without emitting any machine code.

The name of the command can be changed. I can imagine such names:
- `REF`.
- `.REF` (this PoC).
- `.REFERENCE`.
- `.REFERENCED` (it is accepted as an alias to `.REF` in this PoC also).
- `.MAKEREF`.
- `.MAKEREFERENCE`.
- `.MAKEREFERENCED`.

Looking at the `.DEFINE` command, probably `.REFERENCE` is the most logical name for this command. But I would add the short `.REF` also. (Also, I would probably add `.DEF` as an alias for the `.DEFINE` control command, for consistency.)

I'm actually going to use it as `REF` (without `.`) pseudo-instruction in my code, because it will look nicer in place of a replaced `JMP` (which could be used there, but it will emit a couple of useless bytes). I thought that this name probably won't be accepted into the mainline version of the ca65, so this PoC code uses `.REF`. It can be used as `REF` in your code easily using a simple `.DEFINE REF .REF`, so I don't insist on using `REF`, any name is fine for me.

If you are positive about adding such a feature, I'll update this PR to reflect this new command in the documentation, and to change name of the instruction if required.