### PR TITLE
Explicit z: should suppress "Suspicious address expression" warning

### DIFF
--- a/src/ca65/ea.h
+++ b/src/ca65/ea.h
@@ -43,6 +43,10 @@
 /*****************************************************************************/
 
 
+/* EffAddr Flags */
+#define EFFADDR_OVERRIDE_ZP     0x00000001UL
+
+
 
 /* GetEA result struct */
 typedef struct EffAddr EffAddr;
@@ -51,6 +55,7 @@ struct EffAddr {
     unsigned long       AddrModeSet;    /* Possible addressing modes */
     struct ExprNode*    Expr;           /* Expression if any (NULL otherwise) */
     unsigned            Reg;            /* Register number in sweet16 mode */
+    unsigned long       Flags;          /* Other properties */
 
     /* The following fields are used inside instr.c */
     unsigned            AddrMode;       /* Actual addressing mode used */

--- a/src/ca65/ea65.c
+++ b/src/ca65/ea65.c
@@ -72,11 +72,13 @@ void GetEA (EffAddr* A)
     /* Clear the output struct */
     A->AddrModeSet = 0;
     A->Expr = 0;
+    A->Flags = 0;
 
     /* Handle an addressing size override */
     switch (CurTok.Tok) {
         case TOK_OVERRIDE_ZP:
             Restrictions = AM65_DIR | AM65_DIR_X | AM65_DIR_Y;
+            A->Flags |= EFFADDR_OVERRIDE_ZP;
             NextTok ();
             break;
 

--- a/src/ca65/instr.c
+++ b/src/ca65/instr.c
@@ -1269,7 +1269,8 @@ static int EvalEA (const InsDesc* Ins, EffAddr* A)
         ExprNode* Left = A->Expr->Left;
         if ((A->Expr->Op == EXPR_BYTE0 || A->Expr->Op == EXPR_BYTE1) &&
             Left->Op == EXPR_SYMBOL                                  &&
-            GetSymAddrSize (Left->V.Sym) != ADDR_SIZE_ZP) {
+            GetSymAddrSize (Left->V.Sym) != ADDR_SIZE_ZP             &&
+            !(A->Flags & EFFADDR_OVERRIDE_ZP)) {
 
             /* Output a warning */
             Warning (1, "Suspicious address expression");


### PR DESCRIPTION
When using ```z:``` prefix to explicitly request zeropage, it is not suspicious to use ```<``` to truncate an address. (Especially useful for 65816, Hu6280, etc.)

Other cases of the warning are left intact, as it is legitimately trying to warn against a missing ```#```.

Addresses: #194