### PR TITLE
Teach da65 about table units

### DIFF
--- a/doc/da65.sgml
+++ b/doc/da65.sgml
@@ -522,6 +522,11 @@ following attributes are recognized:
 
   </descrip>
 
+  <tag><tt>UNIT</tt></tag>
+  Split the table into sections of this size. For example, if you have a
+  ByteTable of size 48, but it has logical groups of size 16, specifying
+  16 for UNIT adds newlines after every 16 bytes. UNIT is always in bytes.
+
   <tag><tt>ADDRMODE</tt></tag>
   When disassembling 65816 code, this specifies the M and X flag states
   for this range. It's a string argument of the form "mx", capital letters

--- a/src/da65/attrtab.h
+++ b/src/da65/attrtab.h
@@ -71,6 +71,9 @@ typedef enum attr_t {
     atSegmentEnd   = 0x0200,    /* Segment end */
     atSegmentStart = 0x0400,    /* Segment start */
 
+    /* Table unit separator */
+    atTableUnit    = 0x0800,
+
     /* 65816 addressing mode */
     atMem8         = 0x1000,    /* M flag enabled, 8-bit */
     atMem16        = 0x2000,    /* M flag disabled, 16-bit */
@@ -79,7 +82,7 @@ typedef enum attr_t {
 
     atStyleMask    = 0x000F,    /* Output style */
     atLabelMask    = 0x00F0,    /* Label information */
-    atSegmentMask  = 0x0F00,    /* Segment information */
+    atSegmentMask  = 0x0700,    /* Segment information */
     at65816Mask    = 0xF000,    /* 65816 information */
 
 } attr_t;

--- a/src/da65/data.c
+++ b/src/da65/data.c
@@ -70,7 +70,7 @@ static unsigned GetSpan (attr_t Style)
         if ((Attr & atStyleMask) != Style) {
             break;
         }
-        if ((Attr & (atSegmentStart | atSegmentEnd))) {
+        if ((Attr & (atSegmentStart | atSegmentEnd | atTableUnit))) {
             break;
         }
         ++Count;

--- a/src/da65/scanner.h
+++ b/src/da65/scanner.h
@@ -91,6 +91,7 @@ typedef enum token_t {
     INFOTOK_END,
     INFOTOK_TYPE,
     INFOTOK_ADDRMODE,
+    INFOTOK_UNIT,
 
     INFOTOK_CODE,
     INFOTOK_BYTETAB,


### PR DESCRIPTION
Another da65 usability enhancement.

```
  Split the table into sections of this size. For example, if you have a
  ByteTable of size 48, but it has logical groups of size 16, specifying
  16 for UNIT adds newlines after every 16 bytes. UNIT is always in bytes.
```