### PR TITLE
Don't use hardcoded paths on Amiga

### DIFF
--- a/src/ca65/incpath.c
+++ b/src/ca65/incpath.c
@@ -75,7 +75,7 @@ void FinishIncludePaths (void)
     AddSubSearchPathFromEnv (IncSearchPath, "CC65_HOME", "asminc");
 
     /* Add some compiled-in search paths if defined at compile time. */
-#if defined(CA65_INC) && !defined(_WIN32)
+#if defined(CA65_INC) && !defined(_WIN32) && !defined(_AMIGA)
     AddSearchPath (IncSearchPath, CA65_INC);
 #endif
 

--- a/src/cc65/incpath.c
+++ b/src/cc65/incpath.c
@@ -76,7 +76,7 @@ void FinishIncludePaths (void)
     AddSubSearchPathFromEnv (SysIncSearchPath, "CC65_HOME", "include");
 
     /* Add some compiled-in search paths if defined at compile time. */
-#if defined(CC65_INC) && !defined(_WIN32)
+#if defined(CC65_INC) && !defined(_WIN32) && !defined(_AMIGA)
     AddSearchPath (SysIncSearchPath, CC65_INC);
 #endif
 

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -1216,7 +1216,7 @@ static void OptPrintTargetPath (const char* Opt attribute ((unused)),
 
     SearchPaths* TargetPaths = NewSearchPath ();
     AddSubSearchPathFromEnv (TargetPaths, "CC65_HOME", "target");
-#if defined(CL65_TGT) && !defined(_WIN32)
+#if defined(CL65_TGT) && !defined(_WIN32) && !defined(_AMIGA)
     AddSearchPath (TargetPaths, CL65_TGT);
 #endif
     AddSubSearchPathFromBin (TargetPaths, "target");

--- a/src/ld65/filepath.c
+++ b/src/ld65/filepath.c
@@ -88,13 +88,13 @@ void InitSearchPaths (void)
     AddSubSearchPathFromEnv (CfgDefaultPath, "CC65_HOME", "cfg");
 
     /* Add some compiled-in search paths if defined at compile time. */
-#if defined(LD65_LIB) && !defined(_WIN32)
+#if defined(LD65_LIB) && !defined(_WIN32) && !defined(_AMIGA)
     AddSearchPath (LibDefaultPath, LD65_LIB);
 #endif
-#if defined(LD65_OBJ) && !defined(_WIN32)
+#if defined(LD65_OBJ) && !defined(_WIN32) && !defined(_AMIGA)
     AddSearchPath (ObjDefaultPath, LD65_OBJ);
 #endif
-#if defined(LD65_CFG) && !defined(_WIN32)
+#if defined(LD65_CFG) && !defined(_WIN32) && !defined(_AMIGA)
     AddSearchPath (CfgDefaultPath, LD65_CFG);
 #endif
 


### PR DESCRIPTION
Hardcoded paths don't make sense on AmigaOS, AROS and MorphOS.