### PR TITLE
Optimize integer decrements by 1

### DIFF
--- a/src/cc65/codeopt.c
+++ b/src/cc65/codeopt.c
@@ -197,6 +197,7 @@ static OptFunc DOptStore3       = { OptStore3,       "OptStore3",       120, 0, 
 static OptFunc DOptStore4       = { OptStore4,       "OptStore4",        50, 0, 0, 0, 0, 0 };
 static OptFunc DOptStore5       = { OptStore5,       "OptStore5",       100, 0, 0, 0, 0, 0 };
 static OptFunc DOptStoreLoad    = { OptStoreLoad,    "OptStoreLoad",      0, 0, 0, 0, 0, 0 };
+static OptFunc DOptLoadStoreLoad= { OptLoadStoreLoad,"OptLoadStoreLoad",  0, 0, 0, 0, 0, 0 };
 static OptFunc DOptSub1         = { OptSub1,         "OptSub1",         100, 0, 0, 0, 0, 0 };
 static OptFunc DOptSub2         = { OptSub2,         "OptSub2",         100, 0, 0, 0, 0, 0 };
 static OptFunc DOptSub3         = { OptSub3,         "OptSub3",         100, 0, 0, 0, 0, 0 };
@@ -307,6 +308,7 @@ static OptFunc* OptFuncs[] = {
     &DOptStore4,
     &DOptStore5,
     &DOptStoreLoad,
+    &DOptLoadStoreLoad,
     &DOptSub1,
     &DOptSub2,
     &DOptSub3,
@@ -723,6 +725,7 @@ static unsigned RunOptGroup3 (CodeSeg* S)
         C += RunOptFunc (S, &DOptUnusedStores, 1);
         C += RunOptFunc (S, &DOptDupLoads, 1);
         C += RunOptFunc (S, &DOptStoreLoad, 1);
+        C += RunOptFunc (S, &DOptLoadStoreLoad, 1);
         C += RunOptFunc (S, &DOptTransfers1, 1);
         C += RunOptFunc (S, &DOptTransfers3, 1);
         C += RunOptFunc (S, &DOptTransfers4, 1);

--- a/src/cc65/coptind.h
+++ b/src/cc65/coptind.h
@@ -64,6 +64,9 @@ unsigned OptDupLoads (CodeSeg* S);
 unsigned OptStoreLoad (CodeSeg* S);
 /* Remove a store followed by a load from the same location. */
 
+unsigned OptLoadStoreLoad (CodeSeg* S);
+/* Remove a load, store followed by a reload of the same location. */
+
 unsigned OptTransfers1 (CodeSeg* S);
 /* Remove transfers from one register to another and back */
 

--- a/test/val/sub3.c
+++ b/test/val/sub3.c
@@ -1,0 +1,192 @@
+/*
+  !!DESCRIPTION!! Subtraction Test
+  !!ORIGIN!!      SDCC regression tests
+  !!LICENCE!!     GPL, read COPYING.GPL
+*/
+
+#include <stdio.h>
+#include <limits.h>
+
+unsigned char failures=0;
+
+int int0 = 5;
+unsigned int int1 = 5;
+
+void pre_dec_test(void)
+{
+  if(int0 != 5)
+    failures++;
+  if(int1 != 5)
+    failures++;
+
+  --int0;
+  --int1;
+
+  if(int0 != 4)
+    failures++;
+  if(int1 != 4)
+    failures++;
+
+  --int0;
+  --int1;
+  --int0;
+  --int1;
+  --int0;
+  --int1;
+  --int0;
+  --int1;
+
+  if(int0 != 0)
+    failures++;
+  if(int1 != 0)
+    failures++;
+
+  --int0;
+  --int1;
+
+  if(int0 != -1)
+    failures++;
+  if(int1 != 65535U)
+    failures++;
+}
+
+void post_dec_test(void)
+{
+  if(int0 != 5)
+    failures++;
+  if(int1 != 5)
+    failures++;
+
+  int0--;
+  int1--;
+
+  if(int0 != 4)
+    failures++;
+  if(int1 != 4)
+    failures++;
+
+  int0--;
+  int1--;
+  int0--;
+  int1--;
+  int0--;
+  int1--;
+  int0--;
+  int1--;
+
+  if(int0 != 0)
+    failures++;
+  if(int1 != 0)
+    failures++;
+
+  int0--;
+  int1--;
+
+  if(int0 != -1)
+    failures++;
+  if(int1 != 65535U)
+    failures++;
+}
+
+void pre_dec_assign_test(void)
+{
+  int a;
+  unsigned int b;
+  if(int0 != 5)
+    failures++;
+  if(int1 != 5)
+    failures++;
+
+  a = --int0;
+  b = --int1;
+
+  if(int0 != 4 || a != int0)
+    failures++;
+  if(int1 != 4 || b != int1)
+    failures++;
+
+  a = --int0;
+  b = --int1;
+  a = --int0;
+  b = --int1;
+  a = --int0;
+  b = --int1;
+  a = --int0;
+  b = --int1;
+
+  if(int0 != 0 || a != int0)
+    failures++;
+  if(int1 != 0 || b != int1)
+    failures++;
+
+  a = --int0;
+  b = --int1;
+
+  if(int0 != -1 || a != int0)
+    failures++;
+  if(int1 != 65535U || b != int1)
+    failures++;
+}
+
+void post_dec_assign_test(void)
+{
+  int a;
+  unsigned int b;
+  if(int0 != 5)
+    failures++;
+  if(int1 != 5)
+    failures++;
+
+  a = int0--;
+  b = int1--;
+
+  if(int0 != 4 || a != 5)
+    failures++;
+  if(int1 != 4 || b != 5)
+    failures++;
+
+  a = int0--;
+  b = int1--;
+  a = int0--;
+  b = int1--;
+  a = int0--;
+  b = int1--;
+  a = int0--;
+  b = int1--;
+
+  if(int0 != 0 || a != 1)
+    failures++;
+  if(int1 != 0 || b != 1)
+    failures++;
+
+  a = int0--;
+  b = int1--;
+
+  if(int0 != -1 || a != 0)
+    failures++;
+  if(int1 != 65535U || b != 0)
+    failures++;
+}
+
+int main(void)
+{
+  int0 = 5;
+  int1 = 5;
+  pre_dec_test();
+
+  int0 = 5;
+  int1 = 5;
+  post_dec_test();
+
+  int0 = 5;
+  int1 = 5;
+  pre_dec_assign_test();
+
+  int0 = 5;
+  int1 = 5;
+  post_dec_assign_test();
+
+  printf("failures: %d\n",failures);
+
+  return failures;
+}


### PR DESCRIPTION
Decrementing integers could be a little bit faster, esp. on 65C02. Comparisons attached. I added an optimisation pass because the change left a 
``` 
lda M0001
sta M0002
lda M0001
```
That was hurting my eyes.

Without -O:
![sub1-no-opt-comparison](https://github.com/cc65/cc65/assets/1016317/54495cc5-436e-4ab6-b151-4612fbd0e315)

With -O:
![sub1-opt-comparison](https://github.com/cc65/cc65/assets/1016317/6f4383b3-8804-4a69-803e-92ce2b8d531c)
