### PR TITLE
[cc65] Improved preprocessor

### DIFF
--- a/src/cc65/input.h
+++ b/src/cc65/input.h
@@ -70,6 +70,8 @@ extern StrBuf* Line;
 extern char CurC;
 extern char NextC;
 
+typedef struct Collection Collection;
+
 
 
 /*****************************************************************************/
@@ -94,6 +96,14 @@ void NextChar (void);
 ** valid. If end of line is reached, both are set to NUL, no more lines
 ** are read by this function.
 */
+
+Collection* UseInputStack (Collection* InputStack);
+/* Use the provided input stack for incoming input. Return the previously used
+** InputStack.
+*/
+
+void PushLine (StrBuf* L);
+/* Save the current input line and use a new one */
 
 void ClearLine (void);
 /* Clear the current input line */

--- a/src/cc65/macrotab.c
+++ b/src/cc65/macrotab.c
@@ -74,19 +74,17 @@ Macro* NewMacro (const char* Name)
 */
 {
     /* Get the length of the macro name */
-    unsigned Len = strlen(Name);
+    unsigned Len = strlen (Name);
 
     /* Allocate the structure */
     Macro* M = (Macro*) xmalloc (sizeof(Macro) + Len);
 
     /* Initialize the data */
-    M->Next        = 0;
-    M->Expanding   = 0;
-    M->ArgCount    = -1;        /* Flag: Not a function like macro */
-    M->MaxArgs     = 0;
-    InitCollection (&M->FormalArgs);
+    M->Next         = 0;
+    M->ParamCount   = -1;        /* Flag: Not a function-like macro */
+    InitCollection (&M->Params);
     SB_Init (&M->Replacement);
-    M->Variadic    = 0;
+    M->Variadic     = 0;
     memcpy (M->Name, Name, Len+1);
 
     /* Return the new macro */
@@ -102,10 +100,10 @@ void FreeMacro (Macro* M)
 {
     unsigned I;
 
-    for (I = 0; I < CollCount (&M->FormalArgs); ++I) {
-        xfree (CollAtUnchecked (&M->FormalArgs, I));
+    for (I = 0; I < CollCount (&M->Params); ++I) {
+        xfree (CollAtUnchecked (&M->Params, I));
     }
-    DoneCollection (&M->FormalArgs);
+    DoneCollection (&M->Params);
     SB_Done (&M->Replacement);
     xfree (M);
 }
@@ -121,12 +119,12 @@ Macro* CloneMacro (const Macro* M)
     Macro* New = NewMacro (M->Name);
     unsigned I;
 
-    for (I = 0; I < CollCount (&M->FormalArgs); ++I) {
-        /* Copy the argument */
-        const char* Arg = CollAtUnchecked (&M->FormalArgs, I);
-        CollAppend (&New->FormalArgs, xstrdup (Arg));
+    for (I = 0; I < CollCount (&M->Params); ++I) {
+        /* Copy the parameter */
+        const char* Param = CollAtUnchecked (&M->Params, I);
+        CollAppend (&New->Params, xstrdup (Param));
     }
-    New->ArgCount = M->ArgCount;
+    New->ParamCount = M->ParamCount;
     New->Variadic = M->Variadic;
     SB_Copy (&New->Replacement, &M->Replacement);
 
@@ -265,14 +263,14 @@ Macro* FindMacro (const char* Name)
 
 
 
-int FindMacroArg (Macro* M, const char* Arg)
-/* Search for a formal macro argument. If found, return the index of the
-** argument. If the argument was not found, return -1.
+int FindMacroParam (const Macro* M, const char* Param)
+/* Search for a macro parameter. If found, return the index of the parameter.
+** If the parameter was not found, return -1.
 */
 {
     unsigned I;
-    for (I = 0; I < CollCount (&M->FormalArgs); ++I) {
-        if (strcmp (CollAtUnchecked (&M->FormalArgs, I), Arg) == 0) {
+    for (I = 0; I < CollCount (&M->Params); ++I) {
+        if (strcmp (CollAtUnchecked (&M->Params, I), Param) == 0) {
             /* Found */
             return I;
         }
@@ -284,25 +282,25 @@ int FindMacroArg (Macro* M, const char* Arg)
 
 
 
-void AddMacroArg (Macro* M, const char* Arg)
-/* Add a formal macro argument. */
+void AddMacroParam (Macro* M, const char* Param)
+/* Add a macro parameter. */
 {
-    /* Check if we have a duplicate macro argument, but add it anyway.
-    ** Beware: Don't use FindMacroArg here, since the actual argument array
+    /* Check if we have a duplicate macro parameter, but add it anyway.
+    ** Beware: Don't use FindMacroParam here, since the actual argument array
     ** may not be initialized.
     */
     unsigned I;
-    for (I = 0; I < CollCount (&M->FormalArgs); ++I) {
-        if (strcmp (CollAtUnchecked (&M->FormalArgs, I), Arg) == 0) {
+    for (I = 0; I < CollCount (&M->Params); ++I) {
+        if (strcmp (CollAtUnchecked (&M->Params, I), Param) == 0) {
             /* Found */
-            PPError ("Duplicate macro parameter: '%s'", Arg);
+            PPError ("Duplicate macro parameter: '%s'", Param);
             break;
         }
     }
 
-    /* Add the new argument */
-    CollAppend (&M->FormalArgs, xstrdup (Arg));
-    ++M->ArgCount;
+    /* Add the new parameter */
+    CollAppend (&M->Params, xstrdup (Param));
+    ++M->ParamCount;
 }
 
 
@@ -313,14 +311,14 @@ int MacroCmp (const Macro* M1, const Macro* M2)
     int I;
 
     /* Argument count must be identical */
-    if (M1->ArgCount != M2->ArgCount) {
+    if (M1->ParamCount != M2->ParamCount) {
         return 1;
     }
 
-    /* Compare the arguments */
-    for (I = 0; I < M1->ArgCount; ++I) {
-        if (strcmp (CollConstAt (&M1->FormalArgs, I),
-                    CollConstAt (&M2->FormalArgs, I)) != 0) {
+    /* Compare the parameters */
+    for (I = 0; I < M1->ParamCount; ++I) {
+        if (strcmp (CollConstAt (&M1->Params, I),
+                    CollConstAt (&M2->Params, I)) != 0) {
             return 1;
         }
     }

--- a/src/cc65/macrotab.h
+++ b/src/cc65/macrotab.h
@@ -55,10 +55,8 @@
 typedef struct Macro Macro;
 struct Macro {
     Macro*        Next;         /* Next macro with same hash value */
-    int           Expanding;    /* Are we currently expanding this macro? */
-    int           ArgCount;     /* Number of parameters, -1 = no parens */
-    unsigned      MaxArgs;      /* Size of formal argument list */
-    Collection    FormalArgs;   /* Formal argument list (char*) */
+    int           ParamCount;   /* Number of parameters, -1 = no parens */
+    Collection    Params;       /* Parameter list (char*) */
     StrBuf        Replacement;  /* Replacement text */
     unsigned char Variadic;     /* C99 variadic macro */
     char          Name[1];      /* Name, dynamically allocated */
@@ -120,13 +118,13 @@ INLINE int IsMacro (const char* Name)
 #  define IsMacro(Name)         (FindMacro (Name) != 0)
 #endif
 
-int FindMacroArg (Macro* M, const char* Arg);
-/* Search for a formal macro argument. If found, return the index of the
-** argument. If the argument was not found, return -1.
+int FindMacroParam (const Macro* M, const char* Param);
+/* Search for a macro parameter. If found, return the index of the parameter.
+** If the parameter was not found, return -1.
 */
 
-void AddMacroArg (Macro* M, const char* Arg);
-/* Add a formal macro argument. */
+void AddMacroParam (Macro* M, const char* Param);
+/* Add a macro parameter. */
 
 int MacroCmp (const Macro* M1, const Macro* M2);
 /* Compare two macros and return zero if both are identical. */

--- a/src/cc65/preproc.c
+++ b/src/cc65/preproc.c
@@ -3025,6 +3025,7 @@ static int ParseDirectives (unsigned ModeFlags)
                         if (!PPSkip) {
                             if ((ModeFlags & MSM_IN_ARG_LIST) == 0) {
                                 DoPragma ();
+                                return Whitespace;
                             } else {
                                 PPError ("Embedded #pragma directive within macro arguments is unsupported");
                             }
@@ -3153,16 +3154,12 @@ static void PreprocessDirective (StrBuf* Source, StrBuf* Target, unsigned ModeFl
 ** whitespace and comments, then do macro replacement.
 */
 {
-    int         OldIndex = SB_GetIndex (Source);
     MacroExp    E;
 
     SkipWhitespace (0);
     InitMacroExp (&E);
     ReplaceMacros (Source, Target, &E, ModeFlags | MSM_IN_DIRECTIVE);
     DoneMacroExp (&E);
-
-    /* Restore the source input index */
-    SB_SetIndex (Source, OldIndex);
 }
 
 
@@ -3186,7 +3183,9 @@ void Preprocess (void)
     AddPreLine (PLine);
 
     /* Add leading whitespace to prettify preprocessor output */
-    AppendIndent (PLine, SB_GetIndex (Line));
+    if (CurC != '\0') {
+        AppendIndent (PLine, SB_GetIndex (Line));
+    }
 
     /* Expand macros if any */
     InitMacroExp (&E);

--- a/src/cc65/scanner.c
+++ b/src/cc65/scanner.c
@@ -235,10 +235,20 @@ void SymName (char* S)
 
 
 
+int IsWideQuoted (char First, char Second)
+/* Return 1 if the two successive characters indicate a wide string literal or
+** a wide char constant, otherwise return 0.
+*/
+{
+    return First == 'L' && IsQuote(Second);
+}
+
+
+
 int IsSym (char* S)
 /* If a symbol follows, read it and return 1, otherwise return 0 */
 {
-    if (IsIdent (CurC)) {
+    if (IsIdent (CurC) && !IsWideQuoted (CurC, NextC)) {
         SymName (S);
         return 1;
     } else {

--- a/src/cc65/scanner.h
+++ b/src/cc65/scanner.h
@@ -282,6 +282,11 @@ void SymName (char* S);
 ** least of size MAX_IDENTLEN+1.
 */
 
+int IsWideQuoted (char First, char Second);
+/* Return 1 if the two successive characters indicate a wide string literal or
+** a wide char constant, otherwise return 0.
+*/
+
 int IsSym (char* S);
 /* If a symbol follows, read it and return 1, otherwise return 0 */
 


### PR DESCRIPTION
I was originally planning for a real token-based PP parser, but that would require a lot of changes. So I came up with this `StrBuf`-based version.

Example code from #1787 compiled with `-E`:
```c
#define x       3
#define f(a)    f(x * (a))
#undef  x
#define x       2
#define g       f
#define z       z[0]
#define h       g(~
#define m(a)    a(w)
#define w       0,1
#define t(a)    a
#define p()     int
#define q(x)    x
#define r(x,y)  x ## y
#define str(x)  # x

f(y+1) + f(f(z)) % t(t(g) (0) + t)(1);
g(x+(3,4)-w) | h 5) & m(f)^m(m);
p() i[q()] = { q(1), r(2,3), r(4,), r(,5), r(,) };
char c[2][6] = { str(hello), str() };
```
Before:
```c
#line 1 "1787.c"
#line 16 "1787.c"
f(2 * (y+1)) + f(2 * (f(2 * (z[0][0][0])))) % f(2 * (0)) + t(1);
f(2+(3,4)-0,1) | f(~ 5) & f(2 * (0,1))^m(0,1);
int i[] = { 1, 23, 4, 5, };
char c[2][6] = { "hello", "" };
```
After:
```c
#line 1 "1787.c"
#line 16 "1787.c"
f(2 * (y+1)) + f(2 * (f(2 * (z[0])))) % f(2 * (0)) + t(1);
f(2 * (2+(3,4)-0,1)) | f(2 * (~ 5)) & f(2 * (0,1))^m(0,1);
int i[] = { 1, 23, 4, 5, };
char c[2][6] = { "hello", "" };
```