### PR TITLE
ld65 error if computed memory size is negative

### DIFF
--- a/src/ld65/config.c
+++ b/src/ld65/config.c
@@ -1936,6 +1936,11 @@ unsigned CfgProcess (void)
                       GetString (M->Name));
         }
         M->Size = GetExprVal (M->SizeExpr);
+        if (M->Size >= 0x80000000) {
+            CfgError (GetSourcePos (M->LI),
+                      "Size of memory area '%s' is negative: %ld",
+                      GetString (M->Name), (long)M->Size);
+        }
 
         /* Walk through the segments in this memory area */
         for (J = 0; J < CollCount (&M->SegList); ++J) {

--- a/test/dasm/Makefile
+++ b/test/dasm/Makefile
@@ -30,7 +30,7 @@ ISEQUAL = ../../testwrk/isequal$(EXE)
 CC = gcc
 CFLAGS = -O2
 
-START = --start-addr 0x8000
+START = --start-addr 0x7000
 
 .PHONY: all clean
 


### PR DESCRIPTION
Simple error check to address issue #1390 