### PR TITLE
libtest target alternative to lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ mostlyclean clean:
 avail unavail bin:
 	@$(MAKE) -C src     --no-print-directory $@
 
-lib:
+lib libtest:
 	@$(MAKE) -C libsrc  --no-print-directory $@
 
 doc html info:
@@ -43,7 +43,7 @@ util:
 checkstyle:
 	@$(MAKE) -C .github/checks       --no-print-directory $@
 
-# simple "test" target, only run regression tests for c64 target
+# runs regression tests, requires libtest target libraries
 test:
 	@$(MAKE) -C test                 --no-print-directory $@
 

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -39,6 +39,10 @@ TARGETS = apple2       \
           sym1         \
           telestrat
 
+TARGETTEST = none     \
+             sim6502  \
+             sim65c02
+
 DRVTYPES = emd \
            joy \
            mou \
@@ -53,7 +57,7 @@ OUTPUTDIRS := lib                                                               
               $(subst ../,,$(wildcard ../target/*/drv/*))                                     \
               $(subst ../,,$(wildcard ../target/*/util))
 
-.PHONY: all mostlyclean clean install zip lib $(TARGETS)
+.PHONY: all mostlyclean clean install zip lib libtest $(TARGETS)
 
 .SUFFIXES:
 
@@ -80,6 +84,8 @@ ifndef TARGET
 datadir = $(PREFIX)/share/cc65
 
 all lib: $(TARGETS)
+
+libtest: $(TARGETTEST)
 
 mostlyclean:
 	$(call RMDIR,../libwrk)

--- a/test/readme.txt
+++ b/test/readme.txt
@@ -68,7 +68,11 @@ compiler is working as expected (when the tests behave as described):
         which will require additional changes to the makefile(s).
 
 
-To run the tests use "make" in this (top) directory, the makefile should exit
+These tests only require a subset of the platform libraries. In the (top)
+directory above this one, "make libtest" can be used to build only those
+libraries needed for testing, instead of "make lib".
+
+To run the tests use "make" in this (test) directory, the makefile should exit
 with no error.
 
 When a test failed you can use "make continue" to run further tests.


### PR DESCRIPTION
Just a small change to add a make target that is only the lib needed to run tests. This saves me about 20 minutes when I only want to run the regression tests.

Split from #2092 