### PR TITLE
[Tentative: please review] Fix Gamate CONIO: non-solid characters bug

### DIFF
--- a/libsrc/gamate/cputc.s
+++ b/libsrc/gamate/cputc.s
@@ -89,28 +89,32 @@ putchar:
         adc     #>(fontdata-$f8)
         sta     ptr3+1
 
-        lda     CHARCOLOR
-        and     #1
-        beq     @skip_plane1
-
         lda     #LCD_XPOS_PLANE1
         clc
         adc     CURS_X
         sta     LCD_X
 
-        ldy     #$f8
+        lda     CHARCOLOR
+        and     #1
+        beq     @delete1
+
+        ldy     #$F8
 @copylp1:
         lda     (ptr3),y
         eor     RVS
         sta     LCD_DATA
         iny
         bne     @copylp1
+        
+        beq @skip_delete1
 
-@skip_plane1:
+@delete1:
+        lda   #$00
+        sta   LCD_DATA
+        iny
+        bne @delete1
 
-        lda     CHARCOLOR
-        and     #2
-        beq     @skip_plane2
+@skip_delete1:
 
         lda     #LCD_XPOS_PLANE2
         clc
@@ -120,16 +124,29 @@ putchar:
         ldx     CURS_Y
         lda     _plotlo,x
         sta     LCD_Y
+        
+        lda     CHARCOLOR
+        and     #2
+        beq     @delete2
+        
+        ldy     #$F8
 
-        ldy     #$f8
 @copylp2:
         lda     (ptr3),y
         eor     RVS
         sta     LCD_DATA
         iny
         bne     @copylp2
+        
+        beq    @skip_delete2
+        
+@delete2:
+        lda   #$00
+        sta   LCD_DATA
+        iny
+        bne @delete2
 
-@skip_plane2:
+@skip_delete2:
         pla
         tax
         ldy     CURS_X


### PR DESCRIPTION
This tentative pull request fixes #1714.
As a side effect, it also makes all grey colors work correctly (to be further tested).

The fix (and the bug) can be reproduced with
```
#include <conio.h>
#include <unistd.h>

int main(void)
{
    clrscr();
    gotoxy(2,2);
    textcolor(COLOR_BLACK);
    cprintf("hello");
    sleep(1);
    textcolor(COLOR_WHITE);
    gotoxy(2,2);
    cprintf("ciao!");
    sleep(1);
    gotoxy(2,2);
    textcolor(1);
    cprintf("hello");
    sleep(1);
    textcolor(2);
    gotoxy(2,2);
    cprintf("ciao!");
    sleep(1);
    gotoxy(2,2);
    textcolor(COLOR_BLACK);
    cprintf("hello");
    sleep(1);
    textcolor(COLOR_WHITE);
    gotoxy(2,2);
    cprintf("ciao!");    
    while(1){};
    return 0;
}
```