### PR TITLE
ca65: Remove .feature requirement for .addrsize

### DIFF
--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -1409,10 +1409,6 @@ either a string or an expression value.
         .endmacro
   </verb></tscreen>
 
-  This command is new and must be enabled with the <tt/.FEATURE addrsize/ command.
-
-  See: <tt><ref id=".FEATURE" name=".FEATURE"></tt>
-
 
 <sect1><tt>.BANK</tt><label id=".BANK"><p>
 
@@ -2794,12 +2790,6 @@ See: <tt><ref id=".ASCIIZ" name=".ASCIIZ"></tt>,<tt><ref id=".CHARMAP" name=".CH
   The following features are available:
 
   <descrip>
-
-  <tag><tt>addrsize</tt><label id="addrsize"></tag>
-
-    Enables the .ADDRSIZE pseudo function. This function is experimental and not enabled by default.
-
-    See also: <tt><ref id=".ADDRSIZE" name=".ADDRSIZE"></tt>
 
   <tag><tt>at_in_identifiers</tt><label id="at_in_identifiers"></tag>
 

--- a/src/ca65/feature.c
+++ b/src/ca65/feature.c
@@ -121,8 +121,6 @@ void SetFeature (feature_t Feature, unsigned char On)
         case FEAT_BRACKET_AS_INDIRECT:        BracketAsIndirect = On;    break;
         case FEAT_STRING_ESCAPES:             StringEscapes     = On;    break;
         case FEAT_LONG_JSR_JMP_RTS:           LongJsrJmpRts     = On;    break;
-        /* Accept, but ignore addrsize */
-        case FEAT_ADDRSIZE:                                              break;
         default:                                                         break;
     }
 }

--- a/src/ca65/feature.c
+++ b/src/ca65/feature.c
@@ -118,10 +118,11 @@ void SetFeature (feature_t Feature, unsigned char On)
         case FEAT_C_COMMENTS:                 CComments         = On;    break;
         case FEAT_FORCE_RANGE:                ForceRange        = On;    break;
         case FEAT_UNDERLINE_IN_NUMBERS:       UnderlineInNumbers= On;    break;
-        case FEAT_ADDRSIZE:                   AddrSize          = On;    break;
         case FEAT_BRACKET_AS_INDIRECT:        BracketAsIndirect = On;    break;
         case FEAT_STRING_ESCAPES:             StringEscapes     = On;    break;
         case FEAT_LONG_JSR_JMP_RTS:           LongJsrJmpRts     = On;    break;
+        /* Accept, but ignore addrsize */
+        case FEAT_ADDRSIZE:                                              break;
         default:                                                         break;
     }
 }

--- a/src/ca65/global.c
+++ b/src/ca65/global.c
@@ -85,5 +85,4 @@ unsigned char OrgPerSeg          = 0;   /* Make .org local to current seg */
 unsigned char CComments          = 0;   /* Allow C like comments */
 unsigned char ForceRange         = 0;   /* Force values into expected range */
 unsigned char UnderlineInNumbers = 0;   /* Allow underlines in numbers */
-unsigned char AddrSize           = 0;   /* Allow .ADDRSIZE function */
 unsigned char BracketAsIndirect  = 0;   /* Use '[]' not '()' for indirection */

--- a/src/ca65/global.h
+++ b/src/ca65/global.h
@@ -87,7 +87,6 @@ extern unsigned char    OrgPerSeg;          /* Make .org local to current seg */
 extern unsigned char    CComments;          /* Allow C like comments */
 extern unsigned char    ForceRange;         /* Force values into expected range */
 extern unsigned char    UnderlineInNumbers; /* Allow underlines in numbers */
-extern unsigned char    AddrSize;           /* Allow .ADDRSIZE function */
 extern unsigned char    BracketAsIndirect;  /* Use '[]' not '()' for indirection */
 
 

--- a/src/ca65/pseudo.c
+++ b/src/ca65/pseudo.c
@@ -1045,8 +1045,7 @@ static void DoFeature (void)
         }
 
         if (Feature == FEAT_ADDRSIZE) {
-            /* Warn for depreciated .feature addrsize */
-            Warning (1, "Depreciated feature: '.feature addrsize'. Pseudo function .addrsize is always available.");
+            Warning (1, "Deprecated feature: '.feature addrsize'. Pseudo function .addrsize is always available.");
         }
 
         NextTok ();

--- a/src/ca65/pseudo.c
+++ b/src/ca65/pseudo.c
@@ -1043,6 +1043,12 @@ static void DoFeature (void)
             ErrorSkip ("Invalid feature: '%m%p'", &CurTok.SVal);
             return;
         }
+
+        if (Feature == FEAT_ADDRSIZE) {
+            /* Warn for depreciated .feature addrsize */
+            Warning (1, "Depreciated feature: '.feature addrsize'. Pseudo function .addrsize is always available.");
+        }
+
         NextTok ();
 
         /* Optional +/- or ON/OFF */

--- a/src/ca65/scanner.c
+++ b/src/ca65/scanner.c
@@ -748,24 +748,7 @@ static token_t FindDotKeyword (void)
     R = bsearch (&K, DotKeywords, sizeof (DotKeywords) / sizeof (DotKeywords [0]),
                  sizeof (DotKeywords [0]), CmpDotKeyword);
     if (R != 0) {
-
-        /* By default, disable any somewhat experiemental DotKeyword. */
-
-        switch (R->Tok) {
-
-            case TOK_ADDRSIZE:
-                /* Disallow .ADDRSIZE function by default */
-                if (AddrSize == 0) {
-                    return TOK_NONE;
-                }
-                break;
-
-            default:
-                break;
-        }
-
         return R->Tok;
-
     } else {
         return TOK_NONE;
     }

--- a/test/asm/val/addrsize.s
+++ b/test/asm/val/addrsize.s
@@ -1,0 +1,32 @@
+; test .addrsize and ensure .feature addrsize is allowed, but inactive
+
+.export _main
+
+.segment "ZEROPAGE"
+zplabel:
+
+.segment "CODE"
+abslabel:
+
+; exit with 0
+
+_main:
+    lda #0
+    tax
+    rts
+
+
+.assert .addrsize(zplabel) = 1, error, ".addrsize 1 expected for ZEROPAGE"
+.assert .addrsize(abslabel) = 2, error, ".addrsize 2 expected for absolute"
+
+.feature addrsize
+.assert .addrsize(zplabel) = 1, error, ".addrsize 1 expected for ZEROPAGE"
+.assert .addrsize(abslabel) = 2, error, ".addrsize 2 expected for absolute"
+
+.feature addrsize +
+.assert .addrsize(zplabel) = 1, error, ".addrsize 1 expected for ZEROPAGE"
+.assert .addrsize(abslabel) = 2, error, ".addrsize 2 expected for absolute"
+
+.feature addrsize -
+.assert .addrsize(zplabel) = 1, error, ".addrsize 1 expected for ZEROPAGE"
+.assert .addrsize(abslabel) = 2, error, ".addrsize 2 expected for absolute"

--- a/test/asm/val/feature.s
+++ b/test/asm/val/feature.s
@@ -2,12 +2,6 @@
 
 .export _main
 
-.segment "ZEROPAGE"
-zplabel:
-
-.segment "CODE"
-abslabel:
-
 ; exit with 0
 
 _main:
@@ -16,13 +10,6 @@ _main:
     lda #0
     tax
     rts
-
-
-.feature addrsize +
-.assert .addrsize(zplabel) = 1, error, ".addrsize 1 expected for ZEROPAGE"
-.assert .addrsize(abslabel) = 2, error, ".addrsize 2 expected for absolute"
-.feature addrsize -
-
 
 .feature at_in_identifiers on
 ident@with@at:

--- a/test/asm/val/feature.s
+++ b/test/asm/val/feature.s
@@ -2,6 +2,11 @@
 
 .export _main
 
+.segment "ZEROPAGE"
+zplabel:
+
+.segment "CODE"
+
 ; exit with 0
 
 _main:


### PR DESCRIPTION
This will remove the need to use `.feature addrsize` to allow `.addrsize ` to be available. I am unsure if everyone agrees how to handle `.feature addrsize` that may exist in some projects (though this probably wasn't widely used). I opted to silently ignore it, but have the `.addrsize` function always available. Do we need any documentation that explains the .feature is there, but ignored? 