### PR TITLE
[cc65] Forbidden struct itself with flexible array member as struct member or array element

### DIFF
--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -515,6 +515,13 @@ static void CheckArrayElementType (Type* DataType)
                 if (!IsTypeVoid (T) || IS_Get (&Standard) != STD_CC65) {
                     Error ("Array of 0-size element type '%s'", GetFullTypeName (T));
                 }
+            } else {
+                if (IsTypeStruct (T)) {
+                    SymEntry* TagEntry = GetESUTagSym (T);
+                    if (TagEntry && SymHasFlexibleArrayMember (TagEntry)) {
+                        Error ("Invalid use of struct with flexible array member");
+                    }
+                }
             }
         } else {
             ++T;
@@ -1193,6 +1200,9 @@ static SymEntry* ParseStructSpec (const char* Name, unsigned* DSFlags)
                     if (TagEntry && SymHasFlexibleArrayMember (TagEntry)) {
                         Field->Flags |= SC_HAVEFAM;
                         Flags        |= SC_HAVEFAM;
+                        if (IsTypeStruct (Decl.Type)) {
+                            Error ("Invalid use of struct with flexible array member");
+                        }
                     }
                 }
 

--- a/test/err/bug2016-fam-member.c
+++ b/test/err/bug2016-fam-member.c
@@ -1,0 +1,11 @@
+/* Bug #2016 - cc65 erroneously allows struct fields that are structs with flexible array members */
+
+typedef struct x {
+    int a;
+    int b[];    /* Ok: Flexible array member can be last */
+} x;
+
+struct y {
+    x   x;      /* Not ok: Contains flexible array member */
+    int a;
+};

--- a/test/err/bug2017-fam-element.c
+++ b/test/err/bug2017-fam-element.c
@@ -1,0 +1,9 @@
+/* Bug #2017 - cc65 erroneously allows arrays of structs with flexible array members */
+
+struct z {
+    int a;
+    int c;
+    int b[];
+};
+
+struct z y[3];          /* Should be an error */


### PR DESCRIPTION
Fixed #2016.
Fixed #2017.
A structure with a flexible array member shall not be a member of a structure or an element of an array according to the ISO C Standard.