### PR TITLE
Workflow docs artifact, windows test, sim65 fix

### DIFF
--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -54,7 +54,7 @@ jobs:
           make -j2 bin USER_CFLAGS=-Werror CROSS_COMPILE=x86_64-w64-mingw32-
 
   build_windows:
-    name: Build (Windows)
+    name: Build and Test (Windows)
     runs-on: windows-latest
 
     steps:
@@ -72,3 +72,8 @@ jobs:
 
       - name: Build app (release)
         run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
+
+      - name: Build the platform libraries.
+        run: make -j2 lib QUIET=1
+      - name: Run the regression tests.
+        run: make test QUIET=1

--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Build the document files.
         shell: bash
         run: make -j2 doc
+      - name: Upload a documents snapshot.
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: ./html
       - name: Build 64-bit Windows versions of the tools.
         run: |
           make -C src clean

--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -54,7 +54,7 @@ jobs:
           make -j2 bin USER_CFLAGS=-Werror CROSS_COMPILE=x86_64-w64-mingw32-
 
   build_windows:
-    name: Build and Test (Windows)
+    name: Build (Windows)
     runs-on: windows-latest
 
     steps:
@@ -73,7 +73,8 @@ jobs:
       - name: Build app (release)
         run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
 
-      - name: Build the test libraries.
-        run: make -j2 libtest QUIET=1
-      - name: Run the regression tests.
-        run: make test QUIET=1
+      # Disabled because this is 5x slower than the corresponding Linux test.
+      #- name: Build the test libraries.
+      #  run: make -j2 libtest QUIET=1
+      #- name: Run the regression tests.
+      #  run: make -j test QUIET=1

--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build app (release)
         run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
 
-      - name: Build the platform libraries.
-        run: make -j2 lib QUIET=1
+      - name: Build the test libraries.
+        run: make -j2 libtest QUIET=1
       - name: Run the regression tests.
         run: make test QUIET=1

--- a/.github/workflows/snapshot-on-push-master.yml
+++ b/.github/workflows/snapshot-on-push-master.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Build app (release)
         run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
 
-      - name: Build the platform libraries.
-        run: make -j2 lib QUIET=1
+      - name: Build the test libraries.
+        run: make -j2 libtest QUIET=1
       - name: Run the regression tests.
         run: make test QUIET=1
 

--- a/.github/workflows/snapshot-on-push-master.yml
+++ b/.github/workflows/snapshot-on-push-master.yml
@@ -88,12 +88,12 @@ jobs:
       - name: Upload a 32-bit Snapshot Zip
         uses: actions/upload-artifact@v3
         with:
-          name: cc65-snapshot-win32.zip
+          name: cc65-snapshot-win32
           path: cc65-snapshot-win32.zip
       - name: Upload a 64-bit Snapshot Zip
         uses: actions/upload-artifact@v3
         with:
-          name: cc65-snapshot-win64.zip
+          name: cc65-snapshot-win64
           path: cc65-snapshot-win64.zip
 
       - name: Get the online documents repo.
@@ -123,7 +123,7 @@ jobs:
       - name: Upload a Documents Snapshot Zip
         uses: actions/upload-artifact@v3
         with:
-          name: cc65-snapshot-docs.zip
+          name: cc65-snapshot-docs
           path: cc65-snapshot-docs.zip
 
     # enter secrets under "repository secrets"

--- a/.github/workflows/snapshot-on-push-master.yml
+++ b/.github/workflows/snapshot-on-push-master.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build_windows:
-    name: Build (Windows)
+    name: Build, Test (Windows)
     if: github.repository == 'cc65/cc65'
     runs-on: windows-latest
 
@@ -28,6 +28,11 @@ jobs:
 
       - name: Build app (release)
         run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
+
+      - name: Build the platform libraries.
+        run: make -j2 lib QUIET=1
+      - name: Run the regression tests.
+        run: make test QUIET=1
 
   build_linux:
     name: Build, Test, and Snapshot (Linux)

--- a/.github/workflows/snapshot-on-push-master.yml
+++ b/.github/workflows/snapshot-on-push-master.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build_windows:
-    name: Build, Test (Windows)
+    name: Build (Windows)
     if: github.repository == 'cc65/cc65'
     runs-on: windows-latest
 
@@ -29,10 +29,11 @@ jobs:
       - name: Build app (release)
         run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
 
-      - name: Build the test libraries.
-        run: make -j2 libtest QUIET=1
-      - name: Run the regression tests.
-        run: make test QUIET=1
+      # Disabled because this is 5x slower than the corresponding Linux test.
+      #- name: Build the test libraries.
+      #  run: make -j2 libtest QUIET=1
+      #- name: Run the regression tests.
+      #  run: make test QUIET=1
 
   build_linux:
     name: Build, Test, and Snapshot (Linux)

--- a/.github/workflows/snapshot-on-push-master.yml
+++ b/.github/workflows/snapshot-on-push-master.yml
@@ -118,12 +118,28 @@ jobs:
           if git commit -m "Updated from https://github.com/cc65/cc65/commit/${GITHUB_SHA}" ; then
             git push
           fi
+      - name: Package offline documents.
+        run: 7z a cc65-snapshot-docs.zip ./html/*.*
+      - name: Upload a Documents Snapshot Zip
+        uses: actions/upload-artifact@v3
+        with:
+          name: cc65-snapshot-docs.zip
+          path: cc65-snapshot-docs.zip
 
     # enter secrets under "repository secrets"
-      - name: Upload snapshot to sourceforge
+      - name: Upload 32-bit Windows snapshot to sourceforge
         uses: nogsantos/scp-deploy@master
         with:
           src: cc65-snapshot-win32.zip
+          host: ${{ secrets.SSH_HOST }}
+          remote: ${{ secrets.SSH_DIR }}
+          port: ${{ secrets.SSH_PORT }}
+          user: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+      - name: Upload documents snapshot to sourceforge
+        uses: nogsantos/scp-deploy@master
+        with:
+          src: cc65-snapshot-docs.zip
           host: ${{ secrets.SSH_HOST }}
           remote: ${{ secrets.SSH_DIR }}
           port: ${{ secrets.SSH_PORT }}

--- a/.github/workflows/windows-test-manual.yml
+++ b/.github/workflows/windows-test-manual.yml
@@ -1,0 +1,31 @@
+name: Windows Test Manual
+# Manually dispatched because it's much slower than the Linux test.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_windows:
+    name: Build, Test (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - name: Git Setup
+        shell: bash
+        run: git config --global core.autocrlf input
+
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Build app (release)
+        run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
+
+      - name: Build the test libraries.
+        run: make -j2 libtest QUIET=1
+
+      - if: ${{ steps.cache-sha.outputs.cache-hit != 'true' }}
+        name: Run the regression tests.
+        run: make test QUIET=1

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ mostlyclean clean:
 avail unavail bin:
 	@$(MAKE) -C src     --no-print-directory $@
 
-lib:
+lib libtest:
 	@$(MAKE) -C libsrc  --no-print-directory $@
 
 doc html info:
@@ -43,7 +43,7 @@ util:
 checkstyle:
 	@$(MAKE) -C .github/checks       --no-print-directory $@
 
-# simple "test" target, only run regression tests for c64 target
+# runs regression tests, requires libtest target libraries
 test:
 	@$(MAKE) -C test                 --no-print-directory $@
 

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -39,6 +39,10 @@ TARGETS = apple2       \
           sym1         \
           telestrat
 
+TARGETTEST = none     \
+             sim6502  \
+             sim65c02
+
 DRVTYPES = emd \
            joy \
            mou \
@@ -53,7 +57,7 @@ OUTPUTDIRS := lib                                                               
               $(subst ../,,$(wildcard ../target/*/drv/*))                                     \
               $(subst ../,,$(wildcard ../target/*/util))
 
-.PHONY: all mostlyclean clean install zip lib $(TARGETS)
+.PHONY: all mostlyclean clean install zip lib libtest $(TARGETS)
 
 .SUFFIXES:
 
@@ -80,6 +84,8 @@ ifndef TARGET
 datadir = $(PREFIX)/share/cc65
 
 all lib: $(TARGETS)
+
+libtest: $(TARGETTEST)
 
 mostlyclean:
 	$(call RMDIR,../libwrk)

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -140,6 +140,16 @@ static void OptQuitXIns (const char* Opt attribute ((unused)),
 /* quit after MaxCycles cycles */
 {
     MaxCycles = strtoul(Arg, NULL, 0);
+    /* Guard against overflow. */
+    if (MaxCycles == ULONG_MAX && errno == ERANGE) {
+        Error("'-x parameter out of range. Max: %lu",ULONG_MAX);
+    }
+    /* Platforms with 64-bit long should not be permitted to behave differently. */
+#if ULONG_MAX > 0xFFFFFFFFUL
+    if (MaxCycles > 0xFFFFFFFFUL) {
+        Error("'-x parameter out of 32-bit range. Max: %ul",0xFFFFFFFF);
+    }
+#endif
 }
 
 static unsigned char ReadProgramFile (void)

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -195,6 +195,7 @@ static unsigned char ReadProgramFile (void)
     }
 
     /* Get load address */
+    Val2 = 0;
     if (((Val = fgetc(F)) == EOF) ||
         ((Val2 = fgetc(F)) == EOF)) {
         Error ("'%s': Header missing load address", ProgramFile);

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <limits.h>
 
 /* common */
 #include "abend.h"

--- a/src/sim65/paravirt.c
+++ b/src/sim65/paravirt.c
@@ -246,7 +246,9 @@ static void PVClose (CPURegs* Regs)
         RetVal = close (FD);
     } else {
         /* test/val/constexpr "abuses" close, expecting close(-1) to return -1.
-        ** This behaviour is not the same on all target platforms. */
+        ** This behaviour is not the same on all target platforms.
+        ** MSVC's close treats it as a fatal error instead and terminates.
+        */
         RetVal = 0xFFFF;
     }
 

--- a/src/sim65/paravirt.c
+++ b/src/sim65/paravirt.c
@@ -242,7 +242,13 @@ static void PVClose (CPURegs* Regs)
 
     Print (stderr, 2, "PVClose ($%04X)\n", FD);
 
-    RetVal = close (FD);
+    if (FD != 0xFFFF) {
+        RetVal = close (FD);
+    } else {
+        /* test/val/constexpr "abuses" close, expecting close(-1) to return -1.
+        ** This behaviour is not the same on all target platforms. */
+        RetVal = 0xFFFF;
+    }
 
     SetAX (Regs, RetVal);
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,6 +22,7 @@ continue:
 	@$(MAKE) -C val all
 	@$(MAKE) -C ref all
 	@$(MAKE) -C err all
+	@$(MAKE) -C standard all
 	@$(MAKE) -C misc all
 	@$(MAKE) -C todo all
 
@@ -31,6 +32,7 @@ mostlyclean:
 	@$(MAKE) -C val clean
 	@$(MAKE) -C ref clean
 	@$(MAKE) -C err clean
+	@$(MAKE) -C standard clean
 	@$(MAKE) -C misc clean
 	@$(MAKE) -C todo clean
 

--- a/test/asm/val/Makefile
+++ b/test/asm/val/Makefile
@@ -22,7 +22,7 @@ ifdef QUIET
   NULLERR = 2>$(NULLDEV)
 endif
 
-SIM65FLAGS = -x 5000000000
+SIM65FLAGS = -x 4294967295
 
 CA65 := $(if $(wildcard ../../../bin/ca65*),..$S..$S..$Sbin$Sca65,ca65)
 LD65 := $(if $(wildcard ../../../bin/ld65*),..$S..$S..$Sbin$Sld65,ld65)

--- a/test/standard/Makefile
+++ b/test/standard/Makefile
@@ -22,7 +22,7 @@ ifdef QUIET
   NULLERR = 2>$(NULLDEV)
 endif
 
-SIM65FLAGS = -x 5000000000 -c
+SIM65FLAGS = -x 4294967295 -c
 
 CC65 := $(if $(wildcard ../../bin/cc65*),..$S..$Sbin$Scc65,cc65)
 CA65 := $(if $(wildcard ../../bin/ca65*),..$S..$Sbin$Sca65,ca65)

--- a/test/todo/Makefile
+++ b/test/todo/Makefile
@@ -31,7 +31,7 @@ CA65 := $(if $(wildcard ../../bin/ca65*),..$S..$Sbin$Sca65,ca65)
 LD65 := $(if $(wildcard ../../bin/ld65*),..$S..$Sbin$Sld65,ld65)
 SIM65 := $(if $(wildcard ../../bin/sim65*),..$S..$Sbin$Ssim65,sim65)
 
-WORKDIR = ../../testwrk/val
+WORKDIR = ../../testwrk/todo
 
 OPTIONS = g O Os Osi Osir Osr Oi Oir Or
 
@@ -49,7 +49,7 @@ $(WORKDIR):
 define PRG_template
 
 $(WORKDIR)/%.$1.$2.prg: %.c | $(WORKDIR)
-	$(if $(QUIET),echo val/$$*.$1.$2.prg)
+	$(if $(QUIET),echo todo/$$*.$1.$2.prg)
 	$(CC65) -t sim$2 $$(CC65FLAGS) -$1 -o $$(@:.prg=.s) $$< $(NULLERR)
 	$(CA65) -t sim$2 -o $$(@:.prg=.o) $$(@:.prg=.s) $(NULLERR)
 	$(LD65) -t sim$2 -o $$@ $$(@:.prg=.o) sim$2.lib $(NULLERR)

--- a/test/val/Makefile
+++ b/test/val/Makefile
@@ -24,7 +24,7 @@ ifdef QUIET
   NULLERR = 2>$(NULLDEV)
 endif
 
-SIM65FLAGS = -x 5000000000 -c
+SIM65FLAGS = -x 4294967295 -c
 
 CC65 := $(if $(wildcard ../../bin/cc65*),..$S..$Sbin$Scc65,cc65)
 CA65 := $(if $(wildcard ../../bin/ca65*),..$S..$Sbin$Sca65,ca65)


### PR DESCRIPTION
I was trying to investigate some workflow possibilities, but it ended up combining with a few related things.

Changes:
* Added a docs HTML artifact to pull requests, so that someone submitting document changes can use that to preview them.
* Upload a snapshot docs HTML zip to sourceforge alongside the snapshot build.
* Remove ".zip" from artifact filenames, because that's automatically added. (We had .zip.zip files.)
* Added "libtest" target to makefiles to build only the platform libraries needed to run "test".
* Fixed test/todo using testwrk/val for its temporary files by mistake.
* Added test/standard to test makefile, seemed like it was left out by mistake.
* Restrict sim65 to 32-bit values for cycles so that it's the same on both platforms.
* Fixed sim65 crash caused by test/val/constexpr.c using close(-1) in a weird way. MSVC's close(-1) will terminate with a fatal error, rather than return -1.
* Added workflow for windows test, but manually triggered.

So, the initial goal was to generate the HTML docs as an artifact for PR reviews, and also see if the windows version could have its test set run by the build. The docs part worked well. The windows test... was a little weird.

So, it's not hard to add the windows test to the PR and snapshot workflows, but it was taking about 25 minutes on the build machines, seems about 5x slower than the Linux tests. I'm not sure what the cause of this speed disparity is, but it's a little bit disturbing. I kinda suspect the performance difference is to do with "make", and not really a problem with the cc65 windows binaries, but I don't have much information about why at this point.

So, I left comments about that in the workflows, but I don't think it should be enabled, because we probably don't want to be waiting an extra half hour for the CI report every time. Instead I created a separate workflow that can be manually triggered whenever anyone wants to investigate.

The Windows version test was almost fine. The only problem that came up was test/val/constexpr.c, which ended up causing sim65 to crash. After accommodating this with a fix to sim65, the Windows build does manage to run the test set without error.

I also added a "libtest" target to the makefiles which only builds the 3 platform libraries needed to run the test. I also noticed that test/standard wasn't ever added to the test makefile, so I hooked that up too. (Luckily it didn't cause any new errors to appear.)

.

I did my best to test the workflow changes as thoroughly as I could on my own fork, so I don't expect them to fail here, though obviously I could not test the stuff involving secret credentials.