### PR TITLE
Add support for 48x12 video mode on Challenger 1P

### DIFF
--- a/doc/osi.sgml
+++ b/doc/osi.sgml
@@ -187,7 +187,20 @@ Currently the following extra screen configuration modules are implemented:
 <itemize>
 <item><tt>osic1p-screen-s3-32x28.o</tt>: 32 columns by 28 lines mode
 for Briel Superboard ///</item>
+<item><tt>osic1p-screen-c1p-48x12.s</tt>: 48 columns by 12 lines mode
+for Challenger 1P</item>
 </itemize>
+
+On the Briel Superboard /// you enter 32 column mode by holding down
+the BREAK key on powerup.
+
+On the Challenger 1P you can enable 48 column mode by writing a 1 to
+bit 0 of address &dollar;D800, and writing a 0 to go back to 24 column mode.
+You can use code like the following to do this:
+
+<tscreen><verb>
+*(char*)0xd800 = 1; /* Switch to 48 column mode */
+</verb></tscreen>
 
 <sect>Limitations<p>
 

--- a/libsrc/osic1p/extra/screen-c1p-48x12.s
+++ b/libsrc/osic1p/extra/screen-c1p-48x12.s
@@ -1,0 +1,16 @@
+;
+; Implementation of screen-layout related functions for Challenger 1P in 48x12 mode.
+;
+
+        .include        "../osiscreen.inc"
+
+C1P_SCR_BASE    := $D000        ; Base of C1P video RAM
+C1P_VRAM_SIZE   = $0400         ; Size of C1P video RAM (1 kB)
+C1P_SCR_WIDTH   = $30           ; Screen width
+C1P_SCR_HEIGHT  = $0C           ; Screen height
+C1P_SCR_FIRSTCHAR = $8B         ; Offset of cursor position (0, 0) from base
+                                ; of video RAM
+C1P_SCROLL_DIST = $40           ; Memory distance for scrolling by one line
+
+osi_screen_funcs C1P_SCR_BASE, C1P_VRAM_SIZE, C1P_SCR_FIRSTCHAR, \
+                        C1P_SCR_WIDTH, C1P_SCR_HEIGHT, C1P_SCROLL_DIST


### PR DESCRIPTION
Add support for 48x12 video mode on Challenger 1P.
Tested on real C1P hardware.