### PR TITLE
Error for struct/union with a duplicate member

### DIFF
--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -793,6 +793,8 @@ static int HandleSymRedefinition (SymEntry* Sym, const Type* T, unsigned Flags)
                 */
                 Error ("Redeclaration of enumerator constant '%s'", Sym->Name);
                 Sym = 0;
+            } else if (Flags & SC_STRUCTFIELD) {
+                Error ("Duplicate member '%s'", Sym->Name);
             }
         }
     }

--- a/test/err/struct-duplicate-member.c
+++ b/test/err/struct-duplicate-member.c
@@ -1,0 +1,17 @@
+/* Ensure that a duplicate member in a struct produces an error.
+** https://github.com/cc65/cc65/issues/2015
+*/
+
+struct bads {
+    int a;
+    int a; /* this is an error */
+};
+
+union badu {
+    int a, a; /* also an error */
+};
+
+int main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
A struct or union can't have 2 members with an identical name. Fixes: #2015