### PR TITLE
rename '_poserror' to '__poserror'

### DIFF
--- a/doc/funcref.sgml
+++ b/doc/funcref.sgml
@@ -627,7 +627,7 @@ communication, see also <tt>testcode/lib/ser-test.c</tt>.
 <sect1><tt/stdio.h/<label id="stdio.h"><p>
 
 <itemize>
-<item><ref id="_poserror" name="_poserror">
+<item><ref id="__poserror" name="__poserror">
 <item><ref id="clearerr" name="clearerr">
 <!-- <item><ref id="fclose" name="fclose"> -->
 <!-- <item><ref id="fdopen" name="fdopen"> -->
@@ -1058,14 +1058,14 @@ It returns 1 if it does.
 </descrip>
 </quote>
 
-<sect1>_poserror<label id="_poserror"><p>
+<sect1>__poserror<label id="__poserror"><p>
 
 <quote>
 <descrip>
 <tag/Function/Print an error message for the error in <tt/_oserror/.
 <tag/Header/<tt/<ref id="stdio.h" name="stdio.h">/
-<tag/Declaration/<tt/void __fastcall__ _poserror (const char* msg);/
-<tag/Description/<tt/_poserror/ prints an error message to <tt/stderr/. If
+<tag/Declaration/<tt/void __fastcall__ __poserror (const char* msg);/
+<tag/Description/<tt/__poserror/ prints an error message to <tt/stderr/. If
 <tt/msg/ is not <tt/NULL/ and not an empty string, it is printed followed by
 a colon and a blank. Then the error message for the current contents of
 <tt/_oserror/ are printed followed by a newline. The message output is the
@@ -5856,7 +5856,7 @@ be used in presence of a prototype.
 </itemize>
 <tag/Availability/ISO 9899
 <tag/See also/
-<ref id="_poserror" name="_poserror">,
+<ref id="__poserror" name="__poserror">,
 <ref id="strerror" name="strerror">
 <tag/Example/None.
 </descrip>

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -147,7 +147,7 @@ int __fastcall__ vfscanf (FILE* f, const char* format, __va_list ap);
 FILE* __fastcall__ fdopen (int fd, const char* mode);   /* Unix */
 int __fastcall__ fileno (FILE* f);                      /* Unix */
 #endif
-void __fastcall__ _poserror (const char* msg);          /* cc65 */
+void __fastcall__ __poserror (const char* msg);         /* cc65 */
 
 /* Masking macros for some functions */
 #define getc(f)         fgetc (f)               /* ANSI */

--- a/libsrc/common/_poserror.c
+++ b/libsrc/common/_poserror.c
@@ -1,6 +1,6 @@
 /*****************************************************************************/
 /*                                                                           */
-/*                                _poserror.c                                */
+/*                               __poserror.c                                */
 /*                                                                           */
 /*                   Output a system dependent error code                    */
 /*                                                                           */
@@ -39,7 +39,7 @@
 
 
 
-void __fastcall__ _poserror (const char* msg)
+void __fastcall__ __poserror (const char* msg)
 {
     /* Fetch the message that corresponds to _oserror */
     const char* errormsg = _stroserror (_oserror);

--- a/libsrc/geos-common/common/_poserror.c
+++ b/libsrc/geos-common/common/_poserror.c
@@ -1,5 +1,5 @@
 /*
-** _poserror.c
+** __poserror.c
 **
 ** Maciej 'YTM/Elysium' Witkowiak, 25.04.2003
 */
@@ -9,7 +9,7 @@
 #include <errno.h>
 #include <geos.h>
 
-void __fastcall__ _poserror (const char* msg)
+void __fastcall__ __poserror (const char* msg)
 {
     const char *errmsg = _stroserror(_oserror);
 

--- a/samples/geos/overlay-demo.c
+++ b/samples/geos/overlay-demo.c
@@ -65,7 +65,7 @@ void foobar (void)
 void main(int /*argc*/, char *argv[])
 {
     if (OpenRecordFile(argv[0])) {
-        _poserror("OpenRecordFile");
+        __poserror("OpenRecordFile");
         return;
     }
 
@@ -73,7 +73,7 @@ void main(int /*argc*/, char *argv[])
              "Click OK to call Overlay One.");
 
     if (PointRecord(1)) {
-        _poserror("PointRecord.1");
+        __poserror("PointRecord.1");
         return;
     }
 
@@ -82,7 +82,7 @@ void main(int /*argc*/, char *argv[])
     ** size specific to a certain program.
     */
     if (ReadRecord(OVERLAY_ADDR, OVERLAY_SIZE)) {
-        _poserror("ReadRecord.1");
+        __poserror("ReadRecord.1");
         return;
     }
 
@@ -96,7 +96,7 @@ void main(int /*argc*/, char *argv[])
              "Click OK to call Overlay Two.");
 
     if (PointRecord(2)) {
-        _poserror("PointRecord.2");
+        __poserror("PointRecord.2");
         return;
     }
 
@@ -104,7 +104,7 @@ void main(int /*argc*/, char *argv[])
     ** program. This implies that an overlay can never load another overlay.
     */
     if (ReadRecord(OVERLAY_ADDR, OVERLAY_SIZE)) {
-        _poserror("ReadRecord.2");
+        __poserror("ReadRecord.2");
         return;
     }
 
@@ -114,19 +114,19 @@ void main(int /*argc*/, char *argv[])
              "Click OK to call Overlay Three.");
 
     if (PointRecord(3)) {
-        _poserror("PointRecord.3");
+        __poserror("PointRecord.3");
         return;
     }
 
     if (ReadRecord(OVERLAY_ADDR, OVERLAY_SIZE)) {
-        _poserror("ReadRecord.3");
+        __poserror("ReadRecord.3");
         return;
     }
 
     foobar();
 
     if (CloseRecordFile()) {
-        _poserror("CloseRecordFile");
+        __poserror("CloseRecordFile");
         return;
     }
 }

--- a/targettest/rename-test.c
+++ b/targettest/rename-test.c
@@ -58,7 +58,7 @@ int main(void)
     printf("Creating file: %s\n", name1);
     file = fopen(name1, "w");
     if (file == NULL) {
-        _poserror("Disk error making first file");
+        __poserror("Disk error making first file");
         return EXIT_FAILURE;
     }
     fclose(file);
@@ -66,7 +66,7 @@ int main(void)
     /* Verify that the file-name exists now. */
     file = fopen(name1, "r");
     if (file == NULL) {
-        _poserror("Cannot find first name");
+        __poserror("Cannot find first name");
         return EXIT_FAILURE;
     }
     fclose(file);
@@ -78,7 +78,7 @@ int main(void)
     printf("Renaming %s to %s\n", name1, name2);
     r = rename(name1, name2);
     if (r < 0) {
-        _poserror("rename() failed");
+        __poserror("rename() failed");
         return EXIT_FAILURE;
     }
 
@@ -86,14 +86,14 @@ int main(void)
     file = fopen(name1, "r");
     if (file != NULL) {
         fclose(file);
-        _poserror("First name still exists");
+        __poserror("First name still exists");
         return EXIT_FAILURE;
     }
 
     /* Verify that the second file-name exists now. */
     file = fopen(name2, "r");
     if (file == NULL) {
-        _poserror("Cannot find second name");
+        __poserror("Cannot find second name");
         return EXIT_FAILURE;
     }
     fclose(file);
@@ -104,7 +104,7 @@ int main(void)
     printf("Removing %s\n", name2);
     r = remove(name2);
     if (r < 0) {
-        _poserror("remove() failed");
+        __poserror("remove() failed");
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
The old name could be non-conforming to the C standard. The new name
is definitely in the "implementation name space".

See issue #1796.

I didn't add test because, honestly, IDK what to test here. Ok, maybe I could add a test for the case brought up on 1796. Will do that later.