### PR TITLE
[cc65] Fixed and improved C preprocessor

### DIFF
--- a/src/cc65/input.h
+++ b/src/cc65/input.h
@@ -105,6 +105,9 @@ Collection* UseInputStack (Collection* InputStack);
 void PushLine (StrBuf* L);
 /* Save the current input line and use a new one */
 
+void ReuseInputLine (void);
+/* Save and reuse the current line as the next line */
+
 void ClearLine (void);
 /* Clear the current input line */
 

--- a/src/cc65/preproc.c
+++ b/src/cc65/preproc.c
@@ -2216,6 +2216,13 @@ static unsigned ReplaceMacros (StrBuf* Source, StrBuf* Target, MacroExp* E, unsi
                         InitLine (TmpTarget);
                         PushRescanLine (CurRescanStack, TmpTarget, LastTokLen);
 
+                        /* Add a space before a '#' at the beginning of the line */
+                        if (CurC  == '#' &&
+                            NextC != '#' &&
+                            (SB_IsEmpty (Target) || SB_LookAtLast (Target) == '\n')) {
+                            SB_AppendChar (Target, ' ');
+                        }
+
                         /* Switch the buffers */
                         TmpTarget = NewStrBuf ();
                     } else if (PendingNewLines > 0 && MultiLine) {

--- a/src/cc65/preproc.c
+++ b/src/cc65/preproc.c
@@ -878,7 +878,7 @@ static void Stringize (StrBuf* Source, StrBuf* Target)
 
 
 static void OldStyleComment (void)
-/* Remove an old style C comment from line. */
+/* Remove an old style C comment from line */
 {
     /* Remember the current line number, so we can output better error
     ** messages if the comment is not terminated in the current file.
@@ -897,6 +897,7 @@ static void OldStyleComment (void)
                          StartingLine);
                 return;
             }
+            ++PendingNewLines;
         } else {
             if (CurC == '/' && NextC == '*') {
                 PPWarning ("'/*' found inside a comment");
@@ -913,7 +914,7 @@ static void OldStyleComment (void)
 
 
 static void NewStyleComment (void)
-/* Remove a new style C comment from line. */
+/* Remove a new style C comment from line */
 {
     /* Diagnose if this is unsupported */
     if (IS_Get (&Standard) < STD_C99) {


### PR DESCRIPTION
- [x] Fixed check on improper `__VA_ARGS__` usage.
- [x] Improved diagnostics on wrong number of arguments in function-like macro calls.
- [x] Fixed some spacing problems with `-E`.
- - [x] Fixed line number output with `-E` when multiline comments are involved.