### PR TITLE
[Atari7800] clock()

### DIFF
--- a/cfg/atari7800.cfg
+++ b/cfg/atari7800.cfg
@@ -10,7 +10,7 @@ SYMBOLS {
     __ENCRYPT_BOTTOM__:   value = $ff7a, type = export;
     __ENCRYPT_SIZE__:     value = $80, type = export;
     __MEMORY_TOP__:       value = __ENCRYPT_BOTTOM__, type = export;
-    __INIT_SIZE__:        value = 107, type = export;
+    __INIT_SIZE__:        value = 121, type = export;
     __MEMORY_INIT__:      value = __MEMORY_TOP__ - __INIT_SIZE__, type = export;
     __MEMORY_BOTTOM__:    value = $10000 - __CARTSIZE__, type = weak;
     __FREE_ROM_SIZE__:    value = __MEMORY_INIT__ - __MEMORY_BOTTOM__, type = export;

--- a/cfg/atari7800.cfg
+++ b/cfg/atari7800.cfg
@@ -10,7 +10,7 @@ SYMBOLS {
     __ENCRYPT_BOTTOM__:   value = $ff7a, type = export;
     __ENCRYPT_SIZE__:     value = $80, type = export;
     __MEMORY_TOP__:       value = __ENCRYPT_BOTTOM__, type = export;
-    __INIT_SIZE__:        value = 69, type = export;
+    __INIT_SIZE__:        value = 107, type = export;
     __MEMORY_INIT__:      value = __MEMORY_TOP__ - __INIT_SIZE__, type = export;
     __MEMORY_BOTTOM__:    value = $10000 - __CARTSIZE__, type = weak;
     __FREE_ROM_SIZE__:    value = __MEMORY_INIT__ - __MEMORY_BOTTOM__, type = export;

--- a/libsrc/atari7800/clock.s
+++ b/libsrc/atari7800/clock.s
@@ -1,0 +1,89 @@
+;
+; 2022-03-15, Karri Kaksonen
+;
+; clock_t clock (void);
+; clock_t _clocks_per_sec (void);
+;
+
+        .export         _clock, __clocks_per_sec, clock_count
+        .interruptor    update_clock, 2 ; (low priority)
+        .constructor    init_clock
+
+        .import         sreg: zp
+	.import		_zonecounter
+	.import		_paldetected
+        .include        "atari7800.inc"
+
+        .macpack        generic
+
+	.code
+
+;-----------------------------------------------------------------------------
+; Read the clock counter.
+;
+        .proc   _clock
+
+        lda     #0
+        sta     sreg+1          ; Promote 24 bits up to 32 bits
+        lda     clock_count+2
+        sta     sreg
+        ldx     clock_count+1
+        lda     clock_count
+
+        rts
+        .endproc
+
+;-----------------------------------------------------------------------------
+; Return the number of clock ticks in one second.
+;
+        .proc   __clocks_per_sec
+
+        lda     #0
+	tax
+        sta     sreg            ; return 32 bits
+        sta     sreg+1
+        lda     _paldetected
+	bne	pal
+	lda	#60		; NTSC - 60Hz
+	rts
+pal:
+	lda	#50		; PAL - 50Hz
+        rts
+        .endproc
+
+;-----------------------------------------------------------------------------
+; This interrupt handler increments a 24-bit counter at every video
+; vertical-blanking time.
+; Update the clock only on interrupt while the drawing on screen is on
+; _zonecounter == 1 (from 1st visible scanline to last visible scanline)
+;
+update_clock:
+	lda	_zonecounter
+	and	#01
+	beq	@L1
+        inc     clock_count
+        bne     @L1
+        inc     clock_count+1
+        bne     @L1
+        inc     clock_count+2
+@L1:    ;clc                    ; General interrupt was not reset
+        rts
+
+;-----------------------------------------------------------------------------
+; Set time to zero at startup
+;
+        .segment        "ONCE"
+init_clock:
+	lda	#0
+	sta	clock_count+2
+	sta	clock_count+1
+	sta	clock_count
+        rts
+
+;-----------------------------------------------------------------------------
+; Store time in 3 bytes
+;
+        .bss
+clock_count:
+        .res    3
+

--- a/libsrc/atari7800/clock.s
+++ b/libsrc/atari7800/clock.s
@@ -2,16 +2,14 @@
 ; 2022-03-15, Karri Kaksonen
 ;
 ; clock_t clock (void);
-; clock_t _clocks_per_sec (void);
 ;
 
-        .export         _clock, __clocks_per_sec, clock_count
+        .export         _clock, clock_count
         .interruptor    update_clock, 2 ; (low priority)
         .constructor    init_clock
 
         .import         sreg: zp
 	.import		_zonecounter
-	.import		_paldetected
         .include        "atari7800.inc"
 
         .macpack        generic
@@ -30,24 +28,6 @@
         ldx     clock_count+1
         lda     clock_count
 
-        rts
-        .endproc
-
-;-----------------------------------------------------------------------------
-; Return the number of clock ticks in one second.
-;
-        .proc   __clocks_per_sec
-
-        lda     #0
-	tax
-        sta     sreg            ; return 32 bits
-        sta     sreg+1
-        lda     _paldetected
-	bne	pal
-	lda	#60		; NTSC - 60Hz
-	rts
-pal:
-	lda	#50		; PAL - 50Hz
         rts
         .endproc
 

--- a/libsrc/atari7800/clocks_per_sec.s
+++ b/libsrc/atari7800/clocks_per_sec.s
@@ -1,0 +1,34 @@
+;
+; 2022-03-15, Karri Kaksonen
+;
+; clock_t _clocks_per_sec (void);
+;
+
+        .export         __clocks_per_sec
+
+        .import         sreg: zp
+	.import		_paldetected
+        .include        "atari7800.inc"
+
+        .macpack        generic
+
+	.code
+
+;-----------------------------------------------------------------------------
+; Return the number of clock ticks in one second.
+;
+        .proc   __clocks_per_sec
+
+        lda     #0
+	tax
+        sta     sreg            ; return 32 bits
+        sta     sreg+1
+        lda     _paldetected
+	bne	pal
+	lda	#60		; NTSC - 60Hz
+	rts
+pal:
+	lda	#50		; PAL - 50Hz
+        rts
+        .endproc
+

--- a/libsrc/atari7800/crt0.s
+++ b/libsrc/atari7800/crt0.s
@@ -1,5 +1,4 @@
         .export		_zonecounter
-        .export		_paldetected
         .export		 __STARTUP__ : absolute = 1
         .export		 _exit
         .import		 __ROM_START__
@@ -39,29 +38,6 @@ start:
         jsr     zerobss
         jsr     initlib
 
-	; Examine machine type as we need the info early
-vboff:	lda     MSTAT
-	bmi     vboff
-vbon:   lda     MSTAT
-        bpl     vbon
-vboff2: lda     MSTAT
-        bmi     vboff2
-        lda     #$00
-        sta     _paldetected
-        jmp     mtsta
-count:  sta     WSYNC
-        sta     WSYNC
-        dec     _paldetected
-mtsta:  lda     MSTAT
-        bpl     count
-        lda     _paldetected
-        cmp     #$78
-        bcc     mtntsc
-        lda     #$01
-        jmp     mtpal
-mtntsc: lda     #$00
-mtpal:  sta     _paldetected
-
         ; Call main program (pass empty command line)
         jsr     push0           ; argc
         jsr     push0           ; argv
@@ -82,9 +58,6 @@ IRQHandler:
         .segment "DATA"
 _zonecounter:
         .byte   0
-_paldetected:
-	.byte	0		; 0 = NTSC, 1 = PAL
-
 
         .segment "ENCRYPTION"
         .res    126, $ff        ; Reserved for encryption

--- a/libsrc/atari7800/get_tv.s
+++ b/libsrc/atari7800/get_tv.s
@@ -1,26 +1,63 @@
 ;
-; Stefan Haubenthal, 2007-01-21
+; Karri Kaksonen, 2022-03-25
 ;
-; unsigned char get_tv (void);
-; /* Return the video mode the machine is using */
+; unsigned char get_tv (void)
 ;
+	.include	"atari7800.inc"
+	.export		_get_tv
 
-        .include        "atari7800.inc"
-        .include        "get_tv.inc"
-        .importzp       tmp1, tmp2
-	.import		_paldetected
+.segment	"DATA"
 
-;--------------------------------------------------------------------------
-; _get_tv
+_paldetected:
+	.byte	$FF
 
-.proc   _get_tv
+; ---------------------------------------------------------------
+; unsigned char get_tv (void)
+; ---------------------------------------------------------------
 
-        lda	_paldetected
-	beq	ntsc
-	lda	#TV::PAL
+.segment	"CODE"
+
+.proc	_get_tv: near
+
+.segment	"CODE"
+
+	ldx     #$00
+	lda     #$FF
+	cmp     _paldetected
+	bne     L8
+L1:	lda     $0028
+	and     #$80
+	bne     L1
+L2:	lda     $0028
+	and     #$80
+	beq     L2
+L3:	lda     $0028
+	and     #$80
+	bne     L3
+	lda     #$00
+	sta     M0001
+	jmp     L5
+L4:	sta     $0024
+	sta     $0024
+	dec     M0001
+L5:	lda     $0028
+	and     #$80
+	beq     L4
+	lda     M0001
+	cmp     #$78
+	bcc     L6
+	lda     #$00
+	jmp     L7
+L6:	lda     #$01
+L7:	sta     _paldetected
+	ldx     #$00
+L8:	lda     _paldetected
 	rts
-ntsc:
-	lda	#TV::NTSC
-	rts
+
+.segment	"BSS"
+
+M0001:
+	.res	1,$00
 
 .endproc
+

--- a/libsrc/atari7800/get_tv.s
+++ b/libsrc/atari7800/get_tv.s
@@ -6,6 +6,7 @@
 	.include	"atari7800.inc"
         .include        "get_tv.inc"
 	.export		_get_tv
+	.export		_paldetected
 
 .segment	"DATA"
 

--- a/libsrc/atari7800/get_tv.s
+++ b/libsrc/atari7800/get_tv.s
@@ -1,0 +1,26 @@
+;
+; Stefan Haubenthal, 2007-01-21
+;
+; unsigned char get_tv (void);
+; /* Return the video mode the machine is using */
+;
+
+        .include        "atari7800.inc"
+        .include        "get_tv.inc"
+        .importzp       tmp1, tmp2
+	.import		_paldetected
+
+;--------------------------------------------------------------------------
+; _get_tv
+
+.proc   _get_tv
+
+        lda	_paldetected
+	beq	ntsc
+	lda	#TV::PAL
+	rts
+ntsc:
+	lda	#TV::NTSC
+	rts
+
+.endproc

--- a/libsrc/atari7800/get_tv.s
+++ b/libsrc/atari7800/get_tv.s
@@ -4,6 +4,7 @@
 ; unsigned char get_tv (void)
 ;
 	.include	"atari7800.inc"
+        .include        "get_tv.inc"
 	.export		_get_tv
 
 .segment	"DATA"
@@ -25,30 +26,30 @@ _paldetected:
 	lda     #$FF
 	cmp     _paldetected
 	bne     L8
-L1:	lda     $0028
+L1:	lda     MSTAT
 	and     #$80
 	bne     L1
-L2:	lda     $0028
+L2:	lda     MSTAT
 	and     #$80
 	beq     L2
-L3:	lda     $0028
+L3:	lda     MSTAT
 	and     #$80
 	bne     L3
 	lda     #$00
 	sta     M0001
 	jmp     L5
-L4:	sta     $0024
-	sta     $0024
+L4:	sta     MWSYNC
+	sta     MWSYNC
 	dec     M0001
-L5:	lda     $0028
+L5:	lda     MSTAT
 	and     #$80
 	beq     L4
 	lda     M0001
 	cmp     #$78
 	bcc     L6
-	lda     #$00
+        lda     #TV::NTSC
 	jmp     L7
-L6:	lda     #$01
+L6:	lda     #TV::PAL
 L7:	sta     _paldetected
 	ldx     #$00
 L8:	lda     _paldetected

--- a/libsrc/atari7800/irq.s
+++ b/libsrc/atari7800/irq.s
@@ -1,0 +1,36 @@
+;
+; IRQ handling (Atari 7800 version)
+;
+
+        .export         initirq, doneirq, IRQStub
+
+        .import         __INTERRUPTOR_COUNT__, callirq
+
+        .include        "atari7800.inc"
+
+	.code
+; ------------------------------------------------------------------------
+
+initirq:
+doneirq:
+        rts
+
+; ------------------------------------------------------------------------
+
+IRQStub:
+        cld                             ; Just to be sure
+        pha
+        lda     #<(__INTERRUPTOR_COUNT__ * 2)
+        beq     @L1
+        txa
+        pha
+        tya
+        pha
+        jsr     callirq                 ; Call the functions
+	pla
+        tay
+        pla
+        tax
+@L1:	pla
+        rti
+


### PR DESCRIPTION
Issue #1705 The clock() function requires NMI interrupts to work in this implementation. The NMI calls irq.s in order to be able to use interruptors like for other targets. We also need to find out if the machine is a PAL or a NTSC unit. As there is no DLL structures at startup we poll the vsync bits for one frame and count the lines.

I did test the functions by creating a game. But there is not yet enough data in the repo for running the test samples.

Having PAL/NTSC detection, irq's and clock() are very good building blocks for any applications for the Atari7800.