### PR TITLE
Remove an obsolete command-line option from the cc65 compiler.

### DIFF
--- a/src/cc65/main.c
+++ b/src/cc65/main.c
@@ -955,10 +955,6 @@ int main (int argc, char* argv[])
                     OptTarget (Arg, GetArg (&I, 2));
                     break;
 
-                case 'u':
-                    OptCreateDep (Arg, 0);
-                    break;
-
                 case 'v':
                     OptVerbose (Arg, 0);
                     break;


### PR DESCRIPTION
Fixes #1636.