### PR TITLE
Possible serial driver optimisations

### DIFF
--- a/libsrc/apple2/ser/a2.ssc.s
+++ b/libsrc/apple2/ser/a2.ssc.s
@@ -328,20 +328,21 @@ SER_PUT:
 
         ; Try to send
         ldy     SendFreeCnt
-        iny                     ; Y = $FF?
+        cpy     #$FF            ; Nothing to flush
         beq     :+
         pha
         lda     #$00            ; TryHard = false
         jsr     TryToSend
         pla
 
-        ; Put byte into send buffer & send
-:       ldy     SendFreeCnt
+        ; Reload SendFreeCnt after TryToSend
+        ldy     SendFreeCnt
         bne     :+
         lda     #SER_ERR_OVERFLOW
         ldx     #0 ; return value is char
         rts
 
+        ; Put byte into send buffer & send
 :       ldy     SendTail
         sta     SendBuf,y
         inc     SendTail

--- a/libsrc/apple2/ser/a2.ssc.s
+++ b/libsrc/apple2/ser/a2.ssc.s
@@ -427,12 +427,13 @@ Done:   rts
 
 TryToSend:
         sta     tmp1            ; Remember tryHard flag
-Again:  lda     SendFreeCnt
+NextByte:
+        lda     SendFreeCnt
         cmp     #$FF
         beq     Quit            ; Bail out
 
         ; Check for flow stopped
-        lda     Stopped
+Again:  lda     Stopped
         bne     Quit            ; Bail out
 
         ; Check that ACIA is ready to send
@@ -449,4 +450,4 @@ Send:   ldy     SendHead
         sta     ACIA_DATA,x
         inc     SendHead
         inc     SendFreeCnt
-        jmp     Again
+        jmp     NextByte

--- a/libsrc/apple2/ser/a2.ssc.s
+++ b/libsrc/apple2/ser/a2.ssc.s
@@ -291,14 +291,9 @@ InvBaud:lda     #SER_ERR_BAUD_UNAVAIL
 
 SER_GET:
         ldx     Index
-        ldy     SendFreeCnt     ; Send data if necessary
-        iny                     ; Y == $FF?
-        beq     :+
-        lda     #$00            ; TryHard = false
-        jsr     TryToSend
 
         ; Check for buffer empty
-:       lda     RecvFreeCnt     ; (25)
+        lda     RecvFreeCnt     ; (25)
         cmp     #$FF
         bne     :+
         lda     #SER_ERR_NO_DATA

--- a/libsrc/apple2/ser/a2.ssc.s
+++ b/libsrc/apple2/ser/a2.ssc.s
@@ -26,6 +26,7 @@
         .include        "ser-error.inc"
 
         .macpack        module
+        .macpack        cpu
 
 ; ------------------------------------------------------------------------
 ; Header. Includes jump table
@@ -57,9 +58,13 @@
 ;----------------------------------------------------------------------------
 ; I/O definitions
 
+.if (.cpu .bitand CPU_ISET_65C02)
+ACIA            = $C088
+.else
 Offset          = $8F           ; Move 6502 false read out of I/O to page $BF
-
 ACIA            = $C088-Offset
+.endif
+
 ACIA_DATA       = ACIA+0        ; Data register
 ACIA_STATUS     = ACIA+1        ; Status register
 ACIA_CMD        = ACIA+2        ; Command register
@@ -200,7 +205,9 @@ SER_OPEN:
         asl
         asl
         asl
+.if .not (.cpu .bitand CPU_ISET_65C02)
         adc     #Offset                 ; Assume carry to be clear
+.endif
         tax
 
         ; Check if the handshake setting is valid
@@ -315,7 +322,11 @@ SER_GET:
         inc     RecvHead
         inc     RecvFreeCnt
         ldx     #$00            ; (59)
+.if (.cpu .bitand CPU_ISET_65C02)
+        sta     (ptr1)
+.else
         sta     (ptr1,x)
+.endif
         txa                     ; Return code = 0
         rts
 

--- a/libsrc/apple2/ser/a2.ssc.s
+++ b/libsrc/apple2/ser/a2.ssc.s
@@ -404,19 +404,19 @@ SER_IRQ:
         and     #$08
         beq     Done            ; Jump if no ACIA interrupt
         lda     ACIA_DATA,x     ; Get byte from ACIA
-        ldy     RecvFreeCnt     ; Check if we have free space left
+        ldx     RecvFreeCnt     ; Check if we have free space left
         beq     Flow            ; Jump if no space in receive buffer
         ldy     RecvTail        ; Load buffer pointer
         sta     RecvBuf,y       ; Store received byte in buffer
         inc     RecvTail        ; Increment buffer pointer
         dec     RecvFreeCnt     ; Decrement free space counter
-        ldy     RecvFreeCnt     ; Check for buffer space low
-        cpy     #33
+        cpx     #33             ; Check for buffer space low
         bcc     Flow            ; Assert flow control if buffer space low
         rts                     ; Interrupt handled (carry already set)
 
         ; Assert flow control if buffer space too low
-Flow:   lda     RtsOff
+Flow:   ldx     Index
+lda     RtsOff
         sta     ACIA_CMD,x
         sta     Stopped
         sec                     ; Interrupt handled

--- a/libsrc/atmos/ser/atmos-acia.s
+++ b/libsrc/atmos/ser/atmos-acia.s
@@ -352,12 +352,13 @@ Done:   rts
 
 TryToSend:
         sta     tmp1            ; Remember tryHard flag
-Again:  lda     SendFreeCnt
+NextByte:
+        lda     SendFreeCnt
         cmp     #$FF
         beq     Quit            ; Bail out
 
         ; Check for flow stopped
-        lda     Stopped
+Again:  lda     Stopped
         bne     Quit            ; Bail out
 
         ; Check that ACIA is ready to send
@@ -374,4 +375,4 @@ Send:   ldy     SendHead
         sta     ACIA::DATA
         inc     SendHead
         inc     SendFreeCnt
-        jmp     Again
+        jmp     NextByte

--- a/libsrc/atmos/ser/atmos-acia.s
+++ b/libsrc/atmos/ser/atmos-acia.s
@@ -227,14 +227,8 @@ InvBaud:lda     #<SER_ERR_BAUD_UNAVAIL
 ; returned.
 
 SER_GET:
-        ldy     SendFreeCnt     ; Send data if necessary
-        iny                     ; Y == $FF?
-        beq     :+
-        lda     #$00            ; TryHard = false
-        jsr     TryToSend
-
         ; Check for buffer empty
-:       lda     RecvFreeCnt     ; (25)
+        lda     RecvFreeCnt     ; (25)
         cmp     #$FF
         bne     :+
         lda     #SER_ERR_NO_DATA

--- a/libsrc/atmos/ser/atmos-acia.s
+++ b/libsrc/atmos/ser/atmos-acia.s
@@ -329,19 +329,19 @@ SER_IRQ:
         and     #$08
         beq     Done            ; Jump if no ACIA interrupt
         lda     ACIA::DATA,x    ; Get byte from ACIA
-        ldy     RecvFreeCnt     ; Check if we have free space left
+        ldx     RecvFreeCnt     ; Check if we have free space left
         beq     Flow            ; Jump if no space in receive buffer
         ldy     RecvTail        ; Load buffer pointer
         sta     RecvBuf,y       ; Store received byte in buffer
         inc     RecvTail        ; Increment buffer pointer
         dec     RecvFreeCnt     ; Decrement free space counter
-        ldy     RecvFreeCnt     ; Check for buffer space low
-        cpy     #33
+        cpx     #33
         bcc     Flow            ; Assert flow control if buffer space low
         rts                     ; Interrupt handled (carry already set)
 
         ; Assert flow control if buffer space too low
-Flow:   lda     RtsOff
+Flow:   ldx     Index           ; Reload port
+        lda     RtsOff
         sta     ACIA::CMD,x
         sta     Stopped
         sec                     ; Interrupt handled

--- a/libsrc/atmos/ser/atmos-acia.s
+++ b/libsrc/atmos/ser/atmos-acia.s
@@ -269,20 +269,21 @@ SER_GET:
 SER_PUT:
         ; Try to send
         ldy     SendFreeCnt
-        iny                     ; Y = $FF?
+        cpy     #$FF            ; Nothing to flush
         beq     :+
         pha
         lda     #$00            ; TryHard = false
         jsr     TryToSend
         pla
 
-        ; Put byte into send buffer & send
-:       ldy     SendFreeCnt
+        ; Reload SendFreeCnt after TryToSend
+        ldy     SendFreeCnt
         bne     :+
         lda     #SER_ERR_OVERFLOW
         ldx     #0 ; return value is char
         rts
 
+        ; Put byte into send buffer & send
 :       ldy     SendTail
         sta     SendBuf,y
         inc     SendTail

--- a/libsrc/c128/ser/c128-swlink.s
+++ b/libsrc/c128/ser/c128-swlink.s
@@ -314,15 +314,10 @@ SER_CLOSE:
 ;
 
 SER_GET:
-        ldx     SendFreeCnt             ; Send data if necessary
-        inx                             ; X == $FF?
-        beq     @L1
-        lda     #$00
-        jsr     TryToSend
 
 ; Check for buffer empty
 
-@L1:    lda     RecvFreeCnt             ; (25)
+        lda     RecvFreeCnt             ; (25)
         cmp     #$ff
         bne     @L2
         lda     #SER_ERR_NO_DATA

--- a/libsrc/c128/ser/c128-swlink.s
+++ b/libsrc/c128/ser/c128-swlink.s
@@ -466,25 +466,25 @@ NmiHandler:
         sta     tmp1            ; Remember tryHard flag
 @L0:    lda     SendFreeCnt
         cmp     #$ff
-        beq     @L3             ; Bail out
+        beq     @L2             ; Bail out
 
 ; Check for flow stopped
 
 @L1:    lda     Stopped
-        bne     @L3             ; Bail out
+        bne     @L2             ; Bail out
 
 ; Check that swiftlink is ready to send
 
-@L2:    lda     ACIA_STATUS
+        lda     ACIA_STATUS
         and     #$10
-        bne     @L4
+        bne     @L3
         bit     tmp1            ;keep trying if must try hard
-        bmi     @L0
-@L3:    rts
+        bmi     @L1
+@L2:    rts
 
 ; Send byte and try again
 
-@L4:    ldx     SendHead
+@L3:    ldx     SendHead
         lda     SendBuf,x
         sta     ACIA_DATA
         inc     SendHead

--- a/libsrc/c128/ser/c128-swlink.s
+++ b/libsrc/c128/ser/c128-swlink.s
@@ -362,21 +362,23 @@ SER_PUT:
 ; Try to send
 
         ldx     SendFreeCnt
-        inx                             ; X = $ff?
+        cpx     #$FF                   ; Nothing to flush
         beq     @L2
         pha
         lda     #$00
         jsr     TryToSend
         pla
 
-; Put byte into send buffer & send
+; Reload SendFreeCnt after TryToSend
 
-@L2:    ldx     SendFreeCnt
-        bne     @L3
+        ldx     SendFreeCnt
+        bne     @L2
         lda     #SER_ERR_OVERFLOW       ; X is already zero
         rts
 
-@L3:    ldx     SendTail
+; Put byte into send buffer & send
+
+@L2:    ldx     SendTail
         sta     SendBuf,x
         inc     SendTail
         dec     SendFreeCnt

--- a/libsrc/c64/ser/c64-swlink.s
+++ b/libsrc/c64/ser/c64-swlink.s
@@ -443,25 +443,25 @@ NmiHandler:
         sta     tmp1            ; Remember tryHard flag
 @L0:    lda     SendFreeCnt
         cmp     #$ff
-        beq     @L3             ; Bail out
+        beq     @L2             ; Bail out
 
 ; Check for flow stopped
 
 @L1:    lda     Stopped
-        bne     @L3             ; Bail out
+        bne     @L2             ; Bail out
 
 ; Check that swiftlink is ready to send
 
-@L2:    lda     ACIA_STATUS
+        lda     ACIA_STATUS
         and     #$10
-        bne     @L4
+        bne     @L3
         bit     tmp1            ;keep trying if must try hard
-        bmi     @L0
-@L3:    rts
+        bmi     @L1
+@L2:    rts
 
 ; Send byte and try again
 
-@L4:    ldx     SendHead
+@L3:    ldx     SendHead
         lda     SendBuf,x
         sta     ACIA_DATA
         inc     SendHead

--- a/libsrc/c64/ser/c64-swlink.s
+++ b/libsrc/c64/ser/c64-swlink.s
@@ -288,15 +288,10 @@ SER_CLOSE:
 ;
 
 SER_GET:
-        ldx     SendFreeCnt             ; Send data if necessary
-        inx                             ; X == $FF?
-        beq     @L1
-        lda     #$00
-        jsr     TryToSend
 
 ; Check for buffer empty
 
-@L1:    lda     RecvFreeCnt             ; (25)
+        lda     RecvFreeCnt             ; (25)
         cmp     #$ff
         bne     @L2
         lda     #SER_ERR_NO_DATA

--- a/libsrc/c64/ser/c64-swlink.s
+++ b/libsrc/c64/ser/c64-swlink.s
@@ -336,21 +336,23 @@ SER_PUT:
 ; Try to send
 
         ldx     SendFreeCnt
-        inx                             ; X = $ff?
+        cpx     #$FF                   ; Nothing to flush
         beq     @L2
         pha
         lda     #$00
         jsr     TryToSend
         pla
 
-; Put byte into send buffer & send
+; Reload SendFreeCnt after TryToSend
 
-@L2:    ldx     SendFreeCnt
-        bne     @L3
+        ldx     SendFreeCnt
+        bne     @L2
         lda     #SER_ERR_OVERFLOW      ; X is already zero
         rts
 
-@L3:    ldx     SendTail
+; Put byte into send buffer & send
+
+@L2:    ldx     SendTail
         sta     SendBuf,x
         inc     SendTail
         dec     SendFreeCnt

--- a/libsrc/cbm510/ser/cbm510-std.s
+++ b/libsrc/cbm510/ser/cbm510-std.s
@@ -244,15 +244,10 @@ InvBaud:
 ;
 
 SER_GET:
-        ldx     SendFreeCnt             ; Send data if necessary
-        inx                             ; X == $FF?
-        beq     @L1
-        lda     #$00
-        jsr     TryToSend
 
 ; Check for buffer empty
 
-@L1:    lda     RecvFreeCnt
+        lda     RecvFreeCnt
         cmp     #$ff
         bne     @L2
         lda     #SER_ERR_NO_DATA

--- a/libsrc/cbm510/ser/cbm510-std.s
+++ b/libsrc/cbm510/ser/cbm510-std.s
@@ -395,31 +395,31 @@ SER_IRQ:
         sta     IndReg          ; Switch to the system bank
 @L0:    lda     SendFreeCnt
         cmp     #$ff
-        beq     @L3             ; Bail out
+        beq     @L2             ; Bail out
 
 ; Check for flow stopped
 
 @L1:    lda     Stopped
-        bne     @L3             ; Bail out
+        bne     @L2             ; Bail out
 
 ; Check that swiftlink is ready to send
 
-@L2:    ldy     #ACIA::STATUS
+        ldy     #ACIA::STATUS
         lda     (acia),y
         and     #$10
-        bne     @L4
+        bne     @L3
         bit     tmp1            ; Keep trying if must try hard
-        bmi     @L0
+        bmi     @L1
 
 ; Switch back the bank and return
 
-@L3:    lda     ExecReg
+@L2:    lda     ExecReg
         sta     IndReg
         rts
 
 ; Send byte and try again
 
-@L4:    ldx     SendHead
+@L3:    ldx     SendHead
         lda     SendBuf,x
         ldy     #ACIA::DATA
         sta     (acia),y

--- a/libsrc/cbm510/ser/cbm510-std.s
+++ b/libsrc/cbm510/ser/cbm510-std.s
@@ -292,21 +292,23 @@ SER_PUT:
 ; Try to send
 
         ldx     SendFreeCnt
-        inx                             ; X = $ff?
+        cpx     #$FF                   ; Nothing to flush
         beq     @L2
         pha
         lda     #$00
         jsr     TryToSend
         pla
 
-; Put byte into send buffer & send
+; Reload SendFreeCnt after TryToSend
 
-@L2:    ldx     SendFreeCnt
-        bne     @L3
+        ldx     SendFreeCnt
+        bne     @L2
         lda     #SER_ERR_OVERFLOW      ; X is already zero
         rts
 
-@L3:    ldx     SendTail
+; Put byte into send buffer & send
+
+@L2:    ldx     SendTail
         sta     SendBuf,x
         inc     SendTail
         dec     SendFreeCnt

--- a/libsrc/cbm610/ser/cbm610-std.s
+++ b/libsrc/cbm610/ser/cbm610-std.s
@@ -395,31 +395,31 @@ SER_IRQ:
         sta     IndReg          ; Switch to the system bank
 @L0:    lda     SendFreeCnt
         cmp     #$ff
-        beq     @L3             ; Bail out
+        beq     @L2             ; Bail out
 
 ; Check for flow stopped
 
 @L1:    lda     Stopped
-        bne     @L3             ; Bail out
+        bne     @L2             ; Bail out
 
 ; Check that swiftlink is ready to send
 
-@L2:    ldy     #ACIA::STATUS
+       ldy     #ACIA::STATUS
         lda     (acia),y
         and     #$10
-        bne     @L4
+        bne     @L3
         bit     tmp1            ; Keep trying if must try hard
-        bmi     @L0
+        bmi     @L1
 
 ; Switch back the bank and return
 
-@L3:    lda     ExecReg
+@L2:    lda     ExecReg
         sta     IndReg
         rts
 
 ; Send byte and try again
 
-@L4:    ldx     SendHead
+@L3:    ldx     SendHead
         lda     SendBuf,x
         ldy     #ACIA::DATA
         sta     (acia),y

--- a/libsrc/cbm610/ser/cbm610-std.s
+++ b/libsrc/cbm610/ser/cbm610-std.s
@@ -245,15 +245,10 @@ InvBaud:
 ;
 
 SER_GET:
-        ldx     SendFreeCnt             ; Send data if necessary
-        inx                             ; X == $FF?
-        beq     @L1
-        lda     #$00
-        jsr     TryToSend
 
 ; Check for buffer empty
 
-@L1:    lda     RecvFreeCnt
+        lda     RecvFreeCnt
         cmp     #$ff
         bne     @L2
         lda     #SER_ERR_NO_DATA

--- a/libsrc/cbm610/ser/cbm610-std.s
+++ b/libsrc/cbm610/ser/cbm610-std.s
@@ -293,21 +293,23 @@ SER_PUT:
 ; Try to send
 
         ldx     SendFreeCnt
-        inx                             ; X = $ff?
+        cpx     #$ff                   ; Nothing to flush
         beq     @L2
         pha
         lda     #$00
         jsr     TryToSend
         pla
 
-; Put byte into send buffer & send
+; Reload SendFreeCnt after TryToSend
 
-@L2:    ldx     SendFreeCnt
-        bne     @L3
+        ldx     SendFreeCnt
+        bne     @L2
         lda     #SER_ERR_OVERFLOW      ; X is already zero
         rts
 
-@L3:    ldx     SendTail
+; Put byte into send buffer & send
+
+@L2:    ldx     SendTail
         sta     SendBuf,x
         inc     SendTail
         dec     SendFreeCnt

--- a/libsrc/plus4/ser/plus4-stdser.s
+++ b/libsrc/plus4/ser/plus4-stdser.s
@@ -300,21 +300,23 @@ SER_PUT:
 ; Try to send
 
         ldx     SendFreeCnt
-        inx                             ; X = $ff?
+        cpx     #$ff                   ; Nothing to flush
         beq     @L2
         pha
         lda     #$00
         jsr     TryToSend
         pla
 
-; Put byte into send buffer & send
+; Reload SendFreeCnt after TryToSend
 
-@L2:    ldx     SendFreeCnt
-        bne     @L3
+        ldx     SendFreeCnt
+        bne     @L2
         lda     #SER_ERR_OVERFLOW      ; X is already zero
         rts
 
-@L3:    ldx     SendTail
+; Put byte into send buffer & send
+
+@L2:    ldx     SendTail
         sta     SendBuf,x
         inc     SendTail
         dec     SendFreeCnt

--- a/libsrc/plus4/ser/plus4-stdser.s
+++ b/libsrc/plus4/ser/plus4-stdser.s
@@ -252,15 +252,10 @@ InvBaud:
 ;
 
 SER_GET:
-        ldx     SendFreeCnt             ; Send data if necessary
-        inx                             ; X == $FF?
-        beq     @L1
-        lda     #$00
-        jsr     TryToSend
 
 ; Check for buffer empty
 
-@L1:    lda     RecvFreeCnt             ; (25)
+        lda     RecvFreeCnt             ; (25)
         cmp     #$ff
         bne     @L2
         lda     #SER_ERR_NO_DATA

--- a/libsrc/plus4/ser/plus4-stdser.s
+++ b/libsrc/plus4/ser/plus4-stdser.s
@@ -387,25 +387,25 @@ SER_IRQ:
         sta     tmp1            ; Remember tryHard flag
 @L0:    lda     SendFreeCnt
         cmp     #$ff
-        beq     @L3             ; Bail out
+        beq     @L2             ; Bail out
 
 ; Check for flow stopped
 
 @L1:    lda     Stopped
-        bne     @L3             ; Bail out
+        bne     @L2             ; Bail out
 
 ; Check that swiftlink is ready to send
 
-@L2:    lda     ACIA_STATUS
+        lda     ACIA_STATUS
         and     #$10
-        bne     @L4
+        bne     @L3
         bit     tmp1            ;keep trying if must try hard
-        bmi     @L0
-@L3:    rts
+        bmi     @L1
+@L2:    rts
 
 ; Send byte and try again
 
-@L4:    ldx     SendHead
+@L3:    ldx     SendHead
         lda     SendBuf,x
         sta     ACIA_DATA
         inc     SendHead


### PR DESCRIPTION
Hello,

I have made some modifications to Apple2's serial driver and would like to discuss them with you. There are four different optimisations in this pull request. 

The first one is passing --cpu 65c02 when building libsrc/apple2 for the apple2enh ; we then use this to save a single cycle on SER_GET, with sta(ptr1) instead of sta(ptr1,x). 

The second one is in SER_GET too, and consists of *not* trying to send data before receiving. Is this an ACIA 6551 requirement that there's nothing to send before receving? If so, as SER_PUT is not IRQ-driven, maybe we could get rid of the SendBuf and just make sure the byte is out before returning ?
This one shaves 8 cycles if there was nothing to send (and approx 10 bytes on disk/in RAM). I could also put the patch in the other instances of the same driver for the other platforms.

The third one is in SER_IRQ, and reworks the RecvFreeCnt decrement and comparison to do it in the X register. This shaves 4 cycles in the common and best case; in the worst case (where we assert flow control), it saves no cycle as we have to reload X to Index. This one is generalizable too to the other platforms.

Finally, I've defined the most frequently accessed variables, and the ones that are in the "firehose" codepath of receiving bytes, to point to 5 unused bytes in the zero page, thus saving about one cycle per access. This last one is not clean, but could be made clean with a new segment definition and everything, I suppose.

All of these are ideas. What do you think?

Thanks!

PS: This does not save enough cycles to handle 19200 bps : (the ROM IRQ handler does about 240 cycles per call, the ProDOS IRQ handler about 250, and callirq about 42). Plus 54 in SER_IRQ, it's about 600 cycles per IRQ, but getting the data out of ser_get() (about 43 cycles) and into a large buffer still makes it too slow.