### PR TITLE
[cc65] Fixed result types of certain unary operations broken with #1530

### DIFF
--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1726,17 +1726,12 @@ static void PostInc (ExprDesc* Expr)
 
         } else {
 
-            /* Fetch the value and use it (since it's the result of the expression) */
-            LoadExpr (CF_NONE, Expr);
-
             /* Defer the increment until after the value of this expression is used */
             DeferInc (Expr);
-        }
-    }
 
-    /* Adjust the type of the expression */
-    if (IsClassInt (Expr->Type)) {
-        Expr->Type = IntPromotion (Expr->Type);
+            /* Just return */
+            return;
+        }
     }
 
     /* The result is always an expression, no reference */
@@ -1781,17 +1776,12 @@ static void PostDec (ExprDesc* Expr)
 
         } else {
 
-            /* Fetch the value and save it (since it's the result of the expression) */
-            LoadExpr (CF_NONE, Expr);
-
             /* Defer the decrement until after the value of this expression is used */
             DeferDec (Expr);
-        }
-    }
 
-    /* Adjust the type of the expression */
-    if (IsClassInt (Expr->Type)) {
-        Expr->Type = IntPromotion (Expr->Type);
+            /* Just return */
+            return;
+        }
     }
 
     /* The result is always an expression, no reference */

--- a/test/val/opsize.c
+++ b/test/val/opsize.c
@@ -1,0 +1,33 @@
+
+/* Test for result types of certain unary operations */
+
+#include <stdio.h>
+
+signed char x;
+struct S {
+    unsigned char a : 3;
+    unsigned int  b : 3;
+} s;
+
+int main(void)
+{
+    _Static_assert(sizeof (++x) == sizeof (char), "++x result should not have promoted type");
+    _Static_assert(sizeof (--x) == sizeof (char), "--x result should not have promoted type");
+    _Static_assert(sizeof (x++) == sizeof (char), "x++ result should not have promoted type");
+    _Static_assert(sizeof (x--) == sizeof (char), "x-- result should not have promoted type");
+    _Static_assert(sizeof (x=0) == sizeof (char), "x=0 result should not have promoted type");
+
+    _Static_assert(sizeof (+x) == sizeof (int), "+x result should have promoted type");
+    _Static_assert(sizeof (-x) == sizeof (int), "-x result should have promoted type");
+    _Static_assert(sizeof (~x) == sizeof (int), "~x result should have promoted type");
+
+    _Static_assert(sizeof (+s.a) == sizeof (int), "+s.a result should have promoted type");
+    _Static_assert(sizeof (-s.a) == sizeof (int), "-s.a result should have promoted type");
+    _Static_assert(sizeof (~s.a) == sizeof (int), "~s.a result should have promoted type");
+
+    _Static_assert(sizeof (+s.b) == sizeof (int), "+s.b result should have promoted type");
+    _Static_assert(sizeof (-s.b) == sizeof (int), "-s.b result should have promoted type");
+    _Static_assert(sizeof (~s.b) == sizeof (int), "~s.b result should have promoted type");
+
+    return 0;
+}


### PR DESCRIPTION
PR #1530 broke the result types of certain unary operations.
Now they are fixed and checked with new test cases.

In fact, most of the fix consists of removal of the superfluous type hacks.