### PR TITLE
bug895.c compliant token pasting syntax to remove warnings

### DIFF
--- a/test/val/bug895.c
+++ b/test/val/bug895.c
@@ -21,7 +21,7 @@ unsigned int  uia, uib;
 unsigned long ula, ulb;
 
 #define OPTCMP8TEST_SINGLE(num,cmpop,asmprefix,vara,varb,b0,b1,a0,a1,typename,name) \
-    typename name ## _ ## num ## (void) { \
+    typename name ## _ ## num(void) { \
         varb = b0; \
         asm( asmprefix ); \
         vara = a0; \
@@ -30,7 +30,7 @@ unsigned long ula, ulb;
     }
 
 #define OPTCMP8TEST_VERIFY(num,b,desc,printterm,name) \
-    ASSERT_AreEqual(name ## _ ## num ##(),b,printterm,"Incorrect optimization of const comparison (" #name "_" #num ": " desc ").");
+    ASSERT_AreEqual(name ## _ ## num(),b,printterm,"Incorrect optimization of const comparison (" #name "_" #num ": " desc ").");
 
 /* Generates a set of comparison tests for one type and set of test values.
 **     name = a name for this test (no spaces)


### PR DESCRIPTION
Gets rid of some unnecessary warning spam in the test log of lines like this:
```
bug895.c:95: Warning: Pasting formed "unsigned_long_14(", an invalid preprocessing token
```