### PR TITLE
CX16 waitvsync uses Kernal API to retreive jiffies

### DIFF
--- a/libsrc/cx16/waitvsync.s
+++ b/libsrc/cx16/waitvsync.s
@@ -11,9 +11,9 @@
 
         .export         _waitvsync
         .importzp       tmp1
+        .import         RDTIM
 
 .proc _waitvsync: near
-      RDTIM = $FFDE  ; Kernal API for reading the jiffy timer
       jsr RDTIM
       sta tmp1
 keep_waiting:

--- a/libsrc/cx16/waitvsync.s
+++ b/libsrc/cx16/waitvsync.s
@@ -10,15 +10,15 @@
 ;
 
         .export         _waitvsync
+        .importzp       tmp1
 
 .proc _waitvsync: near
       RDTIM = $FFDE  ; Kernal API for reading the jiffy timer
       jsr RDTIM
-      sta lastjiffy
+      sta tmp1
 keep_waiting:
       jsr RDTIM
-      cmp #$FF       ; self-mod the value returned by RDTIM to save memory
-      lastjiffy=(*-1)
+      cmp tmp1
       beq keep_waiting
       rts
 .endproc


### PR DESCRIPTION
Since the Commander X16's Kernal is in continuous development, each new version may have different locations for internal Kernal symbols. As such, cbm.h's routine waitvsync() breaks with each new kernal update because the routine peeks into the Kernal's private variable space.

This patch updates the routine to utilize the published Kernal API which remains stable between updates per the Commander X16 dev team.