### PR TITLE
Add Atari Lynx versions of three samples programs.

### DIFF
--- a/samples/Makefile
+++ b/samples/Makefile
@@ -154,7 +154,7 @@ endif
 # Lists of subdirectories
 
 # disasm depends on cpp
-DIRLIST = tutorial geos atari2600 atari5200 apple2 gamate supervision sym1 cbm
+DIRLIST = tutorial geos atari2600 atari5200 apple2 gamate lynx supervision sym1 cbm
 
 # --------------------------------------------------------------------------
 # Lists of executables

--- a/samples/lynx/Makefile
+++ b/samples/lynx/Makefile
@@ -1,0 +1,59 @@
+
+# Run 'make SYS=<target>'; or, set a SYS env.
+# var. to build for another target system.
+SYS ?= lynx
+
+# Just the usual way to find out if we're
+# using cmd.exe to execute make rules.
+ifneq ($(shell echo),)
+  CMD_EXE = 1
+endif
+
+ifdef CMD_EXE
+  NULLDEV = nul:
+  DEL = -del /f
+else
+  NULLDEV = /dev/null
+  DEL = $(RM)
+endif
+
+ifdef CC65_HOME
+  AS = $(CC65_HOME)/bin/ca65
+  CC = $(CC65_HOME)/bin/cc65
+  CL = $(CC65_HOME)/bin/cl65
+  LD = $(CC65_HOME)/bin/ld65
+else
+  AS := $(if $(wildcard ../../bin/ca65*),../../bin/ca65,ca65)
+  CC := $(if $(wildcard ../../bin/cc65*),../../bin/cc65,cc65)
+  CL := $(if $(wildcard ../../bin/cl65*),../../bin/cl65,cl65)
+  LD := $(if $(wildcard ../../bin/ld65*),../../bin/ld65,ld65)
+endif
+
+EXELIST_lynx = \
+	hello.lnx \
+	mandelbrot.lnx \
+	tgidemo.lnx
+
+.PHONY: samples clean
+
+ifneq ($(EXELIST_$(SYS)),)
+samples: $(EXELIST_$(SYS))
+else
+samples:
+# recipe used to skip systems that will not work with any program in this dir
+ifeq ($(MAKELEVEL),0)
+	@echo "info: Lynx tests not available for" $(SYS)
+else
+# Suppress the "nothing to be done for 'samples' message.
+	@echo "" > $(NULLDEV)
+endif
+endif
+
+.SUFFIXES:
+.SUFFIXES: .c .lnx
+
+%.lnx : %.c
+	$(CL) -t $(SYS) -Oris -m $*.map -o $@ $<
+
+clean:
+	@$(DEL) *.o *.map *.lnx 2>$(NULLDEV)

--- a/samples/lynx/hello.c
+++ b/samples/lynx/hello.c
@@ -1,0 +1,43 @@
+/* Atari Lynx version of samples/hello.c, using TGI instead of conio */
+
+#include <tgi.h>
+
+
+/*****************************************************************************/
+/*                                   Data                                    */
+/*****************************************************************************/
+
+static const char Text[] = "Hello world!";
+
+
+/*****************************************************************************/
+/*                                   Code                                    */
+/*****************************************************************************/
+
+void main (void)
+{
+    unsigned int XMax, YMax;
+
+    tgi_install (tgi_static_stddrv);
+    tgi_init ();
+
+    /* Set screen color. */
+    tgi_setcolor (TGI_COLOR_WHITE);
+
+    /* Clear the screen. */
+    tgi_clear();
+
+    /* Ask for the screen size. */
+    XMax = tgi_getmaxx ();
+    YMax = tgi_getmaxy ();
+
+    /* Draw a frame around the screen. */
+    tgi_line (0, 0, XMax, 0);
+    tgi_lineto (XMax, YMax);
+    tgi_lineto (0, YMax);
+    tgi_lineto (0, 0);
+
+    /* Write the greeting in the middle of the screen. */
+    tgi_outtextxy ((tgi_getxres () - tgi_gettextwidth (Text)) / 2,
+                   (tgi_getyres () - tgi_gettextheight (Text)) / 2, Text);
+}

--- a/samples/lynx/mandelbrot.c
+++ b/samples/lynx/mandelbrot.c
@@ -1,0 +1,86 @@
+/*****************************************************************************\
+** mandelbrot sample program for Atari Lynx                                  **
+**                                                                           **
+** (w) 2002 by groepaz/hitmen, TGI support by Stefan Haubenthal              **
+\*****************************************************************************/
+
+
+
+#include <stdlib.h>
+#include <tgi.h>
+
+
+
+/* Graphics definitions */
+#define SCREEN_X        (tgi_getxres())
+#define SCREEN_Y        (tgi_getyres())
+#define MAXCOL          (tgi_getcolorcount())
+
+#define maxiterations   32
+#define fpshift         (10)
+#define tofp(_x)        ((_x)<<fpshift)
+#define fromfp(_x)      ((_x)>>fpshift)
+#define fpabs(_x)       (abs(_x))
+
+#define mulfp(_a,_b)    ((((signed long)_a)*(_b))>>fpshift)
+#define divfp(_a,_b)    ((((signed long)_a)<<fpshift)/(_b))
+
+/* Use static local variables for speed */
+#pragma static-locals (1);
+
+
+
+static void mandelbrot (signed short x1, signed short y1, signed short x2,
+                        signed short y2)
+{
+    /*  */
+    register signed short r, r1, i;
+    register signed short xs, ys, xx, yy;
+    register signed short x, y;
+    register unsigned char count;
+    register unsigned char maxcol = MAXCOL;
+
+    /* Calc stepwidth */
+    xs = ((x2 - x1) / (SCREEN_X));
+    ys = ((y2 - y1) / (SCREEN_Y));
+
+    yy = y1;
+    for (y = 0; y < (SCREEN_Y); y++) {
+        yy += ys;
+        xx = x1;
+        for (x = 0; x < (SCREEN_X); x++) {
+            xx += xs;
+            /* Do iterations */
+            r = 0;
+            i = 0;
+            for (count = 0; (count < maxiterations) &&
+                 (fpabs (r) < tofp (2)) && (fpabs (i) < tofp (2));
+                 ++count) {
+                r1 = (mulfp (r, r) - mulfp (i, i)) + xx;
+                /* i = (mulfp(mulfp(r,i),tofp(2)))+yy; */
+                i = (((signed long) r * i) >> (fpshift - 1)) + yy;
+                r = r1;
+            }
+            if (count == maxiterations) {
+                tgi_setcolor (0);
+            } else {
+                tgi_setcolor (count % maxcol);
+            }
+            /* Set pixel */
+            tgi_setpixel (x, y);
+        }
+    }
+}
+
+void main (void)
+{
+    /* Install the graphics driver */
+    tgi_install (tgi_static_stddrv);
+
+    /* Initialize graphics */
+    tgi_init ();
+    tgi_clear ();
+
+    /* Calc mandelbrot set */
+    mandelbrot (tofp (-2), tofp (-2), tofp (2), tofp (2));
+}

--- a/samples/lynx/tgidemo.c
+++ b/samples/lynx/tgidemo.c
@@ -1,0 +1,179 @@
+/* Tgidemo modified for the Atari Lynx.
+**
+** Press any of the Lynx's option buttons to go to the next screen.
+*/
+
+#include <cc65.h>
+#include <conio.h>
+#include <tgi.h>
+#include <time.h>
+
+
+#define COLOR_BACK      TGI_COLOR_BLACK
+#define COLOR_FORE      TGI_COLOR_WHITE
+
+
+/*****************************************************************************/
+/*                                   Data                                    */
+/*****************************************************************************/
+
+
+
+/* Driver stuff */
+static unsigned MaxX;
+static unsigned MaxY;
+static unsigned AspectRatio;
+
+
+
+/*****************************************************************************/
+/*                                   Code                                    */
+/*****************************************************************************/
+
+
+
+/* The Lynx draws too fast.  This function delays
+** the drawing so that we can watch it.
+*/
+static void wait (unsigned char ticks)
+{
+    clock_t T = clock () + ticks;
+
+    while (clock () < T) {}
+}
+
+
+
+static void DoCircles (void)
+{
+    unsigned char I;
+    unsigned char Color = COLOR_BACK;
+    const unsigned X = MaxX / 2;
+    const unsigned Y = MaxY / 2;
+    const unsigned Limit = (X < Y) ? Y : X;
+
+    tgi_setcolor (COLOR_FORE);
+    tgi_clear ();
+
+    tgi_line (0, 0, MaxX, MaxY);
+    tgi_line (0, MaxY, MaxX, 0);
+    while (!kbhit ()) {
+        Color = (Color == COLOR_FORE) ? COLOR_BACK : COLOR_FORE;
+        tgi_setcolor (Color);
+        for (I = 10; I <= Limit; I += 10) {
+            tgi_ellipse (X, Y, I, tgi_imulround (I, AspectRatio));
+            wait (9);
+        }
+    }
+
+    cgetc ();
+}
+
+
+
+static void DoCheckerboard (void)
+{
+    unsigned X, Y;
+    unsigned char Color = COLOR_BACK;
+
+    tgi_clear ();
+
+    while (1) {
+        for (Y = 0; Y <= MaxY - 2; Y += 10) {
+            for (X = 0; X <= MaxX; X += 10) {
+                Color = (Color == COLOR_FORE) ? COLOR_BACK : COLOR_FORE;
+                tgi_setcolor (Color);
+                tgi_bar (X, Y, X+9, Y+9);
+                if (kbhit ()) {
+                    cgetc ();
+                    return;
+                }
+                wait (1);
+            }
+            Color = Color == COLOR_FORE ? COLOR_BACK : COLOR_FORE;
+        }
+        Color = Color == COLOR_FORE ? COLOR_BACK : COLOR_FORE;
+    }
+}
+
+
+
+static void DoDiagram (void)
+{
+    int XOrigin, YOrigin;
+    int Amp;
+    int X, Y;
+    unsigned I;
+
+    tgi_setcolor (COLOR_FORE);
+    tgi_clear ();
+
+    /* Determine zero and amplitude */
+    YOrigin = MaxY / 2;
+    XOrigin = 10;
+    Amp     = (MaxY - 19) / 2;
+
+    /* Y axis */
+    tgi_line (XOrigin, 10, XOrigin, MaxY-10);
+    tgi_line (XOrigin-2, 12, XOrigin, 10);
+    tgi_lineto (XOrigin+2, 12);
+
+    /* X axis */
+    tgi_line (XOrigin, YOrigin, MaxX-10, YOrigin);
+    tgi_line (MaxX-12, YOrigin-2, MaxX-10, YOrigin);
+    tgi_lineto (MaxX-12, YOrigin+2);
+
+    /* Sine */
+    tgi_gotoxy (XOrigin, YOrigin);
+    for (I = 0; I <= 360; ++I) {
+        /* Calculate the next points */
+        X = (int)(((long)(MaxX - 19) * I) / 360);
+        Y = (int)(((long)Amp * -_sin (I)) / 256);
+
+        /* Draw the line */
+        tgi_lineto (XOrigin + X, YOrigin + Y);
+    }
+
+    cgetc ();
+}
+
+
+
+static void DoLines (void)
+{
+    unsigned X;
+    const unsigned Min = (MaxX < MaxY) ? MaxX : MaxY;
+
+    tgi_setcolor (COLOR_FORE);
+    tgi_clear ();
+
+    for (X = 0; X <= Min; X += 10) {
+        tgi_line (0, 0, Min, X);
+        tgi_line (0, 0, X, Min);
+        tgi_line (Min, Min, 0, Min-X);
+        tgi_line (Min, Min, Min-X, 0);
+        wait (9);
+    }
+
+    cgetc ();
+}
+
+
+
+void main (void)
+{
+    /* Install the driver */
+    tgi_install (tgi_static_stddrv);
+    tgi_init ();
+
+    /* Get stuff from the driver */
+    MaxX = tgi_getmaxx ();
+    MaxY = tgi_getmaxy ();
+    AspectRatio = tgi_getaspectratio ();
+
+    /* Do graphics stuff */
+    DoCircles ();
+    DoCheckerboard ();
+    DoDiagram ();
+    DoLines ();
+}

--- a/samples/readme.txt
+++ b/samples/readme.txt
@@ -128,7 +128,7 @@ Platforms:      Runs on all platforms that have TGI support:
 
 =============================================================================
 
-Platform specific samples follow:
+Platform-specific samples follow:
 
 atari 2600:
 -----------
@@ -196,6 +196,27 @@ gamate:
 
 Name:           nachtm
 Description:    Plays "Eine kleine Nachtmusik" by Wolfgang Amadeus Mozart.
+-----------------------------------------------------------------------------
+
+lynx:
+-----
+
+These programs are adapted for the Atari Lynx because its library has no conio
+output or stdio.
+
+Name:           hello
+Description:    A nice "Hello world" type program that uses the TGI graphics
+                library for output.
+
+Name:           mandelbrot
+Description:    A mandelbrot demo using integer arithmetic. The demo was
+                written by groepaz, and converted to cc65 using TGI graphics
+                by Stefan Haubenthal.
+
+Name:           tgidemo
+Description:    Shows some of the graphics capabilities of the "Tiny Graphics
+                Interface".
+
 -----------------------------------------------------------------------------
 
 sym1:


### PR DESCRIPTION
The general samples programs `"hello.c"`, `"mandelbrot.c"`, and `"tgidemo.c"` can't be built by the `lynx` target because they use conio output or stdio.  I created special Lynx versions of those programs that don't use that I/O.