### PR TITLE
Build libs with debug symbols

### DIFF
--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -131,8 +131,8 @@ $(TARGETS): | ../lib
 
 else # TARGET
 
-CA65FLAGS =
-CC65FLAGS = -Or -W error
+CA65FLAGS = -g
+CC65FLAGS = -g -Or -W error
 
 EXTZP = cbm510 \
         cbm610 \


### PR DESCRIPTION
Following PR #2169, I have been made aware that I wrote a thousand lines of code for a suboptimal result, where obviously the better solution was to build platform libs with debug info.
So I'm opening this PR to suggest building them with debug info. Maybe it has drawbacks I'm not aware of, but if there isn't any, I think it would be a good thing!