### PR TITLE
Fix switched meaning of '\n' and '\r' for osic1p target

### DIFF
--- a/libsrc/osic1p/osiscreen.inc
+++ b/libsrc/osic1p/osiscreen.inc
@@ -78,13 +78,13 @@ _cputcxy:
 
 ; Plot a character - also used as internal function
 
-_cputc: cmp     #$0A            ; CR?
+_cputc: cmp     #$0D            ; CR?
         bne     L1
         lda     #0
         sta     CURS_X
         beq     plot            ; Recalculate pointers
 
-L1:     cmp     #$0D            ; LF?
+L1:     cmp     #$0A            ; LF?
         beq     newline         ; Recalculate pointers
 
 cputdirect:


### PR DESCRIPTION
When conio was implemented for the osic1p target, the cbm
target was used as a blueprint. But it was overlooked that the
cbm target encodes CR as 0x0A and LF as 0x0D, while the
osic1p target uses the ASCII encoding of CR and LF. Therefore
conio output of '\n' moved the active position to the start of the
line and '\r' moved the active position to the next line.

This change implements the correct semantics of '\n' and '\r'
in conio for the osic1p target.

Fixes #1747.