### PR TITLE
change INIT back to rw for configurations that needed it

### DIFF
--- a/cfg/apple2-hgr.cfg
+++ b/cfg/apple2-hgr.cfg
@@ -27,7 +27,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro   start    = $4000;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = bss;
+    INIT:     load = MAIN,           type = rw;  # uninitialized, but reserves output space
     ONCE:     load = MAIN,           type = ro,  define   = yes;
     LC:       load = MAIN, run = LC, type = ro,  optional = yes;
     BSS:      load = BSS,            type = bss, define   = yes;

--- a/cfg/apple2-overlay.cfg
+++ b/cfg/apple2-overlay.cfg
@@ -43,7 +43,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = bss;
+    INIT:     load = MAIN,           type = rw;  # uninitialized, but reserves output space
     ONCE:     load = MAIN,           type = ro,  define = yes;
     LC:       load = MAIN, run = LC, type = ro,                optional = yes;
     BSS:      load = BSS,            type = bss, define = yes;

--- a/cfg/apple2-system.cfg
+++ b/cfg/apple2-system.cfg
@@ -22,7 +22,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = bss;
+    INIT:     load = MAIN,           type = rw;  # uninitialized, but reserves output space
     ONCE:     load = MAIN,           type = ro,  define   = yes;
     LC:       load = MAIN, run = LC, type = ro,  optional = yes;
     BSS:      load = BSS,            type = bss, define   = yes;

--- a/cfg/apple2.cfg
+++ b/cfg/apple2.cfg
@@ -26,7 +26,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = bss;
+    INIT:     load = MAIN,           type = rw;  # uninitialized, but reserves output space
     ONCE:     load = MAIN,           type = ro,  define   = yes;
     LC:       load = MAIN, run = LC, type = ro,  optional = yes;
     BSS:      load = BSS,            type = bss, define   = yes;

--- a/cfg/apple2enh-hgr.cfg
+++ b/cfg/apple2enh-hgr.cfg
@@ -27,7 +27,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro   start    = $4000;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = bss;
+    INIT:     load = MAIN,           type = rw;  # uninitialized, but reserves output space
     ONCE:     load = MAIN,           type = ro,  define   = yes;
     LC:       load = MAIN, run = LC, type = ro,  optional = yes;
     BSS:      load = BSS,            type = bss, define   = yes;

--- a/cfg/apple2enh-overlay.cfg
+++ b/cfg/apple2enh-overlay.cfg
@@ -43,7 +43,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = bss;
+    INIT:     load = MAIN,           type = rw;  # uninitialized, but reserves output space
     ONCE:     load = MAIN,           type = ro,  define = yes;
     LC:       load = MAIN, run = LC, type = ro,                optional = yes;
     BSS:      load = BSS,            type = bss, define = yes;

--- a/cfg/apple2enh-system.cfg
+++ b/cfg/apple2enh-system.cfg
@@ -22,7 +22,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = bss;
+    INIT:     load = MAIN,           type = rw;  # uninitialized, but reserves output space
     ONCE:     load = MAIN,           type = ro,  define   = yes;
     LC:       load = MAIN, run = LC, type = ro,  optional = yes;
     BSS:      load = BSS,            type = bss, define   = yes;

--- a/cfg/apple2enh.cfg
+++ b/cfg/apple2enh.cfg
@@ -26,7 +26,7 @@ SEGMENTS {
     CODE:     load = MAIN,           type = ro;
     RODATA:   load = MAIN,           type = ro;
     DATA:     load = MAIN,           type = rw;
-    INIT:     load = MAIN,           type = bss;
+    INIT:     load = MAIN,           type = rw;  # uninitialized, but reserves output space
     ONCE:     load = MAIN,           type = ro,  define   = yes;
     LC:       load = MAIN, run = LC, type = ro,  optional = yes;
     BSS:      load = BSS,            type = bss, define   = yes;

--- a/cfg/atmos.cfg
+++ b/cfg/atmos.cfg
@@ -23,7 +23,7 @@ SEGMENTS {
     CODE:     load = MAIN,    type = ro;
     RODATA:   load = MAIN,    type = ro;
     DATA:     load = MAIN,    type = rw;
-    INIT:     load = MAIN,    type = bss;
+    INIT:     load = MAIN,    type = rw;  # uninitialized, but reserves output space
     ONCE:     load = MAIN,    type = ro,  define   = yes;
     BASTAIL:  load = MAIN,    type = ro,  optional = yes;
     BSS:      load = BSS,     type = bss, define   = yes;

--- a/cfg/c64-overlay.cfg
+++ b/cfg/c64-overlay.cfg
@@ -44,7 +44,7 @@ SEGMENTS {
     CODE:     load = MAIN,     type = ro;
     RODATA:   load = MAIN,     type = ro;
     DATA:     load = MAIN,     type = rw;
-    INIT:     load = MAIN,     type = bss;
+    INIT:     load = MAIN,     type = rw;  # uninitialized, but reserves output space
     ONCE:     load = MAIN,     type = ro,  define = yes;
     BSS:      load = BSS,      type = bss, define = yes;
     OVL1ADDR: load = OVL1ADDR, type = ro;

--- a/cfg/c64.cfg
+++ b/cfg/c64.cfg
@@ -23,7 +23,7 @@ SEGMENTS {
     CODE:     load = MAIN,     type = ro;
     RODATA:   load = MAIN,     type = ro;
     DATA:     load = MAIN,     type = rw;
-    INIT:     load = MAIN,     type = bss;
+    INIT:     load = MAIN,     type = rw;  # uninitialized, but reserves output space
     ONCE:     load = MAIN,     type = ro,  define   = yes;
     BSS:      load = BSS,      type = bss, define   = yes;
 }

--- a/cfg/cx16-bank.cfg
+++ b/cfg/cx16-bank.cfg
@@ -57,7 +57,7 @@ SEGMENTS {
     CODE:       load = MAIN,       type = ro;
     RODATA:     load = MAIN,       type = ro;
     DATA:       load = MAIN,       type = rw;
-    INIT:       load = MAIN,       type = bss,optional = yes;
+    INIT:       load = MAIN,       type = rw, optional = yes; # uninitialized, but reserves output space
     ONCE:       load = MAIN,       type = ro,                 define = yes;
     BSS:        load = BSS,        type = bss,                define = yes;
     BRAM01ADDR: load = BRAM01ADDR, type = ro, optional = yes;

--- a/cfg/cx16.cfg
+++ b/cfg/cx16.cfg
@@ -24,7 +24,7 @@ SEGMENTS {
     CODE:     load = MAIN,     type = ro;
     RODATA:   load = MAIN,     type = ro;
     DATA:     load = MAIN,     type = rw;
-    INIT:     load = MAIN,     type = bss,optional = yes;
+    INIT:     load = MAIN,     type = rw, optional = yes; # uninitialized, but reserves output space
     ONCE:     load = MAIN,     type = ro,                 define = yes;
     BSS:      load = BSS,      type = bss,                define = yes;
 }

--- a/cfg/telestrat.cfg
+++ b/cfg/telestrat.cfg
@@ -22,7 +22,7 @@ SEGMENTS {
     CODE:     load = MAIN,    type = ro;
     RODATA:   load = MAIN,    type = ro;
     DATA:     load = MAIN,    type = rw;
-    INIT:     load = MAIN,    type = bss;
+    INIT:     load = MAIN,    type = rw;  # uninitialized, but reserves output space
     ONCE:     load = MAIN,    type = ro,  define   = yes;
     BASTAIL:  load = MAIN,    type = ro,  optional = yes;
     BSS:      load = BSS,     type = bss, define   = yes;


### PR DESCRIPTION
This is a partial revert of #2163 based on the issue raised in #2179.

I had believed incorrectly that placing a `bss` segment into a memory region that outputs to file would either emit fill bytes, or give an error (or at least a warning). However, what it actually does is not emit those bytes, and not give any error or warning about it.

After reading the example given in the [ld65 documentation](https://cc65.github.io/doc/ld65.html#ss5.2), I realized that this behaviour was explicitly intended.

Because we apparently want to be able to assign `bss` segments to memory regions that output to a file, even though they won't be allowed to emit bytes to that file, it cannot give an error, or even a warning, because it is valid input. This was unexpected and unintuitive to me, but nevertheless it was my mistake for not catching this before submitting #2163. I am used to explicitly using `file=""` for memory regions like `RAM`, and hadn't thought it was possible or desirable to just implicitly keep it empty in this manner.

Only the cases where INIT appeared to be reserving space for a file were reverted, and I have added a comment to each to clarify this is the reason they are `rw` and not `bss`.