### PR TITLE
[cc65] Renamed/added/removed some C type facility and fixed a few comments

### DIFF
--- a/src/cc65/assignment.c
+++ b/src/cc65/assignment.c
@@ -607,7 +607,7 @@ void OpAssign (const GenDesc* Gen, ExprDesc* Expr, const char* Op)
     Expr2.Flags |= Expr->Flags & E_MASK_KEEP_SUBEXPR;
 
     /* Only "=" accept struct/union */
-    if (IsClassStruct (ltype) ? Gen != 0 : !IsClassScalar (ltype)) {
+    if (IsClassStruct (ltype) ? Gen != 0 : !IsScalarType (ltype)) {
         Error ("Invalid left operand for binary operator '%s'", Op);
         /* Continue. Wrong code will be generated, but the compiler won't
         ** break, so this is the best error recovery.

--- a/src/cc65/codeseg.c
+++ b/src/cc65/codeseg.c
@@ -521,7 +521,7 @@ CodeSeg* NewCodeSeg (const char* SegName, SymEntry* Func)
     /* If we have a function given, get the return type of the function.
     ** Assume ANY return type besides void will use the A and X registers.
     */
-    if (S->Func && !IsTypeVoid ((RetType = GetFuncReturn (Func->Type)))) {
+    if (S->Func && !IsTypeVoid ((RetType = GetFuncReturnType (Func->Type)))) {
         if (SizeOf (RetType) == SizeOf (type_long)) {
             S->ExitRegs = REG_EAX;
         } else {

--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -150,7 +150,7 @@ void TypeFree (Type* T)
 
 
 int SignExtendChar (int C)
-/* Do correct sign extension of a character */
+/* Do correct sign extension of a character to an int */
 {
     if (IS_Get (&SignedChars) && (C & 0x80) != 0) {
         return C | ~0xFF;
@@ -214,7 +214,7 @@ unsigned BitSizeOf (const Type* T)
 unsigned SizeOf (const Type* T)
 /* Compute size (in bytes) of object represented by type array */
 {
-    switch (GetUnderlyingTypeCode (T)) {
+    switch (GetUnqualTypeCode (T)) {
 
         case T_VOID:
             /* A void variable is a cc65 extension.
@@ -347,7 +347,7 @@ unsigned CheckedPSizeOf (const Type* T)
 
 
 
-static unsigned GetBitFieldMinimalTypeSize (unsigned BitWidth)
+static unsigned GetMinimalTypeSizeByBitWidth (unsigned BitWidth)
 /* Return the size of the smallest integer type that may have BitWidth bits */
 {
     /* Since all integer types supported in cc65 for bit-fields have sizes that
@@ -366,14 +366,14 @@ static unsigned GetBitFieldMinimalTypeSize (unsigned BitWidth)
 
 
 
-TypeCode GetUnderlyingTypeCode (const Type* Type)
-/* Get the type code of the unqualified underlying type of TCode.
-** Return UnqualTypeCode (Type) if Type is not scalar.
+TypeCode GetUnqualTypeCode (const Type* Type)
+/* Get the type code of the unqualified underlying type of Type.
+** Return GetUnqualRawTypeCode (Type) if Type is not scalar.
 */
 {
-    TypeCode Underlying = UnqualifiedType (Type->C);
+    TypeCode Underlying = GetUnqualRawTypeCode (Type);
 
-    if (IsISOChar (Type)) {
+    if (IsDeclTypeChar (Type)) {
 
         return IS_Get (&SignedChars) ? T_SCHAR : T_UCHAR;
 
@@ -382,7 +382,7 @@ TypeCode GetUnderlyingTypeCode (const Type* Type)
 
         /* This should not happen, but just in case */
         if (Type->A.S == 0) {
-            Internal ("Enum tag type error in GetUnderlyingTypeCode");
+            Internal ("Enum tag type error in GetUnqualTypeCode");
         }
 
         /* Inspect the underlying type of the enum */
@@ -390,24 +390,24 @@ TypeCode GetUnderlyingTypeCode (const Type* Type)
             /* Incomplete enum type is used */
             return Underlying;
         }
-        TCode = UnqualifiedType (Type->A.S->V.E.Type->C);
+        TCode = GetUnqualRawTypeCode (Type->A.S->V.E.Type);
 
         /* Replace the type code with integer */
-        Underlying = (TCode & ~T_MASK_TYPE);
+        Underlying = (TCode & ~T_MASK_RANK);
         switch (TCode & T_MASK_SIZE) {
-            case T_SIZE_INT:      Underlying |= T_TYPE_INT;      break;
-            case T_SIZE_LONG:     Underlying |= T_TYPE_LONG;     break;
-            case T_SIZE_SHORT:    Underlying |= T_TYPE_SHORT;    break;
-            case T_SIZE_CHAR:     Underlying |= T_TYPE_CHAR;     break;
-            case T_SIZE_LONGLONG: Underlying |= T_TYPE_LONGLONG; break;
-            default:              Underlying |= T_TYPE_INT;      break;
+            case T_SIZE_INT:      Underlying |= T_RANK_INT;      break;
+            case T_SIZE_LONG:     Underlying |= T_RANK_LONG;     break;
+            case T_SIZE_SHORT:    Underlying |= T_RANK_SHORT;    break;
+            case T_SIZE_CHAR:     Underlying |= T_RANK_CHAR;     break;
+            case T_SIZE_LONGLONG: Underlying |= T_RANK_LONGLONG; break;
+            default:              Underlying |= T_RANK_INT;      break;
         }
     } else if (IsTypeBitField (Type)) {
         /* We consider the smallest type that can represent all values of the
         ** bit-field, instead of the type used in the declaration, the truly
         ** underlying of the bit-field.
         */
-        switch (GetBitFieldMinimalTypeSize (Type->A.B.Width)) {
+        switch (GetMinimalTypeSizeByBitWidth (Type->A.B.Width)) {
             case SIZEOF_CHAR:     Underlying = T_CHAR;      break;
             case SIZEOF_INT:      Underlying = T_INT;       break;
             case SIZEOF_LONG:     Underlying = T_LONG;      break;
@@ -494,7 +494,7 @@ Type* NewPointerTo (const Type* T)
 
 
 
-Type* NewBitFieldType (const Type* T, unsigned BitOffs, unsigned BitWidth)
+Type* NewBitFieldOf (const Type* T, unsigned BitOffs, unsigned BitWidth)
 /* Return a type string that is "T : BitWidth" aligned on BitOffs. The type
 ** string is allocated on the heap and may be freed after use.
 */
@@ -547,20 +547,6 @@ const Type* AddressOf (const Type* T)
 
 
 const Type* Indirect (const Type* T)
-/* Do one indirection for the given type, that is, return the type where the
-** given type points to.
-*/
-{
-    /* We are expecting a pointer expression */
-    CHECK (IsClassPtr (T));
-
-    /* Skip the pointer or array token itself */
-    return T + 1;
-}
-
-
-
-Type* IndirectModifiable (Type* T)
 /* Do one indirection for the given type, that is, return the type where the
 ** given type points to.
 */
@@ -648,12 +634,12 @@ const Type* IntPromotion (const Type* T)
             return IsSignUnsigned (T) ? type_ulong : type_long;
         }
         return T->A.B.Width == INT_BITS && IsSignUnsigned (T) ? type_uint : type_int;
-    } else if (IsTypeChar (T)) {
+    } else if (IsRankChar (T)) {
         /* An integer can represent all values from either signed or unsigned char, so convert
         ** chars to int.
         */
         return type_int;
-    } else if (IsTypeShort (T)) {
+    } else if (IsRankShort (T)) {
         /* An integer cannot represent all values from unsigned short, so convert unsigned short
         ** to unsigned int.
         */
@@ -690,8 +676,8 @@ const Type* ArithmeticConvert (const Type* lhst, const Type* rhst)
     /* If either operand has type unsigned long int, the other operand is converted to
     ** unsigned long int.
     */
-    if ((IsTypeLong (lhst) && IsSignUnsigned (lhst)) ||
-        (IsTypeLong (rhst) && IsSignUnsigned (rhst))) {
+    if ((IsRankLong (lhst) && IsSignUnsigned (lhst)) ||
+        (IsRankLong (rhst) && IsSignUnsigned (rhst))) {
         return type_ulong;
     }
 
@@ -700,74 +686,74 @@ const Type* ArithmeticConvert (const Type* lhst, const Type* rhst)
     ** is converted to long int ; if a long int cannot represent all the values of an unsigned int,
     ** both operands are converted to unsigned long int.
     */
-    if ((IsTypeLong (lhst) && IsTypeInt (rhst) && IsSignUnsigned (rhst)) ||
-        (IsTypeLong (rhst) && IsTypeInt (lhst) && IsSignUnsigned (lhst))) {
+    if ((IsRankLong (lhst) && IsRankInt (rhst) && IsSignUnsigned (rhst)) ||
+        (IsRankLong (rhst) && IsRankInt (lhst) && IsSignUnsigned (lhst))) {
         /* long can represent all unsigneds, so we are in the first sub-case. */
         return type_long;
     }
 
     /* Otherwise, if either operand has type long int, the other operand is converted to long int.
     */
-    if (IsTypeLong (lhst) || IsTypeLong (rhst)) {
+    if (IsRankLong (lhst) || IsRankLong (rhst)) {
         return type_long;
     }
 
     /* Otherwise, if either operand has type unsigned int, the other operand is converted to
     ** unsigned int.
     */
-    if ((IsTypeInt (lhst) && IsSignUnsigned (lhst)) ||
-        (IsTypeInt (rhst) && IsSignUnsigned (rhst))) {
+    if ((IsRankInt (lhst) && IsSignUnsigned (lhst)) ||
+        (IsRankInt (rhst) && IsSignUnsigned (rhst))) {
         return type_uint;
     }
 
     /* Otherwise, both operands have type int. */
-    CHECK (IsTypeInt (lhst));
+    CHECK (IsRankInt (lhst));
     CHECK (IsSignSigned (lhst));
-    CHECK (IsTypeInt (rhst));
+    CHECK (IsRankInt (rhst));
     CHECK (IsSignSigned (rhst));
     return type_int;
 }
 
 
 
-const Type* SignedType (const Type* T)
+const Type* GetSignedType (const Type* T)
 /* Get signed counterpart of the integral type */
 {
-    switch (GetUnderlyingTypeCode (T) & T_MASK_TYPE) {
-        case T_TYPE_CHAR:
+    switch (GetUnqualTypeCode (T) & T_MASK_RANK) {
+        case T_RANK_CHAR:
             return type_schar;
 
-        case T_TYPE_INT:
-        case T_TYPE_SHORT:
+        case T_RANK_INT:
+        case T_RANK_SHORT:
             return type_int;
 
-        case T_TYPE_LONG:
+        case T_RANK_LONG:
             return type_long;
 
         default:
-            Internal ("Unknown type code: %lX", GetUnderlyingTypeCode (T));
+            Internal ("Unknown type code: %lX", GetUnqualTypeCode (T));
             return T;
     }
 }
 
 
 
-const Type* UnsignedType (const Type* T)
+const Type* GetUnsignedType (const Type* T)
 /* Get unsigned counterpart of the integral type */
 {
-    switch (GetUnderlyingTypeCode (T) & T_MASK_TYPE) {
-        case T_TYPE_CHAR:
+    switch (GetUnqualTypeCode (T) & T_MASK_RANK) {
+        case T_RANK_CHAR:
             return type_uchar;
 
-        case T_TYPE_INT:
-        case T_TYPE_SHORT:
+        case T_RANK_INT:
+        case T_RANK_SHORT:
             return type_uint;
 
-        case T_TYPE_LONG:
+        case T_RANK_LONG:
             return type_ulong;
 
         default:
-            Internal ("Unknown type code: %lX", GetUnderlyingTypeCode (T));
+            Internal ("Unknown type code: %lX", GetUnqualTypeCode (T));
             return T;
     }
 }
@@ -777,12 +763,12 @@ const Type* UnsignedType (const Type* T)
 const Type* GetUnderlyingType (const Type* Type)
 /* Get the underlying type of an enum or other integer class type */
 {
-    if (IsISOChar (Type)) {
+    if (IsDeclTypeChar (Type)) {
         return IS_Get (&SignedChars) ? type_schar : type_uchar;
     } else if (IsTypeEnum (Type)) {
         /* This should not happen, but just in case */
         if (Type->A.S == 0) {
-            Internal ("Enum tag type error in GetUnderlyingTypeCode");
+            Internal ("Enum tag type error in GetUnderlyingType");
         }
 
         /* If incomplete enum type is used, just return its raw type */
@@ -794,7 +780,7 @@ const Type* GetUnderlyingType (const Type* Type)
         ** bit-field, instead of the type used in the declaration, the truly
         ** underlying of the bit-field.
         */
-        switch (GetBitFieldMinimalTypeSize (Type->A.B.Width)) {
+        switch (GetMinimalTypeSizeByBitWidth (Type->A.B.Width)) {
             case SIZEOF_CHAR: Type = IsSignSigned (Type) ? type_schar : type_uchar; break;
             case SIZEOF_INT:  Type = IsSignSigned (Type) ? type_int   : type_uint;  break;
             case SIZEOF_LONG: Type = IsSignSigned (Type) ? type_long  : type_ulong; break;
@@ -808,7 +794,7 @@ const Type* GetUnderlyingType (const Type* Type)
 
 
 const Type* GetStructReplacementType (const Type* SType)
-/* Get a replacement type for passing a struct/union in the primary register */
+/* Get a replacement type for passing a struct/union by value in the primary */
 {
     const Type* NewType;
     /* If the size is less than or equal to that of a long, we will copy the
@@ -837,7 +823,7 @@ const Type* GetBitFieldChunkType (const Type* Type)
         return GetUnderlyingType (Type);
     }
 
-    ChunkSize = GetBitFieldMinimalTypeSize (Type->A.B.Offs + Type->A.B.Width);
+    ChunkSize = GetMinimalTypeSizeByBitWidth (Type->A.B.Offs + Type->A.B.Width);
     if (ChunkSize < SizeOf (Type + 1)) {
         /* The end of the bit-field is offset by some bits so that it requires
         ** more bytes to be accessed as a whole than its underlying type does.
@@ -875,50 +861,50 @@ int IsTypeFragBitField (const Type* T)
 
 
 
-int IsClassObject (const Type* T)
+int IsObjectType (const Type* T)
 /* Return true if this is a fully described object type */
 {
-    return !IsTypeFunc (T) && !IsClassIncomplete (T);
+    return !IsTypeFunc (T) && !IsIncompleteType (T);
 }
 
 
 
-int IsClassIncomplete (const Type* T)
+int IsIncompleteType (const Type* T)
 /* Return true if this is an object type lacking size info */
 {
     if (IsTypeArray (T)) {
-        return GetElementCount (T) == UNSPECIFIED || IsClassIncomplete (T + 1);
+        return GetElementCount (T) == UNSPECIFIED || IsIncompleteType (T + 1);
     }
     return IsTypeVoid (T) || IsIncompleteESUType (T);
 }
 
 
 
-int IsClassArithmetic (const Type* T)
-/* Return true if this is an integer or real floating type */
+int IsArithmeticType (const Type* T)
+/* Return true if this is an integer or floating type */
 {
     return IsClassInt (T) || IsClassFloat (T);
 }
 
 
 
-int IsClassBasic (const Type* T)
-/* Return true if this is a char, integer or floating type */
+int IsBasicType (const Type* T)
+/* Return true if this is a character, integer or floating type */
 {
-    return IsClassChar (T) || IsClassInt (T) || IsClassFloat (T);
+    return IsDeclRankChar (T) || IsClassInt (T) || IsClassFloat (T);
 }
 
 
 
-int IsClassScalar (const Type* T)
+int IsScalarType (const Type* T)
 /* Return true if this is an arithmetic or pointer type */
 {
-    return IsClassArithmetic (T) || IsTypePtr (T);
+    return IsArithmeticType (T) || IsTypePtr (T);
 }
 
 
 
-int IsClassDerived (const Type* T)
+int IsDerivedType (const Type* T)
 /* Return true if this is an array, struct, union, function or pointer type */
 {
     return IsTypeArray (T) || IsClassStruct (T) || IsClassFunc (T) || IsTypePtr (T);
@@ -926,7 +912,7 @@ int IsClassDerived (const Type* T)
 
 
 
-int IsClassAggregate (const Type* T)
+int IsAggregateType (const Type* T)
 /* Return true if this is an array or struct type */
 {
     return IsTypeArray (T) || IsTypeStruct (T);
@@ -937,7 +923,7 @@ int IsClassAggregate (const Type* T)
 int IsRelationType (const Type* T)
 /* Return true if this is an arithmetic, array or pointer type */
 {
-    return IsClassArithmetic (T) || IsClassPtr (T);
+    return IsArithmeticType (T) || IsClassPtr (T);
 }
 
 
@@ -945,7 +931,7 @@ int IsRelationType (const Type* T)
 int IsCastType (const Type* T)
 /* Return true if this type can be used for casting */
 {
-    return IsClassScalar (T) || IsTypeVoid (T);
+    return IsScalarType (T) || IsTypeVoid (T);
 }
 
 
@@ -987,7 +973,7 @@ int HasUnknownSize (const Type* T)
 
 
 
-int TypeHasAttr (const Type* T)
+int TypeHasAttrData (const Type* T)
 /* Return true if the given type has attribute data */
 {
     return IsClassStruct (T) || IsTypeArray (T) || IsClassFunc (T);
@@ -1044,7 +1030,7 @@ int IsFastcallFunc (const Type* T)
 ** Check fails if the type is not a function or a pointer to function.
 */
 {
-    if (UnqualifiedType (T->C) == T_PTR) {
+    if (GetUnqualRawTypeCode (T) == T_PTR) {
         /* Pointer to function */
         ++T;
     }
@@ -1056,7 +1042,7 @@ int IsFastcallFunc (const Type* T)
 FuncDesc* GetFuncDesc (const Type* T)
 /* Get the FuncDesc pointer from a function or pointer-to-function type */
 {
-    if (UnqualifiedType (T->C) == T_PTR) {
+    if (GetUnqualRawTypeCode (T) == T_PTR) {
         /* Pointer to function */
         ++T;
     }
@@ -1073,7 +1059,7 @@ FuncDesc* GetFuncDesc (const Type* T)
 void SetFuncDesc (Type* T, FuncDesc* F)
 /* Set the FuncDesc pointer in a function or pointer-to-function type */
 {
-    if (UnqualifiedType (T->C) == T_PTR) {
+    if (GetUnqualRawTypeCode (T) == T_PTR) {
         /* Pointer to function */
         ++T;
     }
@@ -1087,10 +1073,10 @@ void SetFuncDesc (Type* T, FuncDesc* F)
 
 
 
-const Type* GetFuncReturn (const Type* T)
+const Type* GetFuncReturnType (const Type* T)
 /* Return a pointer to the return type of a function or pointer-to-function type */
 {
-    if (UnqualifiedType (T->C) == T_PTR) {
+    if (GetUnqualRawTypeCode (T) == T_PTR) {
         /* Pointer to function */
         ++T;
     }
@@ -1104,10 +1090,10 @@ const Type* GetFuncReturn (const Type* T)
 
 
 
-Type* GetFuncReturnModifiable (Type* T)
+Type* GetFuncReturnTypeModifiable (Type* T)
 /* Return a non-const pointer to the return type of a function or pointer-to-function type */
 {
-    if (UnqualifiedType (T->C) == T_PTR) {
+    if (GetUnqualRawTypeCode (T) == T_PTR) {
         /* Pointer to function */
         ++T;
     }
@@ -1164,7 +1150,16 @@ void SetElementCount (Type* T, long Count)
 
 
 const Type* GetElementType (const Type* T)
-/* Return the element type of the given array type. */
+/* Return the element type of the given array type */
+{
+    CHECK (IsTypeArray (T));
+    return T + 1;
+}
+
+
+
+Type* GetElementTypeModifiable (Type* T)
+/* Return the element type of the given array type */
 {
     CHECK (IsTypeArray (T));
     return T + 1;
@@ -1228,48 +1223,48 @@ const char* GetBasicTypeName (const Type* T)
 ** Return "type" for unknown basic types.
 */
 {
-    switch (GetRawType (T)) {
-    case T_TYPE_ENUM:       return "enum";
-    case T_TYPE_BITFIELD:   return "bit-field";
-    case T_TYPE_FLOAT:      return "float";
-    case T_TYPE_DOUBLE:     return "double";
-    case T_TYPE_VOID:       return "void";
-    case T_TYPE_STRUCT:     return "struct";
-    case T_TYPE_UNION:      return "union";
-    case T_TYPE_ARRAY:      return "array";
-    case T_TYPE_PTR:        return "pointer";
-    case T_TYPE_FUNC:       return "function";
-    case T_TYPE_NONE:       /* FALLTHROUGH */
+    switch (GetRawTypeRank (T)) {
+    case T_RANK_ENUM:       return "enum";
+    case T_RANK_BITFIELD:   return "bit-field";
+    case T_RANK_FLOAT:      return "float";
+    case T_RANK_DOUBLE:     return "double";
+    case T_RANK_VOID:       return "void";
+    case T_RANK_STRUCT:     return "struct";
+    case T_RANK_UNION:      return "union";
+    case T_RANK_ARRAY:      return "array";
+    case T_RANK_PTR:        return "pointer";
+    case T_RANK_FUNC:       return "function";
+    case T_RANK_NONE:       /* FALLTHROUGH */
     default:                break;
     }
     if (IsClassInt (T)) {
         if (IsRawSignSigned (T)) {
-            switch (GetRawType (T)) {
-            case T_TYPE_CHAR:       return "signed char";
-            case T_TYPE_SHORT:      return "short";
-            case T_TYPE_INT:        return "int";
-            case T_TYPE_LONG:       return "long";
-            case T_TYPE_LONGLONG:   return "long long";
+            switch (GetRawTypeRank (T)) {
+            case T_RANK_CHAR:       return "signed char";
+            case T_RANK_SHORT:      return "short";
+            case T_RANK_INT:        return "int";
+            case T_RANK_LONG:       return "long";
+            case T_RANK_LONGLONG:   return "long long";
             default:
                 return "signed integer";
             }
         } else if (IsRawSignUnsigned (T)) {
-            switch (GetRawType (T)) {
-            case T_TYPE_CHAR:       return "unsigned char";
-            case T_TYPE_SHORT:      return "unsigned short";
-            case T_TYPE_INT:        return "unsigned int";
-            case T_TYPE_LONG:       return "unsigned long";
-            case T_TYPE_LONGLONG:   return "unsigned long long";
+            switch (GetRawTypeRank (T)) {
+            case T_RANK_CHAR:       return "unsigned char";
+            case T_RANK_SHORT:      return "unsigned short";
+            case T_RANK_INT:        return "unsigned int";
+            case T_RANK_LONG:       return "unsigned long";
+            case T_RANK_LONGLONG:   return "unsigned long long";
             default:
                 return "unsigned integer";
             }
         } else {
-            switch (GetRawType (T)) {
-            case T_TYPE_CHAR:       return "char";
-            case T_TYPE_SHORT:      return "short";
-            case T_TYPE_INT:        return "int";
-            case T_TYPE_LONG:       return "long";
-            case T_TYPE_LONGLONG:   return "long long";
+            switch (GetRawTypeRank (T)) {
+            case T_RANK_CHAR:       return "char";
+            case T_RANK_SHORT:      return "short";
+            case T_RANK_INT:        return "int";
+            case T_RANK_LONG:       return "long";
+            case T_RANK_LONGLONG:   return "long long";
             default:
                 return "integer";
             }
@@ -1600,7 +1595,7 @@ void PrintFuncSig (FILE* F, const char* Name, const Type* T)
     SB_Done (&ParamList);
 
     /* Complete with the return type */
-    GetFullTypeNameWestEast (&West, &East, GetFuncReturn (T));
+    GetFullTypeNameWestEast (&West, &East, GetFuncReturnType (T));
     SB_Append (&West, &East);
     SB_Terminate (&West);
 

--- a/src/cc65/datatype.h
+++ b/src/cc65/datatype.h
@@ -71,24 +71,24 @@ struct SymEntry;
 enum {
     T_END           = 0x000000,
 
-    /* Basic types */
-    T_TYPE_NONE     = 0x000000,
-    T_TYPE_CHAR     = 0x000001,
-    T_TYPE_SHORT    = 0x000002,
-    T_TYPE_INT      = 0x000003,
-    T_TYPE_LONG     = 0x000004,
-    T_TYPE_LONGLONG = 0x000005,
-    T_TYPE_ENUM     = 0x000008,
-    T_TYPE_BITFIELD = 0x000009,
-    T_TYPE_FLOAT    = 0x00000A,
-    T_TYPE_DOUBLE   = 0x00000B,
-    T_TYPE_VOID     = 0x000010,
-    T_TYPE_STRUCT   = 0x000011,
-    T_TYPE_UNION    = 0x000012,
-    T_TYPE_ARRAY    = 0x000018,
-    T_TYPE_PTR      = 0x000019,
-    T_TYPE_FUNC     = 0x00001A,
-    T_MASK_TYPE     = 0x00001F,
+    /* Basic type ranks */
+    T_RANK_NONE     = 0x000000,
+    T_RANK_CHAR     = 0x000001,
+    T_RANK_SHORT    = 0x000002,
+    T_RANK_INT      = 0x000003,
+    T_RANK_LONG     = 0x000004,
+    T_RANK_LONGLONG = 0x000005,
+    T_RANK_ENUM     = 0x000008,
+    T_RANK_BITFIELD = 0x000009,
+    T_RANK_FLOAT    = 0x00000A,
+    T_RANK_DOUBLE   = 0x00000B,
+    T_RANK_VOID     = 0x000010,
+    T_RANK_STRUCT   = 0x000011,
+    T_RANK_UNION    = 0x000012,
+    T_RANK_ARRAY    = 0x000018,
+    T_RANK_PTR      = 0x000019,
+    T_RANK_FUNC     = 0x00001A,
+    T_MASK_RANK     = 0x00001F,
 
     /* Type classes */
     T_CLASS_NONE    = 0x000000,
@@ -129,28 +129,28 @@ enum {
     T_MASK_QUAL     = 0x7F0000,
 
     /* Types */
-    T_CHAR      = T_TYPE_CHAR     | T_CLASS_INT    | T_SIGN_NONE     | T_SIZE_CHAR,
-    T_SCHAR     = T_TYPE_CHAR     | T_CLASS_INT    | T_SIGN_SIGNED   | T_SIZE_CHAR,
-    T_UCHAR     = T_TYPE_CHAR     | T_CLASS_INT    | T_SIGN_UNSIGNED | T_SIZE_CHAR,
-    T_SHORT     = T_TYPE_SHORT    | T_CLASS_INT    | T_SIGN_SIGNED   | T_SIZE_SHORT,
-    T_USHORT    = T_TYPE_SHORT    | T_CLASS_INT    | T_SIGN_UNSIGNED | T_SIZE_SHORT,
-    T_INT       = T_TYPE_INT      | T_CLASS_INT    | T_SIGN_SIGNED   | T_SIZE_INT,
-    T_UINT      = T_TYPE_INT      | T_CLASS_INT    | T_SIGN_UNSIGNED | T_SIZE_INT,
-    T_LONG      = T_TYPE_LONG     | T_CLASS_INT    | T_SIGN_SIGNED   | T_SIZE_LONG,
-    T_ULONG     = T_TYPE_LONG     | T_CLASS_INT    | T_SIGN_UNSIGNED | T_SIZE_LONG,
-    T_LONGLONG  = T_TYPE_LONGLONG | T_CLASS_INT    | T_SIGN_SIGNED   | T_SIZE_LONGLONG,
-    T_ULONGLONG = T_TYPE_LONGLONG | T_CLASS_INT    | T_SIGN_UNSIGNED | T_SIZE_LONGLONG,
-    T_ENUM      = T_TYPE_ENUM     | T_CLASS_INT    | T_SIGN_NONE     | T_SIZE_NONE,
-    T_SBITFIELD = T_TYPE_BITFIELD | T_CLASS_INT    | T_SIGN_SIGNED   | T_SIZE_NONE,
-    T_UBITFIELD = T_TYPE_BITFIELD | T_CLASS_INT    | T_SIGN_UNSIGNED | T_SIZE_NONE,
-    T_FLOAT     = T_TYPE_FLOAT    | T_CLASS_FLOAT  | T_SIGN_NONE     | T_SIZE_NONE,
-    T_DOUBLE    = T_TYPE_DOUBLE   | T_CLASS_FLOAT  | T_SIGN_NONE     | T_SIZE_NONE,
-    T_VOID      = T_TYPE_VOID     | T_CLASS_NONE   | T_SIGN_NONE     | T_SIZE_NONE,
-    T_STRUCT    = T_TYPE_STRUCT   | T_CLASS_STRUCT | T_SIGN_NONE     | T_SIZE_NONE,
-    T_UNION     = T_TYPE_UNION    | T_CLASS_STRUCT | T_SIGN_NONE     | T_SIZE_NONE,
-    T_ARRAY     = T_TYPE_ARRAY    | T_CLASS_PTR    | T_SIGN_NONE     | T_SIZE_NONE,
-    T_PTR       = T_TYPE_PTR      | T_CLASS_PTR    | T_SIGN_NONE     | T_SIZE_NONE,
-    T_FUNC      = T_TYPE_FUNC     | T_CLASS_FUNC   | T_SIGN_NONE     | T_SIZE_NONE,
+    T_CHAR      = T_RANK_CHAR     | T_CLASS_INT    | T_SIGN_NONE     | T_SIZE_CHAR,
+    T_SCHAR     = T_RANK_CHAR     | T_CLASS_INT    | T_SIGN_SIGNED   | T_SIZE_CHAR,
+    T_UCHAR     = T_RANK_CHAR     | T_CLASS_INT    | T_SIGN_UNSIGNED | T_SIZE_CHAR,
+    T_SHORT     = T_RANK_SHORT    | T_CLASS_INT    | T_SIGN_SIGNED   | T_SIZE_SHORT,
+    T_USHORT    = T_RANK_SHORT    | T_CLASS_INT    | T_SIGN_UNSIGNED | T_SIZE_SHORT,
+    T_INT       = T_RANK_INT      | T_CLASS_INT    | T_SIGN_SIGNED   | T_SIZE_INT,
+    T_UINT      = T_RANK_INT      | T_CLASS_INT    | T_SIGN_UNSIGNED | T_SIZE_INT,
+    T_LONG      = T_RANK_LONG     | T_CLASS_INT    | T_SIGN_SIGNED   | T_SIZE_LONG,
+    T_ULONG     = T_RANK_LONG     | T_CLASS_INT    | T_SIGN_UNSIGNED | T_SIZE_LONG,
+    T_LONGLONG  = T_RANK_LONGLONG | T_CLASS_INT    | T_SIGN_SIGNED   | T_SIZE_LONGLONG,
+    T_ULONGLONG = T_RANK_LONGLONG | T_CLASS_INT    | T_SIGN_UNSIGNED | T_SIZE_LONGLONG,
+    T_ENUM      = T_RANK_ENUM     | T_CLASS_INT    | T_SIGN_NONE     | T_SIZE_NONE,
+    T_SBITFIELD = T_RANK_BITFIELD | T_CLASS_INT    | T_SIGN_SIGNED   | T_SIZE_NONE,
+    T_UBITFIELD = T_RANK_BITFIELD | T_CLASS_INT    | T_SIGN_UNSIGNED | T_SIZE_NONE,
+    T_FLOAT     = T_RANK_FLOAT    | T_CLASS_FLOAT  | T_SIGN_NONE     | T_SIZE_NONE,
+    T_DOUBLE    = T_RANK_DOUBLE   | T_CLASS_FLOAT  | T_SIGN_NONE     | T_SIZE_NONE,
+    T_VOID      = T_RANK_VOID     | T_CLASS_NONE   | T_SIGN_NONE     | T_SIZE_NONE,
+    T_STRUCT    = T_RANK_STRUCT   | T_CLASS_STRUCT | T_SIGN_NONE     | T_SIZE_NONE,
+    T_UNION     = T_RANK_UNION    | T_CLASS_STRUCT | T_SIGN_NONE     | T_SIZE_NONE,
+    T_ARRAY     = T_RANK_ARRAY    | T_CLASS_PTR    | T_SIGN_NONE     | T_SIZE_NONE,
+    T_PTR       = T_RANK_PTR      | T_CLASS_PTR    | T_SIGN_NONE     | T_SIZE_NONE,
+    T_FUNC      = T_RANK_FUNC     | T_CLASS_FUNC   | T_SIGN_NONE     | T_SIZE_NONE,
 
     /* More types for convenience */
     T_C_CHAR    = T_CHAR | T_QUAL_CONST,
@@ -316,7 +316,9 @@ unsigned CheckedPSizeOf (const Type* T);
 
 #if defined(HAVE_INLINE)
 INLINE TypeCode GetQualifier (const Type* T)
-/* Get the qualifier from the given type string */
+/* Get the qualifier from the given type. This doesn't have a "raw" version
+** since an underlying type can never be qualified.
+*/
 {
     return (T->C & T_MASK_QUAL);
 }
@@ -324,66 +326,78 @@ INLINE TypeCode GetQualifier (const Type* T)
 #  define GetQualifier(T)       ((T)->C & T_MASK_QUAL)
 #endif
 
-TypeCode GetUnderlyingTypeCode (const Type* Type);
-/* Get the type code of the unqualified underlying type of TCode.
-** Return TCode if it is not scalar.
+TypeCode GetUnqualTypeCode (const Type* Type);
+/* Get the type code of the unqualified underlying type of Type.
+** Return GetUnqualRawTypeCode (Type) if Type is not scalar.
 */
 
 #if defined(HAVE_INLINE)
-INLINE TypeCode UnqualifiedType (TypeCode T)
-/* Return the unqualified type code */
+INLINE TypeCode GetUnqualRawTypeCode (const Type* T)
+/* Return the unqualified raw type code */
 {
-    return (T & ~T_MASK_QUAL);
+    return (T->C & ~T_MASK_QUAL);
 }
 #else
-#  define UnqualifiedType(T)    ((T) & ~T_MASK_QUAL)
+#  define GetUnqualRawTypeCode(T)   ((T)->C & ~T_MASK_QUAL)
 #endif
 
 #if defined(HAVE_INLINE)
-INLINE TypeCode GetClass (const Type* T)
-/* Get the class of a type string */
+INLINE TypeCode GetTypeClass (const Type* T)
+/* Get the class of a type. This doesn't have a "raw" version since an
+** underlying type can never be in a different class.
+*/
 {
     return (T->C & T_MASK_CLASS);
 }
 #else
-#  define GetClass(T)           ((T)->C & T_MASK_CLASS)
+#  define GetTypeClass(T)       ((T)->C & T_MASK_CLASS)
+#endif
+
+#if defined(HAVE_INLINE)
+INLINE TypeCode GetTypeRank (const Type* T)
+/* Get the type rank of a type */
+{
+    return (GetUnqualTypeCode (T) & T_MASK_RANK);
+}
+#else
+#  define GetTypeRank(T)        (GetUnqualTypeCode (T) & T_MASK_RANK)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE TypeCode GetSignedness (const Type* T)
 /* Get the signedness of a type */
 {
-    return (GetUnderlyingTypeCode (T) & T_MASK_SIGN);
+    return (GetUnqualTypeCode (T) & T_MASK_SIGN);
 }
 #else
-#  define GetSignedness(T)      (GetUnderlyingTypeCode (T) & T_MASK_SIGN)
+#  define GetSignedness(T)      (GetUnqualTypeCode (T) & T_MASK_SIGN)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE TypeCode GetSizeModifier (const Type* T)
 /* Get the size modifier of a type */
 {
-    return (GetUnderlyingTypeCode (T) & T_MASK_SIZE);
+    return (GetUnqualTypeCode (T) & T_MASK_SIZE);
 }
 #else
-#  define GetSizeModifier(T)    (GetUnderlyingTypeCode (T) & T_MASK_SIZE)
+#  define GetSizeModifier(T)    (GetUnqualTypeCode (T) & T_MASK_SIZE)
 #endif
 
 #if defined(HAVE_INLINE)
-INLINE TypeCode GetRawType (const Type* T)
-/* Get the raw type */
+INLINE TypeCode GetRawTypeRank (const Type* T)
+/* Get the raw type rank of a type */
 {
-    return (T->C & T_MASK_TYPE);
+    return (T->C & T_MASK_RANK);
 }
 #else
-#  define GetRawType(T)         ((T)->C & T_MASK_TYPE)
+#  define GetRawTypeRank(T)     ((T)->C & T_MASK_RANK)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE TypeCode GetRawSignedness (const Type* T)
 /* Get the raw signedness of a type */
 {
-    return ((T)->C & T_MASK_SIGN);
+    return (T->C & T_MASK_SIGN);
 }
 #else
 #  define GetRawSignedness(T)   ((T)->C & T_MASK_SIGN)
@@ -391,7 +405,7 @@ INLINE TypeCode GetRawSignedness (const Type* T)
 
 #if defined(HAVE_INLINE)
 INLINE TypeCode GetRawSizeModifier (const Type* T)
-/* Get the size modifier of a raw type */
+/* Get the raw size modifier of a type */
 {
     return (T->C & T_MASK_SIZE);
 }
@@ -418,7 +432,7 @@ Type* NewPointerTo (const Type* T);
 ** on the heap and may be freed after use.
 */
 
-Type* NewBitFieldType (const Type* T, unsigned BitOffs, unsigned BitWidth);
+Type* NewBitFieldOf (const Type* T, unsigned BitOffs, unsigned BitWidth);
 /* Return a type string that is "T : BitWidth" aligned on BitOffs. The type
 ** string is allocated on the heap and may be freed after use.
 */
@@ -429,11 +443,6 @@ const Type* AddressOf (const Type* T);
 */
 
 const Type* Indirect (const Type* T);
-/* Do one indirection for the given type, that is, return the type where the
-** given type points to.
-*/
-
-Type* IndirectModifiable (Type* T);
 /* Do one indirection for the given type, that is, return the type where the
 ** given type points to.
 */
@@ -461,17 +470,17 @@ const Type* IntPromotion (const Type* T);
 const Type* ArithmeticConvert (const Type* lhst, const Type* rhst);
 /* Perform the usual arithmetic conversions for binary operators. */
 
-const Type* SignedType (const Type* T);
+const Type* GetSignedType (const Type* T);
 /* Get signed counterpart of the integral type */
 
-const Type* UnsignedType (const Type* T);
+const Type* GetUnsignedType (const Type* T);
 /* Get unsigned counterpart of the integral type */
 
 const Type* GetUnderlyingType (const Type* Type);
 /* Get the underlying type of an enum or other integer class type */
 
 const Type* GetStructReplacementType (const Type* SType);
-/* Get a replacement type for passing a struct/union in the primary register */
+/* Get a replacement type for passing a struct/union by value in the primary */
 
 const Type* GetBitFieldChunkType (const Type* Type);
 /* Get the type needed to operate on the byte chunk containing the bit-field */
@@ -485,155 +494,127 @@ const Type* GetBitFieldChunkType (const Type* Type);
 
 
 #if defined(HAVE_INLINE)
-INLINE int IsTypeChar (const Type* T)
-/* Return true if this is a char type */
+INLINE int IsRankChar (const Type* T)
+/* Return true if this is a character type */
 {
-    return (GetRawType (GetUnderlyingType (T)) == T_TYPE_CHAR);
+    return (GetTypeRank (T) == T_RANK_CHAR);
 }
 #else
-#  define IsTypeChar(T)         (GetRawType (GetUnderlyingType (T)) == T_TYPE_CHAR)
+#  define IsRankChar(T)         (GetTypeRank (T) == T_RANK_CHAR)
 #endif
 
 #if defined(HAVE_INLINE)
-INLINE int IsTypeShort (const Type* T)
+INLINE int IsRankShort (const Type* T)
 /* Return true if this is a short type (signed or unsigned) */
 {
-    return (GetRawType (GetUnderlyingType (T)) == T_TYPE_SHORT);
+    return (GetTypeRank (T) == T_RANK_SHORT);
 }
 #else
-#  define IsTypeShort(T)        (GetRawType (GetUnderlyingType (T)) == T_TYPE_SHORT)
+#  define IsRankShort(T)        (GetTypeRank (T) == T_RANK_SHORT)
 #endif
 
 #if defined(HAVE_INLINE)
-INLINE int IsTypeInt (const Type* T)
+INLINE int IsRankInt (const Type* T)
 /* Return true if this is an int type (signed or unsigned) */
 {
-    return (GetRawType (GetUnderlyingType (T)) == T_TYPE_INT);
+    return (GetTypeRank (T) == T_RANK_INT);
 }
 #else
-#  define IsTypeInt(T)          (GetRawType (GetUnderlyingType (T)) == T_TYPE_INT)
+#  define IsRankInt(T)          (GetTypeRank (T) == T_RANK_INT)
 #endif
 
 #if defined(HAVE_INLINE)
-INLINE int IsTypeLong (const Type* T)
+INLINE int IsRankLong (const Type* T)
 /* Return true if this is a long int type (signed or unsigned) */
 {
-    return (GetRawType (GetUnderlyingType (T)) == T_TYPE_LONG);
+    return (GetTypeRank (T) == T_RANK_LONG);
 }
 #else
-#  define IsTypeLong(T)         (GetRawType (GetUnderlyingType (T)) == T_TYPE_LONG)
+#  define IsRankLong(T)         (GetTypeRank (T) == T_RANK_LONG)
 #endif
 
 #if defined(HAVE_INLINE)
-INLINE int IsISOChar (const Type* T)
-/* Return true if this is a narrow character type (without signed/unsigned) */
-{
-    return (UnqualifiedType (T->C) == T_CHAR);
-}
-#else
-#  define IsISOChar(T)          (UnqualifiedType ((T)->C) == T_CHAR)
-#endif
-
-#if defined(HAVE_INLINE)
-INLINE int IsClassChar (const Type* T)
-/* Return true if this is a narrow character type (including signed/unsigned).
-** For now this is the same as IsRawTypeChar(T).
+INLINE int IsDeclTypeChar (const Type* T)
+/* Return true if this is declared as a char type (without signed/unsigned).
+** This function is to exclude enums whose underlying type is char.
 */
 {
-    return (GetRawType (T) == T_TYPE_CHAR);
+    return (GetUnqualRawTypeCode (T) == T_CHAR);
 }
 #else
-#  define IsClassChar(T)        (GetRawType (T) == T_TYPE_CHAR)
+#  define IsDeclTypeChar(T)     (GetUnqualRawTypeCode (T) == T_CHAR)
 #endif
 
 #if defined(HAVE_INLINE)
-INLINE int IsRawTypeChar (const Type* T)
-/* Return true if this is a char raw type (including signed/unsigned) */
+INLINE int IsDeclRankChar (const Type* T)
+/* Return true if this is declared as a character type (including signed/unsigned).
+** This function is to exclude enums whose underlying types are character types.
+*/
 {
-    return (GetRawType (T) == T_TYPE_CHAR);
+    return (GetRawTypeRank (T) == T_RANK_CHAR);
 }
 #else
-#  define IsRawTypeChar(T)      (GetRawType (T) == T_TYPE_CHAR)
-#endif
-
-#if defined(HAVE_INLINE)
-INLINE int IsRawTypeInt (const Type* T)
-/* Return true if this is an int raw type (signed or unsigned) */
-{
-    return (GetRawType (T) == T_TYPE_INT);
-}
-#else
-#  define IsRawTypeInt(T)       (GetRawType (T) == T_TYPE_INT)
-#endif
-
-#if defined(HAVE_INLINE)
-INLINE int IsRawTypeLong (const Type* T)
-/* Return true if this is a long raw type (signed or unsigned) */
-{
-    return (GetRawType (T) == T_TYPE_LONG);
-}
-#else
-#  define IsRawTypeLong(T)      (GetRawType (T) == T_TYPE_LONG)
+#  define IsDeclRankChar(T)     (GetRawTypeRank (T) == T_RANK_CHAR)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsTypeFloat (const Type* T)
 /* Return true if this is a float type */
 {
-    return (GetRawType (T) == T_TYPE_FLOAT);
+    return (GetRawTypeRank (T) == T_RANK_FLOAT);
 }
 #else
-#  define IsTypeFloat(T)        (GetRawType (T) == T_TYPE_FLOAT)
+#  define IsTypeFloat(T)        (GetRawTypeRank (T) == T_RANK_FLOAT)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsTypeDouble (const Type* T)
 /* Return true if this is a double type */
 {
-    return (GetRawType (T) == T_TYPE_DOUBLE);
+    return (GetRawTypeRank (T) == T_RANK_DOUBLE);
 }
 #else
-#  define IsTypeDouble(T)       (GetRawType (T) == T_TYPE_DOUBLE)
+#  define IsTypeDouble(T)       (GetRawTypeRank (T) == T_RANK_DOUBLE)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsTypePtr (const Type* T)
 /* Return true if this is a pointer type */
 {
-    return (GetRawType (T) == T_TYPE_PTR);
+    return (GetRawTypeRank (T) == T_RANK_PTR);
 }
 #else
-#  define IsTypePtr(T)          (GetRawType (T) == T_TYPE_PTR)
+#  define IsTypePtr(T)          (GetRawTypeRank (T) == T_RANK_PTR)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsTypeEnum (const Type* T)
 /* Return true if this is an enum type */
 {
-    return (GetRawType (T) == T_TYPE_ENUM);
+    return (GetRawTypeRank (T) == T_RANK_ENUM);
 }
 #else
-#  define IsTypeEnum(T)         (GetRawType (T) == T_TYPE_ENUM)
+#  define IsTypeEnum(T)         (GetRawTypeRank (T) == T_RANK_ENUM)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsTypeSignedBitField (const Type* T)
 /* Return true if this is a signed bit-field */
 {
-    return (UnqualifiedType (T->C) == T_SBITFIELD);
+    return (GetUnqualRawTypeCode (T) == T_SBITFIELD);
 }
 #else
-#  define IsTypeSignedBitField(T)   (UnqualifiedType ((T)->C) == T_SBITFIELD)
+#  define IsTypeSignedBitField(T)   (GetUnqualRawTypeCode (T) == T_SBITFIELD)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsTypeUnsignedBitField (const Type* T)
 /* Return true if this is an unsigned bit-field */
 {
-    return (UnqualifiedType (T->C) == T_UBITFIELD);
+    return (GetUnqualRawTypeCode (T) == T_UBITFIELD);
 }
 #else
-#  define IsTypeUnsignedBitField(T) (UnqualifiedType ((T)->C) == T_UBITFIELD)
+#  define IsTypeUnsignedBitField(T) (GetUnqualRawTypeCode (T) == T_UBITFIELD)
 #endif
 
 #if defined(HAVE_INLINE)
@@ -653,55 +634,55 @@ int IsTypeFragBitField (const Type* T);
 INLINE int IsTypeStruct (const Type* T)
 /* Return true if this is a struct type */
 {
-    return (GetRawType (T) == T_TYPE_STRUCT);
+    return (GetRawTypeRank (T) == T_RANK_STRUCT);
 }
 #else
-#  define IsTypeStruct(T)       (GetRawType (T) == T_TYPE_STRUCT)
+#  define IsTypeStruct(T)       (GetRawTypeRank (T) == T_RANK_STRUCT)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsTypeUnion (const Type* T)
 /* Return true if this is a union type */
 {
-    return (GetRawType (T) == T_TYPE_UNION);
+    return (GetRawTypeRank (T) == T_RANK_UNION);
 }
 #else
-#  define IsTypeUnion(T)        (GetRawType (T) == T_TYPE_UNION)
+#  define IsTypeUnion(T)        (GetRawTypeRank (T) == T_RANK_UNION)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsTypeArray (const Type* T)
 /* Return true if this is an array type */
 {
-    return (GetRawType (T) == T_TYPE_ARRAY);
+    return (GetRawTypeRank (T) == T_RANK_ARRAY);
 }
 #else
-#  define IsTypeArray(T)        (GetRawType (T) == T_TYPE_ARRAY)
+#  define IsTypeArray(T)        (GetRawTypeRank (T) == T_RANK_ARRAY)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsTypeVoid (const Type* T)
 /* Return true if this is a void type */
 {
-    return (GetRawType (T) == T_TYPE_VOID);
+    return (GetRawTypeRank (T) == T_RANK_VOID);
 }
 #else
-#  define IsTypeVoid(T)         (GetRawType (T) == T_TYPE_VOID)
+#  define IsTypeVoid(T)         (GetRawTypeRank (T) == T_RANK_VOID)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsTypeFunc (const Type* T)
-/* Return true if this is a function class */
+/* Return true if this is a function type */
 {
-    return (GetRawType (T) == T_TYPE_FUNC);
+    return (GetRawTypeRank (T) == T_RANK_FUNC);
 }
 #else
-#  define IsTypeFunc(T)         (GetRawType (T) == T_TYPE_FUNC)
+#  define IsTypeFunc(T)         (GetRawTypeRank (T) == T_RANK_FUNC)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsTypeFuncPtr (const Type* T)
-/* Return true if this is a function pointer */
+/* Return true if this is a function pointer type */
 {
     return (IsTypePtr (T) && IsTypeFunc (T+1));
 }
@@ -713,71 +694,71 @@ INLINE int IsTypeFuncPtr (const Type* T)
 INLINE int IsClassInt (const Type* T)
 /* Return true if this is an integer type */
 {
-    return (GetClass (T) == T_CLASS_INT);
+    return (GetTypeClass (T) == T_CLASS_INT);
 }
 #else
-#  define IsClassInt(T)         (GetClass (T) == T_CLASS_INT)
+#  define IsClassInt(T)         (GetTypeClass (T) == T_CLASS_INT)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsClassFloat (const Type* T)
-/* Return true if this is a float type */
+/* Return true if this is a floating type */
 {
-    return (GetClass (T) == T_CLASS_FLOAT);
+    return (GetTypeClass (T) == T_CLASS_FLOAT);
 }
 #else
-#  define IsClassFloat(T)       (GetClass (T) == T_CLASS_FLOAT)
+#  define IsClassFloat(T)       (GetTypeClass (T) == T_CLASS_FLOAT)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsClassPtr (const Type* T)
-/* Return true if this is a pointer type */
+/* Return true if this is a pointer or array type */
 {
-    return (GetClass (T) == T_CLASS_PTR);
+    return (GetTypeClass (T) == T_CLASS_PTR);
 }
 #else
-#  define IsClassPtr(T)         (GetClass (T) == T_CLASS_PTR)
+#  define IsClassPtr(T)         (GetTypeClass (T) == T_CLASS_PTR)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsClassStruct (const Type* T)
 /* Return true if this is a struct or union type */
 {
-    return (GetClass (T) == T_CLASS_STRUCT);
+    return (GetTypeClass (T) == T_CLASS_STRUCT);
 }
 #else
-#  define IsClassStruct(T)      (GetClass (T) == T_CLASS_STRUCT)
+#  define IsClassStruct(T)      (GetTypeClass (T) == T_CLASS_STRUCT)
 #endif
 
 #if defined(HAVE_INLINE)
 INLINE int IsClassFunc (const Type* T)
 /* Return true if this is a function type */
 {
-    return (GetClass (T) == T_CLASS_FUNC);
+    return (GetTypeClass (T) == T_CLASS_FUNC);
 }
 #else
-#  define IsClassFunc(T)        (GetClass (T) == T_CLASS_FUNC)
+#  define IsClassFunc(T)        (GetTypeClass (T) == T_CLASS_FUNC)
 #endif
 
-int IsClassObject (const Type* T);
+int IsObjectType (const Type* T);
 /* Return true if this is a fully described object type */
 
-int IsClassIncomplete (const Type* T);
+int IsIncompleteType (const Type* T);
 /* Return true if this is an object type lacking size info */
 
-int IsClassArithmetic (const Type* T);
-/* Return true if this is an integer or real floating type */
+int IsArithmeticType (const Type* T);
+/* Return true if this is an integer or floating type */
 
-int IsClassBasic (const Type* T);
+int IsBasicType (const Type* T);
 /* Return true if this is a char, integer or floating type */
 
-int IsClassScalar (const Type* T);
+int IsScalarType (const Type* T);
 /* Return true if this is an arithmetic or pointer type */
 
-int IsClassDerived (const Type* T);
+int IsDerivedType (const Type* T);
 /* Return true if this is an array, struct, union, function or pointer type */
 
-int IsClassAggregate (const Type* T);
+int IsAggregateType (const Type* T);
 /* Return true if this is an array or struct type */
 
 int IsRelationType (const Type* T);
@@ -798,7 +779,7 @@ int IsEmptiableObjectType (const Type* T);
 int HasUnknownSize (const Type* T);
 /* Return true if this is an incomplete ESU type or an array of unknown size */
 
-int TypeHasAttr (const Type* T);
+int TypeHasAttrData (const Type* T);
 /* Return true if the given type has attribute data */
 
 #if defined(HAVE_INLINE)
@@ -978,10 +959,10 @@ FuncDesc* GetFuncDesc (const Type* T) attribute ((const));
 void SetFuncDesc (Type* T, FuncDesc* F);
 /* Set the FuncDesc pointer in a function or pointer-to-function type */
 
-const Type* GetFuncReturn (const Type* T) attribute ((const));
+const Type* GetFuncReturnType (const Type* T) attribute ((const));
 /* Return a pointer to the return type of a function or pointer-to-function type */
 
-Type* GetFuncReturnModifiable (Type* T) attribute ((const));
+Type* GetFuncReturnTypeModifiable (Type* T) attribute ((const));
 /* Return a non-const pointer to the return type of a function or pointer-to-function type */
 
 const FuncDesc* GetFuncDefinitionDesc (const Type* T) attribute ((const));
@@ -1006,7 +987,10 @@ void SetElementCount (Type* T, long Count);
 */
 
 const Type* GetElementType (const Type* T);
-/* Return the element type of the given array type. */
+/* Return the element type of the given array type */
+
+Type* GetElementTypeModifiable (Type* T);
+/* Return the element type of the given array type */
 
 const Type* GetBaseElementType (const Type* T);
 /* Return the base element type of a given type. If T is not an array, this

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -128,7 +128,7 @@ unsigned TypeOf (const Type* T)
 {
     unsigned NewType;
 
-    switch (GetUnderlyingTypeCode (T)) {
+    switch (GetUnqualTypeCode (T)) {
 
         case T_SCHAR:
             return CF_CHAR;
@@ -187,7 +187,7 @@ unsigned TypeOf (const Type* T)
 unsigned FuncTypeOf (const Type* T)
 /* Get the code generator flag for calling the function */
 {
-    if (GetUnderlyingTypeCode (T) == T_FUNC) {
+    if (GetUnqualTypeCode (T) == T_FUNC) {
         return (T->A.F->Flags & FD_VARIADIC) ? 0 : CF_FIXARGC;
     } else {
         Error ("Illegal function type %04lX", T->C);
@@ -290,7 +290,7 @@ static unsigned typeadjust (ExprDesc* lhs, const ExprDesc* rhs, int NoPush)
 void LimitExprValue (ExprDesc* Expr, int WarnOverflow)
 /* Limit the constant value of the expression to the range of its type */
 {
-    switch (GetUnderlyingTypeCode (Expr->Type)) {
+    switch (GetUnqualTypeCode (Expr->Type)) {
         case T_INT:
         case T_SHORT:
             if (WarnOverflow && ((Expr->IVal < -0x8000) || (Expr->IVal > 0x7FFF))) {
@@ -1146,7 +1146,7 @@ static void FunctionCall (ExprDesc* Expr)
 
     /* The function result is an rvalue in the primary register */
     ED_FinalizeRValLoad (Expr);
-    ReturnType = GetFuncReturn (Expr->Type);
+    ReturnType = GetFuncReturnType (Expr->Type);
 
     /* Handle struct/union specially */
     if (IsClassStruct (ReturnType)) {
@@ -2568,7 +2568,7 @@ static void hie_compare (const GenDesc* Ops,    /* List of generators */
             }
 
             /* Determine the type of the operation. */
-            if (IsTypeChar (Expr->Type) && rconst && (!LeftSigned || RightSigned)) {
+            if (IsRankChar (Expr->Type) && rconst && (!LeftSigned || RightSigned)) {
 
                 /* Left side is unsigned char, right side is constant.
                 ** Determine the minimum and maximum values
@@ -2651,7 +2651,7 @@ static void hie_compare (const GenDesc* Ops,    /* List of generators */
                     flags |= CF_UNSIGNED;
                 }
 
-            } else if (IsTypeChar (Expr->Type) && IsTypeChar (Expr2.Type) &&
+            } else if (IsRankChar (Expr->Type) && IsRankChar (Expr2.Type) &&
                 GetSignedness (Expr->Type) == GetSignedness (Expr2.Type)) {
 
                 /* Both are chars with the same signedness. We can encode the

--- a/src/cc65/function.c
+++ b/src/cc65/function.c
@@ -81,7 +81,7 @@ static Function* NewFunction (struct SymEntry* Sym, FuncDesc* D)
 
     /* Initialize the fields */
     F->FuncEntry  = Sym;
-    F->ReturnType = GetFuncReturn (Sym->Type);
+    F->ReturnType = GetFuncReturnType (Sym->Type);
     F->Desc       = D;
     F->Reserved   = 0;
     F->RetLab     = 0;
@@ -540,7 +540,7 @@ void NewFunc (SymEntry* Func, FuncDesc* D)
         /* Determine if this is a main function in a C99 environment that
         ** returns an int.
         */
-        if (IsRawTypeInt (F_GetReturnType (CurrentFunc)) &&
+        if (GetUnqualRawTypeCode (ReturnType) == T_INT &&
             IS_Get (&Standard) == STD_C99) {
             C99MainFunc = 1;
         }

--- a/src/cc65/initdata.c
+++ b/src/cc65/initdata.c
@@ -330,12 +330,12 @@ static unsigned ParseArrayInit (Type* T, int* Braces, int AllowFlexibleMembers)
     int HasCurly = 0;
 
     /* Get the array data */
-    Type* ElementType    = IndirectModifiable (T);
+    Type* ElementType    = GetElementTypeModifiable (T);
     unsigned ElementSize = SizeOf (ElementType);
     long ElementCount    = GetElementCount (T);
 
     /* Special handling for a character array initialized by a literal */
-    if (IsClassChar (ElementType) &&
+    if (IsDeclRankChar (ElementType) &&
         (CurTok.Tok == TOK_SCONST || CurTok.Tok == TOK_WCSCONST ||
         (CurTok.Tok == TOK_LCURLY &&
          (NextTok.Tok == TOK_SCONST || NextTok.Tok == TOK_WCSCONST)))) {
@@ -669,7 +669,7 @@ static unsigned ParseVoidInit (Type* T)
     Size = 0;
     do {
         ExprDesc Expr = NoCodeConstExpr (hie1);
-        switch (GetUnderlyingTypeCode (&Expr.Type[0])) {
+        switch (GetUnqualTypeCode (&Expr.Type[0])) {
 
             case T_SCHAR:
             case T_UCHAR:
@@ -737,7 +737,7 @@ static unsigned ParseVoidInit (Type* T)
 static unsigned ParseInitInternal (Type* T, int *Braces, int AllowFlexibleMembers)
 /* Parse initialization of variables. Return the number of data bytes. */
 {
-    switch (GetUnderlyingTypeCode (T)) {
+    switch (GetUnqualTypeCode (T)) {
 
         case T_SCHAR:
         case T_UCHAR:

--- a/src/cc65/stdfunc.c
+++ b/src/cc65/stdfunc.c
@@ -531,7 +531,7 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
 
             /* The function result is an rvalue in the primary register */
             ED_FinalizeRValLoad (Expr);
-            Expr->Type = GetFuncReturn (Expr->Type);
+            Expr->Type = GetFuncReturnType (Expr->Type);
 
             /* Bail out, no need for further processing */
             goto ExitPoint;
@@ -540,7 +540,7 @@ static void StdFunc_memcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
 
     /* The function result is an rvalue in the primary register */
     ED_FinalizeRValLoad (Expr);
-    Expr->Type = GetFuncReturn (Expr->Type);
+    Expr->Type = GetFuncReturnType (Expr->Type);
 
 ExitPoint:
     /* We expect the closing brace */
@@ -757,7 +757,7 @@ static void StdFunc_memset (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
 
             /* The function result is an rvalue in the primary register */
             ED_FinalizeRValLoad (Expr);
-            Expr->Type = GetFuncReturn (Expr->Type);
+            Expr->Type = GetFuncReturnType (Expr->Type);
 
             /* Bail out, no need for further processing */
             goto ExitPoint;
@@ -766,7 +766,7 @@ static void StdFunc_memset (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
 
     /* The function result is an rvalue in the primary register */
     ED_FinalizeRValLoad (Expr);
-    Expr->Type = GetFuncReturn (Expr->Type);
+    Expr->Type = GetFuncReturnType (Expr->Type);
 
 ExitPoint:
     /* We expect the closing brace */
@@ -968,7 +968,7 @@ static void StdFunc_strcmp (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
 
     /* The function result is an rvalue in the primary register */
     ED_FinalizeRValLoad (Expr);
-    Expr->Type = GetFuncReturn (Expr->Type);
+    Expr->Type = GetFuncReturnType (Expr->Type);
 
     /* We expect the closing brace */
     ConsumeRParen ();
@@ -1165,7 +1165,7 @@ static void StdFunc_strcpy (FuncDesc* F attribute ((unused)), ExprDesc* Expr)
 
     /* The function result is an rvalue in the primary register */
     ED_FinalizeRValLoad (Expr);
-    Expr->Type = GetFuncReturn (Expr->Type);
+    Expr->Type = GetFuncReturnType (Expr->Type);
 
 ExitPoint:
     /* We expect the closing brace */

--- a/src/cc65/swstmt.c
+++ b/src/cc65/swstmt.c
@@ -133,7 +133,7 @@ void SwitchStatement (void)
 
     /* Setup the control structure, save the old and activate the new one */
     SwitchData.Nodes        = NewCollection ();
-    SwitchData.ExprType     = GetUnderlyingTypeCode (&SwitchExpr.Type[0]);
+    SwitchData.ExprType     = GetUnqualTypeCode (&SwitchExpr.Type[0]);
     SwitchData.Depth        = SizeOf (SwitchExpr.Type);
     SwitchData.DefaultLabel = 0;
     OldSwitch = Switch;

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -1007,7 +1007,7 @@ SymEntry* AddBitField (const char* Name, const Type* T, unsigned Offs,
         Entry = NewSymEntry (Name, SC_BITFIELD);
 
         /* Set the symbol attributes. Bit-fields are always integral types. */
-        Entry->Type   = NewBitFieldType (T, BitOffs, BitWidth);
+        Entry->Type   = NewBitFieldOf (T, BitOffs, BitWidth);
         Entry->V.Offs = Offs;
 
         if (!SignednessSpecified) {
@@ -1019,7 +1019,7 @@ SymEntry* AddBitField (const char* Name, const Type* T, unsigned Offs,
             ** `char -> unsigned char` adjustment that is performed with other integral types.
             */
             CHECK ((Entry->Type->C & T_MASK_SIGN) == T_SIGN_SIGNED ||
-                   IsTypeChar (Entry->Type));
+                   IsRankChar (Entry->Type));
             Entry->Type[0].C &= ~T_MASK_SIGN;
             Entry->Type[0].C |= T_SIGN_UNSIGNED;
             Entry->Type[1].C &= ~T_MASK_SIGN;

--- a/src/cc65/typeconv.c
+++ b/src/cc65/typeconv.c
@@ -430,7 +430,7 @@ void TypeComposition (Type* lhs, const Type* rhs)
         }
 
         /* Check for sanity */
-        CHECK (GetUnderlyingTypeCode (lhs) == GetUnderlyingTypeCode (rhs));
+        CHECK (GetUnqualTypeCode (lhs) == GetUnqualTypeCode (rhs));
 
         /* Check for special type elements */
         if (IsTypeFunc (lhs)) {


### PR DESCRIPTION
I was hesitating about this, but well, better sooner than later.

- Renamed enum constants:
`T_TYPE_<stuff>` -> `T_RANK_<stuff>`
`T_MASK_TYPE` -> `T_MASK_RANK`

- Renamed functions:
`GetUnderlyingTypeCode` -> `GetUnqualTypeCode`
`UnqualifiedType` -> `GetUnqualRawTypeCode`
`GetClass` -> `GetTypeClass`
`GetRawType` -> `GetRawTypeRank`
`NewBitFieldType` -> `NewBitFieldOf`
`SignedType` -> `GetSignedType`
`UnsignedType` -> `GetUnsignedType`
`IsTypeChar` -> `IsRankChar`
`IsTypeShort` -> `IsRankShort`
`IsTypeInt` -> `IsRankInt`
`IsTypeLong` -> `IsRankLong`
`IsTypeChar` -> `IsRankChar`
`IsClassChar` -> `IsDeclRankChar`
`IsClassObject` -> `IsObjectType`
`IsClassIncomplete` -> `IsIncompleteType`
`IsClassArithmetic` -> `IsArithmeticType`
`IsClassBasic` -> `IsBasicType`
`IsClassScalar` -> `IsScalarType`
`IsClassDerived` -> `IsDerivedType`
`IsClassAggregate` -> `IsAggregateType`
`TypeHasAttr` -> `TypeHasAttrData`
`GetFuncReturn` -> `GetFuncReturnType`
`GetFuncReturnModifiable` -> `GetFuncReturnTypeModifiable`

- Usage replacements:
`IndirectModifiable` -> `GetElementTypeModifiable` only used for refining array members
`IsISOChar` -> `IsDeclTypeChar` more accurate to what this is being used for

- Removed unused functions:
`IsRawTypeChar`
`IsRawTypeInt`
`IsRawTypeLong`

- New function:
`GetTypeRank` used in `IsRank<stuff>` functions