### PR TITLE
Fixes and improvements to KIM-1 i/o routines.

### DIFF
--- a/asminc/kim1.inc
+++ b/asminc/kim1.inc
@@ -15,7 +15,7 @@ OUTCHR   := $1EA0     ; Output character
 INTCHR   := $1E5A     ; Input character without case conversion
 DUMPT    := $1800     ; Dump memory to tape
 LOADT    := $1873     ; Load memory from tape
-
+START    := $1C4F     ; Enter KIM-1 monitor
 
 ; ---------------------------------------------------------------------------
 ; System Memory

--- a/libsrc/kim1/crt0.s
+++ b/libsrc/kim1/crt0.s
@@ -40,8 +40,6 @@ _init:    cld                          ; Clear decimal mode
 
           jsr     _main
 
-; Back from main (this is also the _exit entry).  There may be a more elegant way to
-; return to the monitor on the KIM-1, but I don't know it!
+; Back from main (this is also the _exit entry).  Jumps to the KIM-1 monitor.
 
-_exit:    brk
-
+_exit:    jmp   START

--- a/libsrc/kim1/read.s
+++ b/libsrc/kim1/read.s
@@ -27,15 +27,10 @@ begin:  dec     ptr2
         beq     done             ; If buffer full, return
 
 getch:  jsr     INTCHR           ; Get character using Monitor ROM call
-        ;jsr     OUTCHR           ; Echo it
         and     #$7F             ; Clear top bit
-        cmp     #$07             ; Check for '\a'
-        bne     chkcr            ; ...if BEL character
-        ;jsr     BEEP             ; Make beep sound TODO
-chkcr:  cmp     #$0D             ; Check for '\r'
+        cmp     #$0D             ; Check for '\r'
         bne     putch            ; ...if CR character
         lda     #$0A             ; Replace with '\n'
-        jsr     OUTCHR           ; and echo it
 
 putch:  ldy     #$00             ; Put char into return buffer
         sta     (ptr1),y

--- a/libsrc/kim1/write.s
+++ b/libsrc/kim1/write.s
@@ -28,11 +28,10 @@ begin:  dec     ptr2
 
 outch:  ldy     #0
         lda     (ptr1),y
+        pha                     ; Save A (changed by OUTCHR)
         jsr     OUTCHR          ; Send character using Monitor call
-        cmp     #$07            ; Check for '\a'
-        bne     chklf           ; ...if BEL character
-;jsr     BEEP            ; Make beep sound
-chklf:  cmp     #$0A            ; Check for 'n'
+        pla                     ; Restore A
+        cmp     #$0A            ; Check for '\n'
         bne     next            ; ...if LF character
         lda     #$0D            ; Add a carriage return
         jsr     OUTCHR


### PR DESCRIPTION
Tested on real KIM-1 hardware.

read.s:
- Remove commented out line.
- Remove unused check for bell character.
- Remove echo of newline (hardware always echoes entered characters).
- This fixes gets() and fgets() so they return when CR is entered.

write.s:
- Fix check for adding return after linefeed (failed to work because OUTCHR changes A)
- Remove unused check for bell character.

kim1.inc:
- Add symbol for monitor entry

crt0.s:
- Jump to KIM-1 monitor by address rather than using BRK (which relies on vector being set in RAM)