### PR TITLE
ca65 support for three line ending types: \r, \r\n, \n

### DIFF
--- a/src/ca65/scanner.c
+++ b/src/ca65/scanner.c
@@ -112,6 +112,7 @@ struct CharSource {
     CharSource*                 Next;   /* Linked list of char sources */
     token_t                     Tok;    /* Last token */
     int                         C;      /* Last character */
+    int                         SkipN;  /* For '\r\n' line endings, skip '\n\ if next */
     const CharSourceFunctions*  Func;   /* Pointer to function table */
     union {
         InputFile               File;   /* File data */
@@ -325,6 +326,7 @@ static void UseCharSource (CharSource* S)
     Source      = S;
 
     /* Read the first character from the new file */
+    S->SkipN    = 0;
     S->Func->NextChar (S);
 
     /* Setup the next token so it will be skipped on the next call to
@@ -386,6 +388,10 @@ static void IFNextChar (CharSource* S)
         while (1) {
 
             int N = fgetc (S->V.File.F);
+            if (N == '\n' && S->SkipN)
+                N = fgetc (S->V.File.F);
+            S->SkipN = 0;
+
             if (N == EOF) {
                 /* End of file. Accept files without a newline at the end */
                 if (SB_NotEmpty (&S->V.File.Line)) {
@@ -401,8 +407,11 @@ static void IFNextChar (CharSource* S)
 
             /* Check for end of line */
             } else if (N == '\n') {
-
                 /* End of line */
+                break;
+            } else if (N == '\r') {
+                /* End of line, skip '\n' if it's the next character */
+                S->SkipN = 1;
                 break;
 
             /* Collect other stuff */


### PR DESCRIPTION
Created as a test to address #1894

This should accommodate all 3 line ending types transparently.

Not sure whether it is needed as a feature or not, but if it is desired, the change here seems somewhat minimal. I only implemented this as a test to see if it was viable.

Have not investigated whether cc65 would require a corresponding change. It's scanner is a bit different.