### PR TITLE
Apple2enh / Language card: Fix .cwd_init constructor corrupting code bytes

### DIFF
--- a/libsrc/apple2/syschdir.s
+++ b/libsrc/apple2/syschdir.s
@@ -29,7 +29,8 @@ __syschdir:
         bcs     cleanup
 
         ; Update current working directory
-        jsr     initcwd         ; Returns with A = 0
+        jsr     initcwd
+        lda     #$00
 
         ; Cleanup name
 cleanup:jsr     popname         ; Preserves A


### PR DESCRIPTION
Constructor .cwd_init calls apple2's initcwd, which does an sta/stx to struct mliparam. This struct is stored in BSS, so a few bytes of BSS, which as that time is still possibly containing code destined to be Block-Transfered-Up to the Language Card.

The fix consists of moving the LC code before calling initlib.