### PR TITLE
Update the Telestrat library.

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -102,6 +102,8 @@ extern struct _timezone {
 #  define CLOCKS_PER_SEC        135   /* FIXME */
 #elif defined(__GEOS__)
 #  define CLOCKS_PER_SEC        1
+#elif defined(__TELESTRAT__)
+#  define CLOCKS_PER_SEC        10
 #elif defined(__ATARI__) || defined (__LYNX__)
 /* Read the clock rate at runtime */
 clock_t _clocks_per_sec (void);

--- a/libsrc/telestrat/tgi_stddrv.s
+++ b/libsrc/telestrat/tgi_stddrv.s
@@ -1,0 +1,13 @@
+;
+; Name of the standard TGI driver
+;
+; 2022-02-02, Greg King
+;
+; const char tgi_stddrv[];
+;
+
+        .export _tgi_stddrv
+
+.rodata
+
+_tgi_stddrv:    .asciiz "telestrat-240-200-2.tgi"

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -308,7 +308,10 @@ EXELIST_sym1 =     \
 EXELIST_telestrat = \
         ascii       \
         gunzip65    \
-        hello
+        hello       \
+        mandelbrot  \
+        sieve       \
+#        tgidemo
 
 EXELIST_vic20 =    \
         ascii      \

--- a/targettest/Makefile
+++ b/targettest/Makefile
@@ -516,11 +516,12 @@ EXELIST_atari = \
 
 EXELIST_atarixl = $(EXELIST_atari)
 
-# omitted: clock-test clock cpeek-test deb dir-test em-test exec-test1 exec-test2
+# omitted: clock-test cpeek-test deb dir-test em-test exec-test1 exec-test2
 # joy-test mouse-test rename-test seek ser-test stroserror-test tinyshell
 EXELIST_telestrat = \
 	minimal \
 	arg-test \
+	clock \
 	conio \
 	cprintf \
 	cursor \


### PR DESCRIPTION
These two updates allow the `telestrat` library to build more `samples` and `targettest` programs.