### PR TITLE
[cc65] Renamed type facility functions for deciding code generation type flags

### DIFF
--- a/src/cc65/assignment.c
+++ b/src/cc65/assignment.c
@@ -90,7 +90,7 @@ static void CopyStruct (ExprDesc* LExpr, ExprDesc* RExpr)
         /* Check if the value of the rhs is not in the primary yet */
         if (!ED_IsLocPrimary (RExpr)) {
             /* Just load the value into the primary as the replacement type. */
-            LoadExpr (TypeOf (stype) | CF_FORCECHAR, RExpr);
+            LoadExpr (CG_TypeOf (stype) | CF_FORCECHAR, RExpr);
         }
 
         /* Store it into the location referred in the primary */
@@ -145,8 +145,8 @@ void DoIncDecBitField (ExprDesc* Expr, long Val, unsigned KeepResult)
     ChunkType = GetBitFieldChunkType (Expr->Type);
 
     /* Determine code generator flags */
-    Flags      = TypeOf (Expr->Type) | CF_FORCECHAR;
-    ChunkFlags = TypeOf (ChunkType);
+    Flags      = CG_TypeOf (Expr->Type) | CF_FORCECHAR;
+    ChunkFlags = CG_TypeOf (ChunkType);
     if ((ChunkFlags & CF_TYPEMASK) == CF_CHAR) {
         ChunkFlags |= CF_FORCECHAR;
     }
@@ -232,8 +232,8 @@ static void OpAssignBitField (const GenDesc* Gen, ExprDesc* Expr, const char* Op
     ChunkType = GetBitFieldChunkType (Expr->Type);
 
     /* Determine code generator flags */
-    Flags      = TypeOf (Expr->Type) | CF_FORCECHAR;
-    ChunkFlags = TypeOf (ChunkType);
+    Flags      = CG_TypeOf (Expr->Type) | CF_FORCECHAR;
+    ChunkFlags = CG_TypeOf (ChunkType);
     if ((ChunkFlags & CF_TYPEMASK) == CF_CHAR) {
         ChunkFlags |= CF_FORCECHAR;
     }
@@ -358,7 +358,7 @@ static void OpAssignBitField (const GenDesc* Gen, ExprDesc* Expr, const char* Op
                     unsigned AdjustedFlags = Flags;
                     if (Expr->Type->A.B.Width < INT_BITS || IsSignSigned (Expr->Type)) {
                         AdjustedFlags = (Flags & ~CF_UNSIGNED) | CF_CONST;
-                        AdjustedFlags = g_typeadjust (AdjustedFlags, TypeOf (Expr2.Type) | CF_CONST);
+                        AdjustedFlags = g_typeadjust (AdjustedFlags, CG_TypeOf (Expr2.Type) | CF_CONST);
                     }
                     Gen->Func (g_typeadjust (Flags, AdjustedFlags) | CF_CONST, Expr2.IVal);
                 } else {
@@ -381,11 +381,11 @@ static void OpAssignBitField (const GenDesc* Gen, ExprDesc* Expr, const char* Op
                 unsigned AdjustedFlags = Flags;
                 if (Expr->Type->A.B.Width < INT_BITS || IsSignSigned (Expr->Type)) {
                     AdjustedFlags = (Flags & ~CF_UNSIGNED) | CF_CONST;
-                    AdjustedFlags = g_typeadjust (AdjustedFlags, TypeOf (Expr2.Type) | CF_CONST);
+                    AdjustedFlags = g_typeadjust (AdjustedFlags, CG_TypeOf (Expr2.Type) | CF_CONST);
                 }
                 Gen->Func (g_typeadjust (Flags, AdjustedFlags), 0);
             } else {
-                Gen->Func (g_typeadjust (Flags, TypeOf (Expr2.Type)), 0);
+                Gen->Func (g_typeadjust (Flags, CG_TypeOf (Expr2.Type)), 0);
             }
 
         } else {
@@ -452,7 +452,7 @@ static void OpAssignArithmetic (const GenDesc* Gen, ExprDesc* Expr, const char* 
     Expr2.Flags |= Expr->Flags & E_MASK_KEEP_SUBEXPR;
 
     /* Determine code generator flags */
-    Flags = TypeOf (Expr->Type);
+    Flags = CG_TypeOf (Expr->Type);
 
     /* Determine the type of the lhs */
     MustScale = Gen != 0 && (Gen->Func == g_add || Gen->Func == g_sub) &&
@@ -572,7 +572,7 @@ static void OpAssignArithmetic (const GenDesc* Gen, ExprDesc* Expr, const char* 
 
             if (MustScale) {
                 /* lhs is a pointer, scale rhs */
-                g_scale (TypeOf (Expr2.Type), CheckedSizeOf (Expr->Type+1));
+                g_scale (CG_TypeOf (Expr2.Type), CheckedSizeOf (Expr->Type+1));
             }
 
             /* If the lhs is character sized, the operation may be later done
@@ -583,7 +583,7 @@ static void OpAssignArithmetic (const GenDesc* Gen, ExprDesc* Expr, const char* 
             }
 
             /* Adjust the types of the operands if needed */
-            Gen->Func (g_typeadjust (Flags, TypeOf (Expr2.Type)), 0);
+            Gen->Func (g_typeadjust (Flags, CG_TypeOf (Expr2.Type)), 0);
 
         }
     }
@@ -715,8 +715,8 @@ void OpAddSubAssign (const GenDesc* Gen, ExprDesc *Expr, const char* Op)
     }
 
     /* Setup the code generator flags */
-    lflags |= TypeOf (Expr->Type) | GlobalModeFlags (Expr) | CF_FORCECHAR;
-    rflags |= TypeOf (Expr2.Type) | CF_FORCECHAR;
+    lflags |= CG_TypeOf (Expr->Type) | CG_AddrModeFlags (Expr) | CF_FORCECHAR;
+    rflags |= CG_TypeOf (Expr2.Type) | CF_FORCECHAR;
 
     if (ED_IsConstAbs (&Expr2)) {
         /* The resulting value is a constant */
@@ -736,7 +736,7 @@ void OpAddSubAssign (const GenDesc* Gen, ExprDesc *Expr, const char* Op)
 
         if (MustScale) {
             /* lhs is a pointer, scale rhs */
-            g_scale (TypeOf (Expr2.Type), CheckedSizeOf (Indirect (Expr->Type)));
+            g_scale (CG_TypeOf (Expr2.Type), CheckedSizeOf (Indirect (Expr->Type)));
         }
     }
 

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -80,7 +80,7 @@ static void PostDec (ExprDesc* Expr);
 
 
 
-unsigned GlobalModeFlags (const ExprDesc* Expr)
+unsigned CG_AddrModeFlags (const ExprDesc* Expr)
 /* Return the addressing mode flags for the given expression */
 {
     switch (ED_GetLoc (Expr)) {
@@ -95,7 +95,7 @@ unsigned GlobalModeFlags (const ExprDesc* Expr)
         case E_LOC_LITERAL:     return CF_LITERAL;
         case E_LOC_CODE:        return CF_CODE;
         default:
-            Internal ("GlobalModeFlags: Invalid location flags value: 0x%04X", Expr->Flags);
+            Internal ("CG_AddrModeFlags: Invalid location flags value: 0x%04X", Expr->Flags);
             /* NOTREACHED */
             return 0;
     }
@@ -103,7 +103,7 @@ unsigned GlobalModeFlags (const ExprDesc* Expr)
 
 
 
-static unsigned TypeOfBySize (unsigned Size)
+static unsigned CG_TypeOfBySize (unsigned Size)
 /* Get the code generator replacement type of the object by its size */
 {
     unsigned NewType;
@@ -123,7 +123,7 @@ static unsigned TypeOfBySize (unsigned Size)
 
 
 
-unsigned TypeOf (const Type* T)
+unsigned CG_TypeOf (const Type* T)
 /* Get the code generator base type of the object */
 {
     unsigned NewType;
@@ -163,7 +163,7 @@ unsigned TypeOf (const Type* T)
 
         case T_STRUCT:
         case T_UNION:
-            NewType = TypeOfBySize (SizeOf (T));
+            NewType = CG_TypeOfBySize (SizeOf (T));
             if (NewType != CF_NONE) {
                 return NewType;
             }
@@ -184,8 +184,8 @@ unsigned TypeOf (const Type* T)
 
 
 
-unsigned FuncTypeOf (const Type* T)
-/* Get the code generator flag for calling the function */
+unsigned CG_CallFlags (const Type* T)
+/* Get the code generator flags for calling the function */
 {
     if (GetUnderlyingTypeCode (T) == T_FUNC) {
         return (T->A.F->Flags & FD_VARIADIC) ? 0 : CF_FIXARGC;
@@ -254,7 +254,7 @@ static unsigned typeadjust (ExprDesc* lhs, const ExprDesc* rhs, int NoPush)
     const Type* rhst = rhs->Type;
 
     /* Generate type adjustment code if needed */
-    ltype = TypeOf (lhst);
+    ltype = CG_TypeOf (lhst);
     if (ED_IsConstAbsInt (lhs) && ltype == CF_INT && lhs->IVal >= 0 && lhs->IVal < 256) {
         /* If the lhs is a int constant that fits in an unsigned char, use unsigned char.
         ** g_typeadjust will either promote this to int or unsigned int as appropriate
@@ -269,7 +269,7 @@ static unsigned typeadjust (ExprDesc* lhs, const ExprDesc* rhs, int NoPush)
         /* Value is in primary register*/
         ltype |= CF_PRIMARY;
     }
-    rtype = TypeOf (rhst);
+    rtype = CG_TypeOf (rhst);
     if (ED_IsConstAbsInt (rhs) && rtype == CF_INT && rhs->IVal >= 0 && rhs->IVal < 256) {
         rtype = CF_CHAR | CF_UNSIGNED;
     }
@@ -493,7 +493,7 @@ static void DoInc (ExprDesc* Expr, unsigned KeepResult)
     }
 
     /* Get the flags */
-    Flags = TypeOf (Expr->Type) | GlobalModeFlags (Expr) | CF_FORCECHAR | CF_CONST;
+    Flags = CG_TypeOf (Expr->Type) | CG_AddrModeFlags (Expr) | CF_FORCECHAR | CF_CONST;
     if (KeepResult != OA_NEED_NEW) {
         /* No need to get the result */
         Flags |= CF_NOKEEP;
@@ -580,7 +580,7 @@ static void DoDec (ExprDesc* Expr, unsigned KeepResult)
     }
 
     /* Get the flags */
-    Flags = TypeOf (Expr->Type) | GlobalModeFlags (Expr) | CF_FORCECHAR | CF_CONST;
+    Flags = CG_TypeOf (Expr->Type) | CG_AddrModeFlags (Expr) | CF_FORCECHAR | CF_CONST;
     if (KeepResult != OA_NEED_NEW) {
         /* No need to get the result */
         Flags |= CF_NOKEEP;
@@ -873,7 +873,7 @@ static unsigned FunctionArgList (FuncDesc* Func, int IsFastcall, ExprDesc* ED)
             /* Handle struct/union specially */
             if (IsClassStruct (Expr.Type)) {
                 /* Use the replacement type */
-                Flags |= TypeOf (GetStructReplacementType (Expr.Type));
+                Flags |= CG_TypeOf (GetStructReplacementType (Expr.Type));
 
                 /* Load the value into the primary if it is not already there */
                 LoadExpr (Flags, &Expr);
@@ -882,7 +882,7 @@ static unsigned FunctionArgList (FuncDesc* Func, int IsFastcall, ExprDesc* ED)
                 LoadExpr (CF_NONE, &Expr);
 
                 /* Use the type of the argument for the push */
-                Flags |= TypeOf (Expr.Type);
+                Flags |= CG_TypeOf (Expr.Type);
             }
 
             /* If this is a fastcall function, don't push the last argument */
@@ -1069,7 +1069,7 @@ static void FunctionCall (ExprDesc* Expr)
             }
 
             /* Call the function */
-            g_callind (FuncTypeOf (Expr->Type+1), ArgSize, PtrOffs);
+            g_callind (CG_CallFlags (Expr->Type+1), ArgSize, PtrOffs);
 
         } else {
 
@@ -1137,9 +1137,9 @@ static void FunctionCall (ExprDesc* Expr)
 
             SB_Done (&S);
 
-            g_call (FuncTypeOf (Expr->Type), Func->WrappedCall->Name, ArgSize);
+            g_call (CG_CallFlags (Expr->Type), Func->WrappedCall->Name, ArgSize);
         } else {
-            g_call (FuncTypeOf (Expr->Type), (const char*) Expr->Name, ArgSize);
+            g_call (CG_CallFlags (Expr->Type), (const char*) Expr->Name, ArgSize);
         }
 
     }
@@ -1665,7 +1665,7 @@ void Store (ExprDesc* Expr, const Type* StoreType)
     }
 
     /* Prepare the code generator flags */
-    Flags = TypeOf (StoreType) | GlobalModeFlags (Expr);
+    Flags = CG_TypeOf (StoreType) | CG_AddrModeFlags (Expr);
 
     /* Do the store depending on the location */
     switch (ED_GetLoc (Expr)) {
@@ -1793,7 +1793,7 @@ static void PostInc (ExprDesc* Expr)
     }
 
     /* Get the data type */
-    Flags = TypeOf (Expr->Type);
+    Flags = CG_TypeOf (Expr->Type);
 
     /* We are allowed by the C standard to defer the inc operation until after
     ** the expression is used, so that we don't need to save and reload
@@ -1854,7 +1854,7 @@ static void PostDec (ExprDesc* Expr)
     }
 
     /* Get the data type */
-    Flags = TypeOf (Expr->Type);
+    Flags = CG_TypeOf (Expr->Type);
 
     /* Emit smaller code if a char variable is at a constant location */
     if ((Flags & CF_TYPEMASK) == CF_CHAR && ED_IsLocConst (Expr) && !IsTypeBitField (Expr->Type)) {
@@ -1934,7 +1934,7 @@ static void UnaryOp (ExprDesc* Expr)
         TypeConversion (Expr, Expr->Type);
 
         /* Get code generation flags */
-        Flags = TypeOf (Expr->Type);
+        Flags = CG_TypeOf (Expr->Type);
 
         /* Handle the operation */
         switch (Tok) {
@@ -1984,7 +1984,7 @@ void hie10 (ExprDesc* Expr)
             } else {
                 /* Not constant, load into the primary */
                 LoadExpr (CF_NONE, Expr);
-                g_bneg (TypeOf (Expr->Type));
+                g_bneg (CG_TypeOf (Expr->Type));
                 ED_FinalizeRValLoad (Expr);
                 ED_TestDone (Expr);             /* bneg will set cc */
             }
@@ -2141,7 +2141,7 @@ static void hie_internal (const GenDesc* Ops,   /* List of generators */
 
         /* Get the lhs on stack */
         GetCodePos (&Mark1);
-        ltype = TypeOf (Expr->Type);
+        ltype = CG_TypeOf (Expr->Type);
         lconst = ED_IsConstAbs (Expr);
         if (lconst) {
             /* Constant value */
@@ -2255,7 +2255,7 @@ static void hie_internal (const GenDesc* Ops,   /* List of generators */
             ** operation because this allows for better code.
             */
             unsigned rtype = ltype | CF_CONST;
-            ltype = TypeOf (Expr2.Type);       /* Expr2 is now left */
+            ltype = CG_TypeOf (Expr2.Type); /* Expr2 is now left */
             type = CF_CONST;
             if ((Gen->Flags & GEN_NOPUSH) == 0) {
                 g_push (ltype, 0);
@@ -2279,7 +2279,7 @@ static void hie_internal (const GenDesc* Ops,   /* List of generators */
             ** expects the lhs in the primary, remove the push of the primary
             ** now.
             */
-            unsigned rtype = TypeOf (Expr2.Type);
+            unsigned rtype = CG_TypeOf (Expr2.Type);
             type = 0;
             if (rconst) {
                 /* As above, but for the RHS. */
@@ -2355,7 +2355,7 @@ static void hie_compare (const GenDesc* Ops,    /* List of generators */
 
         /* Get the lhs on stack */
         GetCodePos (&Mark1);
-        ltype = TypeOf (Expr->Type);
+        ltype = CG_TypeOf (Expr->Type);
         if (ED_IsConstAbs (Expr)) {
             /* Numeric constant value */
             GetCodePos (&Mark2);
@@ -2667,7 +2667,7 @@ static void hie_compare (const GenDesc* Ops,    /* List of generators */
                 }
 
             } else {
-                unsigned rtype = TypeOf (Expr2.Type) | (flags & CF_CONST);
+                unsigned rtype = CG_TypeOf (Expr2.Type) | (flags & CF_CONST);
                 flags |= g_typeadjust (ltype, rtype);
             }
 
@@ -2887,7 +2887,7 @@ static void parseadd (ExprDesc* Expr, int DoArrayRef)
                         g_addaddr_local (flags, Expr->IVal);
                     } else {
                         /* Static address */
-                        g_addaddr_static (flags | GlobalModeFlags (Expr), Expr->Name, Expr->IVal);
+                        g_addaddr_static (flags | CG_AddrModeFlags (Expr), Expr->Name, Expr->IVal);
                     }
                 } else {
                     /* Lhs is not numeric. Load it. */
@@ -2905,7 +2905,7 @@ static void parseadd (ExprDesc* Expr, int DoArrayRef)
                         g_addaddr_local (flags, Expr2.IVal);
                     } else {
                         /* Static address */
-                        g_addaddr_static (flags | GlobalModeFlags (&Expr2), Expr2.Name, Expr2.IVal);
+                        g_addaddr_static (flags | CG_AddrModeFlags (&Expr2), Expr2.Name, Expr2.IVal);
                     }
                 }
 
@@ -2932,7 +2932,7 @@ static void parseadd (ExprDesc* Expr, int DoArrayRef)
                 flags |= CF_CONST;
             } else {
                 /* Constant address label */
-                flags |= GlobalModeFlags (Expr);
+                flags |= CG_AddrModeFlags (Expr);
             }
 
             /* Check for pointer arithmetic */
@@ -2976,7 +2976,7 @@ static void parseadd (ExprDesc* Expr, int DoArrayRef)
                     /* Load lhs */
                     LoadExpr (CF_NONE, Expr);
                     /* Use new flags */
-                    flags = CF_CHAR | GlobalModeFlags (&Expr2);
+                    flags = CF_CHAR | CG_AddrModeFlags (&Expr2);
                     /* Add the variable */
                     if (ED_IsLocStack (&Expr2)) {
                         g_addlocal (flags, Expr2.IVal);
@@ -2998,7 +2998,7 @@ static void parseadd (ExprDesc* Expr, int DoArrayRef)
                     ** not a numeric constant, and the scale factor is not one
                     ** (no scaling), we must take the long way over the stack.
                     */
-                    g_push (TypeOf (Expr2.Type), 0);    /* rhs --> stack */
+                    g_push (CG_TypeOf (Expr2.Type), 0); /* rhs --> stack */
                     LoadExpr (CF_NONE, Expr);
                     g_scale (CF_PTR, lscale);
                     g_add (CF_PTR, 0);
@@ -3014,7 +3014,7 @@ static void parseadd (ExprDesc* Expr, int DoArrayRef)
         /* Left hand side is not constant. Get the value onto the stack. */
         LoadExpr (CF_NONE, Expr);               /* --> primary register */
         GetCodePos (&Mark);
-        flags = TypeOf (Expr->Type);            /* default codegen type */
+        flags = CG_TypeOf (Expr->Type);         /* default codegen type */
         g_push (flags, 0);                      /* --> stack */
 
         /* Evaluate the rhs */
@@ -3078,7 +3078,7 @@ static void parseadd (ExprDesc* Expr, int DoArrayRef)
                     g_push (CF_PTR, 0);             /* --> stack */
                     LoadExpr (CF_NONE, &Expr2);     /* Load rhs into primary register */
                 } else {
-                    g_tosint (TypeOf (lhst));       /* Make sure TOS is int */
+                    g_tosint (CG_TypeOf (lhst));    /* Make sure TOS is int */
                     LoadExpr (CF_NONE, &Expr2);     /* Load rhs into primary register */
                     if (lscale != 1) {
                         g_swap (CF_INT);            /* Swap TOS and primary */
@@ -3198,9 +3198,9 @@ static void parsesub (ExprDesc* Expr)
 
     /* Remember the output queue position, then bring the value onto the stack */
     GetCodePos (&Mark1);
-    LoadExpr (CF_NONE, Expr);   /* --> primary register */
+    LoadExpr (CF_NONE, Expr);       /* --> primary register */
     GetCodePos (&Mark2);
-    g_push (TypeOf (lhst), 0);  /* --> stack */
+    g_push (CG_TypeOf (lhst), 0);   /* --> stack */
 
     /* Parse the right hand side */
     MarkedExprWithCheck (hie9, &Expr2);
@@ -3357,7 +3357,7 @@ static void parsesub (ExprDesc* Expr)
                     }
                     /* Load rhs into the primary */
                     LoadExpr (CF_NONE, &Expr2);
-                    g_scale (TypeOf (rhst), rscale);
+                    g_scale (CG_TypeOf (rhst), rscale);
                     /* Generate code for the sub (the & is a hack here) */
                     g_sub (flags & ~CF_CONST, 0);
                 }
@@ -3394,7 +3394,7 @@ static void parsesub (ExprDesc* Expr)
                 }
                 /* Load rhs into the primary */
                 LoadExpr (CF_NONE, &Expr2);
-                g_scale (TypeOf (rhst), rscale);
+                g_scale (CG_TypeOf (rhst), rscale);
                 /* Generate code for the sub (the & is a hack here) */
                 g_sub (flags & ~CF_CONST, 0);
             }

--- a/src/cc65/expr.h
+++ b/src/cc65/expr.h
@@ -48,14 +48,14 @@ typedef struct GenDesc {
 
 
 
-unsigned GlobalModeFlags (const ExprDesc* Expr);
+unsigned CG_AddrModeFlags (const ExprDesc* Expr);
 /* Return the addressing mode flags for the given expression */
 
-unsigned TypeOf (const Type* T);
+unsigned CG_TypeOf (const Type* T);
 /* Get the code generator base type of the object */
 
-unsigned FuncTypeOf (const Type* T);
-/* Get the code generator flag for calling the function */
+unsigned CG_CallFlags (const Type* T);
+/* Get the code generator flags for calling the function */
 
 void ExprWithCheck (void (*Func) (ExprDesc*), ExprDesc* Expr);
 /* Call an expression function with checks. */

--- a/src/cc65/function.c
+++ b/src/cc65/function.c
@@ -565,15 +565,15 @@ void NewFunc (SymEntry* Func, FuncDesc* D)
         /* Generate the push */
         /* Handle struct/union specially */
         if (IsClassStruct (D->LastParam->Type)) {
-            Flags = TypeOf (GetStructReplacementType (D->LastParam->Type)) | CF_FORCECHAR;
+            Flags = CG_TypeOf (GetStructReplacementType (D->LastParam->Type)) | CF_FORCECHAR;
         } else {
-            Flags = TypeOf (D->LastParam->Type) | CF_FORCECHAR;
+            Flags = CG_TypeOf (D->LastParam->Type) | CF_FORCECHAR;
         }
         g_push (Flags, 0);
     }
 
     /* Generate function entry code if needed */
-    g_enter (FuncTypeOf (Func->Type), F_GetParamSize (CurrentFunc));
+    g_enter (CG_CallFlags (Func->Type), F_GetParamSize (CurrentFunc));
 
     /* If stack checking code is requested, emit a call to the helper routine */
     if (IS_Get (&CheckStack)) {

--- a/src/cc65/initdata.c
+++ b/src/cc65/initdata.c
@@ -168,12 +168,12 @@ static void DefineData (ExprDesc* Expr)
 
         case E_LOC_NONE:
             /* Immediate numeric value with no storage */
-            g_defdata (CF_IMM | TypeOf (Expr->Type) | CF_CONST, Expr->IVal, 0);
+            g_defdata (CF_IMM | CG_TypeOf (Expr->Type) | CF_CONST, Expr->IVal, 0);
             break;
 
         case E_LOC_ABS:
             /* Absolute numeric address */
-            g_defdata (CF_ABSOLUTE | TypeOf (Expr->Type) | CF_CONST, Expr->IVal, 0);
+            g_defdata (CF_ABSOLUTE | CG_TypeOf (Expr->Type) | CF_CONST, Expr->IVal, 0);
             break;
 
         case E_LOC_GLOBAL:

--- a/src/cc65/loadexpr.c
+++ b/src/cc65/loadexpr.c
@@ -133,10 +133,10 @@ void LoadExpr (unsigned Flags, struct ExprDesc* Expr)
                 AdjustBitField = 1;
 
                 /* Flags we need operate on the whole bit-field, without CF_FORCECHAR.  */
-                BitFieldFullWidthFlags = Flags | TypeOf (Expr->Type);
+                BitFieldFullWidthFlags = Flags | CG_TypeOf (Expr->Type);
 
                 /* Flags we need operate on the whole chunk containing the bit-field.  */
-                Flags |= TypeOf (GetBitFieldChunkType (Expr->Type));
+                Flags |= CG_TypeOf (GetBitFieldChunkType (Expr->Type));
 
                 /* If we're adjusting, then only load a char (not an int) and do only char ops;
                 ** We will clear the high byte in the adjustment.  CF_FORCECHAR does nothing if
@@ -151,7 +151,7 @@ void LoadExpr (unsigned Flags, struct ExprDesc* Expr)
                 if (IsIncompleteESUType (Expr->Type)) {
                     return;
                 }
-                Flags |= TypeOf (Expr->Type);
+                Flags |= CG_TypeOf (Expr->Type);
             }
         }
 
@@ -175,7 +175,7 @@ void LoadExpr (unsigned Flags, struct ExprDesc* Expr)
 
             case E_LOC_NONE:
                 /* Immediate number constant */
-                g_getimmed (Flags | CF_IMM | TypeOf (Expr->Type) | CF_CONST, Expr->IVal, 0);
+                g_getimmed (Flags | CF_IMM | CG_TypeOf (Expr->Type) | CF_CONST, Expr->IVal, 0);
                 break;
 
             case E_LOC_ABS:

--- a/src/cc65/locals.c
+++ b/src/cc65/locals.c
@@ -164,7 +164,7 @@ static void ParseRegisterDecl (Declarator* Decl, int Reg)
             LoadExpr (CF_NONE, &Expr);
 
             /* Store the value into the variable */
-            g_putstatic (CF_REGVAR | TypeOf (Sym->Type), Reg, 0);
+            g_putstatic (CF_REGVAR | CG_TypeOf (Sym->Type), Reg, 0);
 
             /* This has to be done at sequence point */
             DoDeferred (SQP_KEEP_NONE, &Expr);
@@ -274,7 +274,7 @@ static void ParseAutoDecl (Declarator* Decl)
                 }
 
                 /* Push the value */
-                g_push (Flags | TypeOf (Sym->Type), Expr.IVal);
+                g_push (Flags | CG_TypeOf (Sym->Type), Expr.IVal);
 
                 /* This has to be done at sequence point */
                 DoDeferred (SQP_KEEP_NONE, &Expr);
@@ -353,7 +353,7 @@ static void ParseAutoDecl (Declarator* Decl)
                 LoadExpr (CF_NONE, &Expr);
 
                 /* Store the value into the variable */
-                g_putstatic (CF_STATIC | TypeOf (Sym->Type), DataLabel, 0);
+                g_putstatic (CF_STATIC | CG_TypeOf (Sym->Type), DataLabel, 0);
 
                 /* This has to be done at sequence point */
                 DoDeferred (SQP_KEEP_NONE, &Expr);

--- a/src/cc65/shiftexpr.c
+++ b/src/cc65/shiftexpr.c
@@ -95,14 +95,14 @@ void ShiftExpr (struct ExprDesc* Expr)
         ResultType = IntPromotion (Expr->Type);
 
         /* Prepare the code generator flags */
-        GenFlags = TypeOf (ResultType);
+        GenFlags = CG_TypeOf (ResultType);
 
         /* Calculate the number of bits the lhs operand has */
         ExprBits = SizeOf (ResultType) * 8;
 
         /* Get the lhs on stack */
         GetCodePos (&Mark1);
-        ltype = TypeOf (Expr->Type);
+        ltype = CG_TypeOf (Expr->Type);
         lconst = ED_IsConstAbs (Expr);
         if (lconst) {
             /* Constant value */

--- a/src/cc65/stdfunc.c
+++ b/src/cc65/stdfunc.c
@@ -184,7 +184,7 @@ static void ParseArg (ArgDesc* Arg, const Type* Type, ExprDesc* Expr)
     GetCodePos (&Arg->End);
 
     /* Use the type of the argument for the push */
-    Arg->Flags |= TypeOf (Arg->Expr.Type);
+    Arg->Flags |= CG_TypeOf (Arg->Expr.Type);
 
     /* Propagate from subexpressions */
     Expr->Flags |= Arg->Expr.Flags & E_MASK_VIRAL;

--- a/src/cc65/stmt.c
+++ b/src/cc65/stmt.c
@@ -345,7 +345,7 @@ static void ReturnStatement (void)
                     if (ReturnType == Expr.Type) {
                         Error ("Returning '%s' of this size by value is not supported", GetFullTypeName (Expr.Type));
                     }
-                    LoadExpr (TypeOf (ReturnType), &Expr);
+                    LoadExpr (CG_TypeOf (ReturnType), &Expr);
 
                 } else {
                     /* Load the value into the primary */

--- a/src/cc65/typeconv.c
+++ b/src/cc65/typeconv.c
@@ -111,7 +111,7 @@ static void DoConversion (ExprDesc* Expr, const Type* NewType)
             LoadExpr (CF_NONE, Expr);
 
             /* Emit typecast code */
-            g_typecast (TypeOf (NewType), TypeOf (OldType));
+            g_typecast (CG_TypeOf (NewType), CG_TypeOf (OldType));
 
             /* Value is now in primary and an rvalue */
             ED_FinalizeRValLoad (Expr);
@@ -162,7 +162,7 @@ static void DoConversion (ExprDesc* Expr, const Type* NewType)
             LoadExpr (CF_NONE, Expr);
 
             /* Emit typecast code. */
-            g_typecast (TypeOf (NewType), TypeOf (OldType));
+            g_typecast (CG_TypeOf (NewType), CG_TypeOf (OldType));
 
             /* Value is now an rvalue in the primary */
             ED_FinalizeRValLoad (Expr);


### PR DESCRIPTION
Exposed:
- `FuncTypeOf ` -> `CG_CallFlags `
- `GlobalModeFlags ` -> `CG_AddrModeFlags `
- `TypeOf ` -> `CG_TypeOf `

Internal:
- `TypeOfBySize`  -> `CG_TypeOfBySize `

Rationale: The first three old names have been considered confusing and misleading for a long time. They need be renamed. The last name need be renamed as well for consistency.