### PR TITLE
Apple IIgs serial: Real-life fixes

### DIFF
--- a/libsrc/apple2/ser/a2.gs.s
+++ b/libsrc/apple2/ser/a2.gs.s
@@ -314,20 +314,19 @@ SER_CLOSE:
 
 SER_OPEN:
         bit     $C082                   ; Check if this is a IIgs
-        lda     $FE1F                   ; https://prodos8.com/docs/technote/misc/07/
-        cmp     #$60                    ; Everything but the IIgs has an RTS there
-        bne     HardwareFound
+        sec
+        jsr     $FE1F                   ; https://prodos8.com/docs/technote/misc/07/
+        bcc     IIgs
 
-        ; Device (hardware) not found
         bit     $C080
-        lda     #SER_ERR_NO_DEVICE
+        lda     #SER_ERR_NO_DEVICE      ; Not a IIgs
 SetupErrOut:
         cli
         ldx     #$00                    ; Promote char return value
         stx     Opened                  ; Mark port closed
         rts
 
-HardwareFound:
+IIgs:
         bit     $C080
         sei                             ; Disable interrupts
 

--- a/libsrc/apple2/ser/a2.gs.s
+++ b/libsrc/apple2/ser/a2.gs.s
@@ -305,7 +305,7 @@ SER_CLOSE:
         stx     Opened                  ; Mark port as closed
 
         cli
-:       txa
+:       txa                             ; Promote char return value
         rts
 
 ;----------------------------------------------------------------------------
@@ -313,13 +313,17 @@ SER_CLOSE:
 ; Must return an SER_ERR_xx code in a/x.
 
 SER_OPEN:
-        bit     $C082                   ; Check if this is a IIgs
+        ; Check if this is a IIgs (Apple II Miscellaneous TechNote #7,
+        ; Apple II Family Identification)
         sec
-        jsr     $FE1F                   ; https://prodos8.com/docs/technote/misc/07/
+        bit     $C082
+        jsr     $FE1F
+        bit     $C080
+
         bcc     IIgs
 
-        bit     $C080
         lda     #SER_ERR_NO_DEVICE      ; Not a IIgs
+
 SetupErrOut:
         cli
         ldx     #$00                    ; Promote char return value
@@ -327,8 +331,7 @@ SetupErrOut:
         rts
 
 IIgs:
-        bit     $C080
-        sei                             ; Disable interrupts
+        sei
 
         ; Check if the handshake setting is valid
         ldy     #SER_PARAMS::HANDSHAKE  ; Handshake

--- a/libsrc/apple2/ser/a2.gs.s
+++ b/libsrc/apple2/ser/a2.gs.s
@@ -477,14 +477,13 @@ IntA:
 StoreFlag:
         sta     SER_FLAG
 
-        cli
-
         ldy     #$01                    ; Mark port opened
         lda     #SER_ERR_OK
 
 SetupOut:
         ldx     #$00                    ; Promote char return value
         sty     Opened
+        cli
         rts
 
 ;----------------------------------------------------------------------------

--- a/libsrc/apple2/ser/a2.gs.s
+++ b/libsrc/apple2/ser/a2.gs.s
@@ -602,9 +602,9 @@ SER_IOCTL:
 ; was handled, otherwise with carry clear.
 
 SER_IRQ:
-        ldx     #$01                    ; IRQ status is always in A reg
-        ldy     #RR_INTR_PENDING_STATUS
-        jsr     readSSCReg
+        ldy     #RR_INTR_PENDING_STATUS ; IRQ status is always in A reg
+        sty     SCCAREG
+        lda     SCCAREG
 
         and     CurChanIrqFlags         ; Is this ours?
         beq     Done
@@ -626,9 +626,9 @@ SER_IRQ:
 
 CheckSpecial:
         ; Always check IRQ special flags from Channel B (Ref page 5-24)
-        ; X is still 0 there.
         ldy     #RR_IRQ_STATUS
-        jsr     readSSCReg
+        sty     SCCBREG
+        lda     SCCBREG
 
         and     #IRQ_MASQ
         cmp     #IRQ_SPECIAL
@@ -636,7 +636,6 @@ CheckSpecial:
 
         ; Clear exint
         ldx     Channel
-
         ldy     #WR_INIT_CTRL
         lda     #INIT_CTRL_CLEAR_EIRQ
         jsr     writeSCCReg
@@ -645,7 +644,6 @@ CheckSpecial:
         rts
 
 Flow:   ldx     Channel                 ; Assert flow control if buffer space too low
-
         ldy     #WR_TX_CTRL
         lda     RtsOff
         jsr     writeSCCReg


### PR DESCRIPTION
After having some real hardware tests and continuing on working on this driver, I introduced a regression when I added both channels handling.

Apparently, the real hardware is more finicky than the emulator about addressing mode and/or timing when writing index/value to the control register. So the macros are gone and replaced with functions.

So here's the (fixed) driver, tested on real hardware :) https://www.youtube.com/watch?v=NIU4-WJLx-Y

Also fixed a missing sei at line354, a missing channel load at 679, and a logic bug while waiting to send at 722.