### PR TITLE
Serial kernel: Fix driver lifecycle

### DIFF
--- a/doc/funcref.sgml
+++ b/doc/funcref.sgml
@@ -6693,7 +6693,8 @@ be used in presence of a prototype.
 <tag/Function/Uninstall the currently loaded driver but do not unload it.
 <tag/Header/<tt/<ref id="serial.h" name="serial.h">/
 <tag/Declaration/<tt/unsigned char ser_uninstall (void);/
-<tag/Description/Uninstall the currently loaded driver but do not unload it.
+<tag/Description/Uninstall the currently loaded driver but do not unload it. This
+function returns SER_ERR_NO_DRIVER if no driver was installed, 0 otherwise.
 <tag/Availability/cc65
 <tag/See also/Other serial functions.
 <tag/Example/None.


### PR DESCRIPTION
- Make sure we don't install a driver on top of another one
- Make sure we don't uninstall a driver twice
- Make sure we uninstall a driver if needed at exit