### PR TITLE
RFC: Apple2: Handle IRQs without ProDOS

### DIFF
--- a/asminc/apple2.inc
+++ b/asminc/apple2.inc
@@ -25,6 +25,11 @@ BRKVec  :=      $03F0   ; Break vector
 SOFTEV  :=      $03F2   ; Vector for warm start
 PWREDUP :=      $03F4   ; This must be = EOR #$A5 of SOFTEV+1
 
+ROMIRQVEC :=      $03FE   ; IRQ handler vector, called when an IRQ is fired
+                          ; and we're banked on ROM
+
+RAMIRQVEC :=      $FFFE   ; IRQ handler vector, called when an IRQ is fired
+                          ; and we're banked on RAM
 ;-----------------------------------------------------------------------------
 ; Hardware
 

--- a/libsrc/apple2/irq.s
+++ b/libsrc/apple2/irq.s
@@ -1,5 +1,6 @@
 ;
 ; Oliver Schmidt, 2012-11-17
+; Colin Leroy-Mira, 2023-09-02 - Handle IRQs without ProDOS
 ;
 ; IRQ handling (Apple2 version)
 ;
@@ -10,6 +11,129 @@
         .include        "apple2.inc"
 
         .macpack        apple2
+
+; ------------------------------------------------------------------------
+
+.ifdef __APPLE2ENH__
+; Faster IRQ handler for enhanced Apple2
+
+        .segment       "DATA"
+
+_prev_rom_irq_vector:   .res 2
+_prev_ram_irq_vector:   .res 2
+_a_backup:              .res 1
+
+        .segment        "ONCE"
+
+initirq:
+        ; Disable IRQs
+        sei
+
+        ; Save previous ROM IRQ vector
+        lda     ROMIRQVEC
+        ldx     ROMIRQVEC+1
+        sta     _prev_rom_irq_vector
+        stx     _prev_rom_irq_vector+1
+
+        ; Update ROM IRQ vector
+        lda     #<handle_rom_irq
+        ldx     #>handle_rom_irq
+        sta     ROMIRQVEC
+        stx     ROMIRQVEC+1
+
+        ; Check for Apple IIgs
+        bit     ROMIN
+        lda     $FE1F
+        cmp     #$60
+        ; Keep standard IRQ vector at FFFE/FFFF,
+        ; IIgs uses this one even from ROM
+        ; so we need it standard
+        bne     :+
+
+        ; Switch to RAM
+        bit     LCBANK2
+        bit     LCBANK2
+
+        ; Save previous RAM IRQ vector
+        lda     RAMIRQVEC
+        ldx     RAMIRQVEC+1
+        sta     _prev_ram_irq_vector
+        stx     _prev_ram_irq_vector+1
+
+        ; And update it
+        lda     #<handle_ram_irq
+        ldx     #>handle_ram_irq
+        sta     RAMIRQVEC
+        stx     RAMIRQVEC+1
+
+        ; Enable IRQs
+:       cli
+        rts
+
+; ------------------------------------------------------------------------
+
+.code
+
+doneirq:
+        ; Restore ROM IRQ vector
+        lda     _prev_rom_irq_vector
+        ldx     _prev_rom_irq_vector+1
+        sta     ROMIRQVEC
+        stx     ROMIRQVEC+1
+
+        ; Check for Apple IIgs
+        lda     $FE1F
+        cmp     #$60
+        bne     :+
+
+        ; Switch to RAM
+        bit     LCBANK2
+        bit     LCBANK2
+
+        ; Same for RAM
+        lda     _prev_ram_irq_vector
+        ldx     _prev_ram_irq_vector+1
+        sta     RAMIRQVEC
+        stx     RAMIRQVEC+1
+
+        ; And back to ROM, we're exiting
+        bit     ROMIN
+:       rts
+
+; ------------------------------------------------------------------------
+
+.segment        "LOWCODE"
+
+handle_ram_irq:
+        ; Check for BRK
+        sta     _a_backup
+        pla
+        pha
+        asl     a
+        asl     a
+        asl     a
+        bpl     :+
+        ; Give BRK to the standard handler
+        jmp     (_prev_ram_irq_vector)
+
+        ; It's an IRQ
+:       lda     _a_backup
+        pha                     ; Save A,X,Y
+        phx
+        phy
+        jsr     callirq
+        ply                     ; Restore Y,X,A
+        plx
+        pla
+        rti
+
+handle_rom_irq:                 ; ROM saves things for us
+        jsr     callirq
+        rti
+
+.else
+; Slower, ProDOS-based IRQ handler for unenhanced Apple2 that have
+; firmware quirks
 
         .segment        "ONCE"
 
@@ -89,3 +213,5 @@ intptr:
 i_param:.byte   $02             ; param_count
 int_num:.byte   $00             ; int_num
         .addr   intptr          ; int_code
+
+.endif


### PR DESCRIPTION
This makes IRQ handling very much faster on apple2enh.

**Tests:**
Tested with serial and mouse drivers:
- target `-t apple2` on emulated apple2e, apple2ee, apple2ep, apple2c0, apple2c4, apple2gs* and real apple2c0
- target `-t apple2enh` on emulated apple2ee, apple2ep, apple2c0, apple2c4, apple2gs* and real apple2c0

I couldn't test on apple2 and apple2p due to MAME having issues with the ROMs.
*(serial not tested on apple2gs as it's not the same chip)

**Numbers:**
Previous system had about:
- 248 cycles per ProDOS IRQ handler ($BFEB)
- 42 cycles per callirq call
- 62 cycles per ser_irq call

For a total of 352 cycles per ACIA interrupt (606 if triggered while in ROM, as $C803 has about 254 cycles before returning).

New system has:
- 37 cycles for handle_ram_irq
- no change in either callirq or ser_irq, as this isn't the scope of this patch

For a total of 141 cycles per ACIA interrupt (395 if triggered while in ROM).

**Callgrind profile before:**
![image](https://github.com/cc65/cc65/assets/1016317/0df7855c-7830-48fd-9705-560c3b00b2d4)

**Callgrind profile after:**
![image](https://github.com/cc65/cc65/assets/1016317/d380f3e9-8a37-4c9e-bc3e-1434335af260)

**Why:**
I'm on a quest to be able to use the serial port at 19200bps, and the existing IRQ handling is much too slow for this to succeed: another byte arrives before the IRQ for the previous one has returned. (This page shows how long it takes per byte to arrive: https://lucidar.me/en/serialib/most-used-baud-rates-table/)

**Results of this patch:**
With this patch, I am able to read/write in a sustained manner at 19200bps, **as long as RAM is banked in** when an IRQ arrives. If ROM is banked in, the added cost of the ROM IRQ handler, before execution is passed to the $03fe/$03ff vector, is still too much to sustain 19200 bps. But this means if one is cautious about how/when they receive bytes, double the speed can be achieved.

**Caveats:**
I am quite sure this patch is kind of naive, and there are probably corner cases that should be taken into account when entering the new IRQ handlers. I'd gladly improve the patch if it is necessary and it is deemed interesting to consider merging.

Thanks!