### PR TITLE
Parse file included inside a macro at definition time

### DIFF
--- a/src/ca65/macro.c
+++ b/src/ca65/macro.c
@@ -491,6 +491,23 @@ void MacDef (unsigned Style)
     */
     while (1) {
 
+        /* Check for include */
+        if (CurTok.Tok == TOK_INCLUDE) {
+            /* Include another file */
+            NextTok ();
+            /* Name must follow */
+            if (CurTok.Tok != TOK_STRCON) {
+                ErrorSkip ("String constant expected");
+            } else {
+                SB_Terminate (&CurTok.SVal);
+                if (NewInputFile (SB_GetConstBuf (&CurTok.SVal)) == 0) {
+                    /* Error opening the file, skip remainder of line */
+                    SkipUntilSep ();
+                }
+            }
+            NextTok ();
+        }
+
         /* Check for end of macro */
         if (Style == MAC_STYLE_CLASSIC) {
             /* In classic macros, only .endmacro is allowed */
@@ -508,22 +525,6 @@ void MacDef (unsigned Style)
             if (TokIsSep (CurTok.Tok)) {
                 break;
             }
-        }
-
-        if (CurTok.Tok == TOK_INCLUDE) {
-            /* Include another file */
-            NextTok ();
-            /* Name must follow */
-            if (CurTok.Tok != TOK_STRCON) {
-                ErrorSkip ("String constant expected");
-            } else {
-                SB_Terminate (&CurTok.SVal);
-                if (NewInputFile (SB_GetConstBuf (&CurTok.SVal)) == 0) {
-                    /* Error opening the file, skip remainder of line */
-                    SkipUntilSep ();
-                }
-            }
-            NextTok ();
         }
 
         /* Check for a .LOCAL declaration */

--- a/src/ca65/macro.c
+++ b/src/ca65/macro.c
@@ -510,6 +510,22 @@ void MacDef (unsigned Style)
             }
         }
 
+        if (CurTok.Tok == TOK_INCLUDE) {
+            /* Include another file */
+            NextTok ();
+            /* Name must follow */
+            if (CurTok.Tok != TOK_STRCON) {
+                ErrorSkip ("String constant expected");
+            } else {
+                SB_Terminate (&CurTok.SVal);
+                if (NewInputFile (SB_GetConstBuf (&CurTok.SVal)) == 0) {
+                    /* Error opening the file, skip remainder of line */
+                    SkipUntilSep ();
+                }
+            }
+            NextTok ();
+        }
+
         /* Check for a .LOCAL declaration */
         if (CurTok.Tok == TOK_LOCAL && Style == MAC_STYLE_CLASSIC) {
 


### PR DESCRIPTION
Fixes issue number #1473.
The contents of the included file will be parsed at macro definition time, as if it is part of the current file.