### PR TITLE
Fixed YM2151 struct to match HW behavior

### DIFF
--- a/asminc/cx16.inc
+++ b/asminc/cx16.inc
@@ -538,11 +538,11 @@ NMIVec          := $0318
 ; YM2151 audio chip
 .struct YM2151
                 .org    $9F40
-  .union
-  STATUS        .byte
   ADDR          .byte
-  .endunion
+  .union
   DATA          .byte
+  STATUS        .byte
+  .endunion
 .endstruct
 
 ; X16 Emulator device

--- a/include/cx16.h
+++ b/include/cx16.h
@@ -285,11 +285,11 @@ struct __vera {
 
 /* Audio chip */
 struct __ym2151 {
+    unsigned char       reg;            /* Register number for data */
     union {
-        unsigned char   reg;            /* Register number for data */
+        unsigned char   data;
         unsigned char   status;         /* Busy flag */
     };
-    unsigned char       data;
 };
 #define YM2151  (*(volatile struct __ym2151 *)0x9F40)
 


### PR DESCRIPTION
Fixes #1827

Tested to ensure that code using these symbols compiles and behaves properly against Box16 (which implements the busy flag in emulation) and against x16emu which does not. The test code behaved on both systems as expected vs their known behaviors vs. real YM2151 hardware.