### PR TITLE
[cc65] Support inline, just always ignore it

### DIFF
--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -239,6 +239,10 @@ static TypeCode OptionalQualifiers (TypeCode Qualifiers, TypeCode Allowed)
                 }
                 break;
 
+            case TOK_INLINE:
+                Warning ("inline unsported, ignoring");
+                break;
+
             case TOK_CDECL:
                 if (Allowed & T_QUAL_CDECL) {
                     if (Qualifiers & T_QUAL_CDECL) {


### PR DESCRIPTION
I was trying to compile some code which had functions declared as inline.  I was met with an error `Error: Identifier expected` followed by a handful of other warnings and errors.  Looking into cc65's source I noticed that while the scanner was parsing the token ([here](https://github.com/cc65/cc65/blob/f381d230017a782d5c2fa4ba69308001c9c80112/src/cc65/scanner.c#L129) as well as above for `__inline__`) it wasn't being used anywhere

This simple patch allows for functions declared with inline to compile successfully, although the qualifier is simply ignored.  This should technically be valid as it's the compilers' decision when to actually inline.  With that said I did believe it would be helpful to leave an error letting users know the inline is being ignored.  Furthermore, I didn't add a warning for duplicate `inline`s in the style of the other qualifiers as they're just being ignored.  If that would be desired I would be able to add a check for it no problem.

Not sure if this follows the style of the project or is wanted at all.  I understand this isn't really a properly implemented feature but it should be better than just erroring out. I'm open to any critique!