### PR TITLE
[cc65] Fixed endlessly repeated error messages when a declaration lacks a required identifier

### DIFF
--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -1831,7 +1831,13 @@ static void Declarator (const DeclSpec* Spec, Declaration* D, declmode_t Mode)
             NextToken ();
         } else {
             if (Mode == DM_NEED_IDENT) {
+                /* Some fix point tokens that are used for error recovery */
+                static const token_t TokenList[] = { TOK_COMMA, TOK_SEMI };
+
                 Error ("Identifier expected");
+
+                /* Try some smart error recovery */
+                SkipTokens (TokenList, sizeof(TokenList) / sizeof(TokenList[0]));
             }
             D->Ident[0] = '\0';
         }

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -1419,9 +1419,8 @@ static void ParseTypeSpec (DeclSpec* D, long Default, TypeCode Qualifiers,
             } else {
                 if (CurTok.Tok != TOK_LCURLY) {
                     Error ("Identifier expected");
-                } else {
-                    AnonName (Ident, "enum");
                 }
+                AnonName (Ident, "enum");
             }
             /* Remember we have an extra type decl */
             D->Flags |= DS_EXTRA_TYPE;

--- a/test/misc/Makefile
+++ b/test/misc/Makefile
@@ -155,6 +155,11 @@ $(WORKDIR)/goto.$1.$2.prg: goto.c $(ISEQUAL) | $(WORKDIR)
 	$(CC65) -t sim$2 -$1 -o $$@ $$< 2>$(WORKDIR)/goto.$1.$2.out
 	$(ISEQUAL) $(WORKDIR)/goto.$1.$2.out goto.ref
 
+$(WORKDIR)/bug1889-missing-identifier.$1.$2.prg: bug1889-missing-identifier.c $(ISEQUAL) | $(WORKDIR)
+	$(if $(QUIET),echo misc/bug1889-missing-identifier.$1.$2.error.prg)
+	-$(CC65) -t sim$2 -$1 -o $$(@:.error.prg=.s) $$< 2> $(WORKDIR)/bug1889-missing-identifier.$1.$2.out
+	$(ISEQUAL) $(WORKDIR)/bug1889-missing-identifier.$1.$2.out bug1889-missing-identifier.ref
+
 # the rest are tests that fail currently for one reason or another
 $(WORKDIR)/sitest.$1.$2.prg: sitest.c | $(WORKDIR)
 	@echo "FIXME: " $$@ "currently does not compile."

--- a/test/misc/bug1889-missing-identifier.c
+++ b/test/misc/bug1889-missing-identifier.c
@@ -1,0 +1,9 @@
+/* bug 1889 - endless errors due to failure in recovery from missing identifier */
+
+int enum { a } x;
+inline enum { b };
+
+int main(void)
+{
+    return 0;
+}

--- a/test/misc/bug1889-missing-identifier.ref
+++ b/test/misc/bug1889-missing-identifier.ref
@@ -1,0 +1,3 @@
+bug1889-missing-identifier.c:3: Error: Identifier expected
+bug1889-missing-identifier.c:4: Error: Identifier expected
+bug1889-missing-identifier.c:4: Warning: Implicit 'int' is an obsolete feature


### PR DESCRIPTION
Fixed #1889.