### PR TITLE
Extend #pragma wrapped-call to support "bank" argument

### DIFF
--- a/doc/cc65.sgml
+++ b/doc/cc65.sgml
@@ -1388,7 +1388,10 @@ parameter with the <tt/#pragma/.
   the <tt/Y/ register if it wraps any variadic functions (they have "<tt/.../"
   in their prototypes).
 
-  The identifier is an 8-bit number that's set into <tt/tmp4/.
+  The identifier is an 8-bit number that's set into <tt/tmp4/. If the identifier
+  is "bank", then a <tt><htmlurl url="ca65.html#.BANK" name=".bank"></tt> operator will be used
+  to determine the number from the bank attribute defined in the linker config,
+  see <htmlurl url="ld65.html#MEMORY" name="Other MEMORY area attributes">.
 
   The address of a wrapped function is passed in <tt/ptr4/.  The wrapper can
   call that function by using "<tt/jsr callptr4/".

--- a/doc/cc65.sgml
+++ b/doc/cc65.sgml
@@ -1389,9 +1389,11 @@ parameter with the <tt/#pragma/.
   in their prototypes).
 
   The identifier is an 8-bit number that's set into <tt/tmp4/. If the identifier
-  is "bank", then a <tt><htmlurl url="ca65.html#.BANK" name=".bank"></tt> operator will be used
+  is "bank", then a <tt><url url="ca65.html#.BANK" name=".bank"></tt> operator will be used
   to determine the number from the bank attribute defined in the linker config,
-  see <htmlurl url="ld65.html#MEMORY" name="Other MEMORY area attributes">.
+  see <htmlurl url="ld65.html#MEMORY" name="Other MEMORY area attributes">. Note that
+  this currently implies that only the least significant 8 bits of the bank attribute
+  can be used.
 
   The address of a wrapped function is passed in <tt/ptr4/.  The wrapper can
   call that function by using "<tt/jsr callptr4/".

--- a/doc/ld65.sgml
+++ b/doc/ld65.sgml
@@ -760,7 +760,7 @@ There's a library subroutine called <tt/copydata/ (in a module named
 look at it's inner workings before using it!
 
 
-<sect1>Other MEMORY area attributes<p>
+<sect1>Other MEMORY area attributes<label id="MEMORY"><p>
 
 There are some other attributes not covered above. Before starting the
 reference section, I will discuss the remaining things here.
@@ -821,7 +821,6 @@ has a builtin function named <tt/.BANK/ which may be used with an argument
 that has a segment reference (for example a symbol). The result of this
 function is the value of the bank attribute for the run memory area of the
 segment.
-
 
 <sect1>Other SEGMENT attributes<p>
 

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -1738,8 +1738,7 @@ static FuncDesc* ParseFuncDecl (void)
 {
     SymEntry* Sym;
     SymEntry* WrappedCall;
-    unsigned char WrappedCallData;
-    int WrappedCallUseBank;
+    unsigned int WrappedCallData;
 
     /* Create a new function descriptor */
     FuncDesc* F = NewFuncDesc ();
@@ -1792,11 +1791,10 @@ static FuncDesc* ParseFuncDecl (void)
     RememberFunctionLevel (F);
 
     /* Did we have a WrappedCall for this function? */
-    GetWrappedCall((void **) &WrappedCall, &WrappedCallData, &WrappedCallUseBank);
+    GetWrappedCall((void **) &WrappedCall, &WrappedCallData);
     if (WrappedCall) {
         F->WrappedCall = WrappedCall;
         F->WrappedCallData = WrappedCallData;
-        F->WrappedCallUseBank = WrappedCallUseBank;
     }
 
     /* Return the function descriptor */

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -1739,6 +1739,7 @@ static FuncDesc* ParseFuncDecl (void)
     SymEntry* Sym;
     SymEntry* WrappedCall;
     unsigned char WrappedCallData;
+    int WrappedCallUseBank;
 
     /* Create a new function descriptor */
     FuncDesc* F = NewFuncDesc ();
@@ -1791,10 +1792,11 @@ static FuncDesc* ParseFuncDecl (void)
     RememberFunctionLevel (F);
 
     /* Did we have a WrappedCall for this function? */
-    GetWrappedCall((void **) &WrappedCall, &WrappedCallData);
+    GetWrappedCall((void **) &WrappedCall, &WrappedCallData, &WrappedCallUseBank);
     if (WrappedCall) {
         F->WrappedCall = WrappedCall;
         F->WrappedCallData = WrappedCallData;
+        F->WrappedCallUseBank = WrappedCallUseBank;
     }
 
     /* Return the function descriptor */

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -997,9 +997,16 @@ static void FunctionCall (ExprDesc* Expr)
             char tmp[64];
             StrBuf S = AUTO_STRBUF_INITIALIZER;
 
-            /* Store the WrappedCall data in tmp4 */
-            sprintf(tmp, "ldy #%u", Func->WrappedCallData);
-            SB_AppendStr (&S, tmp);
+            if (Func->WrappedCallUseBank) {
+                /* Store the bank attribute in tmp4 */
+                SB_AppendStr (&S, "ldy #<.bank(_");
+                SB_AppendStr (&S, (const char*) Expr->Name);
+                SB_AppendChar (&S, ')');
+            } else {
+                /* Store the WrappedCall data in tmp4 */
+                sprintf(tmp, "ldy #%u", Func->WrappedCallData);
+                SB_AppendStr (&S, tmp);
+            }
             g_asmcode (&S);
             SB_Clear(&S);
 

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -997,7 +997,7 @@ static void FunctionCall (ExprDesc* Expr)
             char tmp[64];
             StrBuf S = AUTO_STRBUF_INITIALIZER;
 
-            if (Func->WrappedCallUseBank) {
+            if (Func->WrappedCallData == WRAPPED_CALL_USE_BANK) {
                 /* Store the bank attribute in tmp4 */
                 SB_AppendStr (&S, "ldy #<.bank(_");
                 SB_AppendStr (&S, (const char*) Expr->Name);

--- a/src/cc65/funcdesc.c
+++ b/src/cc65/funcdesc.c
@@ -54,14 +54,14 @@ FuncDesc* NewFuncDesc (void)
     FuncDesc* F = (FuncDesc*) xmalloc (sizeof (FuncDesc));
 
     /* Nullify the fields */
-    F->Flags      = 0;
-    F->SymTab     = 0;
-    F->TagTab     = 0;
-    F->ParamCount = 0;
-    F->ParamSize  = 0;
-    F->LastParam  = 0;
-    F->FuncDef    = 0;
-    F->WrappedCall = 0;
+    F->Flags           = 0;
+    F->SymTab          = 0;
+    F->TagTab          = 0;
+    F->ParamCount      = 0;
+    F->ParamSize       = 0;
+    F->LastParam       = 0;
+    F->FuncDef         = 0;
+    F->WrappedCall     = 0;
     F->WrappedCallData = 0;
 
     /* Return the new struct */

--- a/src/cc65/funcdesc.h
+++ b/src/cc65/funcdesc.h
@@ -58,7 +58,7 @@
 /* Bits that must be ignored when comparing funcs */
 #define FD_IGNORE   (FD_INCOMPLETE_PARAM | FD_OLDSTYLE | FD_OLDSTYLE_INTRET | FD_UNNAMED_PARAMS | FD_CALL_WRAPPER)
 
-
+#define WRAPPED_CALL_USE_BANK   0x0100U /* WrappedCall uses .bank() */
 
 /* Function descriptor */
 typedef struct FuncDesc FuncDesc;
@@ -71,8 +71,7 @@ struct FuncDesc {
     struct SymEntry*    LastParam;      /* Pointer to last parameter         */
     struct FuncDesc*    FuncDef;        /* Descriptor used in definition     */
     struct SymEntry*    WrappedCall;    /* Pointer to the WrappedCall        */
-    unsigned char       WrappedCallData;/* The WrappedCall's user data       */
-    int                 WrappedCallUseBank;/* Flag: does WrappedCall use .bank() or literal value */
+    unsigned int        WrappedCallData;/* The WrappedCall's user data       */
 };
 
 

--- a/src/cc65/funcdesc.h
+++ b/src/cc65/funcdesc.h
@@ -72,6 +72,7 @@ struct FuncDesc {
     struct FuncDesc*    FuncDef;        /* Descriptor used in definition     */
     struct SymEntry*    WrappedCall;    /* Pointer to the WrappedCall        */
     unsigned char       WrappedCallData;/* The WrappedCall's user data       */
+    int                 WrappedCallUseBank;/* Flag: does WrappedCall use .bank() or literal value */
 };
 
 

--- a/src/cc65/funcdesc.h
+++ b/src/cc65/funcdesc.h
@@ -45,15 +45,15 @@
 
 
 /* Masks for the Flags field in FuncDesc */
-#define FD_NONE                 0x0000U /* No flags                          */
-#define FD_EMPTY                0x0001U /* Function with empty param list    */
-#define FD_VOID_PARAM           0x0002U /* Function with a void param list   */
-#define FD_VARIADIC             0x0004U /* Function with variable param list */
+#define FD_NONE                 0x0000U /* No flags                            */
+#define FD_EMPTY                0x0001U /* Function with empty param list      */
+#define FD_VOID_PARAM           0x0002U /* Function with a void param list     */
+#define FD_VARIADIC             0x0004U /* Function with variable param list   */
 #define FD_INCOMPLETE_PARAM     0x0008U /* Function with param of unknown size */
-#define FD_OLDSTYLE             0x0010U /* Old style (K&R) function          */
-#define FD_OLDSTYLE_INTRET      0x0020U /* K&R func has implicit int return  */
-#define FD_UNNAMED_PARAMS       0x0040U /* Function has unnamed params       */
-#define FD_CALL_WRAPPER         0x0080U /* This function is used as a wrapper */
+#define FD_OLDSTYLE             0x0010U /* Old style (K&R) function            */
+#define FD_OLDSTYLE_INTRET      0x0020U /* K&R func has implicit int return    */
+#define FD_UNNAMED_PARAMS       0x0040U /* Function has unnamed params         */
+#define FD_CALL_WRAPPER         0x0080U /* This function is used as a wrapper  */
 
 /* Bits that must be ignored when comparing funcs */
 #define FD_IGNORE   (FD_INCOMPLETE_PARAM | FD_OLDSTYLE | FD_OLDSTYLE_INTRET | FD_UNNAMED_PARAMS | FD_CALL_WRAPPER)
@@ -63,15 +63,15 @@
 /* Function descriptor */
 typedef struct FuncDesc FuncDesc;
 struct FuncDesc {
-    unsigned            Flags;          /* Bitmapped flags FD_...            */
-    struct SymTable*    SymTab;         /* Symbol table                      */
-    struct SymTable*    TagTab;         /* Symbol table for structs/enums    */
-    unsigned            ParamCount;     /* Number of parameters              */
-    unsigned            ParamSize;      /* Size of the parameters            */
-    struct SymEntry*    LastParam;      /* Pointer to last parameter         */
-    struct FuncDesc*    FuncDef;        /* Descriptor used in definition     */
-    struct SymEntry*    WrappedCall;    /* Pointer to the WrappedCall        */
-    unsigned int        WrappedCallData;/* The WrappedCall's user data       */
+    unsigned            Flags;           /* Bitmapped flags FD_...            */
+    struct SymTable*    SymTab;          /* Symbol table                      */
+    struct SymTable*    TagTab;          /* Symbol table for structs/enums    */
+    unsigned            ParamCount;      /* Number of parameters              */
+    unsigned            ParamSize;       /* Size of the parameters            */
+    struct SymEntry*    LastParam;       /* Pointer to last parameter         */
+    struct FuncDesc*    FuncDef;         /* Descriptor used in definition     */
+    struct SymEntry*    WrappedCall;     /* Pointer to the WrappedCall        */
+    unsigned int        WrappedCallData; /* The WrappedCall's user data       */
 };
 
 

--- a/src/cc65/pragma.c
+++ b/src/cc65/pragma.c
@@ -497,6 +497,7 @@ static void WrappedCallPragma (StrBuf* B)
     const char *Name;
     long Val;
     SymEntry *Entry;
+    int UseBank = 0;
 
     /* Check for the "push" or "pop" keywords */
     switch (ParsePushPop (B)) {
@@ -535,12 +536,15 @@ static void WrappedCallPragma (StrBuf* B)
         goto ExitPoint;
     }
 
-    if (!GetNumber (B, &Val)) {
+    /* Next must be either a numeric value, or "bank" */
+    if (HasStr (B, "bank")) {
+        UseBank = 1;
+    } else if (!GetNumber (B, &Val)) {
         Error ("Value required for wrapped-call identifier");
         goto ExitPoint;
     }
 
-    if (Val < 0 || Val > 255) {
+    if (!UseBank && (Val < 0 || Val > 255)) {
         Error ("Identifier must be between 0-255");
         goto ExitPoint;
     }
@@ -552,7 +556,7 @@ static void WrappedCallPragma (StrBuf* B)
     /* Check if the name is valid */
     if (Entry && (Entry->Flags & SC_FUNC) == SC_FUNC) {
 
-        PushWrappedCall(Entry, (unsigned char) Val);
+        PushWrappedCall(Entry, (unsigned char) Val, UseBank);
         Entry->Flags |= SC_REF;
         GetFuncDesc (Entry->Type)->Flags |= FD_CALL_WRAPPER;
 

--- a/src/cc65/pragma.c
+++ b/src/cc65/pragma.c
@@ -532,7 +532,7 @@ static void WrappedCallPragma (StrBuf* B)
     /* Skip the following comma */
     if (!GetComma (B)) {
         /* Error already flagged by GetComma */
-        Error ("Value required for wrapped-call identifier");
+        Error ("Value or the word 'bank' required for wrapped-call identifier");
         goto ExitPoint;
     }
 

--- a/src/cc65/pragma.c
+++ b/src/cc65/pragma.c
@@ -497,7 +497,6 @@ static void WrappedCallPragma (StrBuf* B)
     const char *Name;
     long Val;
     SymEntry *Entry;
-    int UseBank = 0;
 
     /* Check for the "push" or "pop" keywords */
     switch (ParsePushPop (B)) {
@@ -538,13 +537,13 @@ static void WrappedCallPragma (StrBuf* B)
 
     /* Next must be either a numeric value, or "bank" */
     if (HasStr (B, "bank")) {
-        UseBank = 1;
+        Val = WRAPPED_CALL_USE_BANK;
     } else if (!GetNumber (B, &Val)) {
         Error ("Value required for wrapped-call identifier");
         goto ExitPoint;
     }
 
-    if (!UseBank && (Val < 0 || Val > 255)) {
+    if (!(Val == WRAPPED_CALL_USE_BANK) && (Val < 0 || Val > 255)) {
         Error ("Identifier must be between 0-255");
         goto ExitPoint;
     }
@@ -556,7 +555,7 @@ static void WrappedCallPragma (StrBuf* B)
     /* Check if the name is valid */
     if (Entry && (Entry->Flags & SC_FUNC) == SC_FUNC) {
 
-        PushWrappedCall(Entry, (unsigned char) Val, UseBank);
+        PushWrappedCall(Entry, (unsigned int) Val);
         Entry->Flags |= SC_REF;
         GetFuncDesc (Entry->Type)->Flags |= FD_CALL_WRAPPER;
 

--- a/src/cc65/wrappedcall.c
+++ b/src/cc65/wrappedcall.c
@@ -64,13 +64,13 @@ static IntPtrStack WrappedCalls;
 
 
 
-void PushWrappedCall (void *Ptr, unsigned char Val)
+void PushWrappedCall (void *Ptr, unsigned char Val, int UseBank)
 /* Push the current WrappedCall */
 {
     if (IPS_IsFull (&WrappedCalls)) {
         Error ("WrappedCall stack overflow");
     } else {
-        IPS_Push (&WrappedCalls, Val, Ptr);
+        IPS_Push (&WrappedCalls, Val | (UseBank << 8), Ptr);
     }
 }
 
@@ -88,7 +88,7 @@ void PopWrappedCall (void)
 
 
 
-void GetWrappedCall (void **Ptr, unsigned char *Val)
+void GetWrappedCall (void **Ptr, unsigned char *Val, int *UseBank)
 /* Get the current WrappedCall */
 {
     if (IPS_GetCount (&WrappedCalls) < 1) {
@@ -97,6 +97,7 @@ void GetWrappedCall (void **Ptr, unsigned char *Val)
     } else {
         long Temp;
         IPS_Get (&WrappedCalls, &Temp, Ptr);
-        *Val = (unsigned char) Temp;
+        *UseBank = (int) Temp >> 8;
+        *Val = (unsigned char) Temp & 0xff;
     }
 }

--- a/src/cc65/wrappedcall.c
+++ b/src/cc65/wrappedcall.c
@@ -64,13 +64,13 @@ static IntPtrStack WrappedCalls;
 
 
 
-void PushWrappedCall (void *Ptr, unsigned char Val, int UseBank)
+void PushWrappedCall (void *Ptr, unsigned int Val)
 /* Push the current WrappedCall */
 {
     if (IPS_IsFull (&WrappedCalls)) {
         Error ("WrappedCall stack overflow");
     } else {
-        IPS_Push (&WrappedCalls, Val | (UseBank << 8), Ptr);
+        IPS_Push (&WrappedCalls, Val, Ptr);
     }
 }
 
@@ -88,7 +88,7 @@ void PopWrappedCall (void)
 
 
 
-void GetWrappedCall (void **Ptr, unsigned char *Val, int *UseBank)
+void GetWrappedCall (void **Ptr, unsigned int *Val)
 /* Get the current WrappedCall */
 {
     if (IPS_GetCount (&WrappedCalls) < 1) {
@@ -97,7 +97,6 @@ void GetWrappedCall (void **Ptr, unsigned char *Val, int *UseBank)
     } else {
         long Temp;
         IPS_Get (&WrappedCalls, &Temp, Ptr);
-        *UseBank = (int) Temp >> 8;
-        *Val = (unsigned char) Temp & 0xff;
+        *Val = (unsigned int) Temp;
     }
 }

--- a/src/cc65/wrappedcall.h
+++ b/src/cc65/wrappedcall.h
@@ -50,13 +50,13 @@
 
 
 
-void PushWrappedCall (void *Ptr, unsigned char Val);
+void PushWrappedCall (void *Ptr, unsigned char Val, int usebank);
 /* Push the current WrappedCall */
 
 void PopWrappedCall (void);
 /* Pop the current WrappedCall */
 
-void GetWrappedCall (void **Ptr, unsigned char *Val);
+void GetWrappedCall (void **Ptr, unsigned char *Val, int *usebank);
 /* Get the current WrappedCall, if any */
 
 

--- a/src/cc65/wrappedcall.h
+++ b/src/cc65/wrappedcall.h
@@ -50,13 +50,13 @@
 
 
 
-void PushWrappedCall (void *Ptr, unsigned char Val, int usebank);
+void PushWrappedCall (void *Ptr, unsigned int Val);
 /* Push the current WrappedCall */
 
 void PopWrappedCall (void);
 /* Pop the current WrappedCall */
 
-void GetWrappedCall (void **Ptr, unsigned char *Val, int *usebank);
+void GetWrappedCall (void **Ptr, unsigned int *Val);
 /* Get the current WrappedCall, if any */
 
 


### PR DESCRIPTION
This adds the option to use "bank" in place of the numeric value in the wrapped-call pragma. So instead of 
```
#pragma wrapped-call (push, mytrampoline, 23)
void somefunc1(void);
#pragma wrapped-call (pop)
```
you can also write
```
#pragma wrapped-call (push, mytrampoline, bank)
void somefunc1(void);
#pragma wrapped-call (pop)
```
in that case the compiler will use the assemblers .bank directive to load the value defined in the bank attribute in the linker config - which removes the requirement to maintain those values manually.

I used "bank" in place of the numeric value (instead of making the value an optional parameter) because this makes it easy to add an additional parameter without breaking anything. For example at some point in the future an additional parameter might be added to pass 16- or more bits of banking info (right now it is always 8 bit).

Please review and let me know how to improve what if this is somehow not meeting the general ideas how things should be done in the compiler - i have very little experience with the compiler internals :)

That said it would be great to get this merged soonish because it will be incredibly useful for what i am doing right now :)