### PR TITLE
Corrected size of BASROM definition in Sym1 config files

### DIFF
--- a/cfg/sym1-32k.cfg
+++ b/cfg/sym1-32k.cfg
@@ -29,7 +29,7 @@ MEMORY {
     EXT:      file = "", define = yes, start = $9000, size = $1000;
     IO:       file = "", define = yes, start = $A000, size = $1000;
     RAE1:     file = "", define = yes, start = $B000, size = $1000;
-    BASROM:   file = "", define = yes, start = $C000, size = $1000;
+    BASROM:   file = "", define = yes, start = $C000, size = $2000;
     RAE2:     file = "", define = yes, start = $E000, size = $1000;
     TOP:      file = "", define = yes, start = $F000, size = $1000;
 }

--- a/cfg/sym1-4k.cfg
+++ b/cfg/sym1-4k.cfg
@@ -29,7 +29,7 @@ MEMORY {
     EXT:      file = "", define = yes, start = $9000, size = $1000;
     IO:       file = "", define = yes, start = $A000, size = $1000;
     RAE1:     file = "", define = yes, start = $B000, size = $1000;
-    BASROM:   file = "", define = yes, start = $C000, size = $1000;
+    BASROM:   file = "", define = yes, start = $C000, size = $2000;
     RAE2:     file = "", define = yes, start = $E000, size = $1000;
     TOP:      file = "", define = yes, start = $F000, size = $1000;
 }

--- a/cfg/sym1.cfg
+++ b/cfg/sym1.cfg
@@ -29,7 +29,7 @@ MEMORY {
     EXT:      file = "", define = yes, start = $9000, size = $1000;
     IO:       file = "", define = yes, start = $A000, size = $1000;
     RAE1:     file = "", define = yes, start = $B000, size = $1000;
-    BASROM:   file = "", define = yes, start = $C000, size = $1000;
+    BASROM:   file = "", define = yes, start = $C000, size = $2000;
     RAE2:     file = "", define = yes, start = $E000, size = $1000;
     TOP:      file = "", define = yes, start = $F000, size = $1000;
 }


### PR DESCRIPTION
BASIC in ROM on a Sym-1 computer resides at location C000 and is 8Kb wide.  However, the configuration files incorrectly label "BASROM" as being 4Kb.  This change corrects that.

There is no change in cc65 behavior because the only segment used is "RAM," which is set for lower memory.   But it's nice for the memory definitions to be right anyway.