### PR TITLE
Remove CFLAGS and ASFLAGS from tests

### DIFF
--- a/targettest/Makefile
+++ b/targettest/Makefile
@@ -114,11 +114,11 @@ DISK_atarixl   = testcode.atr
 %: %.s
 
 .c.o:
-	$(CC) $(CFLAGS) -Ors --codesize 500 -T -g -t $(SYS) $<
+	$(CC) -Ors --codesize 500 -T -g -t $(SYS) $<
 	$(AS) $(<:.c=.s)
 
 .s.o:
-	$(AS) $(ASFLAGS) -t $(SYS) $<
+	$(AS) -t $(SYS) $<
 
 .PRECIOUS: %.o
 


### PR DESCRIPTION
By using the CFLAGS environment variable as set by the user, incompatible arguments such as `-march=native` may be included, stopping the compilation.
This pull request removes the CFLAGS and ASFLAGS variables from the targettest Makefile.