### PR TITLE
Make cbm_open() be more efficient.

### DIFF
--- a/libsrc/cbm/cbm_open.s
+++ b/libsrc/cbm/cbm_open.s
@@ -1,5 +1,6 @@
 ;
-; Ullrich von Bassewitz, 22.06.2002
+; 2002-06-22, Ullrich von Bassewitz
+; 2021-12-23, Greg King
 ;
 ; Original C code by Marc 'BlackJack' Rintsch, 18.03.2001
 ;
@@ -19,26 +20,17 @@
 ;
 
         .export         _cbm_open
+
         .import         popa
         .import         _cbm_k_setlfs, _cbm_k_setnam, _cbm_k_open
         .import         __oserror
 
 _cbm_open:
-        pha
-        txa
-        pha                     ; Save name
+        jsr     _cbm_k_setnam
 
         jsr     popa            ; Get sec_addr
         jsr     _cbm_k_setlfs   ; Call SETLFS, pop all args
 
-        pla
-        tax
-        pla                     ; Get name
-        jsr     _cbm_k_setnam
-
         jsr     _cbm_k_open
         sta     __oserror
-
         rts
-
-


### PR DESCRIPTION
Shrink it by six bytes.