### PR TITLE
INIT segment definitions should be consistent, and bss is the appropriate semantic type

### DIFF
--- a/cfg/apple2-hgr.cfg
+++ b/cfg/apple2-hgr.cfg
@@ -27,7 +27,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro   start    = $4000;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = rw;
+    INIT:     load = MAIN,           type = bss;
     ONCE:     load = MAIN,           type = ro,  define   = yes;
     LC:       load = MAIN, run = LC, type = ro,  optional = yes;
     BSS:      load = BSS,            type = bss, define   = yes;

--- a/cfg/apple2-overlay.cfg
+++ b/cfg/apple2-overlay.cfg
@@ -43,7 +43,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = rw;
+    INIT:     load = MAIN,           type = bss;
     ONCE:     load = MAIN,           type = ro,  define = yes;
     LC:       load = MAIN, run = LC, type = ro,                optional = yes;
     BSS:      load = BSS,            type = bss, define = yes;

--- a/cfg/apple2-system.cfg
+++ b/cfg/apple2-system.cfg
@@ -22,7 +22,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = rw;
+    INIT:     load = MAIN,           type = bss;
     ONCE:     load = MAIN,           type = ro,  define   = yes;
     LC:       load = MAIN, run = LC, type = ro,  optional = yes;
     BSS:      load = BSS,            type = bss, define   = yes;

--- a/cfg/apple2.cfg
+++ b/cfg/apple2.cfg
@@ -26,7 +26,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = rw;
+    INIT:     load = MAIN,           type = bss;
     ONCE:     load = MAIN,           type = ro,  define   = yes;
     LC:       load = MAIN, run = LC, type = ro,  optional = yes;
     BSS:      load = BSS,            type = bss, define   = yes;

--- a/cfg/apple2enh-hgr.cfg
+++ b/cfg/apple2enh-hgr.cfg
@@ -27,7 +27,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro   start    = $4000;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = rw;
+    INIT:     load = MAIN,           type = bss;
     ONCE:     load = MAIN,           type = ro,  define   = yes;
     LC:       load = MAIN, run = LC, type = ro,  optional = yes;
     BSS:      load = BSS,            type = bss, define   = yes;

--- a/cfg/apple2enh-overlay.cfg
+++ b/cfg/apple2enh-overlay.cfg
@@ -43,7 +43,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = rw;
+    INIT:     load = MAIN,           type = bss;
     ONCE:     load = MAIN,           type = ro,  define = yes;
     LC:       load = MAIN, run = LC, type = ro,                optional = yes;
     BSS:      load = BSS,            type = bss, define = yes;

--- a/cfg/apple2enh-system.cfg
+++ b/cfg/apple2enh-system.cfg
@@ -22,7 +22,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = rw;
+    INIT:     load = MAIN,           type = bss;
     ONCE:     load = MAIN,           type = ro,  define   = yes;
     LC:       load = MAIN, run = LC, type = ro,  optional = yes;
     BSS:      load = BSS,            type = bss, define   = yes;

--- a/cfg/apple2enh.cfg
+++ b/cfg/apple2enh.cfg
@@ -26,7 +26,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = rw;
+    INIT:     load = MAIN,           type = bss;
     ONCE:     load = MAIN,           type = ro,  define   = yes;
     LC:       load = MAIN, run = LC, type = ro,  optional = yes;
     BSS:      load = BSS,            type = bss, define   = yes;

--- a/cfg/atari-overlay.cfg
+++ b/cfg/atari-overlay.cfg
@@ -52,7 +52,7 @@ SEGMENTS {
     CODE:      load = MAIN,       type = ro,  define = yes;
     RODATA:    load = MAIN,       type = ro;
     DATA:      load = MAIN,       type = rw;
-    INIT:      load = MAIN,       type = rw,                optional = yes;
+    INIT:      load = MAIN,       type = bss,               optional = yes;
     BSS:       load = MAIN,       type = bss, define = yes;
     AUTOSTRT:  load = TRAILER,    type = ro;
     OVERLAY1:  load = OVL1,       type = ro,  define = yes, optional = yes;

--- a/cfg/atari-xex.cfg
+++ b/cfg/atari-xex.cfg
@@ -36,7 +36,7 @@ SEGMENTS {
     CODE:      load = MAIN,       type = ro,  define = yes;
     RODATA:    load = MAIN,       type = ro;
     DATA:      load = MAIN,       type = rw;
-    INIT:      load = MAIN,       type = rw,                optional = yes;
+    INIT:      load = MAIN,       type = bss,               optional = yes;
     BSS:       load = MAIN,       type = bss, define = yes;
 }
 FEATURES {

--- a/cfg/atari.cfg
+++ b/cfg/atari.cfg
@@ -40,7 +40,7 @@ SEGMENTS {
     CODE:      load = MAIN,       type = ro,  define = yes;
     RODATA:    load = MAIN,       type = ro;
     DATA:      load = MAIN,       type = rw;
-    INIT:      load = MAIN,       type = rw,                optional = yes;
+    INIT:      load = MAIN,       type = bss,               optional = yes;
     BSS:       load = MAIN,       type = bss, define = yes;
     AUTOSTRT:  load = TRAILER,    type = ro;
 }

--- a/cfg/atarixl-largehimem.cfg
+++ b/cfg/atarixl-largehimem.cfg
@@ -67,7 +67,7 @@ SEGMENTS {
     CODE:        load = MAIN,                         type = ro,  define = yes;
     RODATA:      load = MAIN,                         type = ro;
     DATA:        load = MAIN,                         type = rw;
-    INIT:        load = MAIN,                         type = rw,                optional = yes;
+    INIT:        load = MAIN,                         type = bss,               optional = yes;
     BSS:         load = MAIN,                         type = bss, define = yes;
     AUTOSTRT:    load = TRAILER,                      type = ro;
 }

--- a/cfg/atarixl-overlay.cfg
+++ b/cfg/atarixl-overlay.cfg
@@ -78,7 +78,7 @@ SEGMENTS {
     CODE:        load = MAIN,                          type = ro,  define = yes;
     RODATA:      load = MAIN,                          type = ro;
     DATA:        load = MAIN,                          type = rw;
-    INIT:        load = MAIN,                          type = rw,                optional = yes;
+    INIT:        load = MAIN,                          type = bss,               optional = yes;
     BSS:         load = MAIN,                          type = bss, define = yes;
     AUTOSTRT:    load = TRAILER,                       type = ro;
 

--- a/cfg/atarixl-xex.cfg
+++ b/cfg/atarixl-xex.cfg
@@ -58,7 +58,7 @@ SEGMENTS {
     CODE:        load = MAIN,                          type = ro,  define = yes;
     RODATA:      load = MAIN,                          type = ro;
     DATA:        load = MAIN,                          type = rw;
-    INIT:        load = MAIN,                          type = rw,                optional = yes;
+    INIT:        load = MAIN,                          type = bss,               optional = yes;
     BSS:         load = MAIN,                          type = bss, define = yes;
     SRPREPHDR:   load = UNUSED,                        type = ro;
     SRPREPTRL:   load = UNUSED,                        type = ro;

--- a/cfg/atarixl.cfg
+++ b/cfg/atarixl.cfg
@@ -65,7 +65,7 @@ SEGMENTS {
     CODE:        load = MAIN,                          type = ro,  define = yes;
     RODATA:      load = MAIN,                          type = ro;
     DATA:        load = MAIN,                          type = rw;
-    INIT:        load = MAIN,                          type = rw,                optional = yes;
+    INIT:        load = MAIN,                          type = bss,               optional = yes;
     BSS:         load = MAIN,                          type = bss, define = yes;
     AUTOSTRT:    load = TRAILER,                       type = ro;
 }

--- a/cfg/atmos.cfg
+++ b/cfg/atmos.cfg
@@ -23,7 +23,7 @@ SEGMENTS {
     CODE:     load = MAIN,    type = ro;
     RODATA:   load = MAIN,    type = ro;
     DATA:     load = MAIN,    type = rw;
-    INIT:     load = MAIN,    type = rw;
+    INIT:     load = MAIN,    type = bss;
     ONCE:     load = MAIN,    type = ro,  define   = yes;
     BASTAIL:  load = MAIN,    type = ro,  optional = yes;
     BSS:      load = BSS,     type = bss, define   = yes;

--- a/cfg/c64-overlay.cfg
+++ b/cfg/c64-overlay.cfg
@@ -44,7 +44,7 @@ SEGMENTS {
     CODE:     load = MAIN,     type = ro;
     RODATA:   load = MAIN,     type = ro;
     DATA:     load = MAIN,     type = rw;
-    INIT:     load = MAIN,     type = rw;
+    INIT:     load = MAIN,     type = bss;
     ONCE:     load = MAIN,     type = ro,  define = yes;
     BSS:      load = BSS,      type = bss, define = yes;
     OVL1ADDR: load = OVL1ADDR, type = ro;

--- a/cfg/c64.cfg
+++ b/cfg/c64.cfg
@@ -23,7 +23,7 @@ SEGMENTS {
     CODE:     load = MAIN,     type = ro;
     RODATA:   load = MAIN,     type = ro;
     DATA:     load = MAIN,     type = rw;
-    INIT:     load = MAIN,     type = rw;
+    INIT:     load = MAIN,     type = bss;
     ONCE:     load = MAIN,     type = ro,  define   = yes;
     BSS:      load = BSS,      type = bss, define   = yes;
 }

--- a/cfg/creativision.cfg
+++ b/cfg/creativision.cfg
@@ -11,10 +11,10 @@ SEGMENTS {
     ZP:       load = ZP,             type = zp,                optional = yes;
     VECTORS:  load = ROM, run = RAM, type = rw,  define = yes;
     DATA:     load = ROM, run = RAM, type = rw,  define = yes,                 start = $0204;
+    INIT:     load = RAM,            type = bss,               optional = yes;
     BSS:      load = RAM,            type = bss, define = yes;
     ONCE:     load = ROM,            type = ro,                optional = yes;
     CODE:     load = ROM,            type = ro;
-    INIT:     load = ROM,            type = ro;
     RODATA:   load = ROM,            type = ro;
     AUDIO:    load = ROM,            type = ro,                optional = yes, start = $BF00;
     SETUP:    load = ROM,            type = ro,                                start = $BFE8;

--- a/cfg/cx16-bank.cfg
+++ b/cfg/cx16-bank.cfg
@@ -57,7 +57,7 @@ SEGMENTS {
     CODE:       load = MAIN,       type = ro;
     RODATA:     load = MAIN,       type = ro;
     DATA:       load = MAIN,       type = rw;
-    INIT:       load = MAIN,       type = rw, optional = yes;
+    INIT:       load = MAIN,       type = bss,optional = yes;
     ONCE:       load = MAIN,       type = ro,                 define = yes;
     BSS:        load = BSS,        type = bss,                define = yes;
     BRAM01ADDR: load = BRAM01ADDR, type = ro, optional = yes;

--- a/cfg/cx16.cfg
+++ b/cfg/cx16.cfg
@@ -24,7 +24,7 @@ SEGMENTS {
     CODE:     load = MAIN,     type = ro;
     RODATA:   load = MAIN,     type = ro;
     DATA:     load = MAIN,     type = rw;
-    INIT:     load = MAIN,     type = rw, optional = yes;
+    INIT:     load = MAIN,     type = bss,optional = yes;
     ONCE:     load = MAIN,     type = ro,                 define = yes;
     BSS:      load = BSS,      type = bss,                define = yes;
 }

--- a/cfg/telestrat.cfg
+++ b/cfg/telestrat.cfg
@@ -22,7 +22,7 @@ SEGMENTS {
     CODE:     load = MAIN,    type = ro;
     RODATA:   load = MAIN,    type = ro;
     DATA:     load = MAIN,    type = rw;
-    INIT:     load = MAIN,    type = rw;
+    INIT:     load = MAIN,    type = bss;
     ONCE:     load = MAIN,    type = ro,  define   = yes;
     BASTAIL:  load = MAIN,    type = ro,  optional = yes;
     BSS:      load = BSS,     type = bss, define   = yes;

--- a/libsrc/creativision/cputc.s
+++ b/libsrc/creativision/cputc.s
@@ -95,12 +95,6 @@ IS_UPPER:
 BAD_CHAR:
         jmp     plot
 
-;-----------------------------------------------------------------------------
-; Initialize the conio subsystem. "INIT" segment is nothing special on the
-; Creativision, it is part of the "ROM" memory.
-
-.segment        "INIT"
-
 initconio:
         lda     #$0
         sta     SCREEN_PTR


### PR DESCRIPTION
From [this discussion on a recent PR](https://github.com/cc65/cc65/pull/2160#issuecomment-1683999799). Documentation stating the purpose of the INIT segment was given: [Wiki: Segment usage of constructors](https://github.com/cc65/wiki/wiki/Segment-usage-of-constructors)

INIT is uninitialized RAM to be used by constructors, separate from the BSS segment because it is expected that BSS will be cleared after constructors are initialized.

As a linker segment type, this semantically means `bss` type, because it has no initial value. I have amended the existing .cfg files to use this. It will also prevent us from accidentally trying to place initialization values in INIT.

The open question was whether the linker can emit a bss type segment to a file, and it seems there is no issue with that. (This was needed for Apple II configs which reserve bytes for INIT directly in the program data, despite them being uninitialized.)

The only outlier was creativision.cfg which treated INIT as a code segment for stuff doing at startup in one file, but I simply removed this incorrect usage (it only affected on file: creativision/cputc.s).