### PR TITLE
Fix endmacro with define in macro body

### DIFF
--- a/src/ca65/macro.c
+++ b/src/ca65/macro.c
@@ -590,7 +590,7 @@ void MacDef (unsigned Style)
         NextTok ();
     }
 
-/* Reset the Incomplete flag now that parsing is done */
+    /* Reset the Incomplete flag now that parsing is done */
     M->Incomplete = 0;
 
 Done:

--- a/src/ca65/macro.c
+++ b/src/ca65/macro.c
@@ -391,6 +391,7 @@ void MacDef (unsigned Style)
     Macro* M;
     TokNode* N;
     int HaveParams;
+    int DefineActive = 0;
 
     /* We expect a macro name here */
     if (CurTok.Tok != TOK_IDENT) {
@@ -491,8 +492,8 @@ void MacDef (unsigned Style)
     while (1) {
         /* Check for end of macro */
         if (Style == MAC_STYLE_CLASSIC) {
-            /* In classic macros, only .endmacro is allowed */
-            if (CurTok.Tok == TOK_ENDMACRO) {
+            /* In classic macros, only .endmacro is allowed, but ignore it if it is in a .define */
+            if (CurTok.Tok == TOK_ENDMACRO && !DefineActive) {
                 /* Done */
                 break;
             }
@@ -573,6 +574,13 @@ void MacDef (unsigned Style)
         }
         ++M->TokCount;
 
+        /* Mark if .define has been read until end of line has been reached */
+        if (CurTok.Tok == TOK_DEFINE) {
+            DefineActive = 1;
+        } else if (TokIsSep(CurTok.Tok)) {
+            DefineActive = 0;
+        }
+
         /* Read the next token */
         NextTok ();
     }
@@ -582,7 +590,7 @@ void MacDef (unsigned Style)
         NextTok ();
     }
 
-    /* Reset the Incomplete flag now that parsing is done */
+/* Reset the Incomplete flag now that parsing is done */
     M->Incomplete = 0;
 
 Done:


### PR DESCRIPTION
When using .define to create a new symbol that references the .endmacro command outside of a macro, it works as expected:
```
.define startmac .macro
.define endmac .endmacro

startmac test
    .out "Test"
endmac 

test
```
This will result in console output:
`Test`

Attempting to do the same, but defining the endmac symbol inside a macro however:
```
.macro makeStartMac
    .define startmac .macro
.endmacro

.macro makeEndMac 
    .define endmac .endmacro
.endmacro
```
This is as far as the assembler gets while resulting in:

`... : Error: Unexpected '.ENDMACRO'`
While it is unlikely that most users will run into this issue, ca65's behavior is not consistent in this case. This patch fixes this behavior.

Note: The current code also allows `.endmacro` to be anywhere at the end of a line. For example, this works:
```
.macro sayHi 
    .out "Hi!" .endmacro
```