### PR TITLE
cx16: update RAM constants for ROM ver R42

### DIFF
--- a/asminc/cx16.inc
+++ b/asminc/cx16.inc
@@ -239,12 +239,12 @@ BASIC_BUF       := $0200        ; Location of command-line
 BASIC_BUF_LEN   = 81            ; Maximum length of command-line
 
 SCREEN_PTR      := $0262        ; Pointer to current row on text screen (16 bits)
-STATUS          := $0289        ; Status from previous I/O operation
-IN_DEV          := $028D        ; Current input device number
-OUT_DEV         := $028E        ; Current output device number
-FNAM_LEN        := $0291        ; Length of filename
-SECADR          := $0293        ; Secondary address
-DEVNUM          := $0294        ; Device number
+STATUS          := $0287        ; Status from previous I/O operation
+IN_DEV          := $028B        ; Current input device number
+OUT_DEV         := $028C        ; Current output device number
+FNAM_LEN        := $028F        ; Length of filename
+SECADR          := $0291        ; Secondary address
+DEVNUM          := $0292        ; Device number
 CURS_COLOR      := $0373        ; Color under the cursor
 CHARCOLOR       := $0376        ; Cursor's color nybbles (high: background, low: foreground)
 RVS             := $0377        ; Reverse flag
@@ -258,8 +258,8 @@ LLEN            := $0386        ; Line length
 NLINES          := $0387        ; Number of screen lines
 
 ; BASIC
-VARTAB          := $03E2        ; Pointer to start of BASIC variables
-MEMSIZE         := $03EA        ; Pointer to highest BASIC RAM location (+1)
+VARTAB          := $03E1        ; Pointer to start of BASIC variables
+MEMSIZE         := $03E9        ; Pointer to highest BASIC RAM location (+1)
 
 ; ---------------------------------------------------------------------------
 ; Vector and other locations


### PR DESCRIPTION
The RAM locations of some of the internal KERNAL state have changed since R41.  Development on the Commander X16 software upstream had stagnated since Michael Steil has not been around.  We got the blessing of The 8-Bit Guy to fork all of the projects and continue development in another GitHub organization since only Michael holds the keys to the commanderx16 GitHub org.

The new location of the X16 ROM is at https://github.com/X16Community/x16-rom/ and I have been the primary contributor since the fork.  We released R42 under the banner of the X16Community organization earlier this month and we plan to continue releases there.  Now that we have released R42, I'm opening this PR so that C programs can be built for that version of the ROM and will be able to behave, particularly with I/O, where the changed constants have caused forward compatibility issues.

While it is not ideal for any applications to depend on the locations of any of the X16 KERNAL's internal state, I do understand the need, particularly since cc65 borrows a lot of CBM code from the other CBM style platforms, which assumes these locations are stable, such as those on the C64. 

Hopefully we won't need to update these in the future, but unfortunately I can't make an ironclad guarantee.

However, I have added `.assert`s in the ROM source in a best effort attempt to keep these locations stable from this point forward.