### PR TITLE
make avail: check for presence of binaries before creating symbolic links

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -110,22 +110,16 @@ $(RM) /usr/local/bin/$(prog)
 
 endef # UNAVAIL_recipe
 
-define AVAIL_check_prog
-
-@if [ ! -e ../bin/$(prog) ]; then \
-    echo "failed to locate $(prog), please run make first"; \
-    false; \
-fi
-
-endef # AVAIL_check_prog
-
 install:
 	$(INSTALL) -d $(DESTDIR)$(bindir)
 	$(INSTALL) ../bin/* $(DESTDIR)$(bindir)
 
 avail:
-	$(foreach prog,$(PROGS),$(AVAIL_check_prog))
+ifneq ($(patsubst %,../bin/%,$(PROGS)),$(wildcard $(patsubst %,../bin/%,$(PROGS))))
+	$(error executables are missing, please run make first)
+else
 	$(foreach prog,$(PROGS),$(AVAIL_recipe))
+endif
 
 unavail:
 	$(foreach prog,$(PROGS),$(UNAVAIL_recipe))

--- a/src/Makefile
+++ b/src/Makefile
@@ -110,11 +110,21 @@ $(RM) /usr/local/bin/$(prog)
 
 endef # UNAVAIL_recipe
 
+define AVAIL_check_prog
+
+@if [ ! -e ../bin/$(prog) ]; then \
+    echo "failed to locate $(prog), please run make first"; \
+    false; \
+fi
+
+endef # AVAIL_check_prog
+
 install:
 	$(INSTALL) -d $(DESTDIR)$(bindir)
 	$(INSTALL) ../bin/* $(DESTDIR)$(bindir)
 
 avail:
+	$(foreach prog,$(PROGS),$(AVAIL_check_prog))
 	$(foreach prog,$(PROGS),$(AVAIL_recipe))
 
 unavail:


### PR DESCRIPTION
To avoid creating broken symlinks, first check if the binaries exists in `bin/` and exit when they don't, with a message to first run `make`.