### PR TITLE
Speed up sim65 by 10%

### DIFF
--- a/src/sim65/memory.c
+++ b/src/sim65/memory.c
@@ -46,7 +46,7 @@
 
 
 /* THE memory */
-static unsigned char Mem[0x10000];
+unsigned char Mem[0x10000];
 
 
 
@@ -69,14 +69,6 @@ void MemWriteWord (unsigned Addr, unsigned Val)
 {
     MemWriteByte (Addr, Val & 0xFF);
     MemWriteByte (Addr + 1, Val >> 8);
-}
-
-
-
-unsigned char MemReadByte (unsigned Addr)
-/* Read a byte from a memory location */
-{
-    return Mem[Addr];
 }
 
 

--- a/src/sim65/memory.h
+++ b/src/sim65/memory.h
@@ -36,7 +36,9 @@
 #ifndef MEMORY_H
 #define MEMORY_H
 
+#include "inline.h"
 
+extern unsigned char Mem[0x10000];
 
 /*****************************************************************************/
 /*                                   Code                                    */
@@ -50,8 +52,15 @@ void MemWriteByte (unsigned Addr, unsigned char Val);
 void MemWriteWord (unsigned Addr, unsigned Val);
 /* Write a word to a memory location */
 
-unsigned char MemReadByte (unsigned Addr);
+#if defined(HAVE_INLINE)
+INLINE unsigned char MemReadByte (unsigned Addr)
 /* Read a byte from a memory location */
+{
+    return Mem[Addr];
+}
+#else
+#define MemReadByte(Addr) Mem[Addr]
+#endif
 
 unsigned MemReadWord (unsigned Addr);
 /* Read a word from a memory location */


### PR DESCRIPTION
Approx 40% of make test is spent in sim65. 10% of sim65 was spent in MemReadByte. Inline it for nice speed gains.

"make test" takes 10% less time after this, even though the expected increase was only 4%.