### PR TITLE
[cc65] Fixes for nested unspecified-length/flexible arrays

### DIFF
--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -511,7 +511,7 @@ void Compile (const char* FileName)
 
                     /* Mark as defined; so that it will be exported, not imported */
                     Entry->Flags |= SC_DEF;
-                } else {
+                } else if (!IsTypeArray (Entry->Type)) {
                     /* Tentative declared variable is still of incomplete type */
                     Error ("Definition of '%s' has type '%s' that is never completed",
                            Entry->Name,

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -517,7 +517,8 @@ static void CheckArrayElementType (const Type* T)
                     return;
                 }
             } else {
-                if (IsTypeStruct (T)) {
+                /* Elements cannot contain flexible array members themselves */
+                if (IsClassStruct (T)) {
                     SymEntry* TagEntry = GetESUTagSym (T);
                     if (TagEntry && SymHasFlexibleArrayMember (TagEntry)) {
                         Error ("Invalid use of struct with flexible array member");
@@ -1202,9 +1203,7 @@ static SymEntry* ParseStructSpec (const char* Name, unsigned* DSFlags)
                     if (TagEntry && SymHasFlexibleArrayMember (TagEntry)) {
                         Field->Flags |= SC_HAVEFAM;
                         Flags        |= SC_HAVEFAM;
-                        if (IsTypeStruct (Decl.Type)) {
-                            Error ("Invalid use of struct with flexible array member");
-                        }
+                        Error ("Invalid use of struct with flexible array member");
                     }
                 }
 

--- a/test/err/bug2016-fam-member.c
+++ b/test/err/bug2016-fam-member.c
@@ -5,7 +5,12 @@ typedef struct x {
     int b[];    /* Ok: Flexible array member can be last */
 } x;
 
+typedef union u {
+    int a;
+    x   x;      /* Ok: Union member can contain flexible array member */
+} u;
+
 struct y {
-    x   x;      /* Not ok: Contains flexible array member */
+    u   u;      /* Not ok: Contains union that contains flexible array member */
     int a;
 };

--- a/test/err/bug2017-fam-element.c
+++ b/test/err/bug2017-fam-element.c
@@ -1,9 +1,13 @@
 /* Bug #2017 - cc65 erroneously allows arrays of structs with flexible array members */
 
-struct z {
+typedef struct x {
     int a;
-    int c;
-    int b[];
-};
+    int b[];    /* Ok: Flexible array member can be last */
+} x;
 
-struct z y[3];          /* Should be an error */
+typedef union u {
+    int a;
+    x   x;      /* Ok: Union member can contain flexible array member */
+} u;
+
+union u y[3];  /* Should be an error */

--- a/test/err/zero-size.c
+++ b/test/err/zero-size.c
@@ -1,0 +1,6 @@
+char a[][] = { 0, 0 }; /* Error: Array type has incomplete element type 'char[]' */
+
+int main(void)
+{
+    return 0;
+}

--- a/test/val/fam.c
+++ b/test/val/fam.c
@@ -1,0 +1,31 @@
+/* Bug #2016 and #2017 - flexible array members */
+
+typedef struct {
+    int a;
+    int b[];        /* Ok: Flexible array member can be last */
+} X;
+
+typedef union {
+    X   x;          /* Ok: Contains flexible array member */
+    int a;
+} U;
+
+typedef struct {
+    struct {
+        int a;
+    };
+    int b[];    /* Ok: Flexible array member can be last */
+} Y;
+
+X x;
+U u;
+Y y;
+
+_Static_assert(sizeof x == sizeof (int), "sizeof x != sizeof (int)");
+_Static_assert(sizeof u == sizeof (int), "sizeof u != sizeof (int)");
+_Static_assert(sizeof y == sizeof (int), "sizeof y != sizeof (int)");
+
+int main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
```c
int a[][] = { 0 }; /* Should be an error */
```