### PR TITLE
[Telestrat] Kbhit fix

### DIFF
--- a/libsrc/telestrat/cgetc.s
+++ b/libsrc/telestrat/cgetc.s
@@ -5,24 +5,38 @@
 
     .import    cursor
 
+    .export    store_char
+
     .include   "telestrat.inc"
 
 .proc _cgetc
-        ; this routine could be quicker if we wrote in page 2 variables,
-        ; but it's better to use telemon routine in that case, because telemon can manage 4 I/O
-        ldx     cursor       ; if cursor equal to 0, then switch off cursor
+        ; This routine could be quicker if we wrote in page 2 variables,
+        ; But it's better to use telemon routine in that case, because telemon can manage 4 I/O
+        ldx     cursor       ; If cursor equal to 0, then switch off cursor
         beq     switchoff_cursor
 
         ldx     #$00         ; x is the first screen
-        BRK_TELEMON(XCSSCR)  ; display cursor
-        jmp     loop         ; could be replaced by a bne/beq but 'jmp' is cleaner than a bne/beq which could expect some matters
+        BRK_TELEMON(XCSSCR)  ; Display cursor
+        jmp     start        ; Could be replaced by a bne/beq but 'jmp' is cleaner than a bne/beq which could expect some matters
 
 switchoff_cursor:
-        ; at this step X is equal to $00, X must be set, because it's the id of the screen (telestrat can handle 4 virtuals screen)
-        BRK_TELEMON(XCOSCR)  ; switch off cursor
+        ; At this step X is equal to $00, X must be set, because it's the id of the screen (telestrat can handle 4 virtuals screen)
+        BRK_TELEMON(XCOSCR)  ; Switch off cursor
 
-loop:
-        BRK_TELEMON XRD0     ; waits until key is pressed
-        bcs     loop
+
+start:
+        lda     store_char   ; Does kbhit store a value in store_char ?
+        bne     @out         ; Yes, we returns A and we reset store_char
+@wait_key:
+        BRK_TELEMON XRD0     ; Waits until key is pressed
+        bcs     @wait_key
+        ldx     #$00
+        rts
+@out:
+        ldx     #$00
+        stx     store_char
         rts
 .endproc
+.data
+store_char:
+        .byte 0

--- a/libsrc/telestrat/kbhit.s
+++ b/libsrc/telestrat/kbhit.s
@@ -6,12 +6,24 @@
 
         .export         _kbhit
 
+        .import         store_char
+
         .include        "telestrat.inc"
 
 _kbhit:
-        BRK_TELEMON XRD0
+        lda     store_char       ; Check if a key has been detected previously   
+        beq     @call_telemon    ; No, calls Telemon routine
+        lda     #$01             ; There is a key pressed previously, return 1
         ldx     #$00
-        txa
-        rol
-        eor     #$01
+        rts
+@call_telemon:        
+        BRK_TELEMON XRD0
+
+        ldx     #$00
+        bcs     @no_char_action
+        sta     store_char
+        lda     #$01
+        rts
+@no_char_action:
+        tax
         rts


### PR DESCRIPTION


There is a wrong behavior reported from someone.

When kbhit() is called, cgetc() returns the char.

In telestrat target, there is a keyboard buffer. When we get the char, this char is removed from this buffer. Cgetc() does not work.

This PR is done in order to fix this. If kbhit had been called, it set the char into ram (store_char). If cget is called and store_char is equal to 0, it calls Telemon keyboard routine, if it's a different value, it means that kbhit was called previously and cgetc returns store_char

@[greg-king5](https://github.com/greg-king5) greg-king5 [22 hours ago](https://github.com/cc65/cc65/pull/1728#discussion_r857194457)
It's possible that kbhit() could be called several times before cgetc() is called. Therefore, kbhit() should not call Telemon if a character already is waiting.

=> Fixed

[greg-king5](https://github.com/greg-king5) [22 hours ago](https://github.com/cc65/cc65/pull/1728#discussion_r857195483)
If you move that variable to "cgetc.s", then kbhit() won't be linked into programs if it actually isn't called.

("samples/ascii.c" calls cgetc() and doesn't call kbhit().)

=> Fixed