### PR TITLE
[cc65] Fixed '\\' + newline

### DIFF
--- a/src/cc65/input.c
+++ b/src/cc65/input.c
@@ -578,15 +578,16 @@ int NextLine (void)
                 SB_Drop (Line, 1);
             }
 
-            /* If we don't have a line continuation character at the end,
-            ** we're done with this line. Otherwise replace the character
-            ** by a newline and continue reading.
+            /* If we don't have a line continuation character at the end, we
+            ** are done with this line. Otherwise just skip the character and
+            ** continue reading.
             */
-            if (SB_LookAtLast (Line) == '\\') {
-                Line->Buf[Line->Len-1] = '\n';
-            } else {
+            if (SB_LookAtLast (Line) != '\\') {
                 Input->MissingNL = 0;
                 break;
+            } else {
+                SB_Drop (Line, 1);
+                ContinueLine ();
             }
 
         } else if (C != '\0') {         /* Ignore embedded NULs */

--- a/src/cc65/preproc.h
+++ b/src/cc65/preproc.h
@@ -68,6 +68,9 @@ void Preprocess (void);
 void SetPPIfStack (PPIfStack* Stack);
 /* Specify which PP #if stack to use */
 
+void ContinueLine (void);
+/* Continue the current line ended with a '\\' */
+
 void PreprocessBegin (void);
 /* Initialize preprocessor with current file */
 

--- a/test/val/bug1891.c
+++ b/test/val/bug1891.c
@@ -1,0 +1,19 @@
+/* bug #1891 - backslash/newline sequence in string constants is treated wrong */
+
+#include <stdio.h>
+#include <string.h>
+
+const char* a = "hello \
+world";
+const char* b = \
+"hello world";
+
+int main(void)
+{
+    if (strcmp(a, b) != 0) {
+        printf("a:\n%s\n", a);
+        printf("b:\n%s\n", b);
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION

- [x] Fixed #1891 - fixed processing `'\\'` followed with a newline inside a string literal.
- [x] Fixed (though not perfectly) line number output (`-E` compiler option) affected by `'\\'` followed with a newline.