### PR TITLE
cl65: fix regression in --print-target-path

### DIFF
--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -1212,6 +1212,7 @@ static void OptPrintTargetPath (const char* Opt attribute ((unused)),
 /* Print the target file path */
 {
     char* TargetPath;
+    char* tmp;
 
     SearchPaths* TargetPaths = NewSearchPath ();
     AddSubSearchPathFromEnv (TargetPaths, "CC65_HOME", "target");
@@ -1220,7 +1221,15 @@ static void OptPrintTargetPath (const char* Opt attribute ((unused)),
 #endif
     AddSubSearchPathFromBin (TargetPaths, "target");
 
-    TargetPath = GetSearchPath (TargetPaths, 0);
+    TargetPath = SearchFile (TargetPaths, ".");
+    if (!TargetPath) {
+        fprintf (stderr, "%s: error - could not determine target path\n", ProgName);
+        exit (EXIT_FAILURE);
+    }
+    tmp = strrchr(TargetPath, '.');
+    if (tmp) {
+        *(--tmp) = 0;
+    }
     while (*TargetPath) {
         if (*TargetPath == ' ') {
             /* Escape spaces */


### PR DESCRIPTION
since the "empty prefix means run from current dir" hack was removed,
cl65 --print-target-path no longer prints the path relative to the
binary, but the hardcoded library path which points to prefix, because
the code adds the hardcoded path first to the pathsearch, but then actually
only returns the first entry rather than looking whether the path exists.

closes #1754