### PR TITLE
[cc65] Fixes for structs/unions

### DIFF
--- a/src/cc65/assignment.c
+++ b/src/cc65/assignment.c
@@ -44,6 +44,7 @@
 #include "scanner.h"
 #include "stackptr.h"
 #include "stdnames.h"
+#include "symentry.h"
 #include "typecmp.h"
 #include "typeconv.h"
 
@@ -82,6 +83,8 @@ static void CopyStruct (ExprDesc* LExpr, ExprDesc* RExpr)
     if (TypeCmp (ltype, RExpr->Type).C < TC_STRICT_COMPATIBLE) {
         TypeCompatibilityDiagnostic (ltype, RExpr->Type, 1,
             "Incompatible types in assignment to '%s' from '%s'");
+    } else if (SymHasConstMember (ltype->A.S)) {
+        Error ("Assignment to read only variable");
     }
 
     /* Do we copy the value directly using the primary? */
@@ -627,7 +630,7 @@ void OpAssign (const GenDesc* Gen, ExprDesc* Expr, const char* Op)
             }
         } else if (IsQualConst (ltype)) {
             /* Check for assignment to const */
-            Error ("Assignment to const");
+            Error ("Assignment to const variable");
         }
     }
 
@@ -686,7 +689,7 @@ void OpAddSubAssign (const GenDesc* Gen, ExprDesc *Expr, const char* Op)
             Error ("Invalid lvalue in assignment");
         } else if (IsQualConst (Expr->Type)) {
             /* The left side must not be const qualified */
-            Error ("Assignment to const");
+            Error ("Assignment to const variable");
         }
     }
 

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -983,33 +983,36 @@ static SymEntry* ParseUnionSpec (const char* Name, unsigned* DSFlags)
             /* Check for a bit-field declaration */
             FieldWidth = ParseFieldWidth (&Decl);
 
-            /* Ignore zero sized bit fields in a union */
-            if (FieldWidth == 0) {
-                goto NextMember;
-            }
-
-            /* Check for fields without a name */
+            /* Check for fields without names */
             if (Decl.Ident[0] == '\0') {
-                /* In cc65 mode, we allow anonymous structs/unions within
-                ** a union.
-                */
-                if (IS_Get (&Standard) >= STD_CC65 && IsClassStruct (Decl.Type)) {
-                    /* This is an anonymous struct or union */
-                    AnonFieldName (Decl.Ident, GetBasicTypeName (Decl.Type), UnionTagEntry->V.S.ACount);
+                if (FieldWidth < 0) {
+                    /* In cc65 mode, we allow anonymous structs/unions within
+                    ** a union.
+                    */
+                    SymEntry* TagEntry;
+                    if (IS_Get (&Standard) >= STD_CC65          &&
+                        IsClassStruct (Decl.Type)               &&
+                        (TagEntry = GetESUTagSym (Decl.Type))   &&
+                        SymHasAnonName (TagEntry)) {
+                        /* This is an anonymous struct or union */
+                        AnonFieldName (Decl.Ident, GetBasicTypeName (Decl.Type), UnionTagEntry->V.S.ACount);
 
-                    /* Ignore CVR qualifiers */
-                    if (IsQualConst (Decl.Type) || IsQualVolatile (Decl.Type) || IsQualRestrict (Decl.Type)) {
-                        Warning ("Anonymous %s qualifiers are ignored", GetBasicTypeName (Decl.Type));
-                        Decl.Type[0].C &= ~T_QUAL_CVR;
+                        /* Ignore CVR qualifiers */
+                        if (IsQualConst (Decl.Type) || IsQualVolatile (Decl.Type) || IsQualRestrict (Decl.Type)) {
+                            Warning ("Anonymous %s qualifiers are ignored", GetBasicTypeName (Decl.Type));
+                            Decl.Type[0].C &= ~T_QUAL_CVR;
+                        }
+                    } else {
+                        /* A non bit-field without a name is legal but useless */
+                        Warning ("Declaration does not declare anything");
+
+                        goto NextMember;
                     }
-                } else {
-                    /* A non bit-field without a name is legal but useless */
-                    Warning ("Declaration does not declare anything");
+                } else if (FieldWidth > 0) {
+                    /* A bit-field without a name will get an anonymous one */
+                    AnonName (Decl.Ident, "bit-field");
                 }
-            }
-
-            /* Check for incomplete types including 'void' */
-            if (IsIncompleteType (Decl.Type)) {
+            } else if (IsIncompleteType (Decl.Type)) {
                 Error ("Field '%s' has incomplete type '%s'",
                        Decl.Ident,
                        GetFullTypeName (Decl.Type));
@@ -1018,6 +1021,11 @@ static SymEntry* ParseUnionSpec (const char* Name, unsigned* DSFlags)
             /* Check for const types */
             if (IsQualConst (Decl.Type)) {
                 Flags |= SC_HAVECONST;
+            }
+
+            /* Ignore zero sized bit fields in a union */
+            if (FieldWidth == 0) {
+                goto NextMember;
             }
 
             /* Handle sizes */
@@ -1180,36 +1188,17 @@ static SymEntry* ParseStructSpec (const char* Name, unsigned* DSFlags)
                 }
             }
 
-            /* Apart from the above, a bit field with width 0 is not processed
-            ** further.
-            */
-            if (FieldWidth == 0) {
-                goto NextMember;
-            }
-
-            /* Check if this field is a flexible array member, and
-            ** calculate the size of the field.
-            */
-            if (IsTypeArray (Decl.Type) && GetElementCount (Decl.Type) == UNSPECIFIED) {
-                /* Array with unspecified size */
-                if (StructSize == 0) {
-                    Error ("Flexible array member cannot be first struct field");
-                }
-                FlexibleMember = 1;
-                Flags |= SC_HAVEFAM;
-
-                /* Assume zero for size calculations */
-                SetElementCount (Decl.Type, FLEXIBLE);
-            }
-
             /* Check for fields without names */
             if (Decl.Ident[0] == '\0') {
                 if (FieldWidth < 0) {
                     /* In cc65 mode, we allow anonymous structs/unions within
                     ** a struct.
                     */
-                    if (IS_Get (&Standard) >= STD_CC65 && IsClassStruct (Decl.Type)) {
-
+                    SymEntry* TagEntry;
+                    if (IS_Get (&Standard) >= STD_CC65          &&
+                        IsClassStruct (Decl.Type)               &&
+                        (TagEntry = GetESUTagSym (Decl.Type))   &&
+                        SymHasAnonName (TagEntry)) {
                         /* This is an anonymous struct or union */
                         AnonFieldName (Decl.Ident, GetBasicTypeName (Decl.Type), StructTagEntry->V.S.ACount);
 
@@ -1221,23 +1210,46 @@ static SymEntry* ParseStructSpec (const char* Name, unsigned* DSFlags)
                     } else {
                         /* A non bit-field without a name is legal but useless */
                         Warning ("Declaration does not declare anything");
+
+                        goto NextMember;
                     }
-                } else {
+                } else if (FieldWidth > 0) {
                     /* A bit-field without a name will get an anonymous one */
                     AnonName (Decl.Ident, "bit-field");
                 }
-            }
+            } else {
+                /* Check if this field is a flexible array member, and
+                ** calculate the size of the field.
+                */
+                if (IsTypeArray (Decl.Type) && GetElementCount (Decl.Type) == UNSPECIFIED) {
+                    /* Array with unspecified size */
+                    if (StructSize == 0) {
+                        Error ("Flexible array member cannot be first struct field");
+                    }
+                    FlexibleMember = 1;
+                    Flags |= SC_HAVEFAM;
 
-            /* Check for incomplete types including 'void' */
-            if (IsIncompleteType (Decl.Type)) {
-                Error ("Field '%s' has incomplete type '%s'",
-                       Decl.Ident,
-                       GetFullTypeName (Decl.Type));
+                    /* Assume zero for size calculations */
+                    SetElementCount (Decl.Type, FLEXIBLE);
+                }
+
+                if (IsIncompleteType (Decl.Type)) {
+                    Error ("Field '%s' has incomplete type '%s'",
+                           Decl.Ident,
+                           GetFullTypeName (Decl.Type));
+                }
             }
 
             /* Check for const types */
             if (IsQualConst (Decl.Type)) {
                 Flags |= SC_HAVECONST;
+            }
+
+            /* Apart from the above, a bit field with width 0 is not processed
+            ** further.
+            */
+            if (FieldWidth == 0) {
+                goto NextMember;
             }
 
             /* Add a field entry to the table */

--- a/src/cc65/symentry.h
+++ b/src/cc65/symentry.h
@@ -108,6 +108,7 @@ struct CodeEntry;
 #define SC_ALIAS        0x01000000U     /* Alias of global or anonymous field */
 #define SC_FICTITIOUS   0x02000000U     /* Symbol is fictitious (for error recovery) */
 #define SC_HAVEFAM      0x04000000U     /* Type has a Flexible Array Member */
+#define SC_HAVECONST    0x08000000U     /* Type has a const member */
 
 
 
@@ -276,13 +277,23 @@ INLINE int SymHasFlexibleArrayMember (const SymEntry* Sym)
 #endif
 
 #if defined(HAVE_INLINE)
+INLINE int SymHasConstMember (const SymEntry* Sym)
+/* Return true if the given entry has a const member */
+{
+    return ((Sym->Flags & SC_HAVECONST) == SC_HAVECONST);
+}
+#else
+#  define SymHasConstMember(Sym)    (((Sym)->Flags & SC_HAVECONST) == SC_HAVECONST)
+#endif
+
+#if defined(HAVE_INLINE)
 INLINE const char* SymGetAsmName (const SymEntry* Sym)
 /* Return the assembler label name for the symbol (beware: may be NULL!) */
 {
     return Sym->AsmName;
 }
 #else
-#  define SymGetAsmName(Sym)      ((Sym)->AsmName)
+#  define SymGetAsmName(Sym)        ((Sym)->AsmName)
 #endif
 
 const DeclAttr* SymGetAttr (const SymEntry* Sym, DeclAttrType AttrType);

--- a/test/err/bug2018.c
+++ b/test/err/bug2018.c
@@ -1,0 +1,25 @@
+/* Bug #2018 - Compiler has problems with const struct fields */
+
+struct X {
+    struct {
+        int a;
+    } a;
+    union {
+        int a;
+        const int b;
+    } b;
+};
+
+struct X f(void)
+{
+    struct X x = { 42 };
+    return x;
+}
+
+int main(void)
+{
+    struct X x = { 0 };
+    x = f();            /* Error since X is read only */
+
+    return 0;
+}

--- a/test/val/bug2018-ok.c
+++ b/test/val/bug2018-ok.c
@@ -1,0 +1,61 @@
+/* Bug #2018 - Compiler has problems with const struct fields */
+
+#include <stdio.h>
+
+unsigned failures;
+
+struct X {
+    const struct {              /* Qualifier ignored in cc65 */
+        int a;
+    };
+    const union {               /* Qualifier ignored in cc65 */
+        int b;
+    };
+};
+
+union Y {
+    const struct {              /* Qualifier ignored in cc65 */
+        int a;
+    };
+    const union {               /* Qualifier ignored in cc65 */
+        int b;
+    };
+};
+
+struct X f(struct X a)
+{
+    struct X x = { 42 };
+    return --a.a ? a : x;
+}
+
+union Y g(union Y a)
+{
+    union Y y = { 42 };
+    return --a.a ? a : y;
+}
+
+int main(void)
+{
+    struct X x = { 1 };
+    union Y y = { 1 };
+
+    x = f(x);                   /* Allowed in cc65 since X is not read only */
+    y = g(y);                   /* Allowed in cc65 since Y is not read only */
+
+    if (x.a != 42)
+    {
+        ++failures;
+    }
+
+    if (y.a != 42)
+    {
+        ++failures;
+    }
+
+    if (failures > 0)
+    {
+        printf("failures: %u\n", failures);
+    }
+
+    return failures;
+}

--- a/test/val/bug2018-ok.c
+++ b/test/val/bug2018-ok.c
@@ -5,6 +5,11 @@
 unsigned failures;
 
 struct X {
+    const int;                  /* Useless empty declaration */
+    const void;                 /* Useless empty declaration */
+    const struct U;             /* Useless(?) declaration */
+    const struct V { int a; };  /* Useless(?) declaration */
+
     const struct {              /* Qualifier ignored in cc65 */
         int a;
     };
@@ -14,6 +19,11 @@ struct X {
 };
 
 union Y {
+    const int;                  /* Useless empty declaration */
+    const void;                 /* Useless empty declaration */
+    const union W;              /* Useless(?) declaration */
+    const union T { int a; };   /* Useless(?) declaration */
+
     const struct {              /* Qualifier ignored in cc65 */
         int a;
     };


### PR DESCRIPTION
- Fixed #2018. Fixed const qualifiers on named structs/unions members that should prevent assignments to the whole structs/unions.
  Added warning on ignored qualifiers on anonymous structs/unions.
- Fixed empty declarations in structs/unions.
  Note: Empty complete struct/union declarations with tag names but no identifiers as fields names inside a struct/union were wrongly treated as anonymous structs/unions. This is fixed now.