### PR TITLE
Apple2: fail opening serial port on IIgs

### DIFF
--- a/libsrc/apple2/ser/a2.ssc.s
+++ b/libsrc/apple2/ser/a2.ssc.s
@@ -132,16 +132,33 @@ ParityTable:
         .byte   $60             ; SER_PAR_EVEN
         .byte   $A0             ; SER_PAR_MARK
         .byte   $E0             ; SER_PAR_SPACE
+
+        ; (*): The first byte we'll check at offset 0 is
+        ; expected to be a BIT instruction on any Apple2
+        ; machine with an ACIA 6551, including the //c
+        ; and //c+.
+        ; The IIgs, on the other hand, has a
+        ; Zilog Z8530 chip and its firmware starts with
+        ; a SEP instruction. We don't want to load this
+        ; driver on the IIgs' serial port.
+        ;
+        ; The next four bytes we check are the Pascal
+        ; Firmware Protocol Bytes that identify a
+        ; serial card.
+
 IdOfsTable:
+        .byte   $00             ; First instruction
         .byte   $05             ; Pascal 1.0 ID byte
         .byte   $07             ; Pascal 1.0 ID byte
         .byte   $0B             ; Pascal 1.1 generic signature byte
         .byte   $0C             ; Device signature byte
 IdValTable:
-        .byte   $38             ; Fixed
-        .byte   $18             ; Fixed
-        .byte   $01             ; Fixed
-        .byte   $31             ; Serial or parallel I/O card type 1
+        .byte   $2C             ; BIT
+        .byte   $38             ; ID Byte 0 (from Pascal 1.0), fixed
+        .byte   $18             ; ID Byte 1 (from Pascal 1.0), fixed
+        .byte   $01             ; Generic signature for Pascal 1.1, fixed
+        .byte   $31             ; Device signature byte (serial or
+                                ; parallel I/O card type 1)
 
 IdTableLen      = * - IdValTable
 

--- a/libsrc/apple2/ser/a2.ssc.s
+++ b/libsrc/apple2/ser/a2.ssc.s
@@ -133,18 +133,26 @@ ParityTable:
         .byte   $A0             ; SER_PAR_MARK
         .byte   $E0             ; SER_PAR_SPACE
 
-        ; (*): The first byte we'll check at offset 0 is
-        ; expected to be a BIT instruction on any Apple2
-        ; machine with an ACIA 6551, including the //c
-        ; and //c+.
+        ; Check five bytes at known positions on the
+        ; slot's firmware to make sure this is an SSC
+        ; (or Apple //c comm port) firmware that drives
+        ; an ACIA 6551 chip.
+        ;
+        ; The SSC firmware and the Apple //c(+) comm
+        ; port firmware all begin with a BIT instruction.
         ; The IIgs, on the other hand, has a
         ; Zilog Z8530 chip and its firmware starts with
         ; a SEP instruction. We don't want to load this
-        ; driver on the IIgs' serial port.
+        ; driver on the IIgs' serial port. We'll
+        ; differentiate the firmware on this byte.
         ;
         ; The next four bytes we check are the Pascal
         ; Firmware Protocol Bytes that identify a
-        ; serial card.
+        ; serial card. Those are the same bytes for
+        ; SSC firmwares, Apple //c firmwares and IIgs
+        ; Zilog Z8530 firmwares - which is the reason
+        ; we have to check for the firmware's first
+        ; instruction too.
 
 IdOfsTable:
         .byte   $00             ; First instruction


### PR DESCRIPTION
The Pascal Firmware Protocol Bytes ID is not enough to differentiate an SSC card from a IIgs serial firmware:
http://www.1000bit.it/support/manuali/apple/technotes/misc/tn.misc.08.html

Loading a2(e).ssc.ser on a IIgs succeeds, then goes to limbo when one tries to use the serial port.

Check first byte on the slot's firmware, as it's not supposed to be $EF (65C816 sep instruction) on an SSC card, and it is on the IIgs' serial firmware (at least ROM revisions 0, 1, 3).