### PR TITLE
Prevented the automatic switch to ISO mode on the CX16

### DIFF
--- a/libsrc/cx16/crt0.s
+++ b/libsrc/cx16/crt0.s
@@ -83,11 +83,6 @@ init:
         sta     sp
         stx     sp+1            ; Set argument stack ptr
 
-; Switch to the lower/UPPER PetSCII charset.
-
-        lda     #$0E
-        jsr     CHROUT
-
 ; Call the module constructors.
 
         jmp     initlib


### PR DESCRIPTION
This is a relatively simple fix to an issue that has been bugging me for a while.

By default, the CX16 initialization causes the system to switch into ISO mode. This is not desired for many applications since it changes many of the characters on screen, the change isn't reverted when the program exits, and switching back clears the screen(which is also unwanted in a handful of cases).

The following is a screenshot of a simple "Hello world" program showing the effect of ISO mode on the platform.

![image](https://github.com/cc65/cc65/assets/43149296/76925c24-8c5c-4820-9887-01fb7d1587ef)

The change is mostly apparent in the X16 logo in the top corner since all of the regular PETSCII graphics have been converted into ISO characters.

In short, if a programmer wishes to switch into ISO mode they should be able to by sending a `\x0E` character to the screen, but it should not be done automatically since it isn't suitable for every program.