### PR TITLE
[cc65] Type category in a function definition cannot be inherited from a typedef

### DIFF
--- a/test/err/bug2020-definition.c
+++ b/test/err/bug2020-definition.c
@@ -1,0 +1,6 @@
+/* Bug #2020 - ISO/IEC 9899:1999 (E), 6.9.1 footnote 137:
+** "The intent is that the type category in a function definition cannot be inherited from a typedef"
+ */
+
+typedef void F(void);
+F c { }                 /* Should fail */

--- a/test/val/bug2020-ok.c
+++ b/test/val/bug2020-ok.c
@@ -1,0 +1,16 @@
+/* Bug #2020 - Right cases */
+
+typedef int F(void);          // type F is "function with no parameters returning int"
+
+F f, g;                       // f and g both have type compatible with F
+int f(void) { return 0; }     // RIGHT: f has type compatible with F
+int g() { return 0; }         // RIGHT: g has type compatible with F
+F *e(void) { return 0; }      // e returns a pointer to a function
+F *((h))(void) { return 0; }  // similar: parentheses irrelevant
+int (*fp)(void);              // fp points to a function that has type F
+F *Fp;                        // Fp points to a function that has type
+
+int main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
Fixed #2020.