### PR TITLE
[cc65] Fixed diagnostic messages on enumerator overflow

### DIFF
--- a/test/err/bug1890.c
+++ b/test/err/bug1890.c
@@ -1,0 +1,9 @@
+/* bug #1890 - Overflow in enumerator value is not detected */
+
+#include <limits.h>
+enum { a = ULONG_MAX, b } c = b;
+
+int main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
- [x] Resolved #1890.
- [x] An enumerator that would be incremented greater than ULONG_MAX now causes an error.