### PR TITLE
ca65 jmp (abs) wrap warning only applies to 6502, later CPUs do not have this bug

### DIFF
--- a/src/ca65/instr.c
+++ b/src/ca65/instr.c
@@ -1617,7 +1617,7 @@ static void PutJMP (const InsDesc* Ins)
     if (EvalEA (Ins, &A)) {
 
         /* Check for indirect addressing */
-        if (A.AddrModeBit & AM65_ABS_IND && CPU < CPU_65SC02) {
+        if ((A.AddrModeBit & AM65_ABS_IND) && (CPU < CPU_65SC02)) {
 
             /* Compare the low byte of the expression to 0xFF to check for
             ** a page cross. Be sure to use a copy of the expression otherwise

--- a/src/ca65/instr.c
+++ b/src/ca65/instr.c
@@ -1617,11 +1617,12 @@ static void PutJMP (const InsDesc* Ins)
     if (EvalEA (Ins, &A)) {
 
         /* Check for indirect addressing */
-        if (A.AddrModeBit & AM65_ABS_IND) {
+        if (A.AddrModeBit & AM65_ABS_IND && CPU < CPU_65SC02) {
 
             /* Compare the low byte of the expression to 0xFF to check for
             ** a page cross. Be sure to use a copy of the expression otherwise
-            ** things will go weird later.
+            ** things will go weird later. This only affects the 6502 CPU,
+            ** and was corrected in 65C02 and later CPUs in this family.
             */
             ExprNode* E = GenNE (GenByteExpr (CloneExpr (A.Expr)), 0xFF);
 


### PR DESCRIPTION
`jmp (abs)` has a warning case currently which is only relevant to the original 6502. All later 6502-family CPUs have corrected the hardware bug.

This pull request eliminates the warning for later CPUs.

A separate PR #2006 had included this along with promotion of that warning to an error, but since it was contested (see issue #2005), I have separated just the CPU filter change for this PR.