### PR TITLE
Character defines for osic1p target

### DIFF
--- a/include/osic1p.h
+++ b/include/osic1p.h
@@ -44,4 +44,22 @@
 #define _bgcolor(color)         COLOR_BLACK
 #define _bordercolor(color)     COLOR_BLACK
 
+/* Colors are not functional, display is black and white only. */
+#define COLOR_BLACK     0x00
+#define COLOR_WHITE     0x01
+
+#define CH_ULCORNER     0xCC
+#define CH_URCORNER     0xCD
+#define CH_LLCORNER     0xCB
+#define CH_LRCORNER     0xCE
+#define CH_TTEE         0xD9
+#define CH_BTEE         0xD7
+#define CH_LTEE         0xD8
+#define CH_RTEE         0xDA
+#define CH_CROSS        0xDB
+#define CH_HLINE        0x94
+#define CH_VLINE        0x95
+
+#define CH_ENTER        0x0D
+
 #endif

--- a/include/osic1p.h
+++ b/include/osic1p.h
@@ -36,14 +36,6 @@
 #  error "This module may only be used when compiling for the Challenger 1P!"
 #endif
 
-/* The following #defines will cause the matching functions calls in conio.h
-** to be overlaid by macros with the same names, saving the function call
-** overhead.
-*/
-#define _textcolor(color)       COLOR_WHITE
-#define _bgcolor(color)         COLOR_BLACK
-#define _bordercolor(color)     COLOR_BLACK
-
 /* Colors are not functional, display is black and white only. */
 #define COLOR_BLACK     0x00
 #define COLOR_WHITE     0x01
@@ -61,5 +53,14 @@
 #define CH_VLINE        0x95
 
 #define CH_ENTER        0x0D
+
+/* The following #defines will cause the matching functions calls in conio.h
+** to be overlaid by macros with the same names, saving the function call
+** overhead.
+*/
+#define _textcolor(color)       COLOR_WHITE
+#define _bgcolor(color)         COLOR_BLACK
+#define _bordercolor(color)     COLOR_BLACK
+#define _cpeekcolor(color)      COLOR_WHITE
 
 #endif

--- a/targettest/conio.c
+++ b/targettest/conio.c
@@ -130,9 +130,11 @@ void main(void)
                     case CH_ENTER:
                         clrscr();
                         return;
+#ifdef CH_CURS_LEFT
                     case CH_CURS_LEFT:
                         inpos = (inpos - 1) % 8;
                         break;
+#endif
                     case '0': case '1': case '2': case '3': case '4':
                     case '5': case '6': case '7': case '8': case '9':
                         (void)textcolor(i - '0');
@@ -164,7 +166,9 @@ void main(void)
                     default:
                         cputc(i);
                         /* fallthrough */
+#ifdef CH_CURS_RIGHT
                     case CH_CURS_RIGHT:
+#endif
                         inpos = (inpos + 1) % 8;
                 }
 #endif


### PR DESCRIPTION
Added defines for the line graphics characters and the enter key for the osic1p target.

Added `#ifdefs` to the `targettest/conio.c` program so that it compiles for platforms without cursor keys.