### PR TITLE
Mkdir : fix registers calls

### DIFF
--- a/libsrc/telestrat/sysmkdir.s
+++ b/libsrc/telestrat/sysmkdir.s
@@ -3,13 +3,14 @@
 ;
 ; unsigned char _sysmkdir (const char* name, ...);
 ;
+; This routine only works with Orix
+
 
         .export         __sysmkdir
         .import         addysp, popax
 
         .include        "telestrat.inc"
         .include        "zeropage.inc"
-
 
 __sysmkdir:
         ; Throw away all parameters except the name
@@ -20,11 +21,13 @@ __sysmkdir:
         ; Get name
         jsr     popax
 
-        ; Call telemon primitive
+        stx     tmp1
+        ldy     tmp1
 
+        ldx     #$00         ; X register is used to set if all folders must be created
+
+        ; Call telemon primitive
+        
         BRK_TELEMON(XMKDIR)
 
         rts
-
-
-


### PR DESCRIPTION
This PR enhances mkdir calls for Orix and Telestrat target.

AY is the string, and X is the mode : 0 for X means that only one level of the folder will be created

