### PR TITLE
build: properly quote strings passed as cpp macros

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -68,9 +68,9 @@ $(info BUILD_ID: $(BUILD_ID))
 
 CFLAGS += -MMD -MP -O3 -I common \
           -Wall -Wextra -Wno-char-subscripts $(USER_CFLAGS) \
-          -DCA65_INC="$(CA65_INC)" -DCC65_INC="$(CC65_INC)" -DCL65_TGT="$(CL65_TGT)" \
-          -DLD65_LIB="$(LD65_LIB)" -DLD65_OBJ="$(LD65_OBJ)" -DLD65_CFG="$(LD65_CFG)" \
-          -DBUILD_ID="$(BUILD_ID)"
+          -DCA65_INC="\"$(CA65_INC)\"" -DCC65_INC="\"$(CC65_INC)\"" -DCL65_TGT="\"$(CL65_TGT)\"" \
+          -DLD65_LIB="\"$(LD65_LIB)\"" -DLD65_OBJ="\"$(LD65_OBJ)\"" -DLD65_CFG="\"$(LD65_CFG)\"" \
+          -DBUILD_ID="\"$(BUILD_ID)\""
 
 LDLIBS += -lm
 

--- a/src/ca65/incpath.c
+++ b/src/ca65/incpath.c
@@ -76,7 +76,7 @@ void FinishIncludePaths (void)
 
     /* Add some compiled-in search paths if defined at compile time. */
 #if defined(CA65_INC) && !defined(_WIN32)
-    AddSearchPath (IncSearchPath, STRINGIZE (CA65_INC));
+    AddSearchPath (IncSearchPath, CA65_INC);
 #endif
 
     /* Add paths relative to the parent directory of the Windows binary. */

--- a/src/cc65/incpath.c
+++ b/src/cc65/incpath.c
@@ -77,7 +77,7 @@ void FinishIncludePaths (void)
 
     /* Add some compiled-in search paths if defined at compile time. */
 #if defined(CC65_INC) && !defined(_WIN32)
-    AddSearchPath (SysIncSearchPath, STRINGIZE (CC65_INC));
+    AddSearchPath (SysIncSearchPath, CC65_INC);
 #endif
 
     /* Add paths relative to the parent directory of the Windows binary. */

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -1216,7 +1216,7 @@ static void OptPrintTargetPath (const char* Opt attribute ((unused)),
     SearchPaths* TargetPaths = NewSearchPath ();
     AddSubSearchPathFromEnv (TargetPaths, "CC65_HOME", "target");
 #if defined(CL65_TGT) && !defined(_WIN32)
-    AddSearchPath (TargetPaths, STRINGIZE (CL65_TGT));
+    AddSearchPath (TargetPaths, CL65_TGT);
 #endif
     AddSubSearchPathFromWinBin (TargetPaths, "target");
 

--- a/src/common/searchpath.h
+++ b/src/common/searchpath.h
@@ -48,10 +48,6 @@
 
 
 
-/* Convert argument to C string */
-#define _STRINGIZE(arg) #arg
-#define  STRINGIZE(arg) _STRINGIZE(arg)
-
 /* A search path is a pointer to the list */
 typedef struct Collection SearchPaths;
 

--- a/src/common/version.c
+++ b/src/common/version.c
@@ -62,7 +62,7 @@ const char* GetVersionAsString (void)
 {
     static char Buf[60];
 #if defined(BUILD_ID)
-    xsnprintf (Buf, sizeof (Buf), "%u.%u - %s", VER_MAJOR, VER_MINOR, STRINGIZE (BUILD_ID));
+    xsnprintf (Buf, sizeof (Buf), "%u.%u - %s", VER_MAJOR, VER_MINOR, BUILD_ID);
 #else
     xsnprintf (Buf, sizeof (Buf), "%u.%u", VER_MAJOR, VER_MINOR);
 #endif

--- a/src/ld65/filepath.c
+++ b/src/ld65/filepath.c
@@ -89,13 +89,13 @@ void InitSearchPaths (void)
 
     /* Add some compiled-in search paths if defined at compile time. */
 #if defined(LD65_LIB) && !defined(_WIN32)
-    AddSearchPath (LibDefaultPath, STRINGIZE (LD65_LIB));
+    AddSearchPath (LibDefaultPath, LD65_LIB);
 #endif
 #if defined(LD65_OBJ) && !defined(_WIN32)
-    AddSearchPath (ObjDefaultPath, STRINGIZE (LD65_OBJ));
+    AddSearchPath (ObjDefaultPath, LD65_OBJ);
 #endif
 #if defined(LD65_CFG) && !defined(_WIN32)
-    AddSearchPath (CfgDefaultPath, STRINGIZE (LD65_CFG));
+    AddSearchPath (CfgDefaultPath, LD65_CFG);
 #endif
 
     /* Add paths relative to the parent directory of the Windows binary. */


### PR DESCRIPTION
until now, the strings intended to be hardcoded into the binary,
such as directory names and build id, were passed unquoted, which
means they're interpreted by the preprocessor as C tokens, rather
than strings, which can result in all sorts of "interesting"
behaviour such as interpreting paths starting with // as C++-style
comment.
this was then worked around using a stringize macro which turned
the tokens into a string (if they happened to be in a compatible
format).

adresses #1726