### PR TITLE
Fix the warning that is produced for unused functions

### DIFF
--- a/doc/cc65.sgml
+++ b/doc/cc65.sgml
@@ -563,6 +563,8 @@ Here is a description of all the command line options:
         Warn about #pragmas that aren't recognized by cc65.
   <tag><tt/unreachable-code/</tag>
         Warn about unreachable code in cases of comparing constants, etc.
+  <tag><tt/unused-func/</tag>
+        Warn about unused functions.
   <tag><tt/unused-label/</tag>
         Warn about unused labels.
   <tag><tt/unused-param/</tag>

--- a/src/cc65/error.c
+++ b/src/cc65/error.c
@@ -78,6 +78,7 @@ IntStack WarnUnreachableCode= INTSTACK(1);  /* - unreachable code */
 IntStack WarnUnusedLabel    = INTSTACK(1);  /* - unused labels */
 IntStack WarnUnusedParam    = INTSTACK(1);  /* - unused parameters */
 IntStack WarnUnusedVar      = INTSTACK(1);  /* - unused variables */
+IntStack WarnUnusedFunc     = INTSTACK(1);  /* - unused functions */
 
 /* Map the name of a warning to the intstack that holds its state */
 typedef struct WarnMapEntry WarnMapEntry;
@@ -97,6 +98,7 @@ static WarnMapEntry WarnMap[] = {
     { &WarnStructParam,         "struct-param"          },
     { &WarnUnknownPragma,       "unknown-pragma"        },
     { &WarnUnreachableCode,     "unreachable-code"      },
+    { &WarnUnusedFunc,          "unused-func"           },
     { &WarnUnusedLabel,         "unused-label"          },
     { &WarnUnusedParam,         "unused-param"          },
     { &WarnUnusedVar,           "unused-var"            },

--- a/src/cc65/error.h
+++ b/src/cc65/error.h
@@ -75,6 +75,7 @@ extern IntStack WarnUnreachableCode;    /* - unreachable code */
 extern IntStack WarnUnusedLabel;        /* - unused labels */
 extern IntStack WarnUnusedParam;        /* - unused parameters */
 extern IntStack WarnUnusedVar;          /* - unused variables */
+extern IntStack WarnUnusedFunc;         /* - unused functions */
 
 /* Forward */
 struct StrBuf;

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -173,6 +173,10 @@ static void CheckSymTable (SymTable* Tab)
                         if (IS_Get (&WarnUnusedParam)) {
                             Warning ("Parameter '%s' is never used", Entry->Name);
                         }
+                    } else if (Flags & SC_FUNC) {
+                        if (IS_Get (&WarnUnusedFunc)) {
+                            Warning ("Function '%s' is defined but never used", Entry->Name);
+                        }
                     } else {
                         if (IS_Get (&WarnUnusedVar)) {
                             Warning ("Variable '%s' is defined but never used", Entry->Name);


### PR DESCRIPTION
The warning produced for unused functions would say something like

```
test.c(694): Warning: Vatriable 'statusM' is defined but never used
```
this makes it say
```
test.c(694): Warning: Function 'statusM' is defined but never used
```