### PR TITLE
[cc65] Renamed some misleading functions relevent with input file info

### DIFF
--- a/src/cc65/error.c
+++ b/src/cc65/error.c
@@ -120,7 +120,7 @@ static const char* GetDiagnosticFileName (void)
     if (CurTok.LI) {
         return GetInputName (CurTok.LI);
     } else {
-        return GetCurrentFile ();
+        return GetCurrentFilename ();
     }
 }
 
@@ -132,7 +132,7 @@ static unsigned GetDiagnosticLineNum (void)
     if (CurTok.LI) {
         return GetInputLine (CurTok.LI);
     } else {
-        return GetCurrentLine ();
+        return GetCurrentLineNum ();
     }
 }
 
@@ -238,7 +238,7 @@ void PPError (const char* Format, ...)
 {
     va_list ap;
     va_start (ap, Format);
-    IntError (GetCurrentFile(), GetCurrentLine(), Format, ap);
+    IntError (GetCurrentFilename(), GetCurrentLineNum(), Format, ap);
     va_end (ap);
 }
 
@@ -301,7 +301,7 @@ void PPWarning (const char* Format, ...)
 {
     va_list ap;
     va_start (ap, Format);
-    IntWarning (GetCurrentFile(), GetCurrentLine(), Format, ap);
+    IntWarning (GetCurrentFilename(), GetCurrentLineNum(), Format, ap);
     va_end (ap);
 }
 
@@ -379,7 +379,7 @@ void PPNote (const char* Format, ...)
 {
     va_list ap;
     va_start (ap, Format);
-    IntNote (GetCurrentFile(), GetCurrentLine(), Format, ap);
+    IntNote (GetCurrentFilename(), GetCurrentLineNum(), Format, ap);
     va_end (ap);
 }
 

--- a/src/cc65/input.c
+++ b/src/cc65/input.c
@@ -653,7 +653,7 @@ const char* GetInputFile (const struct IFile* IF)
 
 
 
-const char* GetCurrentFile (void)
+const char* GetCurrentFilename (void)
 /* Return the name of the current input file */
 {
     unsigned AFileCount = CollCount (&AFiles);
@@ -668,7 +668,7 @@ const char* GetCurrentFile (void)
 
 
 
-unsigned GetCurrentLine (void)
+unsigned GetCurrentLineNum (void)
 /* Return the line number in the current input file */
 {
     unsigned AFileCount = CollCount (&AFiles);
@@ -683,7 +683,7 @@ unsigned GetCurrentLine (void)
 
 
 
-void SetCurrentLine (unsigned LineNum)
+void SetCurrentLineNum (unsigned LineNum)
 /* Set the line number in the current input file */
 {
     unsigned AFileCount = CollCount (&AFiles);

--- a/src/cc65/input.h
+++ b/src/cc65/input.h
@@ -128,13 +128,13 @@ int PreprocessNextLine (void);
 const char* GetInputFile (const struct IFile* IF);
 /* Return a filename from an IFile struct */
 
-const char* GetCurrentFile (void);
+const char* GetCurrentFilename (void);
 /* Return the name of the current input file */
 
-unsigned GetCurrentLine (void);
+unsigned GetCurrentLineNum (void);
 /* Return the line number in the current input file */
 
-void SetCurrentLine (unsigned LineNum);
+void SetCurrentLineNum (unsigned LineNum);
 /* Set the line number in the current input file */
 
 void SetCurrentFilename (const char* Name);

--- a/src/cc65/locals.c
+++ b/src/cc65/locals.c
@@ -287,7 +287,7 @@ static void ParseAutoDecl (Declaration* Decl)
             ** We abuse the Collection somewhat by using it to store line
             ** numbers.
             */
-            CollReplace (&CurrentFunc->LocalsBlockStack, (void *)(size_t)GetCurrentLine (),
+            CollReplace (&CurrentFunc->LocalsBlockStack, (void *)(size_t)GetCurrentLineNum (),
                 CollCount (&CurrentFunc->LocalsBlockStack) - 1);
 
         } else {

--- a/src/cc65/preproc.c
+++ b/src/cc65/preproc.c
@@ -842,7 +842,7 @@ static void AddPreLine (StrBuf* Str)
             SB_AppendChar (Str, '\n');
         }
         SB_Printf (&Comment, "#line %u \"%s\"\n",
-                   GetCurrentLine () - ContinuedLines, GetCurrentFile ());
+                   GetCurrentLineNum () - ContinuedLines, GetCurrentFilename ());
         SB_Append (Str, &Comment);
     } else {
         /* Output new lines */
@@ -906,7 +906,7 @@ static void OldStyleComment (void)
     /* Remember the current line number, so we can output better error
     ** messages if the comment is not terminated in the current file.
     */
-    unsigned StartingLine = GetCurrentLine ();
+    unsigned StartingLine = GetCurrentLineNum ();
 
     /* Skip the start of comment chars */
     NextChar ();
@@ -2953,7 +2953,7 @@ static void DoLine (void)
 
         /* #line actually sets the line number of the next line */
         if (LineNum > 0) {
-            SetCurrentLine (LineNum - 1);
+            SetCurrentLineNum (LineNum - 1);
             /* Check for extra tokens at the end */
             CheckExtraTokens ("line");
         }
@@ -3216,11 +3216,11 @@ void HandleSpecialMacro (Macro* M, const char* Name)
         SB_Printf (&M->Replacement, "%u", GetCurrentCounter ());
     } else if (strcmp (Name, "__LINE__") == 0) {
         /* Replace __LINE__ with the current line number */
-        SB_Printf (&M->Replacement, "%u", GetCurrentLine ());
+        SB_Printf (&M->Replacement, "%u", GetCurrentLineNum ());
     } else if (strcmp (Name, "__FILE__") == 0) {
         /* Replace __FILE__ with the current filename */
         StrBuf B = AUTO_STRBUF_INITIALIZER;
-        SB_InitFromString (&B, GetCurrentFile ());
+        SB_InitFromString (&B, GetCurrentFilename ());
         SB_Clear (&M->Replacement);
         Stringize (&B, &M->Replacement);
         SB_Done (&B);
@@ -3332,7 +3332,7 @@ void Preprocess (void)
     PLine = InitLine (PLine);
 
     if (Verbosity > 1 && SB_NotEmpty (Line)) {
-        printf ("%s:%u: %.*s\n", GetCurrentFile (), GetCurrentLine (),
+        printf ("%s:%u: %.*s\n", GetCurrentFilename (), GetCurrentLineNum (),
                 (int) SB_GetLen (Line), SB_GetConstBuf (Line));
     }
 

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -1076,7 +1076,7 @@ DefOrRef* AddDefOrRef (SymEntry* E, unsigned Flags)
 
     DOR = xmalloc (sizeof (DefOrRef));
     CollAppend (E->V.L.DefsOrRefs, DOR);
-    DOR->Line = GetCurrentLine ();
+    DOR->Line = GetCurrentLineNum ();
     DOR->LocalsBlockId = (size_t)CollLast (&CurrentFunc->LocalsBlockStack);
     DOR->Flags = Flags;
     DOR->StackPtr = StackPtr;
@@ -1144,7 +1144,7 @@ SymEntry* AddLabelSym (const char* Name, unsigned Flags)
                     (size_t)CollAt (AIC, DOR->Depth - 1) != DOR->LocalsBlockId)) {
                     Warning ("Goto at line %d to label %s jumps into a block with "
                     "initialization of an object that has automatic storage duration",
-                    GetCurrentLine (), Name);
+                    GetCurrentLineNum (), Name);
                 }
             }
 


### PR DESCRIPTION
`GetCurrentFile ` -> `GetCurrentFilename `
`GetCurrentLine` -> `GetCurrentLineNum `
`SetCurrentLine ` -> `SetCurrentLineNum `

Note: `SetCurrentFilename` was OK and thus unchanged.