### PR TITLE
[cc65] Fixed crash in Opt_a_toscmpbool caused by wrong order of condition checks

### DIFF
--- a/src/cc65/coptstop.c
+++ b/src/cc65/coptstop.c
@@ -1113,9 +1113,9 @@ static unsigned Opt_a_toscmpbool (StackOpData* D, const char* BoolTransformer)
 
     D->IP = D->OpIndex + 1;
 
-    if (!D->RhsMultiChg &&
-        (D->Rhs.A.LoadEntry->Flags & CEF_DONT_REMOVE) == 0 &&
-        (D->Rhs.A.Flags & LI_DIRECT) != 0) {
+    if (!D->RhsMultiChg                     &&
+        (D->Rhs.A.Flags & LI_DIRECT) != 0   &&
+        (D->Rhs.A.LoadEntry->Flags & CEF_DONT_REMOVE) == 0) {
 
         /* cmp */
         AddOpLow (D, OP65_CMP, &D->Rhs);


### PR DESCRIPTION
Fixed #1552.