### PR TITLE
Emit warning for signed integer constant overflow

### DIFF
--- a/src/cc65/expr.h
+++ b/src/cc65/expr.h
@@ -59,7 +59,7 @@ void MarkedExprWithCheck (void (*Func) (ExprDesc*), ExprDesc* Expr);
 ** generated code.
 */
 
-void LimitExprValue (ExprDesc* Expr);
+void LimitExprValue (ExprDesc* Expr, int WarnOverflow);
 /* Limit the constant value of the expression to the range of its type */
 
 void PushAddr (const ExprDesc* Expr);

--- a/src/cc65/shiftexpr.c
+++ b/src/cc65/shiftexpr.c
@@ -173,7 +173,7 @@ void ShiftExpr (struct ExprDesc* Expr)
                     }
 
                     /* Limit the calculated value to the range of its type */
-                    LimitExprValue (Expr);
+                    LimitExprValue (Expr, 1);
                 }
 
                 /* Result is already got, remove the generated code */


### PR DESCRIPTION
This is for one of the issues I raised in #1875. This causes a warning for detectable signed overflow in constant expressions, which helps diagnose the resulting undefined behaviour. (This can be especially tricky in this 16-bit integer context.) Other compilers generally seem to have a warning like this.

Unsigned overflow warnings seemed possible too, but there are a few cases it raises in the library/tests that looked spurious/annoying to me. If desired it could also be added.