### PR TITLE
Don't hide errors in error handling

### DIFF
--- a/libsrc/tgi/tgi_unload.s
+++ b/libsrc/tgi/tgi_unload.s
@@ -29,6 +29,6 @@ _tgi_unload:
         jmp     _mod_free               ; Free the driver
 
 no_driver:
-        lda     #<TGI_ERR_NO_DRIVER
+        lda     #TGI_ERR_NO_DRIVER
         sta     _tgi_error
         rts


### PR DESCRIPTION
You don't want the low byte, see `grep _ERR_ libsrc/tgi/*`.