### PR TITLE
cx16: use KERNAL memsiz for MEMSIZE in asminc/cx16.inc

### DIFF
--- a/asminc/cx16.inc
+++ b/asminc/cx16.inc
@@ -259,7 +259,7 @@ NLINES          := $0387        ; Number of screen lines
 
 ; BASIC
 VARTAB          := $03E1        ; Pointer to start of BASIC variables
-MEMSIZE         := $03E9        ; Pointer to highest BASIC RAM location (+1)
+MEMSIZE         := $0259        ; Pointer to highest BASIC RAM location (+1)
 
 ; ---------------------------------------------------------------------------
 ; Vector and other locations


### PR DESCRIPTION
The CX16 ROM has two variables called memsiz, one in KERNAL space and one in BASIC space.  cc65 needs to be updated to look at the one in KERNAL space so that it can honor changes to MEMTOP, which for now it does not.

The two versions of memsiz also led to some bugs which have only been discovered and addressed now, as BASIC itself wasn't honoring changes to MEMTOP either.  (https://github.com/X16Community/x16-rom/pull/132)

My intention is to keep the old memsiz at $3E9 up to date, but the canonical source is the one at $259.  The $3E9 location is deprecated.  Eventually we may reuse the space at $3E9 but for now we're keeping it synchronized so that C programs built with cc65 before this PR will still work.