### PR TITLE
Optimize static long assignment a bit

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,7 @@ ifndef BUILD_ID
 endif
 $(info BUILD_ID: $(BUILD_ID))
 
-CFLAGS += -MMD -MP -O0 -g -I common \
+CFLAGS += -MMD -MP -O3 -I common \
           -Wall -Wextra -Wno-char-subscripts $(USER_CFLAGS) \
           -DCA65_INC="\"$(CA65_INC)\"" -DCC65_INC="\"$(CC65_INC)\"" -DCL65_TGT="\"$(CL65_TGT)\"" \
           -DLD65_LIB="\"$(LD65_LIB)\"" -DLD65_OBJ="\"$(LD65_OBJ)\"" -DLD65_CFG="\"$(LD65_CFG)\"" \

--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,7 @@ ifndef BUILD_ID
 endif
 $(info BUILD_ID: $(BUILD_ID))
 
-CFLAGS += -MMD -MP -O3 -I common \
+CFLAGS += -MMD -MP -O0 -g -I common \
           -Wall -Wextra -Wno-char-subscripts $(USER_CFLAGS) \
           -DCA65_INC="\"$(CA65_INC)\"" -DCC65_INC="\"$(CC65_INC)\"" -DCL65_TGT="\"$(CL65_TGT)\"" \
           -DLD65_LIB="\"$(LD65_LIB)\"" -DLD65_OBJ="\"$(LD65_OBJ)\"" -DLD65_CFG="\"$(LD65_CFG)\"" \

--- a/src/cc65.vcxproj
+++ b/src/cc65.vcxproj
@@ -69,6 +69,7 @@
     <ClInclude Include="cc65\coptcmp.h" />
     <ClInclude Include="cc65\coptind.h" />
     <ClInclude Include="cc65\coptjmp.h" />
+    <ClInclude Include="cc65\coptlong.h" />
     <ClInclude Include="cc65\coptmisc.h" />
     <ClInclude Include="cc65\coptptrload.h" />
     <ClInclude Include="cc65\coptptrstore.h" />
@@ -150,6 +151,7 @@
     <ClCompile Include="cc65\coptcmp.c" />
     <ClCompile Include="cc65\coptind.c" />
     <ClCompile Include="cc65\coptjmp.c" />
+    <ClCompile Include="cc65\coptlong.c" />
     <ClCompile Include="cc65\coptmisc.c" />
     <ClCompile Include="cc65\coptptrload.c" />
     <ClCompile Include="cc65\coptptrstore.c" />

--- a/src/cc65/codegen.c
+++ b/src/cc65/codegen.c
@@ -705,7 +705,6 @@ void g_getimmed (unsigned Flags, uintptr_t Val, long Offs)
 /* Load a constant into the primary register */
 {
     unsigned char B1, B2, B3, B4;
-    unsigned      Done;
 
 
     if ((Flags & CF_CONST) != 0) {
@@ -731,40 +730,15 @@ void g_getimmed (unsigned Flags, uintptr_t Val, long Offs)
                 B3 = (unsigned char) (Val >> 16);
                 B4 = (unsigned char) (Val >> 24);
 
-                /* Remember which bytes are done */
-                Done = 0;
-
-                /* Load the value */
-                AddCodeLine ("ldx #$%02X", B2);
-                Done |= 0x02;
-                if (B2 == B3) {
-                    AddCodeLine ("stx sreg");
-                    Done |= 0x04;
-                }
-                if (B2 == B4) {
-                    AddCodeLine ("stx sreg+1");
-                    Done |= 0x08;
-                }
-                if ((Done & 0x04) == 0 && B1 != B3) {
-                    AddCodeLine ("lda #$%02X", B3);
-                    AddCodeLine ("sta sreg");
-                    Done |= 0x04;
-                }
-                if ((Done & 0x08) == 0 && B1 != B4) {
-                    AddCodeLine ("lda #$%02X", B4);
-                    AddCodeLine ("sta sreg+1");
-                    Done |= 0x08;
-                }
+                /* Load the value. Don't be too smart here and let
+                 * the optimizer do its job.
+                 */
+                AddCodeLine ("lda #$%02X", B4);
+                AddCodeLine ("sta sreg+1");
+                AddCodeLine ("lda #$%02X", B3);
+                AddCodeLine ("sta sreg");
                 AddCodeLine ("lda #$%02X", B1);
-                Done |= 0x01;
-                if ((Done & 0x04) == 0) {
-                    CHECK (B1 == B3);
-                    AddCodeLine ("sta sreg");
-                }
-                if ((Done & 0x08) == 0) {
-                    CHECK (B1 == B4);
-                    AddCodeLine ("sta sreg+1");
-                }
+                AddCodeLine ("ldx #$%02X", B2);
                 break;
 
             default:

--- a/src/cc65/codeopt.c
+++ b/src/cc65/codeopt.c
@@ -57,6 +57,7 @@
 #include "coptcmp.h"
 #include "coptind.h"
 #include "coptjmp.h"
+#include "coptlong.h"
 #include "coptmisc.h"
 #include "coptptrload.h"
 #include "coptptrstore.h"
@@ -150,6 +151,8 @@ static OptFunc DOptJumpTarget3  = { OptJumpTarget3,  "OptJumpTarget3",  100, 0, 
 static OptFunc DOptLoad1        = { OptLoad1,        "OptLoad1",        100, 0, 0, 0, 0, 0 };
 static OptFunc DOptLoad2        = { OptLoad2,        "OptLoad2",        200, 0, 0, 0, 0, 0 };
 static OptFunc DOptLoad3        = { OptLoad3,        "OptLoad3",          0, 0, 0, 0, 0, 0 };
+static OptFunc DOptLongAssign   = { OptLongAssign,   "OptLongAssign",   100, 0, 0, 0, 0, 0 };
+static OptFunc DOptLongCopy     = { OptLongCopy,     "OptLongCopy",     100, 0, 0, 0, 0, 0 };
 static OptFunc DOptNegAX1       = { OptNegAX1,       "OptNegAX1",       165, 0, 0, 0, 0, 0 };
 static OptFunc DOptNegAX2       = { OptNegAX2,       "OptNegAX2",       200, 0, 0, 0, 0, 0 };
 static OptFunc DOptPrecalc      = { OptPrecalc,      "OptPrecalc",      100, 0, 0, 0, 0, 0 };
@@ -262,6 +265,8 @@ static OptFunc* OptFuncs[] = {
     &DOptLoad1,
     &DOptLoad2,
     &DOptLoad3,
+    &DOptLongAssign,
+    &DOptLongCopy,
     &DOptNegAX1,
     &DOptNegAX2,
     &DOptPrecalc,
@@ -632,6 +637,7 @@ static unsigned RunOptGroup1 (CodeSeg* S)
     Changes += RunOptFunc (S, &DOptAdd6, 1);
     Changes += RunOptFunc (S, &DOptSub1, 1);
     Changes += RunOptFunc (S, &DOptSub3, 1);
+    Changes += RunOptFunc (S, &DOptLongAssign, 1);
     Changes += RunOptFunc (S, &DOptStore4, 1);
     Changes += RunOptFunc (S, &DOptStore5, 1);
     Changes += RunOptFunc (S, &DOptShift1, 1);
@@ -641,6 +647,7 @@ static unsigned RunOptGroup1 (CodeSeg* S)
     Changes += RunOptFunc (S, &DOptStore1, 1);
     Changes += RunOptFunc (S, &DOptStore2, 5);
     Changes += RunOptFunc (S, &DOptStore3, 5);
+    Changes += RunOptFunc (S, &DOptLongCopy, 1);
 
     /* Return the number of changes */
     return Changes;

--- a/src/cc65/coptlong.c
+++ b/src/cc65/coptlong.c
@@ -1,0 +1,210 @@
+/*****************************************************************************/
+/*                                                                           */
+/*                                 coptlong.c                                */
+/*                                                                           */
+/*                       Long integers optimizations                         */
+/*                                                                           */
+/*                                                                           */
+/*                                                                           */
+/* (C) 2001-2009, Ullrich von Bassewitz                                      */
+/*                Roemerstrasse 52                                           */
+/*                D-70794 Filderstadt                                        */
+/* EMail:         uz@cc65.org                                                */
+/* (C) 2023, Colin Leroy-Mira <colin@colino.net                              */
+/*                                                                           */
+/*                                                                           */
+/* This software is provided 'as-is', without any expressed or implied       */
+/* warranty.  In no event will the authors be held liable for any damages    */
+/* arising from the use of this software.                                    */
+/*                                                                           */
+/* Permission is granted to anyone to use this software for any purpose,     */
+/* including commercial applications, and to alter it and redistribute it    */
+/* freely, subject to the following restrictions:                            */
+/*                                                                           */
+/* 1. The origin of this software must not be misrepresented; you must not   */
+/*    claim that you wrote the original software. If you use this software   */
+/*    in a product, an acknowledgment in the product documentation would be  */
+/*    appreciated but is not required.                                       */
+/* 2. Altered source versions must be plainly marked as such, and must not   */
+/*    be misrepresented as being the original software.                      */
+/* 3. This notice may not be removed or altered from any source              */
+/*    distribution.                                                          */
+/*                                                                           */
+/*****************************************************************************/
+
+
+
+/* common */
+#include "cpu.h"
+
+/* cc65 */
+#include "codeent.h"
+#include "coptind.h"
+#include "codeinfo.h"
+#include "codeopt.h"
+#include "error.h"
+
+
+/*****************************************************************************/
+/*                      Remove unused loads and stores                       */
+/*****************************************************************************/
+
+
+
+unsigned OptLongAssign (CodeSeg* S)
+/* Simplify long assignments.
+** Recognize
+**      lda     ...       0
+**      sta     sreg+1    1
+**      lda     ...       2
+**      sta     sreg      3
+**      lda     ...       4
+**      ldx     ...       5
+**      sta     M0002     6
+**      stx     M0002+1   7
+**      ldy     sreg      8
+**      sty     M0002+2   9
+**      ldy     sreg+1    10
+**      sty     M0002+3   11
+** and simplify if not used right after.
+*/
+{
+    unsigned Changes = 0;
+
+    /* Walk over the entries */
+    unsigned I = 0;
+    while (I < CS_GetEntryCount (S)) {
+
+        CodeEntry* L[12];
+
+        /* Get next entry */
+        L[0] = CS_GetEntry (S, I);
+
+        if (CS_GetEntries (S, L+1, I+1, 11)) {
+          if (L[0]->OPC == OP65_LDA                                &&
+              L[1]->OPC == OP65_STA                                &&
+                !strcmp (L[1]->Arg, "sreg+1")                      &&
+              L[2]->OPC == OP65_LDA                                &&
+              L[3]->OPC == OP65_STA                                &&
+                !strcmp (L[3]->Arg, "sreg")                        &&
+              L[4]->OPC == OP65_LDA                                &&
+              L[5]->OPC == OP65_LDX                                &&
+              L[6]->OPC == OP65_STA                                &&
+              L[7]->OPC == OP65_STX                                &&
+                !strncmp(L[7]->Arg, L[6]->Arg, strlen(L[6]->Arg))  &&
+                !strcmp(L[7]->Arg + strlen(L[6]->Arg), "+1")       &&
+              L[8]->OPC == OP65_LDY                                &&
+                !strcmp (L[8]->Arg, "sreg")                        &&
+              L[9]->OPC == OP65_STY                                &&
+                !strncmp(L[9]->Arg, L[6]->Arg, strlen(L[6]->Arg))  &&
+                !strcmp(L[9]->Arg + strlen(L[6]->Arg), "+2")       &&
+              L[10]->OPC == OP65_LDY                               &&
+                !strcmp (L[10]->Arg, "sreg+1")                     &&
+              L[11]->OPC == OP65_STY                               &&
+                !strncmp(L[11]->Arg, L[6]->Arg, strlen(L[6]->Arg)) &&
+                !strcmp(L[11]->Arg + strlen(L[6]->Arg), "+3")      &&
+              !RegXUsed (S, I+11)) {
+
+              L[1]->AM = L[11]->AM;
+              CE_SetArg(L[1], L[11]->Arg);
+
+              L[3]->AM = L[9]->AM;
+              CE_SetArg(L[3], L[9]->Arg);
+
+              CS_DelEntries (S, I+8, 4);
+
+              /* Remember, we had changes */
+              ++Changes;
+          }
+        }
+
+        /* Next entry */
+        ++I;
+
+    }
+
+    /* Return the number of changes made */
+    return Changes;
+}
+
+unsigned OptLongCopy (CodeSeg* S)
+/* Simplify long copies.
+** Recognize
+**      lda     XXX+3       0
+**      sta     sreg+1      1
+**      lda     XXX+2       2
+**      sta     sreg        3
+**      ldx     XXX+1       4
+**      lda     XXX         5
+**      sta     YYY         6
+**      stx     YYY+1       7
+**      ldy     sreg        8
+**      sty     YYY+2       9
+**      ldy     sreg+1      10
+**      sty     YYY+3       11
+** and simplify if not used right after.
+*/
+{
+    unsigned Changes = 0;
+
+    /* Walk over the entries */
+    unsigned I = 0;
+    while (I < CS_GetEntryCount (S)) {
+
+        CodeEntry* L[12];
+
+        /* Get next entry */
+        L[0] = CS_GetEntry (S, I);
+
+        if (CS_GetEntries (S, L+1, I+1, 11)) {
+          if (L[0]->OPC == OP65_LDA                                &&
+                !strncmp(L[0]->Arg, L[5]->Arg, strlen(L[5]->Arg))  &&
+                !strcmp(L[0]->Arg + strlen(L[5]->Arg), "+3")       &&
+              L[1]->OPC == OP65_STA                                &&
+                !strcmp (L[1]->Arg, "sreg+1")                      &&
+              L[2]->OPC == OP65_LDA                                &&
+                !strncmp(L[2]->Arg, L[5]->Arg, strlen(L[5]->Arg))  &&
+                !strcmp(L[2]->Arg + strlen(L[5]->Arg), "+2")       &&
+              L[3]->OPC == OP65_STA                                &&
+                !strcmp (L[3]->Arg, "sreg")                        &&
+              L[4]->OPC == OP65_LDX                                &&
+                !strncmp(L[4]->Arg, L[5]->Arg, strlen(L[5]->Arg))  &&
+                !strcmp(L[4]->Arg + strlen(L[5]->Arg), "+1")       &&
+              L[5]->OPC == OP65_LDA                                &&
+              L[6]->OPC == OP65_STA                                &&
+              L[7]->OPC == OP65_STX                                &&
+                !strncmp(L[7]->Arg, L[6]->Arg, strlen(L[6]->Arg))  &&
+                !strcmp(L[7]->Arg + strlen(L[6]->Arg), "+1")       &&
+              L[8]->OPC == OP65_LDY                                &&
+                !strcmp (L[8]->Arg, "sreg")                        &&
+              L[9]->OPC == OP65_STY                                &&
+                !strncmp(L[9]->Arg, L[6]->Arg, strlen(L[6]->Arg))  &&
+                !strcmp(L[9]->Arg + strlen(L[6]->Arg), "+2")       &&
+              L[10]->OPC == OP65_LDY                               &&
+                !strcmp (L[10]->Arg, "sreg+1")                     &&
+              L[11]->OPC == OP65_STY                               &&
+                !strncmp(L[11]->Arg, L[6]->Arg, strlen(L[6]->Arg)) &&
+                !strcmp(L[11]->Arg + strlen(L[6]->Arg), "+3")      &&
+              !RegXUsed (S, I+11)) {
+
+              L[1]->AM = L[11]->AM;
+              CE_SetArg(L[1], L[11]->Arg);
+
+              L[3]->AM = L[9]->AM;
+              CE_SetArg(L[3], L[9]->Arg);
+
+              CS_DelEntries (S, I+8, 4);
+
+              /* Remember, we had changes */
+              ++Changes;
+          }
+        }
+
+        /* Next entry */
+        ++I;
+
+    }
+
+    /* Return the number of changes made */
+    return Changes;
+}

--- a/src/cc65/coptlong.h
+++ b/src/cc65/coptlong.h
@@ -1,0 +1,63 @@
+/*****************************************************************************/
+/*                                                                           */
+/*                                 coptlong.h                                */
+/*                                                                           */
+/*                       Long integers optimizations                         */
+/*                                                                           */
+/*                                                                           */
+/*                                                                           */
+/* (C) 2001-2009, Ullrich von Bassewitz                                      */
+/*                Roemerstrasse 52                                           */
+/*                D-70794 Filderstadt                                        */
+/* EMail:         uz@cc65.org                                                */
+/* (C) 2023, Colin Leroy-Mira <colin@colino.net                              */
+/*                                                                           */
+/*                                                                           */
+/* This software is provided 'as-is', without any expressed or implied       */
+/* warranty.  In no event will the authors be held liable for any damages    */
+/* arising from the use of this software.                                    */
+/*                                                                           */
+/* Permission is granted to anyone to use this software for any purpose,     */
+/* including commercial applications, and to alter it and redistribute it    */
+/* freely, subject to the following restrictions:                            */
+/*                                                                           */
+/* 1. The origin of this software must not be misrepresented; you must not   */
+/*    claim that you wrote the original software. If you use this software   */
+/*    in a product, an acknowledgment in the product documentation would be  */
+/*    appreciated but is not required.                                       */
+/* 2. Altered source versions must be plainly marked as such, and must not   */
+/*    be misrepresented as being the original software.                      */
+/* 3. This notice may not be removed or altered from any source              */
+/*    distribution.                                                          */
+/*                                                                           */
+/*****************************************************************************/
+
+
+
+#ifndef COPTLONG_H
+#define COPTLONG_H
+
+
+
+/* cc65 */
+#include "codeseg.h"
+
+
+
+/*****************************************************************************/
+/*                                   Code                                    */
+/*****************************************************************************/
+
+
+
+unsigned OptLongAssign (CodeSeg* S);
+/* Simplify long assigns. */
+
+unsigned OptLongCopy (CodeSeg* S);
+/* Simplify long copy. */
+
+
+
+/* End of coptind.h */
+
+#endif

--- a/test/val/long.c
+++ b/test/val/long.c
@@ -1,0 +1,41 @@
+#include <stdint.h>
+#include <stdio.h>
+
+int res = 0;
+
+int main(void)
+{
+    long a, b;
+
+    a = 0x12345678L;
+
+    /* Test assignment */
+    b = a;
+    if (b != a) {
+      res++;
+    }
+
+    /* Test increment */
+    b++;
+    if (b != 0x12345679L) {
+      res++;
+    }
+
+    /* Test decrement */
+    b--;
+    if (b != 0x12345678L) {
+      res++;
+    }
+
+    /* Test pre-decrement with test */
+    if (--b != 0x12345677L) {
+      res++;
+    }
+
+    a = --b;
+    if (a != 0x12345676L) {
+      res++;
+    }
+
+    return res;
+}

--- a/test/val/static-long.c
+++ b/test/val/static-long.c
@@ -1,0 +1,41 @@
+#include <stdint.h>
+#include <stdio.h>
+
+int res = 0;
+
+int main(void)
+{
+    static long a, b;
+
+    a = 0x12345678L;
+
+    /* Test assignment */
+    b = a;
+    if (b != a) {
+      res++;
+    }
+
+    /* Test increment */
+    b++;
+    if (b != 0x12345679L) {
+      res++;
+    }
+
+    /* Test decrement */
+    b--;
+    if (b != 0x12345678L) {
+      res++;
+    }
+
+    /* Test pre-decrement with test */
+    if (--b != 0x12345677L) {
+      res++;
+    }
+
+    a = --b;
+    if (a != 0x12345676L) {
+      res++;
+    }
+
+    return res;
+}


### PR DESCRIPTION
I've worked a bit on optimizing the basics about longs: assignments.
It gives something a little larger without -O (because I've simplified that part in codegen.c to ease matching the pattern in coptlong.c), but I think it's worth it as the results with -O are quite good ?

Before/after without -O
![image](https://github.com/cc65/cc65/assets/1016317/40a43252-f043-449d-bcec-911f4fc41ba3)

Before/after with -O
![image](https://github.com/cc65/cc65/assets/1016317/cc01eddc-2658-41ea-8f09-6202bd7725ce)
