### PR TITLE
Improve struct size error message to include the detected size

### DIFF
--- a/src/cc65/function.c
+++ b/src/cc65/function.c
@@ -601,7 +601,7 @@ void NewFunc (SymEntry* Func, FuncDesc* D)
                 ** We don't currently support this case.
                 */
                 if (RType == Param->Type) {
-                    Error ("Passing '%s' of this size by value is not supported", GetFullTypeName (Param->Type));
+                    Error ("Passing '%s' of this size (%d) by value is not supported", GetFullTypeName (Param->Type), SizeOf (RType));
                 }
             }
 


### PR DESCRIPTION
This probably would have helped the confusion of #2079 slightly. :S