### PR TITLE
Invalid flagged errors if token is missing

### DIFF
--- a/src/ca65/expr.c
+++ b/src/ca65/expr.c
@@ -1226,11 +1226,11 @@ static ExprNode* Factor (void)
                 SB_GetLen (&CurTok.SVal) == 1) {
                 /* A character constant */
                 N = GenLiteralExpr (TgtTranslateChar (SB_At (&CurTok.SVal, 0)));
+                NextTok ();
             } else {
                 N = GenLiteral0 ();     /* Dummy */
                 Error ("Syntax error");
             }
-            NextTok ();
             break;
     }
     return N;


### PR DESCRIPTION
A missing factor in an expression causes an expected but missing token
to be skipped, leading to invalid flagged errors in the following line:

l = 3 +
lda     #$00

An error should be output for line 1, but not for line 2. Actually, both
are flagged as errors:

test.s(1): Error: Syntax error
test.s(2): Error: Unexpected trailing garbage characters

This patch (as proposed in issue #1634 by kugelfuhr) fixes this.