### PR TITLE
Reverted EOL settings (LF vs CRLF) for Visual Studio

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,6 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = crlf
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true


### PR DESCRIPTION
WIth the line `end_of_line = crlf` Visual Studio inserts every new line ending as CRLF in all source files despite they all have LF already in them, resulting in mixed line endings saved in source files edited with VS. 

This PR fixes the problem by letting Visual Studio decide which EOL to use by itself.