### PR TITLE
Make NULL conform to POSIX

### DIFF
--- a/include/stddef.h
+++ b/include/stddef.h
@@ -54,7 +54,7 @@ typedef unsigned size_t;
 
 /* NULL pointer */
 #ifndef _HAVE_NULL
-#define NULL    0
+#define NULL    ((void *) 0)
 #define _HAVE_NULL
 #endif
 


### PR DESCRIPTION
POSIX.1-2008 tightened the definition of NULL to be 0 cast to the
type 'void *'.

Defining NULL as 0 is problematic, because it requires users to
cast NULL to a pointer type before passing it to variadic
functions.  Using POSIX's definition is safer, because NULL can be
used in all contexts without a cast, due to the alignment of
'void *' and 'char *' being the same.  It also helps the compiler
be able to detect when NULL is being used in an integer context.

Link: <http://ewontfix.com/11/>
Signed-off-by: Alejandro Colomar <alx.manpages@gmail.com>