### PR TITLE
Added ASM-CFG for VIC-20 and C128

### DIFF
--- a/cfg/c128-asm.cfg
+++ b/cfg/c128-asm.cfg
@@ -1,0 +1,20 @@
+FEATURES {
+    STARTADDRESS: default = $1c01;
+}
+SYMBOLS {
+    __LOADADDR__: type = import;
+}
+MEMORY {
+    ZP:       file = "", start = $0002,  size = $00FE,      define = yes;
+    LOADADDR: file = %O, start = %S - 2, size = $0002;
+    MAIN:     file = %O, start = %S,     size = $D000 - %S;
+}
+SEGMENTS {
+    ZEROPAGE: load = ZP,       type = zp,  optional = yes;
+    LOADADDR: load = LOADADDR, type = ro;
+    EXEHDR:   load = MAIN,     type = ro,  optional = yes;
+    CODE:     load = MAIN,     type = rw;
+    RODATA:   load = MAIN,     type = ro,  optional = yes;
+    DATA:     load = MAIN,     type = rw,  optional = yes;
+    BSS:      load = MAIN,     type = bss, optional = yes, define = yes;
+}

--- a/cfg/vic20-asm.cfg
+++ b/cfg/vic20-asm.cfg
@@ -1,0 +1,19 @@
+FEATURES {
+    STARTADDRESS: default = $1001;
+}
+SYMBOLS {
+    __LOADADDR__: type = import;
+}
+MEMORY {
+    ZP:       file = "", start = $0002,  size = $001A, define = yes;
+    LOADADDR: file = %O, start = $1001, size = $0002;
+    MAIN:     file = %O, start = %S,     size = $0DF3 - %S;
+}
+SEGMENTS {
+    ZEROPAGE: load = ZP,       type = zp,  optional = yes;
+    LOADADDR: load = LOADADDR, type = ro;
+    CODE:     load = MAIN,     type = ro;
+    RODATA:   load = MAIN,     type = ro;
+    DATA:     load = MAIN,     type = rw;
+    BSS:      load = MAIN,     type = bss, optional = yes, define   = yes;
+}


### PR DESCRIPTION
I added a config file for the VIC-20 and the C128 to be used for asm only programming.