### PR TITLE
grc65 fix flawed text parsing

### DIFF
--- a/src/grc65/main.c
+++ b/src/grc65/main.c
@@ -851,10 +851,9 @@ static char *filterInput (FILE *F, char *tbl)
     int a, prevchar = -1, i = 0, bracket = 0, quote = 1;
 
     a = getc(F);
-    while (1)
-    {
+    while (1) {
         if (i >= BLOODY_BIG_BUFFER) {
-            AbEnd ("File too large for internal parsing buffer (%d bytes).",BLOODY_BIG_BUFFER);
+            AbEnd ("File too large for internal parsing buffer (%d bytes)",BLOODY_BIG_BUFFER);
         }
         if ((a == '\n') || (a == '\015')) a = ' ';
         if (a == ',' && quote) a = ' ';

--- a/src/grc65/main.c
+++ b/src/grc65/main.c
@@ -855,12 +855,20 @@ static char *filterInput (FILE *F, char *tbl)
         if (i >= BLOODY_BIG_BUFFER) {
             AbEnd ("File too large for internal parsing buffer (%d bytes)",BLOODY_BIG_BUFFER);
         }
-        if ((a == '\n') || (a == '\015')) a = ' ';
-        if (a == ',' && quote) a = ' ';
-        if (a == '\042') quote =! quote;
+        if (((a == '\n') || (a == '\015')) ||
+            (a == ',' && quote)) {
+            a = ' ';
+        }
+        if (a == '\042') {
+            quote =! quote;
+        }
         if (quote) {
-            if ((a == '{') || (a == '(')) bracket++;
-            if ((a == '}') || (a == ')')) bracket--;
+            if ((a == '{') || (a == '(')) {
+                bracket++;
+            }
+            if ((a == '}') || (a == ')')) {
+                bracket--;
+            }
         }
         if (a == EOF) {
             tbl[i] = '\0';

--- a/src/grc65/main.c
+++ b/src/grc65/main.c
@@ -850,8 +850,12 @@ static char *filterInput (FILE *F, char *tbl)
     /* loads file into buffer filtering it out */
     int a, prevchar = -1, i = 0, bracket = 0, quote = 1;
 
-    for (;;) {
-        a = getc(F);
+    a = getc(F);
+    while (1)
+    {
+        if (i >= BLOODY_BIG_BUFFER) {
+            AbEnd ("File too large for internal parsing buffer (%d bytes).",BLOODY_BIG_BUFFER);
+        }
         if ((a == '\n') || (a == '\015')) a = ' ';
         if (a == ',' && quote) a = ' ';
         if (a == '\042') quote =! quote;
@@ -873,13 +877,18 @@ static char *filterInput (FILE *F, char *tbl)
             if (a == ';' && quote) {
                 do {
                     a = getc (F);
-                } while (a != '\n');
-                fseek (F, -1, SEEK_CUR);
+                } while (a != '\n' && a != EOF);
+                /* Don't discard this newline/EOF, continue to next loop.
+                ** A previous implementation used fseek(F,-1,SEEK_CUR),
+                ** which is invalid for text mode files, and was unreliable across platforms.
+                */
+                continue;
             } else {
                 tbl[i++] = a;
                 prevchar = a;
             }
         }
+        a = getc(F);
     }
 
     if (bracket != 0) AbEnd ("There are unclosed brackets!");


### PR DESCRIPTION
Was using fseek(F,-1,SEEK_CUR) which is invalid for text files, behaviour unreliable across platforms. Added check for internal buffer overflow.

Discovered while working to support #2101 I found that [make samples failed](https://github.com/cc65/cc65/pull/2092#issuecomment-1536868347) with grc65 reporting a strange fragment of a word that should have been an ignored comment. The seek was skipping back several bytes and not just one character.

Split from #2092 