### PR TITLE
Fix computed length for read and write for telestrat target

### DIFF
--- a/libsrc/telestrat/read.s
+++ b/libsrc/telestrat/read.s
@@ -33,11 +33,11 @@
         sec
         lda     PTR_READ_DEST
         sbc     ptr2
-        sta     tmp1
+        pha
         lda     PTR_READ_DEST+1
         sbc     ptr2+1
         tax
-        lda     tmp1
+        pla
 
         rts
 .endproc

--- a/libsrc/telestrat/read.s
+++ b/libsrc/telestrat/read.s
@@ -31,12 +31,12 @@
         BRK_TELEMON     XFREAD
         ;  compute nb of bytes read
         sec
-	lda     PTR_READ_DEST
-	sbc     ptr2
-	sta     tmp1
-	lda     PTR_READ_DEST+1
-	sbc     ptr2+1
-	tax
+        lda     PTR_READ_DEST
+        sbc     ptr2
+        sta     tmp1
+        lda     PTR_READ_DEST+1
+        sbc     ptr2+1
+        tax
         lda     tmp1
 
         rts

--- a/libsrc/telestrat/read.s
+++ b/libsrc/telestrat/read.s
@@ -30,13 +30,14 @@
         ldy     ptr1+1
         BRK_TELEMON     XFREAD
         ;  compute nb of bytes read
-        lda     PTR_READ_DEST+1
         sec
-        sbc     ptr2+1
-        tax
-        lda     PTR_READ_DEST
-        sec
-        sbc     ptr2
-        ; here A and X contains number of bytes read
+	lda     PTR_READ_DEST
+	sbc     ptr2
+	sta     tmp1
+	lda     PTR_READ_DEST+1
+	sbc     ptr2+1
+	tax
+        lda     tmp1
+
         rts
 .endproc

--- a/libsrc/telestrat/write.s
+++ b/libsrc/telestrat/write.s
@@ -42,16 +42,16 @@ next:
         ldy     ptr3+1
         ldx     tmp1            ; send fd in X
         BRK_TELEMON  XFWRITE
+
         ;  compute nb of bytes written
-
-
-        lda     PTR_READ_DEST+1
         sec
-        sbc     ptr1+1
-        tax
-        lda     PTR_READ_DEST
-        sec
-        sbc     ptr1
+	lda     PTR_READ_DEST
+	sbc     ptr1
+	sta     tmp1
+	lda     PTR_READ_DEST+1
+	sbc     ptr1+1
+	tax
+        lda     tmp1
         rts
 
 

--- a/libsrc/telestrat/write.s
+++ b/libsrc/telestrat/write.s
@@ -45,12 +45,12 @@ next:
 
         ;  compute nb of bytes written
         sec
-	lda     PTR_READ_DEST
-	sbc     ptr1
-	sta     tmp1
-	lda     PTR_READ_DEST+1
-	sbc     ptr1+1
-	tax
+        lda     PTR_READ_DEST
+        sbc     ptr1
+        sta     tmp1
+        lda     PTR_READ_DEST+1
+        sbc     ptr1+1
+        tax
         lda     tmp1
         rts
 

--- a/libsrc/telestrat/write.s
+++ b/libsrc/telestrat/write.s
@@ -47,11 +47,11 @@ next:
         sec
         lda     PTR_READ_DEST
         sbc     ptr1
-        sta     tmp1
+        pha
         lda     PTR_READ_DEST+1
         sbc     ptr1+1
         tax
-        lda     tmp1
+        pla
         rts
 
 


### PR DESCRIPTION
The result of the length could be wrong depending of the ptr