### PR TITLE
Fix for #1941

### DIFF
--- a/src/cc65/shiftexpr.c
+++ b/src/cc65/shiftexpr.c
@@ -174,10 +174,9 @@ void ShiftExpr (struct ExprDesc* Expr)
             */
             if (Expr2.IVal == 0 || lconst) {
 
-                /* Set the type */
-                Expr->Type = ResultType;
-
                 if (lconst) {
+                    /* Set the type */
+                    Expr->Type = ResultType;
 
                     /* Evaluate the result */
                     switch (Tok) {

--- a/test/val/bug1941.c
+++ b/test/val/bug1941.c
@@ -6,8 +6,9 @@
 uint8_t foo=1U;
 uint8_t bar=3U; // You need it to reproduce the issue
 
+_Static_assert (sizeof (foo >> 0) == sizeof (int), "Result type of (foo >> 0) should be int");
+
 int main(void)
 {
     return(foo == foo << 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }
-

--- a/test/val/bug1941.c
+++ b/test/val/bug1941.c
@@ -1,0 +1,13 @@
+/* bug #1941 - Shift by literal 0 bits are broken */
+
+#include <stdlib.h>
+#include <stdint.h>
+
+uint8_t foo=1U;
+uint8_t bar=3U; // You need it to reproduce the issue
+
+int main(void)
+{
+    return(foo == foo << 0 ? EXIT_SUCCESS : EXIT_FAILURE);
+}
+

--- a/test/val/bug1941.c
+++ b/test/val/bug1941.c
@@ -1,4 +1,4 @@
-/* bug #1941 - Shift by literal 0 bits are broken */
+/* bug #1941 - Shifts by literal 0 bits are broken */
 
 #include <stdlib.h>
 #include <stdint.h>


### PR DESCRIPTION
Fixes #1941 by making sure the expression type remains unchanged if shift of 0 bits is requested.