### PR TITLE
[cc65] Enabled implicit "return 0" in C99 standard main function in default cc65 mode

### DIFF
--- a/test/ref/custom-reference-error.c
+++ b/test/ref/custom-reference-error.c
@@ -13,9 +13,9 @@
     and then "make" again to confirm
 */
 
-int main(int argc, char* argv[])
+short main(int argc, char* argv[])
 {
-    printf("%02x", 0x42);
-    n = 0; /* produce an error */
-    /* another error */
+    printf("%02x", 0x42); /* produce an error */
+    n = 0;                /* produce an error */
+    /* produce a warning */
 }

--- a/test/ref/custom-reference.c
+++ b/test/ref/custom-reference.c
@@ -20,5 +20,4 @@ int main(int argc, char* argv[])
 {
     printf("%02x", 0x42);
     /* produce a warning */
-    return 0;
 }

--- a/test/ref/custom-reference.cref
+++ b/test/ref/custom-reference.cref
@@ -1,2 +1,2 @@
-custom-reference.c:24: Warning: Parameter 'argc' is never used
-custom-reference.c:24: Warning: Parameter 'argv' is never used
+custom-reference.c:23: Warning: Parameter 'argc' is never used
+custom-reference.c:23: Warning: Parameter 'argv' is never used


### PR DESCRIPTION
The implicit `return 0` for `int main` has been supported in cc65 for a while but not enabled by default. This PR enables it by default.