### PR TITLE
OptStackOps label migration fix

### DIFF
--- a/src/cc65/coptstop.c
+++ b/src/cc65/coptstop.c
@@ -1208,6 +1208,8 @@ static unsigned Opt_a_tosicmp (StackOpData* D)
             /* RHS src is not directly comparable */
             X = NewCodeEntry (OP65_STA, AM65_ZP, D->ZPHi, 0, D->OpEntry->LI);
             InsertEntry (D, X, D->Rhs.A.ChgIndex + 1);
+            /* RHS insertion may have moved the OpIndex, recalculate insertion point to prevent label migration. */
+            D->IP = D->OpIndex + 1;
 
             /* Cmp with stored RHS */
             X = NewCodeEntry (OP65_CMP, AM65_ZP, D->ZPHi, 0, D->OpEntry->LI);

--- a/src/cc65/coptstop.c
+++ b/src/cc65/coptstop.c
@@ -1153,6 +1153,8 @@ static unsigned Opt_a_toscmpbool (StackOpData* D, const char* BoolTransformer)
 
         /* Save lhs into zeropage */
         AddStoreLhsA (D);
+        /* AddStoreLhsA may have moved the OpIndex, recalculate insertion point to prevent label migration. */
+        D->IP = D->OpIndex + 1;
 
         /* cmp */
         X = NewCodeEntry (OP65_CMP, AM65_ZP, D->ZPLo, 0, D->OpEntry->LI);

--- a/test/val/bug1989.c
+++ b/test/val/bug1989.c
@@ -1,0 +1,40 @@
+
+/* bug #1989 - OptStackOps Opt_a_toscmpbool bypassed a comparison, discovered in 544a49c */
+
+#include <stdlib.h>
+
+unsigned char i,r,j;
+
+void fail() // for the r=0 case, the == comparison was getting jumped over by OptStackOps
+{
+    if ((i & 0x1f) == (r ? 0 : 16)) j -=8;
+}
+
+void pass()
+{
+    if ((i & 0x1f) == (unsigned char)(r ? 0 : 16)) j -= 8;
+}
+
+void test(unsigned char ti, unsigned char tr, unsigned char tj)
+{
+    unsigned char rj;
+    i = ti;
+    r = tr;
+    j = tj;
+    pass();
+    rj = j;
+    i = ti;
+    r = tr;
+    j = tj;
+    fail();
+    if (j != rj) exit(1);
+}
+
+int main(void)
+{
+    test( 1,0,33);
+    test( 0,0,33);
+    test( 1,1,33);
+    test(16,1,33);
+    return 0;
+}


### PR DESCRIPTION
Addresses bug found in #1989 affecting a rare case of OptStackOps optimization step where a label was generated exactly on the replaced stack operator.

Opt_a_toscmpbool had one branch which neglected to update its Op replacement insertion pointer after inserting code above it to replaced the Push.

Opt_a_tosicmp appeared to have a version of the same bug, though I could not come up with a test case to trigger it. Have added a prophylactic fix for it.