### PR TITLE
ca65: Suppress '.size' error for multiply-defined symbols

### DIFF
--- a/src/ca65/main.c
+++ b/src/ca65/main.c
@@ -858,7 +858,11 @@ static void OneLine (void)
             /* The line has switched the segment */
             Size = 0;
         }
-        DefSizeOfSymbol (Sym, Size);
+        /* Suppress .size Symbol if this Symbol already has a multiply-defined error,
+        ** as it will only create its own additional unnecessary error.
+        */
+        if ((Sym->Flags & SF_MULTDEF) == 0)
+            DefSizeOfSymbol (Sym, Size);
     }
 
     /* Line separator must come here */

--- a/src/ca65/main.c
+++ b/src/ca65/main.c
@@ -861,8 +861,9 @@ static void OneLine (void)
         /* Suppress .size Symbol if this Symbol already has a multiply-defined error,
         ** as it will only create its own additional unnecessary error.
         */
-        if ((Sym->Flags & SF_MULTDEF) == 0)
+        if ((Sym->Flags & SF_MULTDEF) == 0) {
             DefSizeOfSymbol (Sym, Size);
+        }
     }
 
     /* Line separator must come here */


### PR DESCRIPTION
In #1778 I [made a comment](https://github.com/cc65/cc65/issues/1778#issuecomment-1533191532) that the multiply-defined symbol errors were also generating a secondary '.size' error which adds to the user's confusion.

This change skips generating the ```.size`` symbol for a symbol that has already received the multiply-defined error.

Previously a doubly-defined label would produce a confusing second error about '.size':
```
blah:
blah:
```
Error:
```
.\file.s:2: Error: Symbol 'blah' is already defined
.\file.s:2: Error: Symbol '.size' is already defined
```

This identifies the case as a symbol that was marked multiply-defined via the SF_MULTDEF, which is only applied in the case of an error, so I don't believe this change would hide any error that isn't already redundant.