### PR TITLE
supress spurious "large alignment" warnings

### DIFF
--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -2112,14 +2112,15 @@ Here's a list of all control commands and a description, what they do:
   </verb></tscreen>
 
   the assembler will force a segment alignment to the least common multiple of
-  15, 18 and 251 - which is 22590. To protect the user against errors, the
-  assembler will issue a warning when the combined alignment exceeds 256. The
-  command line option <tt><ref id="option--large-alignment"
-  name="--large-alignment"></tt> will disable this warning.
+  15, 18 and 251 - which is 22590. To protect the user against errors, when the
+  combined alignment is larger than the explicitly requested alignments,
+  and also exceeds 256, the assembler will issue a warning. The  command line
+  option <tt><ref id="option--large-alignment" name="--large-alignment"></tt>
+  will disable this warning.
 
   Please note that with alignments that are a power of two (which were the
-  only alignments possible in older versions of the assembler), the problem is
-  less severe, because the least common multiple of powers to the same base is
+  only alignments possible in older versions of the assembler) will not cause
+  a warning, because the least common multiple of powers to the same base is
   always the larger one.
 
 

--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -2114,14 +2114,13 @@ Here's a list of all control commands and a description, what they do:
   the assembler will force a segment alignment to the least common multiple of
   15, 18 and 251 - which is 22590. To protect the user against errors, when the
   combined alignment is larger than the explicitly requested alignments,
-  and also exceeds 256, the assembler will issue a warning. The  command line
+  the assembler will issue a warning if it also exceeds 256. The command line
   option <tt><ref id="option--large-alignment" name="--large-alignment"></tt>
   will disable this warning.
 
-  Please note that with alignments that are a power of two (which were the
-  only alignments possible in older versions of the assembler) will not cause
-  a warning, because the least common multiple of powers to the same base is
-  always the larger one.
+  Please note that with only alignments that are a power of two, a warning will
+  never occur, because the least common multiple of powers to the same base is
+  always simply the larger one.
 
 
 

--- a/src/ca65/segment.c
+++ b/src/ca65/segment.c
@@ -306,7 +306,7 @@ void SegAlign (unsigned long Alignment, int FillVal)
         ActiveSeg->Align = CombinedAlignment;
 
         /* Output a warning for larger alignments if not suppressed */
-        if (CombinedAlignment >= LARGE_ALIGNMENT && !LargeAlignment) {
+        if (CombinedAlignment >= LARGE_ALIGNMENT && CombinedAlignment > ActiveSeg->Align && CombinedAlignment > Alignment && !LargeAlignment) {
             Warning (0, "Combined alignment is suspiciously large (%lu)",
                      CombinedAlignment);
         }

--- a/src/ld65/segments.c
+++ b/src/ld65/segments.c
@@ -230,7 +230,7 @@ Section* ReadSection (FILE* F, ObjData* O)
                    "%lu. Last module requiring alignment was '%s'.",
                    GetString (Name), Alignment, MAX_ALIGNMENT,
                    GetObjFileName (O));
-        } else if (Alignment >= LARGE_ALIGNMENT && !LargeAlignment) {
+        } else if (Alignment >= LARGE_ALIGNMENT && Alignment > S->Alignment && Alignment > Sec->Alignment && !LargeAlignment) {
             Warning ("Combined alignment for segment '%s' is suspiciously "
                      "large (%lu). Last module requiring alignment was '%s'.",
                      GetString (Name), Alignment, GetObjFileName (O));


### PR DESCRIPTION
There is a warning that attempts to diagnose accidentally "large" alignments when combining mismatched alignment sizes. It put an arbitrary size limit on all alignments that anything > 256 should be a warning.

However, if you request an alignment of 1024 or 32768 or 65536, and that size isn't being increased, this should not be a warning. You're getting exactly what you explicitly asked for. There should be no need to use the cumbersome "--large-alignment" command line option on both the assemble and link to accommodate this need.

I have modified the warning to only trigger if the combined alignment is greater than any of the alignments you actually asked for.