### PR TITLE
[cc65] Fixed assertion failure when there is an undeclared symbol used in a parameter list

### DIFF
--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -1850,6 +1850,7 @@ static FuncDesc* ParseFuncDecl (void)
     }
 
     /* Parse params */
+    PushLexicalLevel (LEX_LEVEL_PARAM_LIST);
     if ((F->Flags & FD_OLDSTYLE) == 0) {
         /* New-style function */
         ParseAnsiParamList (F);
@@ -1857,6 +1858,7 @@ static FuncDesc* ParseFuncDecl (void)
         /* Old-style function */
         ParseOldStyleParamList (F);
     }
+    PopLexicalLevel ();
 
     /* Remember the last function parameter. We need it later for several
     ** purposes, for example when passing stuff to fastcall functions. Since

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -1221,7 +1221,14 @@ SymEntry* AddLocalSym (const char* Name, const Type* T, unsigned Flags, int Offs
     ident Ident;
 
     /* Do we have an entry with this name already? */
-    SymEntry* Entry = FindSymInTable (Tab, Name, HashStr (Name));
+    SymEntry* Entry;
+
+    /* HACK: only allows to add parameter symbols in a parameter list */
+    if ((Flags & SC_PARAM) == 0 && GetLexicalLevel () == LEX_LEVEL_PARAM_LIST) {
+        return 0;
+    }
+
+    Entry = FindSymInTable (Tab, Name, HashStr (Name));
 
     if (Entry) {
         int CheckExtern = 0;
@@ -1419,7 +1426,9 @@ SymEntry* AddGlobalSym (const char* Name, const Type* T, unsigned Flags)
     /* Add an alias of the global symbol to the local symbol table */
     if (Tab == SymTab0 && SymTab != SymTab0 && Entry->Owner != SymTab && Alias == 0) {
         Alias = AddLocalSym (Name, T, SC_ALIAS, 0);
-        Alias->V.A.Field = Entry;
+        if (Alias != 0) {
+            Alias->V.A.Field = Entry;
+        }
     }
 
     /* Return the entry */

--- a/src/cc65/symtab.h
+++ b/src/cc65/symtab.h
@@ -78,6 +78,7 @@ struct LexicalLevel {
 #define LEX_LEVEL_FUNCTION      2U
 #define LEX_LEVEL_BLOCK         3U
 #define LEX_LEVEL_STRUCT        4U
+#define LEX_LEVEL_PARAM_LIST    5U  /* HACK for error recovery */
 
 /* Forwards */
 struct FuncDesc;


### PR DESCRIPTION
Fixed the issue below:
```c
void ddf(int a[c], int b[d()]); /* Wrongly inserted 'c' and 'd' to the parameter symbol table before 'a' and 'b' */
void ddf(int a[], int b[]);     /* Assertion failure as 'c' (or 'd' if there weren't 'c') is not a parameter symbol */
```

Note: the diagnostic message complains about "undefined symbol" whilst it is actually an "undeclared symbol". See #2272.