### PR TITLE
Windows test workflow, sim65 fixes for Windows differences

### DIFF
--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -67,3 +67,10 @@ jobs:
 
       - name: Build app (release)
         run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
+
+      # Disabled because this is 5x slower than the corresponding Linux test.
+      # windows-test-manual.yml provides a manually dispatched alternative.
+      #- name: Build the test libraries.
+      #  run: make -j2 libtest QUIET=1
+      #- name: Run the regression tests.
+      #  run: make -j test QUIET=1

--- a/.github/workflows/snapshot-on-push-master.yml
+++ b/.github/workflows/snapshot-on-push-master.yml
@@ -29,6 +29,13 @@ jobs:
       - name: Build app (release)
         run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
 
+      # Disabled because this is 5x slower than the corresponding Linux test.
+      # windows-test-manual.yml provides a manually dispatched alternative.
+      #- name: Build the test libraries.
+      #  run: make -j2 libtest QUIET=1
+      #- name: Run the regression tests.
+      #  run: make -j test QUIET=1
+
   build_linux:
     name: Build, Test, and Snapshot (Linux)
     if: github.repository == 'cc65/cc65'

--- a/.github/workflows/windows-test-manual.yml
+++ b/.github/workflows/windows-test-manual.yml
@@ -26,18 +26,18 @@ jobs:
       - name: Build app (MSVC release)
         run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
 
-      - name: Build utils (make)
+      - name: Build utils (MinGW)
         shell: cmd
         run: make -j2 util
 
-      - name: Build the platform libraries
+      - name: Build the platform libraries (make lib)
         shell: cmd
         run: make -j2 lib QUIET=1
 
-      - name: Run the regression tests
+      - name: Run the regression tests (make test)
         shell: cmd
         run: make test QUIET=1
 
-      - name: Test that the samples can be built
+      - name: Test that the samples can be built (make samples)
         shell: cmd
         run: make -j2 samples

--- a/.github/workflows/windows-test-manual.yml
+++ b/.github/workflows/windows-test-manual.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build_windows:
-    name: Build, Test (Windows)
+    name: Build, Test (Windows MSVC)
     runs-on: windows-latest
 
     steps:
@@ -20,11 +20,24 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
 
-      - name: Build app (release)
+      - name: Build app (MSVC debug)
+        run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Debug
+
+      - name: Build app (MSVC release)
         run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
 
-      - name: Build the test libraries.
-        run: make -j2 libtest QUIET=1
+      - name: Build utils (make)
+        shell: cmd
+        run: make -j2 util
 
-      - name: Run the regression tests.
+      - name: Build the platform libraries
+        shell: cmd
+        run: make -j2 lib QUIET=1
+
+      - name: Run the regression tests
+        shell: cmd
         run: make test QUIET=1
+
+      - name: Test that the samples can be built
+        shell: cmd
+        run: make -j2 samples

--- a/.github/workflows/windows-test-manual.yml
+++ b/.github/workflows/windows-test-manual.yml
@@ -1,0 +1,30 @@
+name: Windows Test Manual
+# Manually dispatched because it's much slower than the Linux test.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_windows:
+    name: Build, Test (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - name: Git Setup
+        shell: bash
+        run: git config --global core.autocrlf input
+
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Build app (release)
+        run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
+
+      - name: Build the test libraries.
+        run: make -j2 libtest QUIET=1
+
+      - name: Run the regression tests.
+        run: make test QUIET=1

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ mostlyclean clean:
 avail unavail bin:
 	@$(MAKE) -C src     --no-print-directory $@
 
-lib:
+lib libtest:
 	@$(MAKE) -C libsrc  --no-print-directory $@
 
 doc html info:
@@ -43,7 +43,7 @@ util:
 checkstyle:
 	@$(MAKE) -C .github/checks       --no-print-directory $@
 
-# simple "test" target, only run regression tests for c64 target
+# runs regression tests, requires libtest target libraries
 test:
 	@$(MAKE) -C test                 --no-print-directory $@
 

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -39,6 +39,10 @@ TARGETS = apple2       \
           sym1         \
           telestrat
 
+TARGETTEST = none     \
+             sim6502  \
+             sim65c02
+
 DRVTYPES = emd \
            joy \
            mou \
@@ -53,7 +57,7 @@ OUTPUTDIRS := lib                                                               
               $(subst ../,,$(wildcard ../target/*/drv/*))                                     \
               $(subst ../,,$(wildcard ../target/*/util))
 
-.PHONY: all mostlyclean clean install zip lib $(TARGETS)
+.PHONY: all mostlyclean clean install zip lib libtest $(TARGETS)
 
 .SUFFIXES:
 
@@ -80,6 +84,8 @@ ifndef TARGET
 datadir = $(PREFIX)/share/cc65
 
 all lib: $(TARGETS)
+
+libtest: $(TARGETTEST)
 
 mostlyclean:
 	$(call RMDIR,../libwrk)

--- a/src/grc65/main.c
+++ b/src/grc65/main.c
@@ -850,8 +850,12 @@ static char *filterInput (FILE *F, char *tbl)
     /* loads file into buffer filtering it out */
     int a, prevchar = -1, i = 0, bracket = 0, quote = 1;
 
-    for (;;) {
-        a = getc(F);
+    a = getc(F);
+    while (1)
+    {
+        if (i >= BLOODY_BIG_BUFFER) {
+            AbEnd ("File too large for internal parsing buffer (%d bytes).",BLOODY_BIG_BUFFER);
+        }
         if ((a == '\n') || (a == '\015')) a = ' ';
         if (a == ',' && quote) a = ' ';
         if (a == '\042') quote =! quote;
@@ -873,13 +877,18 @@ static char *filterInput (FILE *F, char *tbl)
             if (a == ';' && quote) {
                 do {
                     a = getc (F);
-                } while (a != '\n');
-                fseek (F, -1, SEEK_CUR);
+                } while (a != '\n' && a != EOF);
+                /* Don't discard this newline/EOF, continue to next loop.
+                ** A previous implementation used fseek(F,-1,SEEK_CUR),
+                ** which is invalid for text mode files, and was unreliable across platforms.
+                */
+                continue;
             } else {
                 tbl[i++] = a;
                 prevchar = a;
             }
         }
+        a = getc(F);
     }
 
     if (bracket != 0) AbEnd ("There are unclosed brackets!");

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -195,6 +195,7 @@ static unsigned char ReadProgramFile (void)
     }
 
     /* Get load address */
+    Val2 = 0; /* suppress uninitialized variable warning */
     if (((Val = fgetc(F)) == EOF) ||
         ((Val2 = fgetc(F)) == EOF)) {
         Error ("'%s': Header missing load address", ProgramFile);

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <limits.h>
 
 /* common */
 #include "abend.h"
@@ -140,6 +141,16 @@ static void OptQuitXIns (const char* Opt attribute ((unused)),
 /* quit after MaxCycles cycles */
 {
     MaxCycles = strtoul(Arg, NULL, 0);
+    /* Guard against overflow. */
+    if (MaxCycles == ULONG_MAX && errno == ERANGE) {
+        Error("'-x parameter out of range. Max: %lu",ULONG_MAX);
+    }
+    /* Platforms with 64-bit long should not be permitted to behave differently. */
+#if ULONG_MAX > 0xFFFFFFFFUL
+    if (MaxCycles > 0xFFFFFFFFUL) {
+        Error("'-x parameter out of 32-bit range. Max: %ul",0xFFFFFFFF);
+    }
+#endif
 }
 
 static unsigned char ReadProgramFile (void)

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -145,12 +145,6 @@ static void OptQuitXIns (const char* Opt attribute ((unused)),
     if (MaxCycles == ULONG_MAX && errno == ERANGE) {
         Error("'-x parameter out of range. Max: %lu",ULONG_MAX);
     }
-    /* Platforms with 64-bit long should not be permitted to behave differently. */
-#if ULONG_MAX > 0xFFFFFFFFUL
-    if (MaxCycles > 0xFFFFFFFFUL) {
-        Error("'-x parameter out of 32-bit range. Max: %ul",0xFFFFFFFF);
-    }
-#endif
 }
 
 static unsigned char ReadProgramFile (void)

--- a/src/sim65/paravirt.c
+++ b/src/sim65/paravirt.c
@@ -242,7 +242,15 @@ static void PVClose (CPURegs* Regs)
 
     Print (stderr, 2, "PVClose ($%04X)\n", FD);
 
-    RetVal = close (FD);
+    if (FD != 0xFFFF) {
+        RetVal = close (FD);
+    } else {
+        /* test/val/constexpr.c "abuses" close, expecting close(-1) to return -1.
+        ** This behaviour is not the same on all target platforms.
+        ** MSVC's close treats it as a fatal error instead and terminates.
+        */
+        RetVal = 0xFFFF;
+    }
 
     SetAX (Regs, RetVal);
 }

--- a/test/asm/val/Makefile
+++ b/test/asm/val/Makefile
@@ -22,6 +22,7 @@ ifdef QUIET
   NULLERR = 2>$(NULLDEV)
 endif
 
+# sim65 can support 64-bit cycle counts on some platforms, but not all. This must fit in 32-bit.
 SIM65FLAGS = -x 4294967295
 
 CA65 := $(if $(wildcard ../../../bin/ca65*),..$S..$S..$Sbin$Sca65,ca65)

--- a/test/asm/val/Makefile
+++ b/test/asm/val/Makefile
@@ -22,7 +22,7 @@ ifdef QUIET
   NULLERR = 2>$(NULLDEV)
 endif
 
-SIM65FLAGS = -x 5000000000
+SIM65FLAGS = -x 4294967295
 
 CA65 := $(if $(wildcard ../../../bin/ca65*),..$S..$S..$Sbin$Sca65,ca65)
 LD65 := $(if $(wildcard ../../../bin/ld65*),..$S..$S..$Sbin$Sld65,ld65)

--- a/test/standard/Makefile
+++ b/test/standard/Makefile
@@ -22,7 +22,7 @@ ifdef QUIET
   NULLERR = 2>$(NULLDEV)
 endif
 
-SIM65FLAGS = -x 5000000000 -c
+SIM65FLAGS = -x 4294967295 -c
 
 CC65 := $(if $(wildcard ../../bin/cc65*),..$S..$Sbin$Scc65,cc65)
 CA65 := $(if $(wildcard ../../bin/ca65*),..$S..$Sbin$Sca65,ca65)

--- a/test/standard/Makefile
+++ b/test/standard/Makefile
@@ -22,6 +22,7 @@ ifdef QUIET
   NULLERR = 2>$(NULLDEV)
 endif
 
+# sim65 can support 64-bit cycle counts on some platforms, but not all. This must fit in 32-bit.
 SIM65FLAGS = -x 4294967295 -c
 
 CC65 := $(if $(wildcard ../../bin/cc65*),..$S..$Sbin$Scc65,cc65)

--- a/test/val/Makefile
+++ b/test/val/Makefile
@@ -24,7 +24,7 @@ ifdef QUIET
   NULLERR = 2>$(NULLDEV)
 endif
 
-SIM65FLAGS = -x 5000000000 -c
+SIM65FLAGS = -x 4294967295 -c
 
 CC65 := $(if $(wildcard ../../bin/cc65*),..$S..$Sbin$Scc65,cc65)
 CA65 := $(if $(wildcard ../../bin/ca65*),..$S..$Sbin$Sca65,ca65)

--- a/test/val/Makefile
+++ b/test/val/Makefile
@@ -24,6 +24,7 @@ ifdef QUIET
   NULLERR = 2>$(NULLDEV)
 endif
 
+# sim65 can support 64-bit cycle counts on some platforms, but not all. This must fit in 32-bit.
 SIM65FLAGS = -x 4294967295 -c
 
 CC65 := $(if $(wildcard ../../bin/cc65*),..$S..$Sbin$Scc65,cc65)


### PR DESCRIPTION
This creates a manual-dispatch Windows test workflow that we can trigger as needed to help verify the integrity of that build. It was not added to the PR or snapshot workflows because it currently takes about 25 minutes on the github build machines.

The Windows build actually did pass the regression tests, but it exposed 2 issues with sim65. The first is the issue of "long" being 64-bit on the Linux builds but 32-bit on Windows. Some of the tests were using 5000000000 as their requested cycle count. I put checks into sim65 to disallow this so that the two platforms are not allowed to behave differently on this input. The second issue is that [test/val/constexpr.c](https://github.com/cc65/cc65/blob/a7676bdff5f07ee940e6054373d989f8737dd5e3/test/val/constexpr.c) is using ```close(-1)``` for an expected ```-1``` return value. On MSVC ```close(-1)``` will terminate the program instead of returning any value.

Also added a "libtest" makefile target that builds only the 3 platform libraries needed for "make test". This allows a faster setup for when we only wants to run the tests.

Summary:
* Restrict sim65 to 32-bit values for cycles so that it's the same on both platforms.
* Fixed sim65 crash caused by test/val/constexpr.c using close(-1) in a weird way. MSVC's close(-1) will terminate with a fatal error, rather than return -1.
* Suppress uninitialized variable warning in sim65.
* Added "libtest" target to makefiles to build only the platform libraries needed to run "test".
* Added workflow for windows test, but manually triggered because it's slow.

Split from #2089