### PR TITLE
Optimize multiplication by zero

### DIFF
--- a/src/cc65/codegen.c
+++ b/src/cc65/codegen.c
@@ -2726,7 +2726,12 @@ void g_mul (unsigned flags, unsigned long val)
                 if (flags & CF_FORCECHAR) {
                     /* Handle some special cases */
                     switch (val) {
-
+                        case 0:
+                            AddCodeLine ("lda #$00");
+                            return;
+                        case 1:
+                            /* Nothing to do */
+                            return;
                         case 3:
                             AddCodeLine ("sta tmp1");
                             AddCodeLine ("asl a");
@@ -2764,6 +2769,13 @@ void g_mul (unsigned flags, unsigned long val)
 
             case CF_INT:
                 switch (val) {
+                    case 0:
+                        AddCodeLine ("lda #$00");
+                        AddCodeLine ("tax");
+                        return;
+                    case 1:
+                        /* Nothing to do */
+                        return;
                     case 3:
                         AddCodeLine ("jsr mulax3");
                         return;

--- a/test/val/mult1.c
+++ b/test/val/mult1.c
@@ -55,6 +55,7 @@ void m3(unsigned char uc)
   /* testing literal multiply with same source and destination */
   vuc = uc;
   uc2 = 0;
+  uc1 = vuc; uc1 = uc1*0; if( uc1 != 0 )              failures++;
   uc1 = vuc; uc1 = uc1*1; if( uc1 != (uc2+=TESTLIT) ) failures++;
   uc1 = vuc; uc1 = uc1*2; if( uc1 != (uc2+=TESTLIT) ) failures++;
   uc1 = vuc; uc1 = uc1*3; if( uc1 != (uc2+=TESTLIT) ) failures++;


### PR DESCRIPTION
Before, without -O:
```
; c = width * 0;
;
	lda     M0004
	ldx     M0004+1
	jsr     pushax
	ldx     #$00
	lda     #$00
	jsr     tosmulax
	sta     M0003
	stx     M0003+1
```
Before, with -O:
```
; c = width * 0;
;
	lda     M0004
	ldx     M0004+1
	jsr     pushax
	lda     #$00
	jsr     tosmula0
	sta     M0003
	stx     M0003+1
```

After, without -O:
```
; c = width * 0;
;
	lda     M0004
	ldx     M0004+1
	lda     #$00
	tax
	sta     M0003
	stx     M0003+1

```

After, with -O:
```
; c = width * 0;
;
	stz     M0003
	stz     M0003+1
```