### PR TITLE
workflow for manually dispatched Windows build and test

### DIFF
--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -67,3 +67,7 @@ jobs:
 
       - name: Build app (release)
         run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
+
+      # The regression tests are currently too slow to run for this Windows build,
+      # but the "Windows Test Manual" workflow (windows-test-manual.yml) can by
+      # manually dispatched from the Actions menu to test as needed.

--- a/.github/workflows/snapshot-on-push-master.yml
+++ b/.github/workflows/snapshot-on-push-master.yml
@@ -29,6 +29,10 @@ jobs:
       - name: Build app (release)
         run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
 
+      # The regression tests are currently too slow to run for this Windows build,
+      # but the "Windows Test Manual" workflow (windows-test-manual.yml) can by
+      # manually dispatched from the Actions menu to test as needed.
+
   build_linux:
     name: Build, Test, and Snapshot (Linux)
     if: github.repository == 'cc65/cc65'

--- a/.github/workflows/windows-test-manual.yml
+++ b/.github/workflows/windows-test-manual.yml
@@ -1,0 +1,43 @@
+name: Windows Test Manual
+# Manually dispatched because it's much slower than the Linux test.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_windows:
+    name: Build, Test (Windows MSVC)
+    runs-on: windows-latest
+
+    steps:
+      - name: Git Setup
+        shell: bash
+        run: git config --global core.autocrlf input
+
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Build app (MSVC debug)
+        run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Debug
+
+      - name: Build app (MSVC release)
+        run: msbuild src\cc65.sln -t:rebuild -property:Configuration=Release
+
+      - name: Build utils (MinGW)
+        shell: cmd
+        run: make -j2 util
+
+      - name: Build the platform libraries (make lib)
+        shell: cmd
+        run: make -j2 lib QUIET=1
+
+      - name: Run the regression tests (make test)
+        shell: cmd
+        run: make test QUIET=1
+
+      - name: Test that the samples can be built (make samples)
+        shell: cmd
+        run: make -j2 samples


### PR DESCRIPTION
This will help generally with additional build testing, and diagnosing cross-platform issues. The immediate goal was to help diagnose one particular issue (#2087) with type sizes that change for different platform targets.

In the process of testing this, I had to discover and resolve some existing cross-platform issues to get this workflow to be able to build green. I put all of these together in one PR initially (#2092) but as requested I have split them. These two additional PRs will have to be merged before this test can successfully run:
* #2098 
* #2099 

However, because make is apparently very slow on the Windows platform (#2095), I made this into an action that can be manually dispatched, rather than add it to the automatic snapshot or PR workflows. An extra 25 minutes of test time doesn't seem reasonable for every single PR.

So, because it's basically a way to test the build on-request, I's still okay to merge without those two pre-requisites.

I also considered running it as a scheduled action, maybe once every 5 days if there are any changes. However,  notifications for a scheduled action go to the person who committed it, and GitHub doesn't seem to have very good abilities to select which build failures you get or do not get e-mails for, unfortunately.

@mrdudz also requested that it use the cmd shell, so it does this. These two issues were cited:
* #1920 
* #1937

This workflow does successfully pass the full build and test with #2092 (#2092 =. #2098 + #2099 + this) I was also able build #2092 locally from my cmd shell. As far as I can tell this should obsolete both #1029 and #1937, but I'm not fully clear on the description of the problem in them.