### PR TITLE
Remove .exe from file output

### DIFF
--- a/src/common/cmdline.c
+++ b/src/common/cmdline.c
@@ -181,6 +181,17 @@ void InitCmdLine (int* aArgCount, char*** aArgVec, const char* aProgName)
             /* Use the default */
             ProgName = aProgName;
         }
+        else {
+            /* remove .exe extension, if there is any
+            **
+            ** Note: This creates a new string that is
+            ** never free()d.
+            ** As this is exactly only string, and it
+            ** lives for the whole lifetime of the tool,
+            ** this is not an issue.
+            */
+            ProgName = MakeFilename (ProgName, "");
+        }
     }
 
     /* Make a CmdLine struct */


### PR DESCRIPTION
Whenever a tool like ld65 wants to output its name into a log file, it uses the name of command-line parameter 0. However, this parameter also includes the .exe suffix if it is on Windows.

This patch removes the .exe suffix, so that the output is clean and consistent across platforms.

This fixes #1990.