### PR TITLE
Conio: 65c02 optimisations

### DIFF
--- a/libsrc/conio/cputs.s
+++ b/libsrc/conio/cputs.s
@@ -8,28 +8,46 @@
         .export         _cputsxy, _cputs
         .import         gotoxy, _cputc
         .importzp       ptr1, tmp1
+        .macpack        cpu
 
 _cputsxy:
         sta     ptr1            ; Save s for later
         stx     ptr1+1
         jsr     gotoxy          ; Set cursor, pop x and y
+.if (.cpu .bitand CPU_ISET_65SC02)
+        bra     L0              ; Same as cputs...
+.else
         jmp     L0              ; Same as cputs...
+.endif
 
 _cputs: sta     ptr1            ; Save s
         stx     ptr1+1
-L0:     ldy     #0
-L1:     lda     (ptr1),y
-        beq     L9              ; Jump if done
+
+.if (.cpu .bitand CPU_ISET_65SC02)
+
+L0:     lda     (ptr1)          ; (5)
+        beq     L9              ; (7)  Jump if done
+        jsr     _cputc          ; (13) Output char, advance cursor
+        inc     ptr1            ; (18) Bump low byte
+        bne     L0              ; (20) Next char
+        inc     ptr1+1          ; (25) Bump high byte
+        bne     L0
+
+.else
+
+L0:     ldy     #0              ; (2)
+L1:     lda     (ptr1),y        ; (7)
+        beq     L9              ; (9)  Jump if done
         iny
-        sty     tmp1            ; Save offset
-        jsr     _cputc          ; Output char, advance cursor
-        ldy     tmp1            ; Get offset
-        bne     L1              ; Next char
-        inc     ptr1+1          ; Bump high byte
+        sty     tmp1            ; (14) Save offset
+        jsr     _cputc          ; (20) Output char, advance cursor
+        ldy     tmp1            ; (23) Get offset
+        bne     L1              ; (25) Next char
+        inc     ptr1+1          ; (30) Bump high byte
         bne     L1
+
+.endif
 
 ; Done
 
 L9:     rts
-
-

--- a/libsrc/conio/vcprintf.s
+++ b/libsrc/conio/vcprintf.s
@@ -10,7 +10,7 @@
         .importzp       sp, ptr1, ptr2, ptr3, tmp1
 
         .macpack        generic
-
+        .macpack        cpu
 
 .data
 
@@ -74,20 +74,39 @@ out:    jsr     popax           ; count
 
 ; Loop outputting characters
 
+.if (.cpu .bitand CPU_ISET_65SC02)
+
 @L1:    dec     outdesc+6
         beq     @L4
-@L2:    ldy     tmp1
-        lda     (ptr1),y
-        iny
-        bne     @L3
-        inc     ptr1+1
-@L3:    sty     tmp1
-        jsr     _cputc
-        jmp     @L1
+@L2:    lda     (ptr1)          ; (5)
+        inc     ptr1            ; (10)
+        bne     @L3             ; (12)
+        inc     ptr1+1          ; (17)
+@L3:    jsr     _cputc          ; (23)
+        bra     @L1             ; (26)
 
 @L4:    dec     outdesc+7
         bne     @L2
         rts
+
+.else
+
+@L1:    dec     outdesc+6
+        beq     @L4
+@L2:    ldy     tmp1            ; (3)
+        lda     (ptr1),y        ; (8)
+        iny                     ; (10)
+        bne     @L3             ; (12)
+        inc     ptr1+1          ; (17)
+@L3:    sty     tmp1            ; (20)
+        jsr     _cputc          ; (26)
+        jmp     @L1             ; (32)
+
+@L4:    dec     outdesc+7
+        bne     @L2
+        rts
+
+.endif
 
 ; ----------------------------------------------------------------------------
 ; vcprintf - formatted console i/o


### PR DESCRIPTION
cputc: -2 cycles per char, -2 cycles per carriage return
cputs: -5 cycles per char
vcprintf: -6 cycles per char