### PR TITLE
Allow MINGW environments to find installed config

### DIFF
--- a/src/ca65/incpath.c
+++ b/src/ca65/incpath.c
@@ -75,8 +75,10 @@ void FinishIncludePaths (void)
     AddSubSearchPathFromEnv (IncSearchPath, "CC65_HOME", "asminc");
 
     /* Add some compiled-in search paths if defined at compile time. */
-#if defined(CA65_INC) && !defined(_WIN32) && !defined(_AMIGA)
+#if defined(CA65_INC) && !defined(_AMIGA)
+#if !defined(_WIN32) || defined(__MINGW32__)
     AddSearchPath (IncSearchPath, CA65_INC);
+#endif
 #endif
 
     /* Add paths relative to the parent directory of the Windows binary. */

--- a/src/cc65/incpath.c
+++ b/src/cc65/incpath.c
@@ -76,9 +76,12 @@ void FinishIncludePaths (void)
     AddSubSearchPathFromEnv (SysIncSearchPath, "CC65_HOME", "include");
 
     /* Add some compiled-in search paths if defined at compile time. */
-#if defined(CC65_INC) && !defined(_WIN32) && !defined(_AMIGA)
+#if defined(CC65_INC) && !defined(_AMIGA)
+#if !defined(_WIN32) || defined(__MINGW32__)
     AddSearchPath (SysIncSearchPath, CC65_INC);
 #endif
+#endif
+
 
     /* Add paths relative to the parent directory of the Windows binary. */
     AddSubSearchPathFromBin (SysIncSearchPath, "include");

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -1216,8 +1216,10 @@ static void OptPrintTargetPath (const char* Opt attribute ((unused)),
 
     SearchPaths* TargetPaths = NewSearchPath ();
     AddSubSearchPathFromEnv (TargetPaths, "CC65_HOME", "target");
-#if defined(CL65_TGT) && !defined(_WIN32) && !defined(_AMIGA)
+#if defined(CL65_TGT) && !defined(_AMIGA)
+#if !defined(_WIN32) || defined(__MINGW32__)
     AddSearchPath (TargetPaths, CL65_TGT);
+#endif
 #endif
     AddSubSearchPathFromBin (TargetPaths, "target");
 

--- a/src/ld65/filepath.c
+++ b/src/ld65/filepath.c
@@ -88,14 +88,20 @@ void InitSearchPaths (void)
     AddSubSearchPathFromEnv (CfgDefaultPath, "CC65_HOME", "cfg");
 
     /* Add some compiled-in search paths if defined at compile time. */
-#if defined(LD65_LIB) && !defined(_WIN32) && !defined(_AMIGA)
+#if defined(LD65_LIB) && !defined(_AMIGA)
+#if !defined(_WIN32) || defined(__MINGW32__)
     AddSearchPath (LibDefaultPath, LD65_LIB);
 #endif
-#if defined(LD65_OBJ) && !defined(_WIN32) && !defined(_AMIGA)
+#endif
+#if defined(LD65_OBJ) && !defined(_AMIGA)
+#if !defined(_WIN32) || defined(__MINGW32__)
     AddSearchPath (ObjDefaultPath, LD65_OBJ);
 #endif
-#if defined(LD65_CFG) && !defined(_WIN32) && !defined(_AMIGA)
+#endif
+#if defined(LD65_CFG) && !defined(_AMIGA)
+#if !defined(_WIN32) || defined(__MINGW32__)
     AddSearchPath (CfgDefaultPath, LD65_CFG);
+#endif
 #endif
 
     /* Add paths relative to the parent directory of the Windows binary. */


### PR DESCRIPTION
This PR allows MinGW environments in windows to build and compile from source, and have the installed directories (e.g. lib, asminc, cfg, ...) be found in the same way linux installs do.

Installing cc65 via a MinGW environment currently does not work fully without setting the following environment variables.

```shell
$ export CC65_HOME=/usr/local/cc65
$ export CA65_INC=/usr/local/cc65/share/cc65/asminc
$ export CC65_INC=/usr/local/cc65/share/cc65/include
$ export LD65_LIB=/usr/local/cc65/share/cc65/lib
```

(Or whatever prefix is preferred when building).

At the moment, the `_WIN32` variable blocks the values of CA65_INC, CC65_INC, CL65_TGT, LD65_LIB, LD65_OBJ, and LD65_CFG from being used in MINGW environments.

This PR adds a check for `__MINGW32__` definition, and if it exists, treats the path in the same way as a standard Linux build, thus allowing `/usr/local/share/cc65/` to act as a directory for configuration. This directory exists and is usable in MinGW environments.

This means the source can be compiled and used in Cygwin, MinGW64, UCRT64 environments, in the same way as Linux.

```shell
$ PREFIX=/usr/local/cc65 make
$ PREFIX=/usr/local/cc65 make install
```
will install the binaries, cfg etc under /usr/local/cc65/bin, and /usr/local/share/cc65/asminc, etc, and allow the `cl65` (etc) applications to find them in these directories without resorting to environment variables.

Note, there is no sudo for MinGW, so it is not needed for the install.
