### PR TITLE
Apple2: Always copy cmdline

### DIFF
--- a/libsrc/apple2/exec.s
+++ b/libsrc/apple2/exec.s
@@ -213,8 +213,6 @@ source: jsr     $BF00
         bcs     error
 
         ; Check for cmdline handling
-        lda     $0100           ; Valid cmdline?
-        beq     jump            ; No, jump to program right away
         ldx     file_type       ; SYS file?
         bne     system          ; Yes, check for startup filename
 


### PR DESCRIPTION
Otherwise, the last exec() cmdline lingers around for the next exec("file", NULL).

Example:
- program A does exec("B", "parameter1 parameter2")
- program B does exec("C", NULL)
- program C starts with argc == 3, argv[1] == "parameter1" and argv[2] == "parameter2"