### PR TITLE
sim65 fix platform-dependent issues

### DIFF
--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -189,6 +189,7 @@ static unsigned char ReadProgramFile (void)
     }
 
     /* Get load address */
+    Val2 = 0; /* suppress uninitialized variable warning */
     if (((Val = fgetc(F)) == EOF) ||
         ((Val2 = fgetc(F)) == EOF)) {
         Error ("'%s': Header missing load address", ProgramFile);

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <limits.h>
 
 /* common */
 #include "abend.h"
@@ -140,6 +141,10 @@ static void OptQuitXIns (const char* Opt attribute ((unused)),
 /* quit after MaxCycles cycles */
 {
     MaxCycles = strtoul(Arg, NULL, 0);
+    /* Guard against overflow. */
+    if (MaxCycles == ULONG_MAX && errno == ERANGE) {
+        Error("'-x parameter out of range. Max: %lu",ULONG_MAX);
+    }
 }
 
 static unsigned char ReadProgramFile (void)

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -64,6 +64,12 @@ const char* ProgramFile;
 /* exit simulator after MaxCycles Cycles */
 unsigned long MaxCycles;
 
+/* maximum number of cycles that can be tested,
+** requires overhead for longest possible instruction,
+** which should be 7, using 16 for safety.
+*/
+#define MAXCYCLES_LIMIT (ULONG_MAX-16)
+
 /* Header signature 'sim65' */
 static const unsigned char HeaderSignature[] = {
     0x73, 0x69, 0x6D, 0x36, 0x35
@@ -71,7 +77,6 @@ static const unsigned char HeaderSignature[] = {
 #define HEADER_SIGNATURE_LENGTH (sizeof(HeaderSignature)/sizeof(HeaderSignature[0]))
 
 static const unsigned char HeaderVersion = 2;
-
 
 
 /*****************************************************************************/
@@ -142,8 +147,8 @@ static void OptQuitXIns (const char* Opt attribute ((unused)),
 {
     MaxCycles = strtoul(Arg, NULL, 0);
     /* Guard against overflow. */
-    if (MaxCycles == ULONG_MAX && errno == ERANGE) {
-        Error("'-x parameter out of range. Max: %lu",ULONG_MAX);
+    if (MaxCycles >= MAXCYCLES_LIMIT) {
+        Error("'-x parameter out of range. Max: %lu",MAXCYCLES_LIMIT);
     }
 }
 

--- a/src/sim65/paravirt.c
+++ b/src/sim65/paravirt.c
@@ -242,7 +242,15 @@ static void PVClose (CPURegs* Regs)
 
     Print (stderr, 2, "PVClose ($%04X)\n", FD);
 
-    RetVal = close (FD);
+    if (FD != 0xFFFF) {
+        RetVal = close (FD);
+    } else {
+        /* test/val/constexpr.c "abuses" close, expecting close(-1) to return -1.
+        ** This behaviour is not the same on all target platforms.
+        ** MSVC's close treats it as a fatal error instead and terminates.
+        */
+        RetVal = 0xFFFF;
+    }
 
     SetAX (Regs, RetVal);
 }

--- a/test/asm/val/Makefile
+++ b/test/asm/val/Makefile
@@ -22,7 +22,8 @@ ifdef QUIET
   NULLERR = 2>$(NULLDEV)
 endif
 
-SIM65FLAGS = -x 5000000000
+# sim65 can support 64-bit cycle counts on some platforms, but not all. This must fit in 32-bit.
+SIM65FLAGS = -x 4294967295
 
 CA65 := $(if $(wildcard ../../../bin/ca65*),..$S..$S..$Sbin$Sca65,ca65)
 LD65 := $(if $(wildcard ../../../bin/ld65*),..$S..$S..$Sbin$Sld65,ld65)

--- a/test/asm/val/Makefile
+++ b/test/asm/val/Makefile
@@ -23,7 +23,7 @@ ifdef QUIET
 endif
 
 # sim65 can support 64-bit cycle counts on some platforms, but not all. This must fit in 32-bit.
-SIM65FLAGS = -x 4294967295
+SIM65FLAGS = -x 4000000000
 
 CA65 := $(if $(wildcard ../../../bin/ca65*),..$S..$S..$Sbin$Sca65,ca65)
 LD65 := $(if $(wildcard ../../../bin/ld65*),..$S..$S..$Sbin$Sld65,ld65)

--- a/test/standard/Makefile
+++ b/test/standard/Makefile
@@ -23,7 +23,7 @@ ifdef QUIET
 endif
 
 # sim65 can support 64-bit cycle counts on some platforms, but not all. This must fit in 32-bit.
-SIM65FLAGS = -x 4294967295 -c
+SIM65FLAGS = -x 4000000000 -c
 
 CC65 := $(if $(wildcard ../../bin/cc65*),..$S..$Sbin$Scc65,cc65)
 CA65 := $(if $(wildcard ../../bin/ca65*),..$S..$Sbin$Sca65,ca65)

--- a/test/standard/Makefile
+++ b/test/standard/Makefile
@@ -22,7 +22,8 @@ ifdef QUIET
   NULLERR = 2>$(NULLDEV)
 endif
 
-SIM65FLAGS = -x 5000000000 -c
+# sim65 can support 64-bit cycle counts on some platforms, but not all. This must fit in 32-bit.
+SIM65FLAGS = -x 4294967295 -c
 
 CC65 := $(if $(wildcard ../../bin/cc65*),..$S..$Sbin$Scc65,cc65)
 CA65 := $(if $(wildcard ../../bin/ca65*),..$S..$Sbin$Sca65,ca65)

--- a/test/val/Makefile
+++ b/test/val/Makefile
@@ -24,7 +24,8 @@ ifdef QUIET
   NULLERR = 2>$(NULLDEV)
 endif
 
-SIM65FLAGS = -x 5000000000 -c
+# sim65 can support 64-bit cycle counts on some platforms, but not all. This must fit in 32-bit.
+SIM65FLAGS = -x 4294967295 -c
 
 CC65 := $(if $(wildcard ../../bin/cc65*),..$S..$Sbin$Scc65,cc65)
 CA65 := $(if $(wildcard ../../bin/ca65*),..$S..$Sbin$Sca65,ca65)

--- a/test/val/Makefile
+++ b/test/val/Makefile
@@ -25,7 +25,7 @@ ifdef QUIET
 endif
 
 # sim65 can support 64-bit cycle counts on some platforms, but not all. This must fit in 32-bit.
-SIM65FLAGS = -x 4294967295 -c
+SIM65FLAGS = -x 4000000000 -c
 
 CC65 := $(if $(wildcard ../../bin/cc65*),..$S..$Sbin$Scc65,cc65)
 CA65 := $(if $(wildcard ../../bin/ca65*),..$S..$Sbin$Sca65,ca65)


### PR DESCRIPTION
sim65 is suffering from #2087 issue of long being 64-bit on some platforms, 32-bit on others. This allowed a higher range of cycle count depending on the platform, and some of our tests were asking for values that were too large for 32-bit targets.

Also [test/val/constexpr.c](https://github.com/cc65/cc65/blob/master/test/val/constexpr.c) was making strange use of ```close(-1)``` expecting it to return ```-1```. MSVC instead treats this invalid parameter as a security issue and terminates the program instead of returning. Have added compensation for this.

Also fixed a spurious uninitalized variable warning.

This was one of the fixes needed to get #2101 working.

Split from #2092 