### PR TITLE
VIC-20 TGI needs 16K to be usable

### DIFF
--- a/cfg/vic20-tgi.cfg
+++ b/cfg/vic20-tgi.cfg
@@ -1,5 +1,5 @@
 # Memory configuration which supports the "vic20-hi.tgi" driver.
-# Memory configuration for a VIC-20 with, at least, 8K expansion RAM.
+# Memory configuration for a VIC-20 with, at least, 16K expansion RAM.
 FEATURES {
     STARTADDRESS: default = $1201;
 }
@@ -8,7 +8,7 @@ SYMBOLS {
     __EXEHDR__:    type = import;
     __TGIHDR__:    type = import;
     __STACKSIZE__: type = weak, value = $0200; # 512-byte stack
-    __HIMEM__:     type = weak, value = $4000;
+    __HIMEM__:     type = weak, value = $6000;
 }
 MEMORY {
     ZP:       file = "", define = yes, start = $0002,  size = $001A;


### PR DESCRIPTION
With 8K expansion tgidemo can't be compiled. I think it is reasonable to require 16k expansion.