### PR TITLE
Fix Pop() implementation in src/sim65/paravirt.c (fixes #1625)

### DIFF
--- a/src/sim65/paravirt.c
+++ b/src/sim65/paravirt.c
@@ -105,7 +105,7 @@ static void SetAX (CPURegs* Regs, unsigned Val)
 
 static unsigned char Pop (CPURegs* Regs)
 {
-    return MemReadByte (0x0100 + ++Regs->SP);
+    return MemReadByte (0x0100 + (++Regs->SP & 0xFF));
 }
 
 
@@ -327,5 +327,7 @@ void ParaVirtHooks (CPURegs* Regs)
     Hooks[Regs->PC - PARAVIRT_BASE] (Regs);
 
     /* Simulate RTS */
-    Regs->PC = Pop(Regs) + (Pop(Regs) << 8) + 1;
+    unsigned lo = Pop(Regs);
+    unsigned hi = Pop(Regs);
+    Regs->PC = lo + (hi << 8) + 1;
 }

--- a/src/sim65/paravirt.c
+++ b/src/sim65/paravirt.c
@@ -317,6 +317,8 @@ void ParaVirtInit (unsigned aArgStart, unsigned char aSPAddr)
 void ParaVirtHooks (CPURegs* Regs)
 /* Potentially execute paravirtualization hooks */
 {
+    unsigned lo;
+
     /* Check for paravirtualization address range */
     if (Regs->PC <  PARAVIRT_BASE ||
         Regs->PC >= PARAVIRT_BASE + sizeof (Hooks) / sizeof (Hooks[0])) {
@@ -327,6 +329,6 @@ void ParaVirtHooks (CPURegs* Regs)
     Hooks[Regs->PC - PARAVIRT_BASE] (Regs);
 
     /* Simulate RTS */
-    unsigned lo = Pop(Regs);
+    lo = Pop(Regs);
     Regs->PC = lo + (Pop(Regs) << 8) + 1;
 }

--- a/src/sim65/paravirt.c
+++ b/src/sim65/paravirt.c
@@ -329,6 +329,6 @@ void ParaVirtHooks (CPURegs* Regs)
     Hooks[Regs->PC - PARAVIRT_BASE] (Regs);
 
     /* Simulate RTS */
-    lo = Pop(Regs);
-    Regs->PC = lo + (Pop(Regs) << 8) + 1;
+    lo = Pop (Regs);
+    Regs->PC = lo + (Pop (Regs) << 8) + 1;
 }

--- a/src/sim65/paravirt.c
+++ b/src/sim65/paravirt.c
@@ -328,6 +328,5 @@ void ParaVirtHooks (CPURegs* Regs)
 
     /* Simulate RTS */
     unsigned lo = Pop(Regs);
-    unsigned hi = Pop(Regs);
-    Regs->PC = lo + (hi << 8) + 1;
+    Regs->PC = lo + (Pop(Regs) << 8) + 1;
 }


### PR DESCRIPTION
The Pop() function was not handling stack pointer wrap around correctly.

Also, change the simulated RTS implementation in ParaVirtHooks() to
explicitly sequence the two Pop() calls in the correct order.