### PR TITLE
Add features: nested macros, newline sequence, etc

### DIFF
--- a/src/ca65/macro.c
+++ b/src/ca65/macro.c
@@ -376,7 +376,7 @@ void MacDef (unsigned Style)
     int NestedMacroCount;
     unsigned int MacroErrorCount;
 
-    /* For classic macros, this indicates when in a nested macro. 
+    /* For classic macros, this indicates when in a nested macro.
     ** Only end the macro defintion with .endmacro when this is zero
     */
     NestedMacroCount = 0;
@@ -414,8 +414,8 @@ void MacDef (unsigned Style)
     /* Define the macro */
     M = NewMacro (&CurTok.SVal, Style);
 
-    /* For a .define: at this point, allow user newline sequences to be read 
-    ** and stored as part of the macro definition 
+    /* For a .define: at this point, allow user newline sequences to be read
+    ** and stored as part of the macro definition
     */
     PRECONDITION (AllowNewlineToken == 0);
     if (Style == MAC_STYLE_DEFINE) {
@@ -488,7 +488,7 @@ void MacDef (unsigned Style)
     }
 
     /* Preparse the macro body. We will read the tokens until we reach end of
-    ** file, or a final .endmacro (or end of line for DEFINE-style macros) and 
+    ** file, or a final .endmacro (or end of line for DEFINE-style macros) and
     ** store them into a token list internal to the macro. For classic macros,
     ** the .LOCAL command is detected and removed, at this time.
     */
@@ -502,7 +502,7 @@ void MacDef (unsigned Style)
                 }
 
                 /* If we found .endmacro at the start of a line, then check for
-                ** nested macros. If none, the macro defintion is complete. 
+                ** nested macros. If none, the macro defintion is complete.
                 */
                 if (CurTok.Tok == TOK_ENDMACRO) {
                     if (NestedMacroCount) {
@@ -521,7 +521,7 @@ void MacDef (unsigned Style)
                     NewlineTokenAllow ();
                 }
 
-                /* If we found an .insert token, skip it. This allows 
+                /* If we found an .insert token, skip it. This allows
                 ** .endmacro and .macro to be added to the macro definition
                 ** without being part of a nested macro. It also
                 ** allows a .define definition without disabling define-style
@@ -539,7 +539,7 @@ void MacDef (unsigned Style)
                 break;
             }
         } else {
-            /* Accept a true end of line or end of file to terminate the 
+            /* Accept a true end of line or end of file to terminate the
             ** definition of .define style macros
             */
             if (TokIsSep (CurTok.Tok)) {
@@ -555,8 +555,8 @@ void MacDef (unsigned Style)
             CurTok.IVal = (NestedMacroCount == 0);
         }
 
-        /* For classic macros, check for a .local declaration. This should only 
-        ** be evaluated when .local is at the start of a line and not in a nested 
+        /* For classic macros, check for a .local declaration. This should only
+        ** be evaluated when .local is at the start of a line and not in a nested
         ** macro defintion
         */
         if (CurTok.Tok == TOK_LOCAL && Style == MAC_STYLE_CLASSIC &&
@@ -597,7 +597,7 @@ void MacDef (unsigned Style)
         N = NewTokNode ();
 
         /* If the token is an identifier, and in the main macro body,
-        ** check if it is a local parameter 
+        ** check if it is a local parameter
         */
         if (CurTok.Tok == TOK_IDENT && NestedMacroCount == 0) {
             unsigned Count = 0;
@@ -629,9 +629,9 @@ void MacDef (unsigned Style)
         /* Remember if current token is preceeded by a separator */
         L = LastTokWasSep;
 
-        /* Remember if the current token was a separator to indicate if 
-        ** beginning a line for the next iteration of the loop. This 
-        ** will also end any .define lines inside a classic macro: 
+        /* Remember if the current token was a separator to indicate if
+        ** beginning a line for the next iteration of the loop. This
+        ** will also end any .define lines inside a classic macro:
         ** Tell the scanner to return a separator for newline tokens
         */
         if (LastTokWasSep = TokIsSep (CurTok.Tok)) {
@@ -639,8 +639,8 @@ void MacDef (unsigned Style)
         }
 
         /* Read the next token:
-        ** If the current token is a valid .define or .undefine, 
-        ** turn off define-stlye macros while reading the next token 
+        ** If the current token is a valid .define or .undefine,
+        ** turn off define-stlye macros while reading the next token
         ** (which should be an indentifier for the macro name)
         */
         if (L && (CurTok.Tok == TOK_DEFINE || CurTok.Tok == TOK_UNDEF)) {
@@ -761,8 +761,8 @@ ExpandParam:
         /* Set pointer to next token */
         Mac->Exp = Mac->Exp->Next;
 
-        /* Is it a request for actual parameter count? If the IVal is set, 
-        ** process .paramcount. If not, it is in a nested macro, so just 
+        /* Is it a request for actual parameter count? If the IVal is set,
+        ** process .paramcount. If not, it is in a nested macro, so just
         ** return the .paramcount token
         */
         if (CurTok.Tok == TOK_PARAMCOUNT) {
@@ -783,7 +783,7 @@ ExpandParam:
             goto ExpandParam;
         }
 
-        /* Is it a newline sequence? (This token should only be found when 
+        /* Is it a newline sequence? (This token should only be found when
         ** expanding a .define)
         */
         if (CurTok.Tok == TOK_NL) {

--- a/src/ca65/macro.c
+++ b/src/ca65/macro.c
@@ -634,7 +634,7 @@ void MacDef (unsigned Style)
         ** will also end any .define lines inside a classic macro:
         ** Tell the scanner to return a separator for newline tokens
         */
-        if (LastTokWasSep = TokIsSep (CurTok.Tok)) {
+        if ((LastTokWasSep = TokIsSep (CurTok.Tok))) {
             NewlineTokenAsSep ();
         }
 

--- a/src/ca65/pseudo.c
+++ b/src/ca65/pseudo.c
@@ -2136,6 +2136,7 @@ static CtrlDesc CtrlCmdTab [] = {
     { ccNone,           DoImportZP      },
     { ccNone,           DoIncBin        },
     { ccNone,           DoInclude       },
+    { ccNone,           DoUnexpected    },      /* .INSERT */
     { ccNone,           DoInterruptor   },
     { ccNone,           DoUnexpected    },      /* .ISIZE */
     { ccNone,           DoUnexpected    },      /* .ISMNEMONIC */

--- a/src/ca65/scanner.h
+++ b/src/ca65/scanner.h
@@ -50,8 +50,9 @@
 
 
 /* Scanner variables */
-extern Token CurTok;            /* Current input token incl. attributes */
-extern int   ForcedEnd;         /* Force end of assembly */
+extern Token CurTok;                /* Current input token incl. attributes */
+extern int   ForcedEnd;             /* Force end of assembly */
+extern int   AllowNewlineToken;     /* Keep newline sequence */
 
 
 
@@ -102,6 +103,24 @@ void InitScanner (const char* InFile);
 
 void DoneScanner (void);
 /* Release scanner resources */
+
+#if defined(HAVE_INLINE)
+INLINE void NewlineTokenAllow (void)
+{
+    AllowNewlineToken = 1;
+}
+#else
+#define NewlineTokenAllow()     (AllowNewlineToken = 1)
+#endif
+
+#if defined(HAVE_INLINE)
+INLINE void NewlineTokenAsSep (void)
+{
+    AllowNewlineToken = 0;
+}
+#else
+#define NewlineTokenAsSep()     (AllowNewlineToken = 0)
+#endif
 
 
 

--- a/src/ca65/token.h
+++ b/src/ca65/token.h
@@ -56,6 +56,7 @@ typedef enum token_t {
     TOK_NONE,           /* Start value, invalid */
     TOK_EOF,            /* End of input file */
     TOK_SEP,            /* Separator (usually newline) */
+    TOK_NL,             /* Newline sequence: .\ */
     TOK_IDENT,          /* An identifier */
     TOK_LOCAL_IDENT,    /* A cheap local identifier */
 
@@ -203,6 +204,7 @@ typedef enum token_t {
     TOK_IMPORTZP,
     TOK_INCBIN,
     TOK_INCLUDE,
+    TOK_INSERT,
     TOK_INTERRUPTOR,
     TOK_ISIZE,
     TOK_ISMNEMONIC,


### PR DESCRIPTION
I've made some changes, mostly to the .macro definition routines to add some features and also found and fixed some bugs.

Quick summary:

Add a "newline" token represented by `.\` that behaves as a end of line separator unless defining a .define style macro, where it is captured as part of the macro definition. Allow for nested macro definitions. Some bug fixes and code changes related to macro definitions.

More detail:

Add features:

1) Add "newline" token sequence `.\` to allow for more than one statement per line. It will behave exactly as a true end of line, with one exception in (2).
2) Allow .define style macros to store the newline token when it is found in a definition. Definition is terminated by a true line ending.
3) Allow "nested" macros: Other macros can be defined while expanding a macro.
4) Add .insert token. Only valid inside a classic macro body. This allows defining the .macro token in a macro without triggering a nested macro block. It will also allow the name for a .define definition to be expanded if it the name is a .define style macro, otherwise .define style macros are disabled while reading the name given after a .define statement.

Bug fixes:

1) Control commands that affect a macro definition must be at the beginning of the line to be active: .local, .macro, .endmacro (already fixed) and also .insert
2) A .define or .undefine found at the beginning of a line when in a macro body will result in .define style macros being disabled while reading the next token (the macro name). Currently they are not, and a previously defined .define style macro matching the macro name will result in a macro expansion during the definition. (This does already work this way outside of macro definitions.)

Other info:

1) Any control commands that affect macro definition will be skipped when in a nested macro. (Enclosing macro would have to be expanded to define the nested macro and have its corresponding control commands active.)
2) The .define command will only result in define style macros being disabled and newline tokens being read as described when it is at the beginning of the line.
3) The .paramcount function will not be processed if found in a nested macro while expanding the enclosing macro. The .paramount function will always return the number of parameters for the .macro it is used in. If used in a .define style macro (and not inside a .macro definition) it will return the number of parameters for the .define macro (Matches current behavior.)
4) When expanding .define style macros, any newline tokens found will be converted into end of line separator tokens, unless defining a new .define.
5) Symbols defined in the macro using .local are accessible within nested macros, and can be used to change the definition of the nested macro. New symbols defined with .local in the nested macro can use duplicate names from the enclosing macro and will internally be assigned a new name.
6) Function MacSkipDef is removed, due to the inconsistent error message when .endmacro is not found. If there is an error, the MacDef function will still continue to read the macro definition and check for a missing .endmacro. Any other errors will result in the macro being set as as incomplete. 

Some simple examples:

```
.macro myMacro1 foo
    .local bar
    bar .set 0
    .if foo = 1
        bar .set 2
    .endif
    .macro myMacro2
        .out .sprintf("Bar is %d", bar)
    .endmacro
.endmacro

myMacro1 1
myMacro2        ; console output: Bar is 2

; build again:
myMacro1 0
myMacro2        ; console output: Bar is 0
```

This becomes two statements: `clc` (newline separator) `adc #$10`
```
.define add(op) clc .\ adc op
add #$10
```

Three statements:
```
lda #<foo .\ ldx #>foo .\ jsr load
```

I've been testing these changes for some time and am confident I have discovered and fixed any issues. There shouldn't be anything in these changes that breaks anyone's current code. If this request looks like it will be accepted, I will add documentation and tests.
