### PR TITLE
[Lib] Removed an extra colon from libsrc/dbg/dbg.c

### DIFF
--- a/libsrc/dbg/dbg.c
+++ b/libsrc/dbg/dbg.c
@@ -1063,7 +1063,7 @@ static char StackHandler (void)
                 break;
 
             case 'a':
-#ifdef CH_CURS_UP:
+#ifdef CH_CURS_UP
             case CH_CURS_UP:
 #endif
                 --StackAddr;


### PR DESCRIPTION
Found in https://github.com/cc65/cc65/runs/7487489823?check_suite_focus=true#step:8:19 with https://github.com/cc65/cc65/commit/355ee38c54d3a124a1f6643d4813b228ef478c94.