### PR TITLE
Telestrat : change default start address

### DIFF
--- a/cfg/telestrat.cfg
+++ b/cfg/telestrat.cfg
@@ -11,7 +11,7 @@ SYMBOLS {
 MEMORY {
     ZP:      file = "", define = yes, start = $00B0,            size = $003A;
     ORIXHDR: file = %O, type   = ro,  start = $0000,            size = $001F;
-    MAIN:    file = %O, define = yes, start = %S,            size = __RAMEND__ - __MAIN_START__;
+    MAIN:    file = %O, define = yes, start = %S,               size = __RAMEND__ - __MAIN_START__;
     BSS:     file = "",               start = __ONCE_RUN__,     size = __RAMEND__ - __STACKSIZE__ - __ONCE_RUN__;
 }
 SEGMENTS {

--- a/cfg/telestrat.cfg
+++ b/cfg/telestrat.cfg
@@ -1,3 +1,7 @@
+FEATURES {
+    STARTADDRESS: default = $1000;
+}
+
 SYMBOLS {
     __ORIXHDR__:   type = import;
     __STACKSIZE__: type = weak, value = $0800; # 2K stack
@@ -7,7 +11,7 @@ SYMBOLS {
 MEMORY {
     ZP:      file = "", define = yes, start = $00B0,            size = $003A;
     ORIXHDR: file = %O, type   = ro,  start = $0000,            size = $001F;
-    MAIN:    file = %O, define = yes, start = $0800,            size = __RAMEND__ - __MAIN_START__;
+    MAIN:    file = %O, define = yes, start = %S,            size = __RAMEND__ - __MAIN_START__;
     BSS:     file = "",               start = __ONCE_RUN__,     size = __RAMEND__ - __STACKSIZE__ - __ONCE_RUN__;
 }
 SEGMENTS {


### PR DESCRIPTION
This change is to set to $1000 the default address, and now --start-addr works from command line