### PR TITLE
[cc65] Removed extra "'}' expected" error message

### DIFF
--- a/src/cc65/initdata.c
+++ b/src/cc65/initdata.c
@@ -497,7 +497,7 @@ static unsigned ParseStructInit (Type* T, int* Braces, int AllowFlexibleMembers)
 
             if (HasCurly) {
                 Error ("Excess elements in %s initializer", GetBasicTypeName (T));
-                SkipInitializer (HasCurly);
+                SkipInitializer (0);
             }
             break;
         }


### PR DESCRIPTION
Removed the extra "'}' expected" error message following a "Excess elements in struct/union initializer" error message:

```c
/* test.c */
struct {
    int a;
} z = { 1, 2 };
```
Before:
```
test.c:4: Error: Excess elements in struct initializer
test.c:4: Error: '}' expected
```
After:
```
test.c:4: Error: Excess elements in struct initializer
```
