### PR TITLE
Implement digit separators

### DIFF
--- a/doc/cc65.sgml
+++ b/doc/cc65.sgml
@@ -853,6 +853,16 @@ This cc65 version has some extensions to the ISO C standard.
         unsigned char foo = 0b101; // sets it to 5
         </verb></tscreen>
 
+<item>  Digit separators in literals, a C++14 feature, are accepted. They are
+        often used to separate thousands in decimal or bit groups in binary literals.
+        They can be disabled with the <tt><ref id="option--standard"
+        name="--standard"></tt> option.
+
+        <tscreen><verb>
+        unsigned char foo = 0b11'00'11'00; // sets foo to 0b11001100
+        unsigned int bar  = 42'069;        // sets bar to 42069
+        </verb></tscreen>
+
 </itemize>
 <p>
 

--- a/src/cc65/preproc.c
+++ b/src/cc65/preproc.c
@@ -914,6 +914,12 @@ static unsigned Pass1 (StrBuf* Source, StrBuf* Target)
                 SB_AppendStr (Target, Ident);
             }
         } else if (IsQuote (CurC)) {
+            /* Remove digit separators between two digits. This is a C++14 feature supported as an extension in the CC65 standard mode. */
+            if (IS_Get (&Standard) >= STD_CC65 && (IsDigit (SB_LookAtLast (Target)) && IsDigit (NextC))) {
+                NextChar ();
+                continue;
+            }
+
             CopyQuotedString (Target);
         } else if (CurC == '/' && NextC == '*') {
             if (!IsSpace (SB_LookAtLast (Target))) {

--- a/test/val/digit-separator.c
+++ b/test/val/digit-separator.c
@@ -1,0 +1,13 @@
+#define DO_TEST(actual, expected) \
+    if (actual != expected) { \
+        return 1; \
+    }
+
+int main() {
+    DO_TEST(1'2'3'4'5, 12345);
+    DO_TEST(0x1'2'3'4, 0x1234);
+    DO_TEST(0'1'2'3'4, 01234);
+    DO_TEST(0b1'0'1'1'0'1'0'0, 0b10110100);
+
+    return 0;
+}


### PR DESCRIPTION
Digit separators are a C++14 feature added to cc65 as an extension. They're a generally useful feature for separating thousands in decimal and bit groups in binary literals.

Example:
```c
unsigned char foo = 0b11'00'11;
unsigned int bar = 42'000;
```

I implemented the feature together with tests and documentation.
The feature is implemented on the preprocessor level meaning that the digit separator characters (`'`) are removed before the code is scanned and parsed as the compiler doesn't need to be aware of their existance.