### PR TITLE
Added Sym-1 link to documentation doc/index.sgml

### DIFF
--- a/doc/index.sgml
+++ b/doc/index.sgml
@@ -172,6 +172,9 @@
   <tag><htmlurl url="supervision.html" name="supervision.html"></tag>
   Topics specific to the Watara Supervision Console.
 
+  <tag><htmlurl url="sym1.html" name="sym1.html"></tag>
+  Topics specific to the Synertek Systems Sym-1.
+
   <tag><htmlurl url="telestrat.html" name="telestrat.html"></tag>
   Topics specific to the Oric Telestrat.
 


### PR DESCRIPTION
This pull request adds a link to the Sym-1 documentation page in the doc/index.sgml file.