### PR TITLE
Remove unused abc_score_ptr* zp entries for lynx lib

### DIFF
--- a/libsrc/lynx/extzp.inc
+++ b/libsrc/lynx/extzp.inc
@@ -12,10 +12,6 @@
         .global         __iodir: zp
         .global         __viddma: zp
         .global         __sprsys: zp
-        .global         _abc_score_ptr0: zp
-        .global         _abc_score_ptr1: zp
-        .global         _abc_score_ptr2: zp
-        .global         _abc_score_ptr3: zp
         .global         _FileEntry: zp
         .global         _FileStartBlock: zp
         .global         _FileBlockOffset: zp
@@ -25,6 +21,3 @@
         .global         _FileCurrBlock: zp
         .global         _FileBlockByte: zp
         .global         _FileDestPtr: zp
-
-
-

--- a/libsrc/lynx/extzp.s
+++ b/libsrc/lynx/extzp.s
@@ -17,13 +17,6 @@ __viddma:   .res    1
 __sprsys:   .res    1
 
 ; ------------------------------------------------------------------------
-; sound effect pointers for multitimbral Lynx music hardware
-_abc_score_ptr0: .res 2
-_abc_score_ptr1: .res 2
-_abc_score_ptr2: .res 2
-_abc_score_ptr3: .res 2
-
-; ------------------------------------------------------------------------
 ; Filesystem variables needed for reading stuff from the Lynx cart
 _FileEntry:                     ; The file directory entry is 8 bytes
 _FileStartBlock:    .res   1
@@ -35,4 +28,3 @@ _FileFileLen:       .res   2
 _FileCurrBlock:     .res   1
 _FileBlockByte:     .res   2
 _FileDestPtr:       .res   2
-


### PR DESCRIPTION
This wastes 8 bytes in the zp for no reason...