### PR TITLE
ca65: .constructor after .export fails

### DIFF
--- a/src/ca65/symentry.c
+++ b/src/ca65/symentry.c
@@ -546,6 +546,18 @@ void SymConDes (SymEntry* S, unsigned char AddrSize, unsigned Type, unsigned Pri
         return;
     }
 
+    /* If the symbol is already defined, check symbol size against the
+    ** exported size.
+    */
+    if (S->Flags & SF_DEFINED) {
+        if (AddrSize == ADDR_SIZE_DEFAULT) {
+            /* Use the real size of the symbol */
+            AddrSize = S->AddrSize;
+        } else if (S->AddrSize != AddrSize) {
+            Error ("Address size mismatch for symbol '%m%p'", GetSymName (S));
+        }
+    }
+
     /* If the symbol was already marked as an export or global, check if
     ** this was done specifiying the same address size. In case of a global
     ** declaration, silently remove the global flag.
@@ -557,18 +569,6 @@ void SymConDes (SymEntry* S, unsigned char AddrSize, unsigned Type, unsigned Pri
         S->Flags &= ~SF_GLOBAL;
     }
     S->ExportSize = AddrSize;
-
-    /* If the symbol is already defined, check symbol size against the
-    ** exported size.
-    */
-    if (S->Flags & SF_DEFINED) {
-        if (S->ExportSize == ADDR_SIZE_DEFAULT) {
-            /* Use the real size of the symbol */
-            S->ExportSize = S->AddrSize;
-        } else if (S->AddrSize != S->ExportSize) {
-            Error ("Address size mismatch for symbol '%m%p'", GetSymName (S));
-        }
-    }
 
     /* If the symbol already was declared as a condes of this type,
     ** check if the new priority value is the same as the old one.


### PR DESCRIPTION
The actor directives (.constructor, .destructor, .interruptor, and .condes)
can't handle a symbol that's already exported.

The relevant code does the checks in the wrong order.

For example, the following correct snippet does not assemble:

        .export         C
C:      .constructor    C, 5

The assembler outputs: test.s:2: Error: Address size mismatch for symbol 'C'

Exchanging both lines makes it work.

This fixes #1647; the patch is provided by 'kugelfuhr' and taken from there.