### PR TITLE
Update _atari5200os.h

### DIFF
--- a/include/_atari5200os.h
+++ b/include/_atari5200os.h
@@ -44,25 +44,31 @@ struct __os {
         void*   sdlst;               // = $05,$06   Display list shadow
     };
 
-    unsigned char sdmctl;            // = $07       DMACTL shadow
-    unsigned char pcolr0;            // = $08       PM color 0
-    unsigned char pcolr1;            // = $09       PM color 1
-    unsigned char pcolr2;            // = $0A       PM color 2
-    unsigned char pcolr3;            // = $0B       PM color 3
-    unsigned char color0;            // = $0C       PF color 0
-    unsigned char color1;            // = $0D       PF color 1
-    unsigned char color2;            // = $0E       PF color 2
-    unsigned char color3;            // = $0F       PF color 3
-    unsigned char color4;            // = $10       PF color 4
-    unsigned char pot0;              // = $11       POT0 shadow
-    unsigned char pot1;              // = $12       POT1 shadow
-    unsigned char pot2;              // = $13       POT2 shadow
-    unsigned char pot3;              // = $14       POT3 shadow
-    unsigned char pot4;              // = $15       POT4 shadow
-    unsigned char pot5;              // = $16       POT5 shadow
-    unsigned char pot6;              // = $17       POT6 shadow
-    unsigned char pot7;              // = $18       POT7 shadow
-    unsigned char _free_1[0xE7];     // = $19-$FF   User space
+   unsigned char sdmctl;            // = $07       DMACTL shadow
+   unsigned char pcolr0;            // = $08       PM color 0
+   unsigned char pcolr1;            // = $09       PM color 1
+   unsigned char pcolr2;            // = $0A       PM color 2
+   unsigned char pcolr3;            // = $0B       PM color 3
+   unsigned char color0;            // = $0C       PF color 0
+   unsigned char color1;            // = $0D       PF color 1
+   unsigned char color2;            // = $0E       PF color 2
+   unsigned char color3;            // = $0F       PF color 3
+   unsigned char color4;            // = $10       PF color 4
+   unsigned char paddl0;            // = $11       POT0 Shadow
+   unsigned char paddl1;            // = $12       POT1 Shadow
+   unsigned char paddl2;            // = $13       POT2 Shadow
+   unsigned char paddl3;            // = $14       POT3 Shadow
+   unsigned char paddl4;            // = $15       POT4 Shadow
+   unsigned char paddl5;            // = $16       POT5 Shadow
+   unsigned char paddl6;            // = $17       POT6 Shadow
+   unsigned char paddl7;            // = $18       POT7 Shadow
+   
+   /*cc65 runtime zero page variables*/
+   unsigned char rowcrs_5200;       // = $19       Cursor row (conio)
+   unsigned char colcrs_5200;       // = $1A       Cursor column (conio)
+   unsigned char* savmsc;           // = $1B/$1C   Pointer to screen memory (conio)
+    
+   unsigned char _filler_1[0xE3];   // = $1D-$FF   Filler
 
     /*Stack*/
     unsigned char stack[0x100];      // = $100-$1FF Stack

--- a/include/_atari5200os.h
+++ b/include/_atari5200os.h
@@ -44,31 +44,31 @@ struct __os {
         void*   sdlst;               // = $05,$06   Display list shadow
     };
 
-   unsigned char sdmctl;            // = $07       DMACTL shadow
-   unsigned char pcolr0;            // = $08       PM color 0
-   unsigned char pcolr1;            // = $09       PM color 1
-   unsigned char pcolr2;            // = $0A       PM color 2
-   unsigned char pcolr3;            // = $0B       PM color 3
-   unsigned char color0;            // = $0C       PF color 0
-   unsigned char color1;            // = $0D       PF color 1
-   unsigned char color2;            // = $0E       PF color 2
-   unsigned char color3;            // = $0F       PF color 3
-   unsigned char color4;            // = $10       PF color 4
-   unsigned char paddl0;            // = $11       POT0 Shadow
-   unsigned char paddl1;            // = $12       POT1 Shadow
-   unsigned char paddl2;            // = $13       POT2 Shadow
-   unsigned char paddl3;            // = $14       POT3 Shadow
-   unsigned char paddl4;            // = $15       POT4 Shadow
-   unsigned char paddl5;            // = $16       POT5 Shadow
-   unsigned char paddl6;            // = $17       POT6 Shadow
-   unsigned char paddl7;            // = $18       POT7 Shadow
-   
-   /*cc65 runtime zero page variables*/
-   unsigned char rowcrs_5200;       // = $19       Cursor row (conio)
-   unsigned char colcrs_5200;       // = $1A       Cursor column (conio)
-   unsigned char* savmsc;           // = $1B/$1C   Pointer to screen memory (conio)
-    
-   unsigned char _filler_1[0xE3];   // = $1D-$FF   Filler
+    unsigned char sdmctl;            // = $07       DMACTL shadow
+    unsigned char pcolr0;            // = $08       PM color 0
+    unsigned char pcolr1;            // = $09       PM color 1
+    unsigned char pcolr2;            // = $0A       PM color 2
+    unsigned char pcolr3;            // = $0B       PM color 3
+    unsigned char color0;            // = $0C       PF color 0
+    unsigned char color1;            // = $0D       PF color 1
+    unsigned char color2;            // = $0E       PF color 2
+    unsigned char color3;            // = $0F       PF color 3
+    unsigned char color4;            // = $10       PF color 4
+    unsigned char paddl0;            // = $11       POT0 Shadow
+    unsigned char paddl1;            // = $12       POT1 Shadow
+    unsigned char paddl2;            // = $13       POT2 Shadow
+    unsigned char paddl3;            // = $14       POT3 Shadow
+    unsigned char paddl4;            // = $15       POT4 Shadow
+    unsigned char paddl5;            // = $16       POT5 Shadow
+    unsigned char paddl6;            // = $17       POT6 Shadow
+    unsigned char paddl7;            // = $18       POT7 Shadow
+
+    /*cc65 runtime zero page variables*/
+    unsigned char rowcrs_5200;       // = $19       Cursor row (conio)
+    unsigned char colcrs_5200;       // = $1A       Cursor column (conio)
+    unsigned char* savmsc;           // = $1B/$1C   Pointer to screen memory (conio)
+
+    unsigned char _filler_1[0xE3];   // = $1D-$FF   Filler
 
     /*Stack*/
     unsigned char stack[0x100];      // = $100-$1FF Stack


### PR DESCRIPTION
Update the page 0 symbols, synchronize the names with the _atarios.h, add locations used by Atari 5200 conio. 
Continuation of the PR #2141 based on the discussion.