### PR TITLE
Sim65 : new command line option to disable terminal echo + buffering AND kbhit implementation

### DIFF
--- a/libsrc/sim6502/paravirt.s
+++ b/libsrc/sim6502/paravirt.s
@@ -7,8 +7,9 @@
 ; int __fastcall__ write (int fd, const void* buf, unsigned count);
 ;
 
-        .export         exit, args, _open, _close, _read, _write
+        .export         exit, args, _open, _close, _read, _write, _kbhit
 
+_kbhit          := $FFF3
 _open           := $FFF4
 _close          := $FFF5
 _read           := $FFF6

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -35,10 +35,8 @@
 
 #include <string.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <termios.h>
 
 /* common */
 #include "abend.h"
@@ -52,7 +50,10 @@
 #include "memory.h"
 #include "paravirt.h"
 
-
+#ifndef(_WIN32)
+#include <unistd.h>
+#include <termios.h>
+#endif
 
 /*****************************************************************************/
 /*                                   Data                                    */
@@ -82,9 +83,11 @@ static const unsigned char HeaderVersion = 2;
 /*                                   Code                                    */
 /*****************************************************************************/
 
+#ifndef(_WIN32)
 void Exit() {
     tcsetattr(STDIN_FILENO, TCSANOW, &OldTermAttrs);
 }
+#endif
 
 static void Usage (void)
 {
@@ -92,7 +95,7 @@ static void Usage (void)
             "Short options:\n"
             "  -h\t\t\tHelp (this text)\n"
             "  -c\t\t\tPrint amount of executed CPU cycles\n"
-            "  -t\t\t\tDisable term echo and buffering\n"
+            "  -t\t\t\tDisable term echo and buffering (*Nix only)\n"
             "  -v\t\t\tIncrease verbosity\n"
             "  -V\t\t\tPrint the simulator version number\n"
             "  -x <num>\t\tExit simulator after <num> cycles\n"
@@ -100,7 +103,7 @@ static void Usage (void)
             "Long options:\n"
             "  --help\t\tHelp (this text)\n"
             "  --cycles\t\tPrint amount of executed CPU cycles\n"
-            "  --termsetup\t\tDisable term echo and buffering\n"
+            "  --termsetup\t\tDisable term echo and buffering (*Nix only)\n"
             "  --verbose\t\tIncrease verbosity\n"
             "  --version\t\tPrint the simulator version number\n",
             ProgName);
@@ -324,6 +327,7 @@ int main (int argc, char* argv[])
 
     Reset ();
 
+#ifndef(_WIN32)
     if(SetTermAttrs) {
         tcgetattr(STDIN_FILENO, &OldTermAttrs);
         NewTermAttrs = OldTermAttrs;
@@ -331,6 +335,7 @@ int main (int argc, char* argv[])
         tcsetattr(STDIN_FILENO, TCSANOW, &NewTermAttrs);
         atexit(Exit);
     }
+#endif
 
     while (1) {
         ExecuteInsn ();

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -97,7 +97,9 @@ static void Usage (void)
             "Short options:\n"
             "  -h\t\t\tHelp (this text)\n"
             "  -c\t\t\tPrint amount of executed CPU cycles\n"
-            "  -t\t\t\tDisable term echo and buffering (*Nix only)\n"
+#ifndef _WIN32
+            "  -t\t\t\tDisable term echo and buffering\n"
+#endif
             "  -v\t\t\tIncrease verbosity\n"
             "  -V\t\t\tPrint the simulator version number\n"
             "  -x <num>\t\tExit simulator after <num> cycles\n"
@@ -105,7 +107,9 @@ static void Usage (void)
             "Long options:\n"
             "  --help\t\tHelp (this text)\n"
             "  --cycles\t\tPrint amount of executed CPU cycles\n"
-            "  --termsetup\t\tDisable term echo and buffering (*Nix only)\n"
+#ifndef _WIN32
+            "  --termsetup\t\tDisable term echo and buffering\n"
+#endif
             "  --verbose\t\tIncrease verbosity\n"
             "  --version\t\tPrint the simulator version number\n",
             ProgName);

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -67,7 +67,9 @@ const char* ProgramFile;
 /* exit simulator after MaxCycles Cycles */
 unsigned long MaxCycles;
 unsigned char SetTermAttrs;
+#ifndef _WIN32
 static struct termios OldTermAttrs, NewTermAttrs;
+#endif
 
 /* Header signature 'sim65' */
 static const unsigned char HeaderSignature[] = {

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -35,7 +35,7 @@
 
 #include <string.h>
 #include <stdio.h>
-#include <unistd.h> 
+#include <unistd.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <termios.h>

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -89,6 +89,9 @@ static const unsigned char HeaderVersion = 2;
 void Exit() {
     tcsetattr(STDIN_FILENO, TCSANOW, &OldTermAttrs);
 }
+void INT_Handler(int signal) {
+    exit(128 + signal);
+}
 #endif
 
 static void Usage (void)
@@ -340,6 +343,7 @@ int main (int argc, char* argv[])
         NewTermAttrs.c_lflag &= ~(ICANON) & ~(ECHO);
         tcsetattr(STDIN_FILENO, TCSANOW, &NewTermAttrs);
         atexit(Exit);
+        signal(SIGINT, INT_Handler);
     }
 #endif
 

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -148,7 +148,7 @@ static void OptTermSetup (const char* Opt attribute ((unused)),
                        const char* Arg attribute ((unused)))
 /* Disable input echo and buffering */
 {
-	SetTermAttrs = 1;
+    SetTermAttrs = 1;
 }
 
 static void OptQuitXIns (const char* Opt attribute ((unused)),

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -53,6 +53,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #include <termios.h>
+#include <signal.h>
 #endif
 
 /*****************************************************************************/

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -50,7 +50,7 @@
 #include "memory.h"
 #include "paravirt.h"
 
-#ifndef(_WIN32)
+#ifndef _WIN32
 #include <unistd.h>
 #include <termios.h>
 #endif
@@ -83,7 +83,7 @@ static const unsigned char HeaderVersion = 2;
 /*                                   Code                                    */
 /*****************************************************************************/
 
-#ifndef(_WIN32)
+#ifndef _WIN32
 void Exit() {
     tcsetattr(STDIN_FILENO, TCSANOW, &OldTermAttrs);
 }
@@ -327,7 +327,7 @@ int main (int argc, char* argv[])
 
     Reset ();
 
-#ifndef(_WIN32)
+#ifndef _WIN32
     if(SetTermAttrs) {
         tcgetattr(STDIN_FILENO, &OldTermAttrs);
         NewTermAttrs = OldTermAttrs;

--- a/src/sim65/paravirt.c
+++ b/src/sim65/paravirt.c
@@ -37,6 +37,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/time.h>
 #if defined(_WIN32)
 #  define O_INITIAL O_BINARY
 #else
@@ -292,9 +293,20 @@ static void PVWrite (CPURegs* Regs)
     SetAX (Regs, RetVal);
 }
 
-
+static void PVKbhit (CPURegs* Regs)
+{
+    struct timeval tv;
+    fd_set fds;
+    tv.tv_sec = 0;
+    tv.tv_usec = 0;
+    FD_ZERO(&fds);
+    FD_SET(STDIN_FILENO, &fds); //STDIN_FILENO is 0
+    select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv);
+	SetAX (Regs, FD_ISSET(STDIN_FILENO, &fds));
+}
 
 static const PVFunc Hooks[] = {
+    PVKbhit,
     PVOpen,
     PVClose,
     PVRead,

--- a/src/sim65/paravirt.c
+++ b/src/sim65/paravirt.c
@@ -302,7 +302,7 @@ static void PVKbhit (CPURegs* Regs)
     FD_ZERO(&fds);
     FD_SET(STDIN_FILENO, &fds); //STDIN_FILENO is 0
     select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv);
-	SetAX (Regs, FD_ISSET(STDIN_FILENO, &fds));
+    SetAX (Regs, FD_ISSET(STDIN_FILENO, &fds));
 }
 
 static const PVFunc Hooks[] = {

--- a/src/sim65/paravirt.c
+++ b/src/sim65/paravirt.c
@@ -37,7 +37,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <sys/stat.h>
-#include <sys/time.h>
+
 #if defined(_WIN32)
 #  define O_INITIAL O_BINARY
 #else
@@ -48,6 +48,7 @@
 #  include <io.h>
 #else
 /* Anyone else */
+#  include <sys/time.h>
 #  include <unistd.h>
 #endif
 #ifndef S_IREAD
@@ -295,6 +296,7 @@ static void PVWrite (CPURegs* Regs)
 
 static void PVKbhit (CPURegs* Regs)
 {
+#ifndef(_WIN32)
     struct timeval tv;
     fd_set fds;
     tv.tv_sec = 0;
@@ -303,6 +305,9 @@ static void PVKbhit (CPURegs* Regs)
     FD_SET(STDIN_FILENO, &fds); //STDIN_FILENO is 0
     select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv);
     SetAX (Regs, FD_ISSET(STDIN_FILENO, &fds));
+#else
+    SetAX (Regs, 0);
+#endif
 }
 
 static const PVFunc Hooks[] = {

--- a/src/sim65/paravirt.c
+++ b/src/sim65/paravirt.c
@@ -296,7 +296,7 @@ static void PVWrite (CPURegs* Regs)
 
 static void PVKbhit (CPURegs* Regs)
 {
-#ifndef(_WIN32)
+#ifndef _WIN32
     struct timeval tv;
     fd_set fds;
     tv.tv_sec = 0;

--- a/src/sim65/paravirt.h
+++ b/src/sim65/paravirt.h
@@ -44,7 +44,7 @@
 
 
 
-#define PARAVIRT_BASE        0xFFF4
+#define PARAVIRT_BASE        0xFFF3
 /* Lowest address used by a paravirtualization hook */
 
 


### PR DESCRIPTION
Hi, I started using Sim65 to prototype a simple game.

The more I use Sim65 the more I love it :
- instant startup
- host native speed
- run on terminal under VS Code
- advanced display (hello ANSI sequences)

Something that I was missing is :
- getchar() : disabling echo and buffering (using ENTER to get the char)
- no kbhit implementation

Notes : 
- these two commits are closely related
- untested under Linux (but I could) but is likely to works
- no guards for other OSes (eg. Windows), this patched version will certainly fail to compile except on MacOS and Linux - And I have no Windows host to make tests

First PR ever so if there's something more that I could do, or do better, please tell.

