### PR TITLE
Rephrasing warnings for suspicious decimal integer constants

### DIFF
--- a/src/cc65/scanner.c
+++ b/src/cc65/scanner.c
@@ -643,7 +643,7 @@ static void NumericConst (void)
             if (IVal <= 0xFFFF              &&
                 (Types & IT_UINT) == 0      &&
                 (WarnTypes & IT_LONG) != 0) {
-                Warning ("Integer constant is long");
+                Warning ("Integer constant implies signed long");
             }
         }
         if (IVal > 0xFFFF) {
@@ -660,7 +660,7 @@ static void NumericConst (void)
             ** a preceding unary op or when it is used in constant calculation.
             */
             if (WarnTypes & IT_ULONG) {
-                Warning ("Integer constant is unsigned long");
+                Warning ("Integer constant implies unsigned long");
             }
         }
 


### PR DESCRIPTION
Rephrasing two warnings about integer constants.

I felt the existing warning implied that long or unsigned long integer constants were _themselves_ a bad thing, but they are in fact valid code and are properly handled by the compiler.

After understanding the intent of the warnings is to point out suspicious cases where the programmer _probably_ should have used a suffix (e.g. do you expect 65535 to be an unsigned int or a signed long?). I have reworded the two warnings in a way that I think makes this purpose clearer.

(Investigated during #1875.)