### PR TITLE
Don't use a,x,y in macro parameter example, document why not.

### DIFF
--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -4262,8 +4262,13 @@ macro actually takes in the definition. You may also leave intermediate
 parameters empty. Empty parameters are replaced by empty space (that is,
 they are removed when the macro is expanded). If you have a look at our
 macro definition above, you will see, that replacing the "addr" parameter
-by nothing will lead to wrong code in most lines. To help you, writing
-macros with a variable parameter list, there are some control commands:
+by nothing will lead to wrong code in most lines.
+
+The names "a", "x" and "y" should be avoided for macro parameters, as these
+will usually conflict with the 6502 registers.
+
+For writing macros with a variable parameter list, control commands are
+available:
 
 <tt><ref id=".IFBLANK" name=".IFBLANK"></tt> tests the rest of the line and
 returns true, if there are any tokens on the remainder of the line. Since
@@ -4274,15 +4279,15 @@ opposite.
 Look at this example:
 
 <tscreen><verb>
-.macro  ldaxy   a, x, y
-.ifnblank       a
-        lda     #a
+.macro  ldaxy   i, j, k
+.ifnblank       i
+        lda     #i
 .endif
-.ifnblank       x
-        ldx     #x
+.ifnblank       j
+        ldx     #j
 .endif
-.ifnblank       y
-        ldy     #y
+.ifnblank       k
+        ldy     #k
 .endif
 .endmacro
 </verb></tscreen>


### PR DESCRIPTION
The documentation has a non-working example macro due to the use of a, x, and y as parameters. Replacing the names so the code can work, and added a brief note to avoid those parameter names.

Partially addresses: #392