### PR TITLE
Rework debug file format to include all exports

### DIFF
--- a/src/dbginfo/dbginfo.h
+++ b/src/dbginfo/dbginfo.h
@@ -181,6 +181,53 @@ void cc65_free_csyminfo (cc65_dbginfo handle, const cc65_csyminfo* info);
 
 
 /*****************************************************************************/
+/*                                 Exports                                   */
+/*****************************************************************************/
+
+
+
+/* Exports information */
+typedef struct cc65_exportdata cc65_exportdata;
+struct cc65_exportdata {
+    unsigned            export_id;      /* The internal export id */
+    const char*         export_name;    /* Name of the export */
+    cc65_size           export_size;    /* Size of export, 0 if unknown */
+    long                export_value;   /* Value of export */
+    unsigned            symbol_id;      /* Matching symbol */
+
+};
+
+typedef struct cc65_exportinfo cc65_exportinfo;
+struct cc65_exportinfo {
+    unsigned            count;          /* Number of data sets that follow */
+    cc65_exportdata    data[1];         /* Data sets, number is dynamic */
+};
+
+
+
+const cc65_exportinfo* cc65_get_exportlist (cc65_dbginfo handle);
+/* Return a list of all exports */
+
+const cc65_exportinfo* cc65_export_byid (cc65_dbginfo handle, unsigned id);
+/* Return information about a export with a specific id. The function
+** returns NULL if the id is invalid (no such export) and otherwise a
+** cc65_exportinfo structure with one entry that contains the requested
+** export information.
+*/
+
+const cc65_exportinfo* cc65_export_inrange (cc65_dbginfo handle,
+                                            cc65_addr start, cc65_addr end);
+/* Return a list of exports in the given range. end is inclusive. The function
+** return NULL if no exports within the given range are found.
+*/
+
+
+void cc65_free_exportinfo (cc65_dbginfo handle, const cc65_exportinfo* info);
+/* Free a export info record */
+
+
+
+/*****************************************************************************/
 /*                                 Libraries                                 */
 /*****************************************************************************/
 
@@ -600,6 +647,9 @@ struct cc65_symbolinfo {
 
 
 
+const cc65_symbolinfo* cc65_get_symbollist (cc65_dbginfo handle);
+/* Return a list of all symbols */
+
 const cc65_symbolinfo* cc65_symbol_byid (cc65_dbginfo handle, unsigned id);
 /* Return the symbol with a given id. The function returns NULL if no symbol
 ** with this id was found.
@@ -705,6 +755,3 @@ void cc65_free_typedata (cc65_dbginfo Handle, const cc65_typedata* data);
 
 /* End of dbginfo.h */
 #endif
-
-
-

--- a/src/ld65/dbgfile.c
+++ b/src/ld65/dbgfile.c
@@ -41,6 +41,7 @@
 #include "dbgfile.h"
 #include "dbgsyms.h"
 #include "error.h"
+#include "exports.h"
 #include "fileinfo.h"
 #include "global.h"
 #include "library.h"
@@ -71,6 +72,8 @@ static void AssignIds (void)
     unsigned ScopeBaseId  = 0;
     unsigned SpanBaseId   = 0;
     unsigned SymBaseId    = 0;
+    unsigned ExpBaseId    = 0;
+
     for (I = 0; I < CollCount (&ObjDataList); ++I) {
 
         /* Get this module */
@@ -84,12 +87,14 @@ static void AssignIds (void)
         O->ScopeBaseId  = ScopeBaseId;
         O->SpanBaseId   = SpanBaseId;
         O->SymBaseId    = SymBaseId;
+        O->ExpBaseId    = ExpBaseId;
 
         /* Bump the base ids */
         HLLSymBaseId  += CollCount (&O->HLLDbgSyms);
         ScopeBaseId   += CollCount (&O->Scopes);
         SpanBaseId    += CollCount (&O->Spans);
         SymBaseId     += CollCount (&O->DbgSyms);
+        ExpBaseId     += CollCount (&O->Exports);
     }
 
     /* Assign the ids to the file infos */
@@ -97,6 +102,9 @@ static void AssignIds (void)
 
     /* Assign the ids to line infos */
     AssignLineInfoIds ();
+
+    /* Assign the ids to export infos */
+    AssignExportInfoIds ();
 }
 
 
@@ -160,6 +168,9 @@ void CreateDbgFile (void)
 
     /* Output symbols */
     PrintDbgSyms (F);
+
+    /* Output exports */
+    PrintExports (F);
 
     /* Output types */
     PrintDbgTypes (F);

--- a/src/ld65/dbgsyms.c
+++ b/src/ld65/dbgsyms.c
@@ -404,6 +404,11 @@ void PrintDbgSyms (FILE* F)
                 /* Output the type */
                 fputs (",type=imp", F);
 
+                /* Print the corresponding export's address */
+                if (Exp->Obj) {
+                  fprintf(F, ",val=0x%lX,size=%u", GetExportVal(Exp), Exp->Size);
+                }
+
                 /* If this is not a linker generated symbol, and the module
                 ** that contains the export has debug info, output the debug
                 ** symbol id for the export

--- a/src/ld65/dbgsyms.h
+++ b/src/ld65/dbgsyms.h
@@ -59,8 +59,22 @@
 struct Scope;
 struct HLLDbgSym;
 
-/* Opaque debug symbol structure */
+/* Debug symbol structure */
 typedef struct DbgSym DbgSym;
+struct DbgSym {
+    unsigned            Id;             /* Id of debug symbol */
+    DbgSym*             Next;           /* Pool linear list link */
+    ObjData*            Obj;            /* Object file that exports the name */
+    Collection          DefLines;       /* Line infos for definition */
+    Collection          RefLines;       /* Line infos for references */
+    ExprNode*           Expr;           /* Expression (0 if not def'd) */
+    unsigned            Size;           /* Symbol size if any */
+    unsigned            OwnerId;        /* Id of parent/owner */
+    unsigned            ImportId;       /* Id of import if this is one */
+    unsigned            Name;           /* Name */
+    unsigned short      Type;           /* Type of symbol */
+    unsigned short      AddrSize;       /* Address size of symbol */
+};
 
 
 

--- a/src/ld65/exports.h
+++ b/src/ld65/exports.h
@@ -47,6 +47,7 @@
 
 /* ld65 */
 #include "config.h"
+#include "dbgsyms.h"
 #include "lineinfo.h"
 #include "memarea.h"
 #include "objdata.h"
@@ -77,6 +78,7 @@ struct Import {
 /* Export symbol structure */
 typedef struct Export Export;
 struct Export {
+    unsigned            Id;             /* Export id */
     unsigned            Name;           /* Name */
     Export*             Next;           /* Hash table link */
     unsigned            Flags;          /* Generic flags */
@@ -87,7 +89,7 @@ struct Export {
     unsigned            Size;           /* Size of the symbol if any */
     Collection          DefLines;       /* Line infos of definition */
     Collection          RefLines;       /* Line infos of reference */
-    unsigned            DbgSymId;       /* Id of debug symbol for this export */
+    DbgSym*             DbgSymbol;      /* debug symbol for this export */
     unsigned short      Type;           /* Type of export */
     unsigned short      AddrSize;       /* Address size of export */
     unsigned char       ConDes[CD_TYPE_COUNT];  /* Constructor/destructor decls */
@@ -209,6 +211,15 @@ int ExportHasMark (Export* E);
 
 void CircularRefError (const Export* E);
 /* Print an error about a circular reference using to define the given export */
+
+unsigned ExportInfoCount (void);
+/* Return the total number of export infos */
+
+void AssignExportInfoIds (void);
+/* Assign the ids to the export infos */
+
+void PrintExports (FILE* F);
+/* Print the exports with no debug symbol in a debug file */
 
 
 

--- a/src/ld65/lineinfo.c
+++ b/src/ld65/lineinfo.c
@@ -284,3 +284,17 @@ void PrintDbgLineInfo (FILE* F)
         }
     }
 }
+
+void PrintLineInfoReferences (FILE* F, const Collection* LineInfos, const char* Format)
+/* Output an attribute with line infos */
+{
+    if (CollCount (LineInfos) > 0) {
+        unsigned I;
+        const LineInfo* LI = CollConstAt (LineInfos, 0);
+        fprintf (F, Format, LI->Id);
+        for (I = 1; I < CollCount (LineInfos); ++I) {
+            LI = CollConstAt (LineInfos, I);
+            fprintf (F, "+%u", LI->Id);
+        }
+    }
+}

--- a/src/ld65/lineinfo.h
+++ b/src/ld65/lineinfo.h
@@ -183,6 +183,9 @@ void AssignLineInfoIds (void);
 void PrintDbgLineInfo (FILE* F);
 /* Output the line infos to a debug info file */
 
+void PrintLineInfoReferences (FILE* F, const Collection* LineInfos, const char* Format);
+/* Print a list of line information references */
+
 
 
 /* End of lineinfo.h */

--- a/src/ld65/objdata.h
+++ b/src/ld65/objdata.h
@@ -78,6 +78,7 @@ struct ObjData {
     unsigned            SymBaseId;      /* Debug info base id for symbols */
     unsigned            ScopeBaseId;    /* Debug info base id for scopes */
     unsigned            SpanBaseId;     /* Debug info base id for spans */
+    unsigned            ExpBaseId;      /* Debug info base id for exports */
 
     Collection          Files;          /* List of input files */
     Collection          Sections;       /* List of all sections */


### PR DESCRIPTION
Some symbols/addresses address values are missing in the .dbg file, for imports namely. This makes mapping addresses to symbols more complicated than needed, and requires us to generate both a .dbg and a .lbl file (where those appear).

Cf next comment for a solution that allows us to get all available addresses.