### PR TITLE
More specific git commit error suppression in doc upload

### DIFF
--- a/.github/workflows/snapshot-on-push-master.yml
+++ b/.github/workflows/snapshot-on-push-master.yml
@@ -115,9 +115,8 @@ jobs:
           git config push.default simple
           git add -A
           # prevent failure when there is nothing to commit
-          if git commit -m "Updated from https://github.com/cc65/cc65/commit/${GITHUB_SHA}" ; then
-            git push
-          fi
+          git diff-index --quiet HEAD || git commit -m "Updated from https://github.com/cc65/cc65/commit/${GITHUB_SHA}"
+          git push
 
     # enter secrets under "repository secrets"
       - name: Upload snapshot to sourceforge


### PR DESCRIPTION
The bash if solution to avoid the git commit error when there are no changes has the potential to suppress other git commit errors.

The diff-index approach targets only the one error we want to eliminate (error because of no changes to commit).

As mentioned in #2065 [here](https://github.com/cc65/cc65/issues/2065#issuecomment-1535364766)