### PR TITLE
[cc65] Improved diagnostics

### DIFF
--- a/src/cc65/asmstmt.c
+++ b/src/cc65/asmstmt.c
@@ -102,7 +102,7 @@ static SymEntry* AsmGetSym (unsigned Arg, unsigned Type)
 
     /* Did we find a symbol with this name? */
     if (Sym == 0) {
-        Error ("Undefined symbol '%s' for argument %u", CurTok.Ident, Arg);
+        Error ("Undeclared symbol '%s' for argument %u", CurTok.Ident, Arg);
         AsmErrorSkip ();
         return 0;
     }

--- a/src/cc65/declare.h
+++ b/src/cc65/declare.h
@@ -128,11 +128,19 @@ typedef enum {
 
 
 
+int SmartErrorSkip (void);
+/* Try some smart error recovery. Skip tokens until either a comma or semicolon
+** that is not enclosed in an open parenthesis/bracket/curly brace, or until an
+** unpaired right parenthesis/bracket/curly brace is reached. Return 0 if it is
+** the former case, or -1 if it is the latter case. */
+
 Type* ParseType (Type* Type);
 /* Parse a complete type specification */
 
-void ParseDecl (const DeclSpec* Spec, Declarator* D, declmode_t Mode);
-/* Parse a variable, type or function declarator */
+int ParseDecl (const DeclSpec* Spec, Declarator* D, declmode_t Mode);
+/* Parse a variable, type or function declarator. Return -1 if this stops at
+** an unpaired right parenthesis/bracket/curly brace.
+*/
 
 void ParseDeclSpec (DeclSpec* Spec, typespec_t TSFlags, unsigned DefStorage);
 /* Parse a declaration specification */

--- a/src/cc65/declare.h
+++ b/src/cc65/declare.h
@@ -98,11 +98,26 @@ struct Declarator {
     unsigned    Index;              /* Used to build Type */
 };
 
-/* Modes for ParseDecl */
+/* Modes for ParseDecl:
+**  - DM_NEED_IDENT means:
+**      we *must* have a type and a variable identifer.
+**  - DM_NO_IDENT means:
+**      we must have a type but no variable identifer
+**      (if there is one, it's not read).
+**  - DM_ACCEPT_IDENT means:
+**      we *may* have an identifier, or none. If it is the latter case,
+**      the type must be used as an empty declaration, or it is an error.
+**      Note: this is used for struct/union members.
+**  - DM_IGNORE_IDENT means:
+**      we *may* have an identifier. If there is an identifier,
+**      it is read, but it is no error, if there is none.
+**      Note: this is used for function parameter type lists.
+*/
 typedef enum {
-    DM_NEED_IDENT,                      /* We must have an identifier */
-    DM_NO_IDENT,                        /* We won't read an identifier */
-    DM_ACCEPT_IDENT,                    /* We will accept an id if there is one */
+    DM_NEED_IDENT,
+    DM_NO_IDENT,
+    DM_ACCEPT_IDENT,
+    DM_ACCEPT_PARAM_IDENT,
 } declmode_t;
 
 

--- a/src/cc65/error.c
+++ b/src/cc65/error.c
@@ -61,6 +61,8 @@
 /* Count of errors/warnings */
 unsigned ErrorCount     = 0;
 unsigned WarningCount   = 0;
+unsigned RecentLineNo     = 0;
+unsigned RecentErrorCount = 0;
 
 /* Warning and error options */
 IntStack WarnEnable         = INTSTACK(1);  /* Enable warnings */
@@ -205,8 +207,16 @@ static void IntError (const char* Filename, unsigned LineNo, const char* Msg, va
     if (Line) {
         Print (stderr, 1, "Input: %.*s\n", (int) SB_GetLen (Line), SB_GetConstBuf (Line));
     }
+
     ++ErrorCount;
-    if (ErrorCount > 20) {
+    if (RecentLineNo != LineNo) {
+        RecentLineNo = LineNo;
+        RecentErrorCount = 0;
+    } else {
+        ++RecentErrorCount;
+    }
+
+    if (RecentErrorCount > 20 || ErrorCount > 200) {
         Fatal ("Too many errors");
     }
 }

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1322,10 +1322,10 @@ static void Primary (ExprDesc* E)
                     E->Name  = (uintptr_t) Sym->Name;
                 } else {
                     /* Undeclared Variable */
+                    Error ("Undeclared identifier '%s'", Ident);
                     Sym = AddLocalSym (Ident, type_int, SC_AUTO | SC_REF, 0);
                     E->Flags = E_LOC_STACK | E_RTYPE_LVAL;
                     E->Type  = type_int;
-                    Error ("Undefined symbol: '%s'", Ident);
                 }
 
             }

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -1484,7 +1484,7 @@ void MakeZPSym (const char* Name)
     if (Entry) {
         Entry->Flags |= SC_ZEROPAGE;
     } else {
-        Error ("Undefined symbol: '%s'", Name);
+        Error ("Undeclared symbol: '%s'", Name);
     }
 }
 

--- a/test/ref/bug1889-missing-identifier.cref
+++ b/test/ref/bug1889-missing-identifier.cref
@@ -1,5 +1,3 @@
 bug1889-missing-identifier.c:3: Error: Identifier expected
 bug1889-missing-identifier.c:3: Error: ';' expected
-bug1889-missing-identifier.c:3: Warning: Implicit 'int' is an obsolete feature
 bug1889-missing-identifier.c:4: Error: Identifier expected
-bug1889-missing-identifier.c:4: Warning: Implicit 'int' is an obsolete feature

--- a/test/ref/custom-reference-error.cref
+++ b/test/ref/custom-reference-error.cref
@@ -1,5 +1,5 @@
 custom-reference-error.c:18: Error: Call to undeclared function 'printf'
-custom-reference-error.c:19: Error: Undefined symbol: 'n'
+custom-reference-error.c:19: Error: Undeclared identifier 'n'
 custom-reference-error.c:21: Warning: Control reaches end of non-void function [-Wreturn-type]
 custom-reference-error.c:21: Warning: Parameter 'argc' is never used
 custom-reference-error.c:21: Warning: Parameter 'argv' is never used


### PR DESCRIPTION
- [x] Resolved #2023.
- [x] Corrected "undefined symbol" with "undeclared symbol".
- [x] Fixed some rare cases when a single file-scope error could get reapeated endlessly until the maximum total count of errors allowed is reached.
- [X] Maximum total count of errors before the compiler unconditionally bails out is now 200.
- [X] If more than 20 errors occur on the same source line, the compiler will immediately bail out.