### PR TITLE
doc: psg_silence: Remove empty notes

### DIFF
--- a/doc/funcref.sgml
+++ b/doc/funcref.sgml
@@ -5880,8 +5880,6 @@ void main (void)
 <tag/Declaration/<tt/void psg_silence (void);/
 <tag/Description/The function resets the Programmable Sound Generator,
 then sends $9F, $BF, $DF, $FF to the PSG.
-<tag/Notes/<itemize>
-</itemize>
 <tag/Availability/cc65
 <tag/See also/
 <ref id="psg_delay" name="psg_delay">,


### PR DESCRIPTION
The notes section of psg_silence (Creativision funcref) contained an
empty Notes section, consisting of an empty <itemize> only.

Newer sgmltools fail on this, as they insist on having an <item>
element, or they fail compilation:

[  225s] Processing file ../doc/funcref.sgml
[  225s] onsgmls:/tmp/linuxdoc-tools.NfxbjODQbW/sgmltmp.funcref.01.precmdout:5884:9:E:end tag for "ITEMIZE" which is not finished

Fixed this by removing the (empty) Notes section altogether.