### PR TITLE
[cc65] Fixed symbol visibility and usage problems with extern/static declarations

### DIFF
--- a/src/cc65/locals.c
+++ b/src/cc65/locals.c
@@ -465,8 +465,8 @@ static void ParseOneDecl (const DeclSpec* Spec)
         /* The default storage class could be wrong. Just clear them */
         Decl.StorageClass &= ~SC_STORAGEMASK;
 
-        /* This is always a declaration */
-        Decl.StorageClass |= SC_DECL;
+        /* This is always an extern declaration */
+        Decl.StorageClass |= SC_DECL | SC_EXTERN;
     }
 
     /* If we don't have a name, this was flagged as an error earlier.
@@ -524,7 +524,9 @@ static void ParseOneDecl (const DeclSpec* Spec)
 
         if ((Decl.StorageClass & SC_EXTERN) == SC_EXTERN ||
             (Decl.StorageClass & SC_FUNC) == SC_FUNC) {
-            /* Add the global symbol to the local symbol table */
+            /* Add the global symbol to both of the global and local symbol
+            ** tables.
+            */
             AddGlobalSym (Decl.Ident, Decl.Type, Decl.StorageClass);
         } else {
             /* Add the local symbol to the local symbol table */

--- a/src/cc65/symentry.h
+++ b/src/cc65/symentry.h
@@ -105,8 +105,8 @@ struct CodeEntry;
 #define SC_SPADJUSTMENT 0x400000U
 #define SC_GOTO_IND     0x800000U       /* Indirect goto */
 
-#define SC_ALIAS        0x01000000U     /* Alias of anonymous field */
-#define SC_FICTITIOUS   0x02000000U     /* Symbol is fictitious */
+#define SC_ALIAS        0x01000000U     /* Alias of global or anonymous field */
+#define SC_FICTITIOUS   0x02000000U     /* Symbol is fictitious (for error recovery) */
 #define SC_HAVEFAM      0x04000000U     /* Type has a Flexible Array Member */
 
 

--- a/test/val/extern.c
+++ b/test/val/extern.c
@@ -1,0 +1,31 @@
+/* Test for shadowing and linkage of file-scope "static" and block-scope "extern" declarations */
+
+static int g(int x);            /* Generated functions with internal linkage are not always kept in cc65 */
+
+int main(void)
+{
+    char f = 'f';               /* Shadows global "int f(void)" (if any) */
+    char c = 'c';               /* Shadows global "int c" (if any) */
+    {
+        void* f = 0;            /* Shadows local  "char f" */
+        void* c = 0;            /* Shadows local  "char c" */
+        {
+            int f(void);        /* Shadows local  "char f" and "void* f" */
+            extern int g(int);  /* Shadows global "int g(int x)" */
+            extern int c;       /* Shadows local  "char c" and "void* c" */
+            return f() ^ g(c);  /* Link to global "int g(int x)" */
+        }
+    }
+}
+
+int c = 42;
+
+int f(void)
+{
+    return 42;
+}
+
+int g(int x)
+{
+    return x;
+}


### PR DESCRIPTION
- [X] Fixed block-scope `extern` declarations visibility:
```c
int c = 1;
int main(void)
{
    void* c = 0;
    {
        extern int c;   /* BUG: Conflicting types for 'c' */
        return c - 1;   /* BUG: Converting pointer to integer without a cast */
    }
}
```
- [X] Fixed missing file-scope `static` function codegen output in a rare care:
```c
static void f(void) {}  /* Generated functions with internal linkage are not always kept in cc65 */
int main(void)
{
    void f(void);       /* Function with internal linkage declared in block scope */
    f();                /* BUG: Unresolved external to _f in ld65 */
}
```