### PR TITLE
feat: add pce-16k.cfg and pce-32k.cfg for larger cartridges of TurboGrafx-16

### DIFF
--- a/cfg/pce-16k.cfg
+++ b/cfg/pce-16k.cfg
@@ -1,0 +1,40 @@
+SYMBOLS {
+    __CARTSIZE__:  type = weak, value = $4000;
+    __STACKSIZE__: type = weak, value = $0300; # 3 pages stack
+}
+MEMORY {
+    ZP:   file = "", start =  $0000, define = yes,  size = $0100;
+    # RAM bank
+    MAIN: file = "", start =  $2200, define = yes,  size = $1E00 - __STACKSIZE__;
+    # ROM banks, before swapping, and after mapping
+    ROM:  file = %O, start = $10000 - __CARTSIZE__, size = __CARTSIZE__, fill = yes, fillval = $FF;
+}
+SEGMENTS {
+    ZEROPAGE: load = ZP,              type = zp;
+    EXTZP:    load = ZP,              type = zp,  optional = yes;
+    APPZP:    load = ZP,              type = zp,  optional = yes;
+    DATA:     load = ROM, run = MAIN, type = rw,                  define = yes;
+    INIT:     load = MAIN,            type = bss, optional = yes;
+    BSS:      load = MAIN,            type = bss,                 define = yes;
+    RODATA:   load = ROM,             type = ro;
+    CODE:     load = ROM,             type = ro;
+    LOWCODE:  load = ROM,             type = ro,  optional = yes;
+    ONCE:     load = ROM,             type = ro,  optional = yes;
+    STARTUP:  load = ROM,             type = ro,  start = $FFF6 - $0066;
+    VECTORS:  load = ROM,             type = ro,  start = $FFF6;
+}
+FEATURES {
+    CONDES: type    = constructor,
+            label   = __CONSTRUCTOR_TABLE__,
+            count   = __CONSTRUCTOR_COUNT__,
+            segment = ONCE;
+    CONDES: type    = destructor,
+            label   = __DESTRUCTOR_TABLE__,
+            count   = __DESTRUCTOR_COUNT__,
+            segment = RODATA;
+    CONDES: type    = interruptor,
+            label   = __INTERRUPTOR_TABLE__,
+            count   = __INTERRUPTOR_COUNT__,
+            segment = RODATA,
+            import  = __CALLIRQ__;
+}

--- a/cfg/pce-32k.cfg
+++ b/cfg/pce-32k.cfg
@@ -1,0 +1,40 @@
+SYMBOLS {
+    __CARTSIZE__:  type = weak, value = $8000;
+    __STACKSIZE__: type = weak, value = $0300; # 3 pages stack
+}
+MEMORY {
+    ZP:   file = "", start =  $0000, define = yes,  size = $0100;
+    # RAM bank
+    MAIN: file = "", start =  $2200, define = yes,  size = $1E00 - __STACKSIZE__;
+    # ROM banks, before swapping, and after mapping
+    ROM:  file = %O, start = $10000 - __CARTSIZE__, size = __CARTSIZE__, fill = yes, fillval = $FF;
+}
+SEGMENTS {
+    ZEROPAGE: load = ZP,              type = zp;
+    EXTZP:    load = ZP,              type = zp,  optional = yes;
+    APPZP:    load = ZP,              type = zp,  optional = yes;
+    DATA:     load = ROM, run = MAIN, type = rw,                  define = yes;
+    INIT:     load = MAIN,            type = bss, optional = yes;
+    BSS:      load = MAIN,            type = bss,                 define = yes;
+    RODATA:   load = ROM,             type = ro;
+    CODE:     load = ROM,             type = ro;
+    LOWCODE:  load = ROM,             type = ro,  optional = yes;
+    ONCE:     load = ROM,             type = ro,  optional = yes;
+    STARTUP:  load = ROM,             type = ro,  start = $FFF6 - $0066;
+    VECTORS:  load = ROM,             type = ro,  start = $FFF6;
+}
+FEATURES {
+    CONDES: type    = constructor,
+            label   = __CONSTRUCTOR_TABLE__,
+            count   = __CONSTRUCTOR_COUNT__,
+            segment = ONCE;
+    CONDES: type    = destructor,
+            label   = __DESTRUCTOR_TABLE__,
+            count   = __DESTRUCTOR_COUNT__,
+            segment = RODATA;
+    CONDES: type    = interruptor,
+            label   = __INTERRUPTOR_TABLE__,
+            count   = __INTERRUPTOR_COUNT__,
+            segment = RODATA,
+            import  = __CALLIRQ__;
+}


### PR DESCRIPTION
I think it can be useful as you don't have to create a .cfg in your own project just to change a number, when it could just be a browser flag `--config pce-16k.cfg`