### PR TITLE
[cc65] Fixed #pragma charmap for string literals

### DIFF
--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1263,6 +1263,8 @@ static void Primary (ExprDesc* E)
             /* String literal */
             if ((Flags & E_EVAL_UNEVAL) != E_EVAL_UNEVAL) {
                 E->V.LVal = UseLiteral (CurTok.SVal);
+                /* Translate into target charset */
+                TranslateLiteral (E->V.LVal);
             } else {
                 E->V.LVal = CurTok.SVal;
             }

--- a/src/cc65/litpool.c
+++ b/src/cc65/litpool.c
@@ -126,9 +126,6 @@ static void FreeLiteral (Literal* L)
 static void OutputLiteral (Literal* L)
 /* Output one literal to the currently active data segment */
 {
-    /* Translate the literal into the target charset */
-    TranslateLiteral (L);
-
     /* Define the label for the literal */
     g_defliterallabel (L->Label);
 
@@ -386,9 +383,6 @@ static void OutputReadOnlyLiterals (Collection* Literals)
         if (L->RefCount == 0 || L->Output) {
             continue;
         }
-
-        /* Translate the literal into the target charset */
-        TranslateLiteral (L);
 
         /* Check if this literal is part of another one. Since the literals
         ** are sorted by size (larger ones first), it can only be part of a

--- a/test/val/bug1373.c
+++ b/test/val/bug1373.c
@@ -1,0 +1,54 @@
+
+/* #1373 - #pragma charmap works in unexpected ways */
+
+#include <stdio.h>
+#include <string.h>
+
+char res0[10];
+char res1[10];
+char res2[10];
+char res3[10];
+char res4[10];
+
+int err = 0;
+
+#pragma charmap(0x61, 0x44)
+#define STRING_A "abABa"
+
+extern char mappedA[10];
+
+#pragma charmap(0x61, 0x61)
+char notmappedA[10] = "abABa";
+
+void test(void);
+
+#pragma charmap(0x61, 0x42)
+int main(void)
+{
+    char mappedB[10] = STRING_A;
+    sprintf(res0, "abABa");      /* expected: BbABB */
+
+#pragma charmap(0x61, 0x61)
+    sprintf(res1, mappedA);      /* expected: CbABC */
+    sprintf(res2, STRING_A);     /* expected: abABa */
+    sprintf(res3, mappedB);      /* expected: BbABB */
+
+#pragma charmap(0x61, 0x43)
+    sprintf(res4, notmappedA);   /* expected: abABa */
+
+    test();
+
+    return err;
+}
+
+char mappedA[10] = "abABa";
+
+#pragma charmap(0x61, 0x61)
+void test(void)
+{
+    puts(res0); if (strcmp(res0, "BbABB") != 0) { puts("expected: BbABB"); err++; }
+    puts(res1); if (strcmp(res1, "CbABC") != 0) { puts("expected: CbABC"); err++; }
+    puts(res2); if (strcmp(res2, "abABa") != 0) { puts("expected: abABa"); err++; }
+    puts(res3); if (strcmp(res3, "BbABB") != 0) { puts("expected: BbABB"); err++; }
+    puts(res4); if (strcmp(res4, "abABa") != 0) { puts("expected: abABa"); err++; }
+}


### PR DESCRIPTION
Resolves #1373.
```c
#include <stdio.h>

#pragma charmap(0x61, 0x44)
#define STRING_A "abAB"

extern char mappedA[5];

#pragma charmap(0x61, 0x61)
char notmappedA[5] = "abAB";

#pragma charmap(0x61, 0x42)
int main(void)
{
    char mappedB[5] = STRING_A;
    puts("abAB");       /* expected: BbAB */

#pragma charmap(0x61, 0x61)
    puts(mappedA);      /* expected: CbAB */
    puts(STRING_A);     /* expected: abAB */
    puts(mappedB);      /* expected: BbAB */

#pragma charmap(0x61, 0x43)
    puts(notmappedA);   /* expected: abAB */

    return 0;
}

char mappedA[5] = "abAB";
```
Output:
```
BbAB
CbAB
abAB
BbAB
abAB
```