### PR TITLE
[cc65] SymEntry cleanups

### DIFF
--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -478,7 +478,7 @@ void Compile (const char* FileName)
         for (Entry = GetGlobalSymTab ()->SymHead; Entry; Entry = Entry->NextSym) {
             if ((Entry->Flags & (SC_STORAGE | SC_DEF | SC_STATIC)) == (SC_STORAGE | SC_STATIC)) {
                 /* Assembly definition of uninitialized global variable */
-                SymEntry* TagSym = GetSymType (Entry->Type);
+                SymEntry* TagSym = GetESUTagSym (Entry->Type);
                 unsigned Size = SizeOf (Entry->Type);
 
                 if (Size == 0 && IsTypeArray (Entry->Type)) {
@@ -489,7 +489,7 @@ void Compile (const char* FileName)
                         Warning ("Incomplete array '%s[]' assumed to have one element", Entry->Name);
                     }
 
-                    TagSym = GetSymType (GetElementType (Entry->Type));
+                    TagSym = GetESUTagSym (GetElementType (Entry->Type));
                 }
 
                 /* For non-ESU types, Size != 0 */

--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -79,7 +79,7 @@ static void Parse (void)
 /* Top level parser routine. */
 {
     int comma;
-    SymEntry* Entry;
+    SymEntry* Sym;
     FuncDesc* FuncDef = 0;
 
     /* Initialization for deferred operations */
@@ -142,7 +142,7 @@ static void Parse (void)
         }
 
         /* Read declarations for this type */
-        Entry = 0;
+        Sym = 0;
         comma = 0;
         while (1) {
 
@@ -196,10 +196,10 @@ static void Parse (void)
             }
 
             /* Add an entry to the symbol table */
-            Entry = AddGlobalSym (Decl.Ident, Decl.Type, Decl.StorageClass);
+            Sym = AddGlobalSym (Decl.Ident, Decl.Type, Decl.StorageClass);
 
             /* Add declaration attributes */
-            SymUseAttr (Entry, &Decl);
+            SymUseAttr (Sym, &Decl);
 
             /* Reserve storage for the variable if we need to */
             if (Decl.StorageClass & SC_STORAGE) {
@@ -211,11 +211,11 @@ static void Parse (void)
                 if (CurTok.Tok == TOK_ASSIGN) {
 
                     /* This is a definition with storage */
-                    if (SymIsDef (Entry)) {
+                    if (SymIsDef (Sym)) {
                         Error ("Global variable '%s' has already been defined",
-                               Entry->Name);
+                               Sym->Name);
                     }
-                    Entry->Flags |= SC_DEF;
+                    Sym->Flags |= SC_DEF;
 
                     /* We cannot initialize types of unknown size, or
                     ** void types in ISO modes.
@@ -245,21 +245,21 @@ static void Parse (void)
                     }
 
                     /* Define a label */
-                    g_defgloblabel (Entry->Name);
+                    g_defgloblabel (Sym->Name);
 
                     /* Skip the '=' */
                     NextToken ();
 
                     /* Parse the initialization */
-                    ParseInit (Entry->Type);
+                    ParseInit (Sym->Type);
                 } else {
 
                     /* This is a declaration */
                     if (IsTypeVoid (Decl.Type)) {
                         /* We cannot declare variables of type void */
                         Error ("Illegal type for variable '%s'", Decl.Ident);
-                        Entry->Flags &= ~(SC_STORAGE | SC_DEF);
-                    } else if (Size == 0 && SymIsDef (Entry) && !IsEmptiableObjectType (Decl.Type)) {
+                        Sym->Flags &= ~(SC_STORAGE | SC_DEF);
+                    } else if (Size == 0 && SymIsDef (Sym) && !IsEmptiableObjectType (Decl.Type)) {
                         /* Size is unknown. Is it an array? */
                         if (!IsTypeArray (Decl.Type)) {
                             Error ("Variable '%s' has unknown size", Decl.Ident);
@@ -286,11 +286,11 @@ static void Parse (void)
                         */
                         const char* bssName = GetSegName (SEG_BSS);
 
-                        if (Entry->V.BssName && strcmp (Entry->V.BssName, bssName) != 0) {
+                        if (Sym->V.BssName && strcmp (Sym->V.BssName, bssName) != 0) {
                             Error ("Global variable '%s' already was defined in the '%s' segment.",
-                                   Entry->Name, Entry->V.BssName);
+                                   Sym->Name, Sym->V.BssName);
                         }
-                        Entry->V.BssName = xstrdup (bssName);
+                        Sym->V.BssName = xstrdup (bssName);
 
                         /* This is to make the automatical zeropage setting of the symbol
                         ** work right.
@@ -300,9 +300,9 @@ static void Parse (void)
                 }
 
                 /* Make the symbol zeropage according to the segment address size */
-                if ((Entry->Flags & SC_STATIC) != 0) {
+                if ((Sym->Flags & SC_STATIC) != 0) {
                     if (GetSegAddrSize (GetSegName (CS->CurDSeg)) == ADDR_SIZE_ZP) {
-                        Entry->Flags |= SC_ZEROPAGE;
+                        Sym->Flags |= SC_ZEROPAGE;
                     }
                 }
 
@@ -318,7 +318,7 @@ static void Parse (void)
         }
 
         /* Function declaration? */
-        if (Entry && IsTypeFunc (Entry->Type)) {
+        if (Sym && IsTypeFunc (Sym->Type)) {
 
             /* Function */
             if (!comma) {
@@ -327,7 +327,7 @@ static void Parse (void)
                     NextToken ();
                 } else {
                     /* Parse the function body */
-                    NewFunc (Entry, FuncDef);
+                    NewFunc (Sym, FuncDef);
 
                     /* Make sure we aren't omitting any work */
                     CheckDeferredOpAllDone ();
@@ -478,8 +478,9 @@ void Compile (const char* FileName)
         for (Entry = GetGlobalSymTab ()->SymHead; Entry; Entry = Entry->NextSym) {
             if ((Entry->Flags & (SC_STORAGE | SC_DEF | SC_STATIC)) == (SC_STORAGE | SC_STATIC)) {
                 /* Assembly definition of uninitialized global variable */
-                SymEntry* Sym = GetSymType (Entry->Type);
+                SymEntry* TagSym = GetSymType (Entry->Type);
                 unsigned Size = SizeOf (Entry->Type);
+
                 if (Size == 0 && IsTypeArray (Entry->Type)) {
                     if (GetElementCount (Entry->Type) == UNSPECIFIED) {
                         /* Assume array size of 1 */
@@ -488,11 +489,11 @@ void Compile (const char* FileName)
                         Warning ("Incomplete array '%s[]' assumed to have one element", Entry->Name);
                     }
 
-                    Sym = GetSymType (GetElementType (Entry->Type));
+                    TagSym = GetSymType (GetElementType (Entry->Type));
                 }
 
                 /* For non-ESU types, Size != 0 */
-                if (Size != 0 || (Sym != 0 && SymIsDef (Sym))) {
+                if (Size != 0 || (TagSym != 0 && SymIsDef (TagSym))) {
                     /* Set the segment name only when it changes */
                     if (strcmp (GetSegName (SEG_BSS), Entry->V.BssName) != 0) {
                         SetSegName (SEG_BSS, Entry->V.BssName);

--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -1307,9 +1307,9 @@ int IsESUType (const Type* T)
 int IsIncompleteESUType (const Type* T)
 /* Return true if this is an incomplete ESU type */
 {
-    SymEntry* Sym = GetSymType (T);
+    SymEntry* TagSym = GetSymType (T);
 
-    return Sym != 0 && !SymIsDef (Sym);
+    return TagSym != 0 && !SymIsDef (TagSym);
 }
 
 

--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -48,6 +48,7 @@
 #include "fp.h"
 #include "funcdesc.h"
 #include "global.h"
+#include "ident.h"
 #include "symtab.h"
 
 
@@ -83,6 +84,83 @@ const Type type_c_void_p[]  = { TYPE(T_PTR),    TYPE(T_C_VOID), TYPE(T_END) };
 /*****************************************************************************/
 /*                                   Code                                    */
 /*****************************************************************************/
+
+
+
+const char* GetBasicTypeName (const Type* T)
+/* Return a const name string of the basic type.
+** Return "type" for unknown basic types.
+*/
+{
+    switch (GetRawType (T)) {
+    case T_TYPE_ENUM:       return "enum";
+    case T_TYPE_BITFIELD:   return "bit-field";
+    case T_TYPE_FLOAT:      return "float";
+    case T_TYPE_DOUBLE:     return "double";
+    case T_TYPE_VOID:       return "void";
+    case T_TYPE_STRUCT:     return "struct";
+    case T_TYPE_UNION:      return "union";
+    case T_TYPE_ARRAY:      return "array";
+    case T_TYPE_PTR:        return "pointer";
+    case T_TYPE_FUNC:       return "function";
+    case T_TYPE_NONE:       /* FALLTHROUGH */
+    default:                break;
+    }
+    if (IsClassInt (T)) {
+        if (IsRawSignSigned (T)) {
+            switch (GetRawType (T)) {
+            case T_TYPE_CHAR:       return "signed char";
+            case T_TYPE_SHORT:      return "short";
+            case T_TYPE_INT:        return "int";
+            case T_TYPE_LONG:       return "long";
+            case T_TYPE_LONGLONG:   return "long long";
+            default:
+                return "signed integer";
+            }
+        } else if (IsRawSignUnsigned (T)) {
+            switch (GetRawType (T)) {
+            case T_TYPE_CHAR:       return "unsigned char";
+            case T_TYPE_SHORT:      return "unsigned short";
+            case T_TYPE_INT:        return "unsigned int";
+            case T_TYPE_LONG:       return "unsigned long";
+            case T_TYPE_LONGLONG:   return "unsigned long long";
+            default:
+                return "unsigned integer";
+            }
+        } else {
+            switch (GetRawType (T)) {
+            case T_TYPE_CHAR:       return "char";
+            case T_TYPE_SHORT:      return "short";
+            case T_TYPE_INT:        return "int";
+            case T_TYPE_LONG:       return "long";
+            case T_TYPE_LONGLONG:   return "long long";
+            default:
+                return "integer";
+            }
+        }
+    }
+    return "type";
+}
+
+
+
+static const char* GetTagSymName (const Type* T)
+/* Return a name string of the type or the symbol name if it is an ESU type.
+** Note: This may use a static buffer that could be overwritten by other calls.
+*/
+{
+    static char TypeName [IDENTSIZE + 16];
+    SymEntry* TagSym;
+
+    TagSym = GetESUTagSym (T);
+    if (TagSym == 0) {
+        return GetBasicTypeName (T);
+    }
+    sprintf (TypeName, "%s %s", GetBasicTypeName (T),
+             TagSym->Name[0] != '\0' ? TagSym->Name : "<unknown>");
+
+    return TypeName;
+}
 
 
 
@@ -208,7 +286,7 @@ static struct StrBuf* GetFullTypeNameWestEast (struct StrBuf* West, struct StrBu
         }
 
         if (!IsTypeBitField (T)) {
-            SB_AppendStr (&Buf, GetSymTypeName (T));
+            SB_AppendStr (&Buf, GetTagSymName (T));
         } else {
             SB_AppendStr (&Buf, GetBasicTypeName (T + 1));
         }
@@ -224,63 +302,6 @@ static struct StrBuf* GetFullTypeNameWestEast (struct StrBuf* West, struct StrBu
 
     SB_Done (&Buf);
     return West;
-}
-
-
-
-const char* GetBasicTypeName (const Type* T)
-/* Return a const name string of the basic type.
-** Return "type" for unknown basic types.
-*/
-{
-    switch (GetRawType (T)) {
-    case T_TYPE_ENUM:       return "enum";
-    case T_TYPE_BITFIELD:   return "bit-field";
-    case T_TYPE_FLOAT:      return "float";
-    case T_TYPE_DOUBLE:     return "double";
-    case T_TYPE_VOID:       return "void";
-    case T_TYPE_STRUCT:     return "struct";
-    case T_TYPE_UNION:      return "union";
-    case T_TYPE_ARRAY:      return "array";
-    case T_TYPE_PTR:        return "pointer";
-    case T_TYPE_FUNC:       return "function";
-    case T_TYPE_NONE:       /* FALLTHROUGH */
-    default:                break;
-    }
-    if (IsClassInt (T)) {
-        if (IsRawSignSigned (T)) {
-            switch (GetRawType (T)) {
-            case T_TYPE_CHAR:       return "signed char";
-            case T_TYPE_SHORT:      return "short";
-            case T_TYPE_INT:        return "int";
-            case T_TYPE_LONG:       return "long";
-            case T_TYPE_LONGLONG:   return "long long";
-            default:
-                return "signed integer";
-            }
-        } else if (IsRawSignUnsigned (T)) {
-            switch (GetRawType (T)) {
-            case T_TYPE_CHAR:       return "unsigned char";
-            case T_TYPE_SHORT:      return "unsigned short";
-            case T_TYPE_INT:        return "unsigned int";
-            case T_TYPE_LONG:       return "unsigned long";
-            case T_TYPE_LONGLONG:   return "unsigned long long";
-            default:
-                return "unsigned integer";
-            }
-        } else {
-            switch (GetRawType (T)) {
-            case T_TYPE_CHAR:       return "char";
-            case T_TYPE_SHORT:      return "short";
-            case T_TYPE_INT:        return "int";
-            case T_TYPE_LONG:       return "long";
-            case T_TYPE_LONGLONG:   return "long long";
-            default:
-                return "integer";
-            }
-        }
-    }
-    return "type";
 }
 
 
@@ -1307,7 +1328,7 @@ int IsESUType (const Type* T)
 int IsIncompleteESUType (const Type* T)
 /* Return true if this is an incomplete ESU type */
 {
-    SymEntry* TagSym = GetSymType (T);
+    SymEntry* TagSym = GetESUTagSym (T);
 
     return TagSym != 0 && !SymIsDef (TagSym);
 }
@@ -1486,20 +1507,21 @@ const Type* GetBaseElementType (const Type* T)
 
 
 
-struct SymEntry* GetESUSymEntry (const Type* T)
-/* Return a SymEntry pointer from an enum/struct/union type */
+struct SymEntry* GetESUTagSym (const Type* T)
+/* Get the tag symbol entry of the enum/struct/union type.
+** Return 0 if it is not an enum/struct/union.
+*/
 {
-    /* Only enums, structs or unions have a SymEntry attribute */
-    CHECK (IsClassStruct (T) || IsTypeEnum (T));
-
-    /* Return the attribute */
-    return T->A.S;
+    if ((IsClassStruct (T) || IsTypeEnum (T))) {
+        return T->A.S;
+    }
+    return 0;
 }
 
 
 
-void SetESUSymEntry (Type* T, struct SymEntry* S)
-/* Set the SymEntry pointer for an enum/struct/union type */
+void SetESUTagSym (Type* T, struct SymEntry* S)
+/* Set the tag symbol entry of the enum/struct/union type */
 {
     /* Only enums, structs or unions have a SymEntry attribute */
     CHECK (IsClassStruct (T) || IsTypeEnum (T));
@@ -1570,7 +1592,7 @@ void PrintFuncSig (FILE* F, const char* Name, const Type* T)
         if (SymIsRegVar (Param)) {
             SB_AppendStr (&ParamList, "register ");
         }
-        if (!HasAnonName (Param)) {
+        if (!SymHasAnonName (Param)) {
             SB_AppendStr (&Buf, Param->Name);
         }
         SB_AppendStr (&ParamList, SB_GetConstBuf (GetFullTypeNameBuf (&Buf, Param->Type)));

--- a/src/cc65/datatype.h
+++ b/src/cc65/datatype.h
@@ -943,11 +943,13 @@ const Type* GetBaseElementType (const Type* T);
 ** the element type that is not an array.
 */
 
-struct SymEntry* GetESUSymEntry (const Type* T) attribute ((const));
-/* Return a SymEntry pointer from an enum/struct/union type */
+struct SymEntry* GetESUTagSym (const Type* T) attribute ((const));
+/* Get the tag symbol entry of the enum/struct/union type.
+** Return 0 if it is not an enum/struct/union.
+*/
 
-void SetESUSymEntry (Type* T, struct SymEntry* S);
-/* Set the SymEntry pointer for an enum/struct/union type */
+void SetESUTagSym (Type* T, struct SymEntry* S);
+/* Set the tag symbol entry of the enum/struct/union type */
 
 TypeCode AddrSizeQualifier (unsigned AddrSize);
 /* Return T_QUAL_NEAR or T_QUAL_FAR depending on the address size */

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -815,7 +815,7 @@ static unsigned AliasAnonStructFields (const Declaration* D, SymEntry* Anon)
     /* Get the symbol table containing the fields. If it is empty, there has
     ** been an error before, so bail out.
     */
-    SymTable* Tab = GetESUSymEntry (D->Type)->V.S.SymTab;
+    SymTable* Tab = GetESUTagSym (D->Type)->V.S.SymTab;
     if (Tab == 0) {
         /* Incomplete definition - has been flagged before */
         return 0;
@@ -951,7 +951,7 @@ static SymEntry* ParseUnionDecl (const char* Name, unsigned* DSFlags)
 
                 /* Check if the field itself has a flexible array member */
                 if (IsClassStruct (Decl.Type)) {
-                    SymEntry* TagEntry = GetSymType (Decl.Type);
+                    SymEntry* TagEntry = GetESUTagSym (Decl.Type);
                     if (TagEntry && SymHasFlexibleArrayMember (TagEntry)) {
                         Field->Flags |= SC_HAVEFAM;
                         Flags        |= SC_HAVEFAM;
@@ -1153,7 +1153,7 @@ static SymEntry* ParseStructDecl (const char* Name, unsigned* DSFlags)
 
                 /* Check if the field itself has a flexible array member */
                 if (IsClassStruct (Decl.Type)) {
-                    SymEntry* TagEntry = GetSymType (Decl.Type);
+                    SymEntry* TagEntry = GetESUTagSym (Decl.Type);
                     if (TagEntry && SymHasFlexibleArrayMember (TagEntry)) {
                         Field->Flags |= SC_HAVEFAM;
                         Flags        |= SC_HAVEFAM;
@@ -1385,7 +1385,7 @@ static void ParseTypeSpec (DeclSpec* D, long Default, TypeCode Qualifiers,
             TagEntry = ParseUnionDecl (Ident, &D->Flags);
             /* Encode the union entry into the type */
             D->Type[0].C = T_UNION;
-            SetESUSymEntry (D->Type, TagEntry);
+            SetESUTagSym (D->Type, TagEntry);
             D->Type[1].C = T_END;
             break;
 
@@ -1404,7 +1404,7 @@ static void ParseTypeSpec (DeclSpec* D, long Default, TypeCode Qualifiers,
             TagEntry = ParseStructDecl (Ident, &D->Flags);
             /* Encode the struct entry into the type */
             D->Type[0].C = T_STRUCT;
-            SetESUSymEntry (D->Type, TagEntry);
+            SetESUTagSym (D->Type, TagEntry);
             D->Type[1].C = T_END;
             break;
 
@@ -1427,7 +1427,7 @@ static void ParseTypeSpec (DeclSpec* D, long Default, TypeCode Qualifiers,
             TagEntry = ParseEnumDecl (Ident, &D->Flags);
             /* Encode the enum entry into the type */
             D->Type[0].C |= T_ENUM;
-            SetESUSymEntry (D->Type, TagEntry);
+            SetESUTagSym (D->Type, TagEntry);
             D->Type[1].C = T_END;
             /* The signedness of enums is determined by the type, so say this is specified to avoid
             ** the int -> unsigned int handling for plain int bit-fields in AddBitField.
@@ -1596,7 +1596,7 @@ static void ParseOldStyleParamList (FuncDesc* F)
                     */
                     if (Param->Flags & SC_DEFTYPE) {
                         /* Found it, change the default type to the one given */
-                        ChangeSymType (Param, ParamTypeCvt (Decl.Type));
+                        SymChangeType (Param, ParamTypeCvt (Decl.Type));
                         /* Reset the "default type" flag */
                         Param->Flags &= ~SC_DEFTYPE;
                     } else {

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -502,18 +502,18 @@ static SymEntry* ESUForwardDecl (const char* Name, unsigned Flags, unsigned* DSF
     /* Try to find an enum/struct/union with the given name. If there is none,
     ** insert a forward declaration into the current lexical level.
     */
-    SymEntry* Entry = FindTagSym (Name);
-    if (Entry == 0) {
+    SymEntry* TagEntry = FindTagSym (Name);
+    if (TagEntry == 0) {
         if ((Flags & SC_ESUTYPEMASK) != SC_ENUM) {
-            Entry = AddStructSym (Name, Flags, 0, 0, DSFlags);
+            TagEntry = AddStructSym (Name, Flags, 0, 0, DSFlags);
         } else {
-            Entry = AddEnumSym (Name, Flags, 0, 0, DSFlags);
+            TagEntry = AddEnumSym (Name, Flags, 0, 0, DSFlags);
         }
-    } else if ((Entry->Flags & SC_TYPEMASK) != (Flags & SC_ESUTYPEMASK)) {
+    } else if ((TagEntry->Flags & SC_TYPEMASK) != (Flags & SC_ESUTYPEMASK)) {
         /* Already defined, but not the same type class */
         Error ("Symbol '%s' is already different kind", Name);
     }
-    return Entry;
+    return TagEntry;
 }
 
 
@@ -809,15 +809,13 @@ static unsigned AliasAnonStructFields (const Declaration* D, SymEntry* Anon)
 */
 {
     unsigned Count = 0;
+    SymEntry* Field;
     SymEntry* Alias;
-
-    /* Get the pointer to the symbol table entry of the anon struct */
-    SymEntry* Entry = GetESUSymEntry (D->Type);
 
     /* Get the symbol table containing the fields. If it is empty, there has
     ** been an error before, so bail out.
     */
-    SymTable* Tab = Entry->V.S.SymTab;
+    SymTable* Tab = GetESUSymEntry (D->Type)->V.S.SymTab;
     if (Tab == 0) {
         /* Incomplete definition - has been flagged before */
         return 0;
@@ -826,24 +824,24 @@ static unsigned AliasAnonStructFields (const Declaration* D, SymEntry* Anon)
     /* Get a pointer to the list of symbols. Then walk the list adding copies
     ** of the embedded struct to the current level.
     */
-    Entry = Tab->SymHead;
-    while (Entry) {
+    Field = Tab->SymHead;
+    while (Field) {
 
         /* Enter an alias of this symbol */
-        if (!IsAnonName (Entry->Name)) {
-            Alias = AddLocalSym (Entry->Name, Entry->Type, SC_STRUCTFIELD|SC_ALIAS, 0);
-            Alias->V.A.Field = Entry;
-            Alias->V.A.Offs  = Anon->V.Offs + Entry->V.Offs;
+        if (!IsAnonName (Field->Name)) {
+            Alias = AddLocalSym (Field->Name, Field->Type, SC_STRUCTFIELD|SC_ALIAS, 0);
+            Alias->V.A.Field = Field;
+            Alias->V.A.Offs  = Anon->V.Offs + Field->V.Offs;
             ++Count;
         }
 
         /* Currently, there can not be any attributes, but if there will be
         ** some in the future, we want to know this.
         */
-        CHECK (Entry->Attr == 0);
+        CHECK (Field->Attr == 0);
 
         /* Next entry */
-        Entry = Entry->NextSym;
+        Field = Field->NextSym;
     }
 
     /* Return the count of created aliases */
@@ -861,7 +859,7 @@ static SymEntry* ParseUnionDecl (const char* Name, unsigned* DSFlags)
     int       FieldWidth;       /* Width in bits, -1 if not a bit-field */
     SymTable* FieldTab;
     SymEntry* UnionTagEntry;
-    SymEntry* Entry;
+    SymEntry* Field;
     unsigned  Flags = 0;
     unsigned  PrevErrorCount = ErrorCount;
 
@@ -945,17 +943,17 @@ static SymEntry* ParseUnionDecl (const char* Name, unsigned* DSFlags)
                 AddBitField (Decl.Ident, Decl.Type, 0, 0, FieldWidth,
                              SignednessSpecified);
             } else if (Decl.Ident[0] != '\0') {
-                Entry = AddLocalSym (Decl.Ident, Decl.Type, SC_STRUCTFIELD, 0);
+                Field = AddLocalSym (Decl.Ident, Decl.Type, SC_STRUCTFIELD, 0);
                 if (IsAnonName (Decl.Ident)) {
-                    Entry->V.A.ANumber = UnionTagEntry->V.S.ACount++;
-                    AliasAnonStructFields (&Decl, Entry);
+                    Field->V.A.ANumber = UnionTagEntry->V.S.ACount++;
+                    AliasAnonStructFields (&Decl, Field);
                 }
 
                 /* Check if the field itself has a flexible array member */
                 if (IsClassStruct (Decl.Type)) {
-                    SymEntry* Sym = GetSymType (Decl.Type);
-                    if (Sym && SymHasFlexibleArrayMember (Sym)) {
-                        Entry->Flags |= SC_HAVEFAM;
+                    SymEntry* TagEntry = GetSymType (Decl.Type);
+                    if (TagEntry && SymHasFlexibleArrayMember (TagEntry)) {
+                        Field->Flags |= SC_HAVEFAM;
                         Flags        |= SC_HAVEFAM;
                     }
                 }
@@ -1002,7 +1000,7 @@ static SymEntry* ParseStructDecl (const char* Name, unsigned* DSFlags)
     int       FieldWidth;       /* Width in bits, -1 if not a bit-field */
     SymTable* FieldTab;
     SymEntry* StructTagEntry;
-    SymEntry* Entry;
+    SymEntry* Field;
     unsigned  Flags = 0;
     unsigned  PrevErrorCount = ErrorCount;
 
@@ -1147,17 +1145,17 @@ static SymEntry* ParseStructDecl (const char* Name, unsigned* DSFlags)
                 StructSize += BitOffs / CHAR_BITS;
                 BitOffs %= CHAR_BITS;
             } else if (Decl.Ident[0] != '\0') {
-                Entry = AddLocalSym (Decl.Ident, Decl.Type, SC_STRUCTFIELD, StructSize);
+                Field = AddLocalSym (Decl.Ident, Decl.Type, SC_STRUCTFIELD, StructSize);
                 if (IsAnonName (Decl.Ident)) {
-                    Entry->V.A.ANumber = StructTagEntry->V.S.ACount++;
-                    AliasAnonStructFields (&Decl, Entry);
+                    Field->V.A.ANumber = StructTagEntry->V.S.ACount++;
+                    AliasAnonStructFields (&Decl, Field);
                 }
 
                 /* Check if the field itself has a flexible array member */
                 if (IsClassStruct (Decl.Type)) {
-                    SymEntry* Sym = GetSymType (Decl.Type);
-                    if (Sym && SymHasFlexibleArrayMember (Sym)) {
-                        Entry->Flags |= SC_HAVEFAM;
+                    SymEntry* TagEntry = GetSymType (Decl.Type);
+                    if (TagEntry && SymHasFlexibleArrayMember (TagEntry)) {
+                        Field->Flags |= SC_HAVEFAM;
                         Flags        |= SC_HAVEFAM;
                     }
                 }
@@ -1214,7 +1212,7 @@ static void ParseTypeSpec (DeclSpec* D, long Default, TypeCode Qualifiers,
 */
 {
     ident       Ident;
-    SymEntry*   Entry;
+    SymEntry*   TagEntry;
 
     if (SignednessSpecified != NULL) {
         *SignednessSpecified = 0;
@@ -1384,10 +1382,10 @@ static void ParseTypeSpec (DeclSpec* D, long Default, TypeCode Qualifiers,
             /* Remember we have an extra type decl */
             D->Flags |= DS_EXTRA_TYPE;
             /* Declare the union in the current scope */
-            Entry = ParseUnionDecl (Ident, &D->Flags);
+            TagEntry = ParseUnionDecl (Ident, &D->Flags);
             /* Encode the union entry into the type */
             D->Type[0].C = T_UNION;
-            SetESUSymEntry (D->Type, Entry);
+            SetESUSymEntry (D->Type, TagEntry);
             D->Type[1].C = T_END;
             break;
 
@@ -1403,10 +1401,10 @@ static void ParseTypeSpec (DeclSpec* D, long Default, TypeCode Qualifiers,
             /* Remember we have an extra type decl */
             D->Flags |= DS_EXTRA_TYPE;
             /* Declare the struct in the current scope */
-            Entry = ParseStructDecl (Ident, &D->Flags);
+            TagEntry = ParseStructDecl (Ident, &D->Flags);
             /* Encode the struct entry into the type */
             D->Type[0].C = T_STRUCT;
-            SetESUSymEntry (D->Type, Entry);
+            SetESUSymEntry (D->Type, TagEntry);
             D->Type[1].C = T_END;
             break;
 
@@ -1426,10 +1424,10 @@ static void ParseTypeSpec (DeclSpec* D, long Default, TypeCode Qualifiers,
             /* Remember we have an extra type decl */
             D->Flags |= DS_EXTRA_TYPE;
             /* Parse the enum decl */
-            Entry = ParseEnumDecl (Ident, &D->Flags);
+            TagEntry = ParseEnumDecl (Ident, &D->Flags);
             /* Encode the enum entry into the type */
             D->Type[0].C |= T_ENUM;
-            SetESUSymEntry (D->Type, Entry);
+            SetESUSymEntry (D->Type, TagEntry);
             D->Type[1].C = T_END;
             /* The signedness of enums is determined by the type, so say this is specified to avoid
             ** the int -> unsigned int handling for plain int bit-fields in AddBitField.
@@ -1442,11 +1440,11 @@ static void ParseTypeSpec (DeclSpec* D, long Default, TypeCode Qualifiers,
         case TOK_IDENT:
             /* This could be a label */
             if (NextTok.Tok != TOK_COLON || GetLexicalLevel () == LEX_LEVEL_STRUCT) {
-                Entry = FindSym (CurTok.Ident);
-                if (Entry && SymIsTypeDef (Entry)) {
+                TagEntry = FindSym (CurTok.Ident);
+                if (TagEntry && SymIsTypeDef (TagEntry)) {
                     /* It's a typedef */
                     NextToken ();
-                    TypeCopy (D->Type, Entry->Type);
+                    TypeCopy (D->Type, TagEntry->Type);
                     /* If it's a typedef, we should actually use whether the signedness was
                     ** specified on the typedef, but that information has been lost.  Treat the
                     ** signedness as being specified to work around the ICE in #1267.
@@ -1591,19 +1589,19 @@ static void ParseOldStyleParamList (FuncDesc* F)
             if (Decl.Ident[0] != '\0') {
 
                 /* We have a name given. Search for the symbol */
-                SymEntry* Sym = FindLocalSym (Decl.Ident);
-                if (Sym) {
+                SymEntry* Param = FindLocalSym (Decl.Ident);
+                if (Param) {
                     /* Check if we already changed the type for this
                     ** parameter
                     */
-                    if (Sym->Flags & SC_DEFTYPE) {
+                    if (Param->Flags & SC_DEFTYPE) {
                         /* Found it, change the default type to the one given */
-                        ChangeSymType (Sym, ParamTypeCvt (Decl.Type));
+                        ChangeSymType (Param, ParamTypeCvt (Decl.Type));
                         /* Reset the "default type" flag */
-                        Sym->Flags &= ~SC_DEFTYPE;
+                        Param->Flags &= ~SC_DEFTYPE;
                     } else {
                         /* Type has already been changed */
-                        Error ("Redefinition for parameter '%s'", Sym->Name);
+                        Error ("Redefinition for parameter '%s'", Param->Name);
                     }
                 } else {
                     Error ("Unknown identifier: '%s'", Decl.Ident);
@@ -1633,7 +1631,7 @@ static void ParseAnsiParamList (FuncDesc* F)
 
         DeclSpec        Spec;
         Declaration     Decl;
-        SymEntry*       Sym;
+        SymEntry*       Param;
 
         /* Allow an ellipsis as last parameter */
         if (CurTok.Tok == TOK_ELLIPSIS) {
@@ -1681,10 +1679,10 @@ static void ParseAnsiParamList (FuncDesc* F)
         ParseAttribute (&Decl);
 
         /* Create a symbol table entry */
-        Sym = AddLocalSym (Decl.Ident, ParamTypeCvt (Decl.Type), Decl.StorageClass, 0);
+        Param = AddLocalSym (Decl.Ident, ParamTypeCvt (Decl.Type), Decl.StorageClass, 0);
 
         /* Add attributes if we have any */
-        SymUseAttr (Sym, &Decl);
+        SymUseAttr (Param, &Decl);
 
         /* If the parameter is a struct or union, emit a warning */
         if (IsClassStruct (Decl.Type)) {

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -282,7 +282,7 @@ static unsigned ExprCheckedSizeOf (const Type* T)
     unsigned Size = SizeOf (T);
 
     if (Size == 0) {
-        SymEntry* TagSym = GetSymType (T);
+        SymEntry* TagSym = GetESUTagSym (T);
         if (TagSym == 0 || !SymIsDef (TagSym)) {
             Error ("Cannot apply 'sizeof' to incomplete type '%s'", GetFullTypeName (T));
         }

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -280,11 +280,10 @@ static unsigned ExprCheckedSizeOf (const Type* T)
 /* Specially checked SizeOf() used in 'sizeof' expressions */
 {
     unsigned Size = SizeOf (T);
-    SymEntry* Sym;
 
     if (Size == 0) {
-        Sym = GetSymType (T);
-        if (Sym == 0 || !SymIsDef (Sym)) {
+        SymEntry* TagSym = GetSymType (T);
+        if (TagSym == 0 || !SymIsDef (TagSym)) {
             Error ("Cannot apply 'sizeof' to incomplete type '%s'", GetFullTypeName (T));
         }
     }

--- a/src/cc65/function.c
+++ b/src/cc65/function.c
@@ -613,7 +613,7 @@ void NewFunc (SymEntry* Func, FuncDesc* D)
                 /* Could we allocate a register? */
                 if (Reg < 0) {
                     /* No register available: Convert parameter to auto */
-                    CvtRegVarToAuto (Param);
+                    SymCvtRegVarToAuto (Param);
                 } else {
                     /* Remember the register offset */
                     Param->V.R.RegOffs = Reg;

--- a/src/cc65/initdata.c
+++ b/src/cc65/initdata.c
@@ -452,7 +452,7 @@ static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
     }
 
     /* Get a pointer to the struct entry from the type */
-    TagSym = GetESUSymEntry (T);
+    TagSym = GetESUTagSym (T);
 
     /* Get the size of the struct from the symbol table entry */
     SI.Size = TagSym->V.S.Size;

--- a/src/cc65/initdata.c
+++ b/src/cc65/initdata.c
@@ -437,7 +437,7 @@ static unsigned ParseArrayInit (Type* T, int* Braces, int AllowFlexibleMembers)
 static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
 /* Parse initialization of a struct or union. Return the number of data bytes. */
 {
-    SymEntry*       Sym;
+    SymEntry*       TagSym;
     SymTable*       Tab;
     StructInitData  SI;
     int             HasCurly  = 0;
@@ -452,15 +452,15 @@ static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
     }
 
     /* Get a pointer to the struct entry from the type */
-    Sym = GetESUSymEntry (T);
+    TagSym = GetESUSymEntry (T);
 
     /* Get the size of the struct from the symbol table entry */
-    SI.Size = Sym->V.S.Size;
+    SI.Size = TagSym->V.S.Size;
 
     /* Check if this struct definition has a field table. If it doesn't, it
     ** is an incomplete definition.
     */
-    Tab = Sym->V.S.SymTab;
+    Tab = TagSym->V.S.SymTab;
     if (Tab == 0) {
         Error ("Cannot initialize variables with incomplete type");
         /* Try error recovery */
@@ -470,7 +470,7 @@ static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
     }
 
     /* Get a pointer to the list of symbols */
-    Sym = Tab->SymHead;
+    TagSym = Tab->SymHead;
 
     /* Initialize fields */
     SI.Offs    = 0;
@@ -479,7 +479,7 @@ static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
     while (CurTok.Tok != TOK_RCURLY) {
 
         /* Check for excess elements */
-        if (Sym == 0) {
+        if (TagSym == 0) {
             /* Is there just one trailing comma before a closing curly? */
             if (NextTok.Tok == TOK_RCURLY && CurTok.Tok == TOK_COMMA) {
                 /* Skip comma and exit scope */
@@ -495,7 +495,7 @@ static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
         }
 
         /* Check for special members that don't consume the initializer */
-        if ((Sym->Flags & SC_ALIAS) == SC_ALIAS) {
+        if ((TagSym->Flags & SC_ALIAS) == SC_ALIAS) {
             /* Just skip */
             goto NextMember;
         }
@@ -503,13 +503,13 @@ static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
         /* This may be an anonymous bit-field, in which case it doesn't
         ** have an initializer.
         */
-        if (SymIsBitField (Sym) && (IsAnonName (Sym->Name))) {
+        if (SymIsBitField (TagSym) && (IsAnonName (TagSym->Name))) {
             /* Account for the data and output it if we have at least a full
             ** byte. We may have more if there was storage unit overlap, for
             ** example two consecutive 7 bit fields. Those would be packed
             ** into 2 bytes.
             */
-            SI.ValBits += Sym->Type->A.B.Width;
+            SI.ValBits += TagSym->Type->A.B.Width;
             CHECK (SI.ValBits <= CHAR_BIT * sizeof(SI.BitVal));
             /* TODO: Generalize this so any type can be used. */
             CHECK (SI.ValBits <= LONG_BITS);
@@ -526,7 +526,7 @@ static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
             SkipComma = 0;
         }
 
-        if (SymIsBitField (Sym)) {
+        if (SymIsBitField (TagSym)) {
 
             /* Parse initialization of one field. Bit-fields need a special
             ** handling.
@@ -537,14 +537,14 @@ static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
             unsigned Shift;
 
             /* Calculate the bitmask from the bit-field data */
-            unsigned long Mask = shl_l (1UL, Sym->Type->A.B.Width) - 1UL;
+            unsigned long Mask = shl_l (1UL, TagSym->Type->A.B.Width) - 1UL;
 
             /* Safety ... */
-            CHECK (Sym->V.Offs * CHAR_BITS + Sym->Type->A.B.Offs ==
+            CHECK (TagSym->V.Offs * CHAR_BITS + TagSym->Type->A.B.Offs ==
                    SI.Offs     * CHAR_BITS + SI.ValBits);
 
             /* Read the data, check for a constant integer, do a range check */
-            Field = ParseScalarInitInternal (IntPromotion (Sym->Type));
+            Field = ParseScalarInitInternal (IntPromotion (TagSym->Type));
             if (!ED_IsConstAbsInt (&Field)) {
                 Error ("Constant initializer expected");
                 ED_MakeConstAbsInt (&Field, 1);
@@ -554,19 +554,19 @@ static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
             ** any useful bits.
             */
             Val = (unsigned long) Field.IVal & Mask;
-            if (IsSignUnsigned (Sym->Type)) {
+            if (IsSignUnsigned (TagSym->Type)) {
                 if (Field.IVal < 0 || (unsigned long) Field.IVal != Val) {
                     Warning (IsSignUnsigned (Field.Type) ?
                              "Implicit truncation from '%s' to '%s : %u' in bit-field initializer"
                              " changes value from %lu to %lu" :
                              "Implicit truncation from '%s' to '%s : %u' in bit-field initializer"
                              " changes value from %ld to %lu",
-                             GetFullTypeName (Field.Type), GetFullTypeName (Sym->Type),
-                             Sym->Type->A.B.Width, Field.IVal, Val);
+                             GetFullTypeName (Field.Type), GetFullTypeName (TagSym->Type),
+                             TagSym->Type->A.B.Width, Field.IVal, Val);
                 }
             } else {
                 /* Sign extend back to full width of host long. */
-                unsigned ShiftBits = sizeof (long) * CHAR_BIT - Sym->Type->A.B.Width;
+                unsigned ShiftBits = sizeof (long) * CHAR_BIT - TagSym->Type->A.B.Width;
                 long RestoredVal = asr_l (asl_l (Val, ShiftBits), ShiftBits);
                 if (Field.IVal != RestoredVal) {
                     Warning (IsSignUnsigned (Field.Type) ?
@@ -574,17 +574,17 @@ static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
                              " changes value from %lu to %ld" :
                              "Implicit truncation from '%s' to '%s : %u' in bit-field initializer"
                              " changes value from %ld to %ld",
-                             GetFullTypeName (Field.Type), GetFullTypeName (Sym->Type),
-                             Sym->Type->A.B.Width, Field.IVal, RestoredVal);
+                             GetFullTypeName (Field.Type), GetFullTypeName (TagSym->Type),
+                             TagSym->Type->A.B.Width, Field.IVal, RestoredVal);
                 }
             }
 
             /* Add the value to the currently stored bit-field value */
-            Shift = (Sym->V.Offs - SI.Offs) * CHAR_BITS + Sym->Type->A.B.Offs;
+            Shift = (TagSym->V.Offs - SI.Offs) * CHAR_BITS + TagSym->Type->A.B.Offs;
             SI.BitVal |= (Val << Shift);
 
             /* Account for the data and output any full bytes we have. */
-            SI.ValBits += Sym->Type->A.B.Width;
+            SI.ValBits += TagSym->Type->A.B.Width;
             /* Make sure unsigned is big enough to hold the value, 32 bits.
             ** This cannot be more than 32 bits because a 16-bit or 32-bit
             ** bit-field will always be byte-aligned with padding before it
@@ -609,7 +609,7 @@ static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
             /* Flexible array members may only be initialized if they are
             ** the last field (or part of the last struct field).
             */
-            SI.Offs += ParseInitInternal (Sym->Type, Braces, AllowFlexibleMembers && Sym->NextSym == 0);
+            SI.Offs += ParseInitInternal (TagSym->Type, Braces, AllowFlexibleMembers && TagSym->NextSym == 0);
         }
 
         /* More initializers? */
@@ -624,10 +624,10 @@ NextMember:
         /* Next member. For unions, only the first one can be initialized */
         if (IsTypeUnion (T)) {
             /* Union */
-            Sym = 0;
+            TagSym = 0;
         } else {
             /* Struct */
-            Sym = Sym->NextSym;
+            TagSym = TagSym->NextSym;
         }
     }
 

--- a/src/cc65/symentry.c
+++ b/src/cc65/symentry.c
@@ -40,6 +40,7 @@
 
 /* cc65 */
 #include "anonname.h"
+#include "asmlabel.h"
 #include "declare.h"
 #include "error.h"
 #include "symentry.h"
@@ -65,13 +66,12 @@ SymEntry* NewSymEntry (const char* Name, unsigned Flags)
     E->NextHash = 0;
     E->PrevSym  = 0;
     E->NextSym  = 0;
-    E->Link     = 0;
     E->Owner    = 0;
     E->Flags    = Flags;
     E->Type     = 0;
     E->Attr     = 0;
     E->AsmName  = 0;
-    E->V.BssName = 0;
+    memset (&E->V, 0, sizeof (E->V));
     memcpy (E->Name, Name, Len+1);
 
     /* Return the new entry */
@@ -250,7 +250,9 @@ void SymUseAttr (SymEntry* Sym, struct Declaration* D)
 
 
 void SymSetAsmName (SymEntry* Sym)
-/* Set the assembler name for an external symbol from the name of the symbol */
+/* Set the assembler name for an external symbol from the name of the symbol.
+** The symbol must have no assembler name set yet.
+*/
 {
     unsigned Len;
 

--- a/src/cc65/symentry.c
+++ b/src/cc65/symentry.c
@@ -268,7 +268,7 @@ void SymSetAsmName (SymEntry* Sym)
 
 
 
-void CvtRegVarToAuto (SymEntry* Sym)
+void SymCvtRegVarToAuto (SymEntry* Sym)
 /* Convert a register variable to an auto variable */
 {
     /* Change the storage class */
@@ -280,59 +280,26 @@ void CvtRegVarToAuto (SymEntry* Sym)
 
 
 
-SymEntry* GetSymType (const Type* T)
-/* Get the symbol entry of the enum/struct/union type
-** Return 0 if it is not an enum/struct/union.
-*/
-{
-    if ((IsClassStruct (T) || IsTypeEnum (T))) {
-        return T->A.S;
-    }
-    return 0;
-}
-
-
-
-const char* GetSymTypeName (const Type* T)
-/* Return a name string of the type or the symbol name if it is an ESU type.
-** Note: This may use a static buffer that could be overwritten by other calls.
-*/
-{
-    static char TypeName [IDENTSIZE + 16];
-    SymEntry* Sym;
-
-    Sym = GetSymType (T);
-    if (Sym == 0) {
-        return GetBasicTypeName (T);
-    }
-    sprintf (TypeName, "%s %s", GetBasicTypeName (T),
-             Sym->Name[0] != '\0' ? Sym->Name : "<unknown>");
-
-    return TypeName;
-}
-
-
-
-void ChangeSymType (SymEntry* Entry, const Type* T)
+void SymChangeType (SymEntry* Sym, const Type* T)
 /* Change the type of the given symbol */
 {
-    TypeFree (Entry->Type);
-    Entry->Type = TypeDup (T);
+    TypeFree (Sym->Type);
+    Sym->Type = TypeDup (T);
 }
 
 
 
-void ChangeAsmName (SymEntry* Entry, const char* NewAsmName)
+void SymChangeAsmName (SymEntry* Sym, const char* NewAsmName)
 /* Change the assembler name of the symbol */
 {
-    xfree (Entry->AsmName);
-    Entry->AsmName = xstrdup (NewAsmName);
+    xfree (Sym->AsmName);
+    Sym->AsmName = xstrdup (NewAsmName);
 }
 
 
 
-int HasAnonName (const SymEntry* Entry)
+int SymHasAnonName (const SymEntry* Sym)
 /* Return true if the symbol entry has an anonymous name */
 {
-    return IsAnonName (Entry->Name);
+    return IsAnonName (Sym->Name);
 }

--- a/src/cc65/symentry.h
+++ b/src/cc65/symentry.h
@@ -128,7 +128,6 @@ struct SymEntry {
     SymEntry*                   NextHash; /* Next entry in hash list */
     SymEntry*                   PrevSym;  /* Previous symbol in dl list */
     SymEntry*                   NextSym;  /* Next symbol double linked list */
-    SymEntry*                   Link;     /* General purpose single linked list */
     struct SymTable*            Owner;    /* Symbol table the symbol is in */
     unsigned                    Flags;    /* Symbol flags */
     Type*                       Type;     /* Symbol type */
@@ -138,26 +137,8 @@ struct SymEntry {
     /* Data that differs for the different symbol types */
     union {
 
-        /* Offset for locals or struct members */
+        /* Offset for locals */
         int                     Offs;
-
-        /* Data for anonymous struct or union members */
-        struct {
-            int                 Offs;     /* Byte offset into struct */
-            unsigned            ANumber;  /* Numeric ID */
-            SymEntry*           Field;    /* The real field aliased */
-        } A;
-
-
-        /* Label name for static symbols */
-        struct {
-            unsigned            Label;
-            Collection          *DefsOrRefs;
-            struct CodeEntry    *IndJumpFrom;
-        } L;
-
-        /* Value of SP adjustment needed after forward 'goto' */
-        unsigned short      SPAdjustment;
 
         /* Register bank offset and offset of the saved copy on stack for
         ** register variables.
@@ -167,21 +148,11 @@ struct SymEntry {
             int                 SaveOffs;
         } R;
 
-        /* Value for constants (including enums) */
+        /* Segment name for tentantive global definitions */
+        const char*             BssName;
+
+        /* Value for integer constants (including enumerators) */
         long                    ConstVal;
-
-        /* Data for structs/unions */
-        struct {
-            struct SymTable*    SymTab;   /* Member symbol table */
-            unsigned            Size;     /* Size of the union/struct */
-            unsigned            ACount;   /* Count of anonymous fields */
-        } S;
-
-        /* Data for enums */
-        struct {
-            struct SymTable*    SymTab;   /* Member symbol table */
-            const Type*         Type;     /* Underlying type */
-        } E;
 
         /* Data for functions */
         struct {
@@ -189,10 +160,38 @@ struct SymEntry {
             struct LiteralPool* LitPool;  /* Literal pool for this function */
         } F;
 
-        /* Segment name for tentantive global definitions */
-        const char*             BssName;
+        /* Label name for static symbols */
+        struct {
+            unsigned            Label;
+            Collection          *DefsOrRefs;
+            struct CodeEntry    *IndJumpFrom;
+        } L;
+
+        /* Value of SP adjustment needed after forward 'goto' */
+        unsigned short          SPAdjustment;
+
+        /* Data for anonymous struct or union members */
+        struct {
+            int                 Offs;     /* Byte offset into struct */
+            unsigned            ANumber;  /* Numeric ID */
+            SymEntry*           Field;    /* The real field aliased */
+        } A;
+
+        /* Data for structs/unions tags */
+        struct {
+            struct SymTable*    SymTab;   /* Member symbol table */
+            unsigned            Size;     /* Size of the union/struct */
+            unsigned            ACount;   /* Count of anonymous fields */
+        } S;
+
+        /* Data for enums tags */
+        struct {
+            struct SymTable*    SymTab;   /* Member symbol table */
+            const Type*         Type;     /* Underlying type */
+        } E;
+
     } V;
-    char                       Name[1]; /* Name, dynamically allocated */
+    char                        Name[1]; /* Name, dynamically allocated */
 };
 
 
@@ -303,7 +302,9 @@ void SymUseAttr (SymEntry* Sym, struct Declaration* D);
 /* Use the attributes from the declaration for this symbol */
 
 void SymSetAsmName (SymEntry* Sym);
-/* Set the assembler name for an external symbol from the name of the symbol */
+/* Set the assembler name for an external symbol from the name of the symbol.
+** The symbol must have no assembler name set yet.
+*/
 
 void CvtRegVarToAuto (SymEntry* Sym);
 /* Convert a register variable to an auto variable */

--- a/src/cc65/symentry.h
+++ b/src/cc65/symentry.h
@@ -306,26 +306,16 @@ void SymSetAsmName (SymEntry* Sym);
 ** The symbol must have no assembler name set yet.
 */
 
-void CvtRegVarToAuto (SymEntry* Sym);
+void SymCvtRegVarToAuto (SymEntry* Sym);
 /* Convert a register variable to an auto variable */
 
-SymEntry* GetSymType (const Type* T);
-/* Get the symbol entry of the enum/struct/union type
-** Return 0 if it is not an enum/struct/union.
-*/
-
-const char* GetSymTypeName (const Type* T);
-/* Return a name string of the type or the symbol name if it is an ESU type.
-** Note: This may use a static buffer that could be overwritten by other calls.
-*/
-
-void ChangeSymType (SymEntry* Entry, const Type* T);
+void SymChangeType (SymEntry* Sym, const Type* T);
 /* Change the type of the given symbol */
 
-void ChangeAsmName (SymEntry* Entry, const char* NewAsmName);
+void SymChangeAsmName (SymEntry* Sym, const char* NewAsmName);
 /* Change the assembler name of the symbol */
 
-int HasAnonName (const SymEntry* Entry);
+int SymHasAnonName (const SymEntry* Sym);
 /* Return true if the symbol entry has an anonymous name */
 
 

--- a/src/cc65/symtab.h
+++ b/src/cc65/symtab.h
@@ -169,10 +169,10 @@ unsigned short FindSPAdjustment (const char* Name);
 
 
 SymEntry* AddEnumSym (const char* Name, unsigned Flags, const Type* Type, SymTable* Tab, unsigned* DSFlags);
-/* Add an enum entry and return it */
+/* Add an enum tag entry and return it */
 
 SymEntry* AddStructSym (const char* Name, unsigned Flags, unsigned Size, SymTable* Tab, unsigned* DSFlags);
-/* Add a struct/union entry and return it */
+/* Add a struct/union tag entry and return it */
 
 SymEntry* AddBitField (const char* Name, const Type* Type, unsigned Offs,
                        unsigned BitOffs, unsigned BitWidth, int SignednessSpecified);

--- a/src/cc65/typecmp.c
+++ b/src/cc65/typecmp.c
@@ -303,8 +303,8 @@ static void DoCompare (const Type* lhs, const Type* rhs, typecmp_t* Result)
         if ((IsTypeEnum (lhs) || IsTypeEnum (rhs))) {
 
             /* Compare the tag types */
-            Sym1 = IsTypeEnum (lhs) ? GetESUSymEntry (lhs) : 0;
-            Sym2 = IsTypeEnum (rhs) ? GetESUSymEntry (rhs) : 0;
+            Sym1 = IsTypeEnum (lhs) ? GetESUTagSym (lhs) : 0;
+            Sym2 = IsTypeEnum (rhs) ? GetESUTagSym (rhs) : 0;
 
             if (Sym1 != Sym2) {
                 if (Sym1 == 0 || Sym2 == 0) {
@@ -420,8 +420,8 @@ static void DoCompare (const Type* lhs, const Type* rhs, typecmp_t* Result)
             case T_TYPE_STRUCT:
             case T_TYPE_UNION:
                 /* Compare the tag types */
-                Sym1 = GetESUSymEntry (lhs);
-                Sym2 = GetESUSymEntry (rhs);
+                Sym1 = GetESUTagSym (lhs);
+                Sym2 = GetESUTagSym (rhs);
 
                 CHECK (Sym1 != 0 || Sym2 != 0);
 


### PR DESCRIPTION
Renamed functions (https://github.com/cc65/cc65/pull/1879/commits/a2dfa7c721ae0a0c3393c58740e0e286ec7e9b4c):

now in _src/cc65/datatype.c_
- `GetSymType` and `GetESUSymEntry` -> `GetESUTagSym`
- `GetSymTypeName` -> `GetTagSymName`
- `SetESUSymEntry` -> `SetESUTagSym`

now in _src/cc65/symentry.c_
- `CvtRegVarToAuto` -> `SymCvtRegVarToAuto`
- `ChangeSymType` -> `SymChangeType`
- `ChangeAsmName` -> `SymChangeAsmName`
- `HasAnonName` -> `SymHasAnonName`

Note: It was actually `GetSymType` that got renamed to `GetESUTagSym` rather than `GetESUSymEntry` would look like to be (from the name). The two renamed (or removed) functions were doing almost the same thing except that `GetESUSymEntry` had a narrower constraint asserting the type of the symbol should be `ESU` (`enum`, `struct` or `union`) than `GetSymType` had that would simply return NUL if the type was non-`ESU`.