### PR TITLE
[cc65] Diagnostics improvements

### DIFF
--- a/src/cc65/error.h
+++ b/src/cc65/error.h
@@ -92,7 +92,7 @@ void Fatal (const char* Format, ...) attribute ((noreturn, format (printf, 1, 2)
 /* Print a message about a fatal error and die */
 
 void Internal (const char* Format, ...) attribute ((noreturn, format (printf, 1, 2)));
-/* Print a message about an internal compiler error and die. */
+/* Print a message about an internal compiler error and die */
 
 void Error (const char* Format, ...) attribute ((format (printf, 1, 2)));
 /* Print an error message */
@@ -101,16 +101,16 @@ void LIError (const LineInfo* LI, const char* Format, ...) attribute ((format (p
 /* Print an error message with the line info given explicitly */
 
 void PPError (const char* Format, ...) attribute ((format (printf, 1, 2)));
-/* Print an error message. For use within the preprocessor.  */
+/* Print an error message. For use within the preprocessor */
 
 void Warning (const char* Format, ...) attribute ((format (printf, 1, 2)));
-/* Print warning message. */
+/* Print a warning message */
 
 void LIWarning (const LineInfo* LI, const char* Format, ...) attribute ((format (printf, 2, 3)));
 /* Print a warning message with the line info given explicitly */
 
 void PPWarning (const char* Format, ...) attribute ((format (printf, 1, 2)));
-/* Print warning message. For use within the preprocessor. */
+/* Print a warning message. For use within the preprocessor */
 
 IntStack* FindWarning (const char* Name);
 /* Search for a warning in the WarnMap table and return a pointer to the
@@ -119,6 +119,15 @@ IntStack* FindWarning (const char* Name);
 
 void ListWarnings (FILE* F);
 /* Print a list of warning types/names to the given file */
+
+void Note (const char* Format, ...) attribute ((format (printf, 1, 2)));
+/* Print a note message */
+
+void LINote (const LineInfo* LI, const char* Format, ...) attribute ((format (printf, 2, 3)));
+/* Print a note message with the line info given explicitly */
+
+void PPNote (const char* Format, ...) attribute ((format (printf, 1, 2)));
+/* Print a note message. For use within the preprocessor */
 
 void ErrorReport (void);
 /* Report errors (called at end of compile) */

--- a/src/cc65/global.c
+++ b/src/cc65/global.c
@@ -49,6 +49,7 @@ unsigned char DebugInfo         = 0;    /* Add debug info to the obj */
 unsigned char PreprocessOnly    = 0;    /* Just preprocess the input */
 unsigned char DebugOptOutput    = 0;    /* Output debug stuff */
 unsigned      RegisterSpace     = 6;    /* Space available for register vars */
+unsigned      AllowNewComments  = 0;    /* Allow new style comments in C89 mode */
 
 /* Stackable options */
 IntStack WritableStrings    = INTSTACK(0);  /* Literal strings are r/w */

--- a/src/cc65/global.h
+++ b/src/cc65/global.h
@@ -57,6 +57,7 @@ extern unsigned char    DebugInfo;              /* Add debug info to the obj */
 extern unsigned char    PreprocessOnly;         /* Just preprocess the input */
 extern unsigned char    DebugOptOutput;         /* Output debug stuff */
 extern unsigned         RegisterSpace;          /* Space available for register vars */
+extern unsigned         AllowNewComments;       /* Allow new style comments in C89 mode */
 
 /* Stackable options */
 extern IntStack         WritableStrings;        /* Literal strings are r/w */

--- a/src/cc65/pragma.c
+++ b/src/cc65/pragma.c
@@ -784,7 +784,7 @@ static void IntPragma (StrBuf* B, IntStack* Stack, long Low, long High)
 
 static void MakeMessage (const char* Message)
 {
-    fprintf (stderr, "%s:%u: Note: %s\n", GetInputName (CurTok.LI), GetInputLine (CurTok.LI), Message);
+    Note ("%s", Message);
 }
 
 

--- a/src/cc65/preproc.c
+++ b/src/cc65/preproc.c
@@ -402,8 +402,10 @@ static void NewStyleComment (void)
 /* Remove a new style C comment from line. */
 {
     /* Diagnose if this is unsupported */
-    if (IS_Get (&Standard) < STD_C99) {
+    if (IS_Get (&Standard) < STD_C99 && !AllowNewComments) {
         PPError ("C++ style comments are not allowed in C89");
+        PPNote ("(this will be reported only once per input file)");
+        AllowNewComments = 1;
     }
 
     /* Beware: Because line continuation chars are handled when reading
@@ -1800,6 +1802,9 @@ void PreprocessBegin (void)
 
     /* Remember to update source file location in preprocess-only mode */
     FileChanged = 1;
+
+    /* Enable diagnostics on new style comments in C89 mode */
+    AllowNewComments = 0;
 }
 
 

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -702,6 +702,7 @@ static int HandleSymRedefinition (SymEntry* Entry, const Type* T, unsigned Flags
         if (SCType == SC_TYPEDEF) {
             if (IsDistinctRedef (E_Type, T, TC_IDENTICAL, TCF_MASK_QUAL)) {
                 Error ("Conflicting types for typedef '%s'", Entry->Name);
+                Note ("'%s' vs '%s'", GetFullTypeName (T), GetFullTypeName (E_Type));
                 Entry = 0;
             }
         } else {
@@ -728,7 +729,7 @@ static int HandleSymRedefinition (SymEntry* Entry, const Type* T, unsigned Flags
                 /* New type must be compatible with the composite prototype */
                 if (IsDistinctRedef (E_Type, T, TC_EQUAL, TCF_MASK_QUAL)) {
                     Error ("Conflicting function types for '%s'", Entry->Name);
-                    TypeCompatibilityDiagnostic (T, E_Type, 0, "'%s' vs '%s'");
+                    Note ("'%s' vs '%s'", GetFullTypeName (T), GetFullTypeName (E_Type));
                     Entry = 0;
                 } else {
                     /* Refine the existing composite prototype with this new
@@ -760,6 +761,7 @@ static int HandleSymRedefinition (SymEntry* Entry, const Type* T, unsigned Flags
                 IsDistinctRedef (E_Type + 1, T + 1, TC_IDENTICAL, TCF_MASK_QUAL)) {
                 /* Conflicting element types */
                 Error ("Conflicting array types for '%s[]'", Entry->Name);
+                Note ("'%s' vs '%s'", GetFullTypeName (T), GetFullTypeName (E_Type));
                 Entry = 0;
             } else {
                 /* Check if we have a size in the existing definition */
@@ -777,6 +779,7 @@ static int HandleSymRedefinition (SymEntry* Entry, const Type* T, unsigned Flags
                 Entry = 0;
             } else if (IsDistinctRedef (E_Type, T, TC_EQUAL, TCF_MASK_QUAL)) {
                 Error ("Conflicting types for '%s'", Entry->Name);
+                Note ("'%s' vs '%s'", GetFullTypeName (T), GetFullTypeName (E_Type));
                 Entry = 0;
             } else if (E_SCType == SC_ENUMERATOR) {
                 /* Enumerators aren't allowed to be redeclared at all, even if


### PR DESCRIPTION
- [x] Added a "note" diagnostic message type that just provides some info in detail of errors/warnings.
- [x] Improved diagnostic info (with the new "note" messages) on conflicted `typedef`s.
- [x] C++-style comments only causes 1 error per input file in C89 mode.