### PR TITLE
[cc65] Fixed superfluous warning on pointer types comparing a non-void pointer to a void pointer.

### DIFF
--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -2340,7 +2340,7 @@ static void hie_compare (const GenDesc* Ops,    /* List of generators */
         } else if (IsClassPtr (Expr->Type)) {
             if (IsClassPtr (Expr2.Type)) {
                 /* Pointers are allowed in comparison */
-                if (TypeCmp (Expr->Type, Expr2.Type).C < TC_STRICT_COMPATIBLE) {
+                if (TypeCmp (Expr->Type, Expr2.Type).C < TC_VOID_PTR) {
                     /* Warn about distinct pointer types */
                     TypeCompatibilityDiagnostic (PtrConversion (Expr->Type), PtrConversion (Expr2.Type), 0,
                         "Distinct pointer types comparing '%s' with '%s'");


### PR DESCRIPTION
This fixes the pointer comparison issue in #1826.