### PR TITLE
Source listing in bootstrap.s is incorrect.

### DIFF
--- a/libsrc/osic1p/bootstrap.s
+++ b/libsrc/osic1p/bootstrap.s
@@ -34,7 +34,7 @@ ram_top         :=      __MAIN_START__ + __MAIN_SIZE__
 
 .ifdef ASM
 
-        .include        "osic1p.inc"
+        .include        "screen-c1p-24x24.s"
         .macpack        generic
 
 load            :=      $08             ; private variables
@@ -45,21 +45,23 @@ GETCHAR         :=      $FFBF           ; gets one character from ACIA
 FIRSTVISC       =       $85             ; Offset of first visible character in video RAM
 LINEDIST        =       $20             ; Offset in video RAM between two lines
 
-        ldy     #<$0000
+        ldy     #$00
         lda     #<load_addr
         ldx     #>load_addr
         sta     load
         stx     load+1
 
-        ldx     #(<load_size) + 1
-        stx     count
-        ldx     #(>load_size) + 1
-        stx     count+1                 ; save size with each byte incremented separately
+        lda     #<load_size
+        eor     #$FF
+        sta     count
+        lda     #>load_size
+        eor     #$FF
+        sta     count+1
 
-L1:     dec     count
-        bnz     L2
-        dec     count+1
-        bze     L3
+L1:     inc     count
+        bne     L2
+        inc     count+1
+        beq     L3
 L2:     jsr     GETCHAR                 ; (doesn't change .Y)
         sta     (load),y
 
@@ -70,12 +72,12 @@ L2:     jsr     GETCHAR                 ; (doesn't change .Y)
         lsr     a
         and     #8 - 1
         ora     #$10                    ; eight arrow characters
-        sta     SCRNBASE + FIRSTVISC + 2 * LINEDIST + 11
+        sta     C1P_SCR_BASE + FIRSTVISC + 2 * LINEDIST + 11
 
         iny
-        bnz     L1
+        bne     L1
         inc     load+1
-        bnz     L1                      ; branch always
+        bne     L1                      ; branch always
 
 L3:     jmp     load_addr
 

--- a/libsrc/osic1p/bootstrap.s
+++ b/libsrc/osic1p/bootstrap.s
@@ -35,7 +35,6 @@ ram_top         :=      __MAIN_START__ + __MAIN_SIZE__
 .ifdef ASM
 
         .include        "screen-c1p-24x24.s"
-        .macpack        generic
 
 load            :=      $08             ; private variables
 count           :=      $0A
@@ -51,16 +50,14 @@ LINEDIST        =       $20             ; Offset in video RAM between two lines
         sta     load
         stx     load+1
 
-        lda     #<load_size
-        eor     #$FF
-        sta     count
-        lda     #>load_size
-        eor     #$FF
-        sta     count+1
+        ldx     #(<load_size) + 1
+        stx     count
+        ldx     #(>load_size) + 1
+        stx     count+1                 ; save size with each byte incremented separately
 
-L1:     inc     count
+L1:     dec     count
         bne     L2
-        inc     count+1
+        dec     count+1
         beq     L3
 L2:     jsr     GETCHAR                 ; (doesn't change .Y)
         sta     (load),y
@@ -114,18 +111,15 @@ CR      =       $0D
         hex2    >load_addr
         .byte   CR, "85", CR, "08", CR
         .byte   "86", CR, "09", CR
-        .byte   "A9", CR
-        hex2    <load_size
-        .byte   CR, "49", CR, "FF", CR
-        .byte   "85", CR, "0A", CR
-        .byte   "A9", CR
-        hex2    >load_size
-        .byte   CR, "49", CR, "FF", CR
-        .byte   "85", CR, "0B", CR
-
-        .byte   "E6", CR, "0A", CR
+        .byte   "A2", CR
+        hex2    (<load_size) + 1
+        .byte   CR, "86", CR, "0A", CR
+        .byte   "A2", CR
+        hex2    (>load_size) + 1
+        .byte   CR, "86", CR, "0B", CR
+        .byte   "C6", CR, "0A", CR
         .byte   "D0", CR, "04", CR
-        .byte   "E6", CR, "0B", CR
+        .byte   "C6", CR, "0B", CR
         .byte   "F0", CR, "16", CR
         .byte   "20", CR, "BF", CR, "FF", CR
         .byte   "91", CR, "08", CR


### PR DESCRIPTION
The OSI C1P alternative boot file format works, but the code in the source listing does not match the ASCII-coded hex translation (which is actually used). This is confusing to anyone trying to maintain the code.

Also, the source code does not assemble when ASM is defined.

With these changes the source file should correctly match what is used at run time.