### PR TITLE
Snapshot build on push master.

### DIFF
--- a/.github/workflows/snapshot-on-push-master.yml
+++ b/.github/workflows/snapshot-on-push-master.yml
@@ -1,0 +1,69 @@
+name: Snapshot Build 
+on:
+  push:
+    branches:
+      master
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_windows:
+    name: Build (Windows)
+    runs-on: windows-latest
+    
+    steps:
+      - shell: bash
+        run: git config --global core.autocrlf input
+      
+      - name: Checkout Source
+        uses: actions/checkout@v2
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Build app (debug)
+        run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Debug
+      
+      - name: Build app (release)
+        run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
+
+  build_linux:
+    name: Build, Test and Snaphot (Linux)
+    runs-on: ubuntu-latest
+    needs: build_windows
+    
+    steps:
+      - shell: bash
+        run: git config --global core.autocrlf input
+      
+      - name: Checkout Source
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass
+          
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          make -j2 bin USER_CFLAGS=-Werror
+          make -j2 lib QUIET=1
+          make test QUIET=1
+          make -j2 samples
+          make -C src clean
+          make -j2 bin USER_CFLAGS=-Werror CROSS_COMPILE=i686-w64-mingw32-
+          make -C samples clean
+          make -j2 doc zip
+      
+      - name: Upload Snapshot Zip
+        uses: actions/upload-artifact@v2
+        with:
+          name: cc65-snapshot-win32.zip
+          path: cc65.zip
+
+      # TODO: Update docs at https://github.com/cc65/doc
+      # TODO: Publish snapshot zip at https://github.com/cc65/cc65.github.io


### PR DESCRIPTION
For now, the snapshot zip can be obtained from the latest successful snapshot build at:
https://github.com/cc65/cc65/actions/workflows/snapshot-on-push-master.yml

TODO: Update docs at https://github.com/cc65/doc
TODO: Publish snapshot zip at https://github.com/cc65/cc65.github.io