### PR TITLE
Silencing confusing util/zlib 'warning' target

### DIFF
--- a/util/zlib/Makefile
+++ b/util/zlib/Makefile
@@ -9,17 +9,19 @@ CFLAGS += -O3 -Wall -Wextra -Wno-char-subscripts $(USER_CFLAGS)
 
 .PHONY: mostlyclean clean
 
-zlib: warning
+zlib:
+#zlib: warning
 #zlib: deflater
 
 warning:
-	@echo "deflater needs zlib installed, use 'make deflater' to build"
+	@echo "util/zlib/deflater is no longer built by default"
+	@echo "use 'make deflater' to build if you need it"
+	@echo "note that you need zlib installed first"
 
 deflater: deflater.c
 	$(CC) $(CFLAGS) -o deflater deflater.c -lz
 
 mostlyclean clean:
 	$(RM) deflater
-	
-install zip:
 
+install zip:

--- a/util/zlib/readme.txt
+++ b/util/zlib/readme.txt
@@ -1,0 +1,2 @@
+Deflater program in this directory is not built by default
+Use 'make deflater' to build. Note that you need zlib installed first


### PR DESCRIPTION
This PR silences the `warning` message emitted from `util/zlib` when building cc65 and adds explanations in `readme.txt` file