### PR TITLE
Expand macros in listing

### DIFF
--- a/src/ca65/global.c
+++ b/src/ca65/global.c
@@ -69,6 +69,7 @@ unsigned char RelaxChecks        = 0;   /* Relax a few assembler checks */
 unsigned char StringEscapes      = 0;   /* Allow C-style escapes in strings */
 unsigned char LongJsrJmpRts      = 0;   /* Allow JSR/JMP/RTS as alias for JSL/JML/RTL */
 unsigned char WarningsAsErrors   = 0;   /* Error if any warnings */
+unsigned char ExpandMacros       = 0;   /* Expand macros in listing */
 
 /* Emulation features */
 unsigned char DollarIsPC         = 0;   /* Allow the $ symbol as current PC */

--- a/src/ca65/global.h
+++ b/src/ca65/global.h
@@ -71,6 +71,7 @@ extern unsigned char    RelaxChecks;        /* Relax a few assembler checks */
 extern unsigned char    StringEscapes;      /* Allow C-style escapes in strings */
 extern unsigned char    LongJsrJmpRts;      /* Allow JSR/JMP/RTS as alias for JSL/JML/RTL */
 extern unsigned char    WarningsAsErrors;   /* Error if any warnings */
+extern unsigned char    ExpandMacros;       /* Expand macros in listing */
 
 /* Emulation features */
 extern unsigned char    DollarIsPC;         /* Allow the $ symbol as current PC */

--- a/src/ca65/istack.c
+++ b/src/ca65/istack.c
@@ -93,6 +93,7 @@ void PushInput (int (*Func) (void*), void* Data, const char* Desc)
 
     /* Push it */
     E->Next = IStack;
+    ICount++;
     IStack  = E;
 }
 
@@ -111,7 +112,7 @@ void PopInput (void)
 
     /* Pop it */
     IStack = IStack->Next;
-
+    ICount--;
     /* And delete it */
     xfree (E);
 }
@@ -155,4 +156,9 @@ void CheckInputStack (void)
     if (IStack) {
         Error ("Open %s", IStack->Desc);
     }
+}
+
+unsigned GetStackDepth (void)
+{
+    return ICount;
 }

--- a/src/ca65/istack.h
+++ b/src/ca65/istack.h
@@ -63,7 +63,7 @@ void CheckInputStack (void);
 ** stuff on the input stack.
 */
 
-
+unsigned GetStackDepth (void);
 
 /* End of istack.h */
 

--- a/src/ca65/macro.c
+++ b/src/ca65/macro.c
@@ -1112,8 +1112,8 @@ static StrBuf MakeLineFromTokens (TokNode* first)
             SB_AppendStr (&T, token_string);
             xfree (token_string);
         } else if (token->Tok == TOK_INTCON) {
-            char ival[11]; // max size a long can be
-            snprintf (ival, 11, "%d", token->IVal);
+            char ival[12]; // max size a long can be
+            snprintf (ival, sizeof(ival), "%ld", token->IVal);
             SB_AppendStr (&T, ival);
         } else if ((token_string = GetTokenString (token)) != NULL)
         {

--- a/src/ca65/macro.c
+++ b/src/ca65/macro.c
@@ -705,6 +705,7 @@ ExpandParam:
             if (new_expand_line) {
                 StrBuf  mac_line = MakeLineFromTokens (Mac->Exp);
                 NewListingLine (&mac_line, 0, 0);
+                InitListingLine ();
                 SB_Done (&mac_line);
                 new_expand_line = 0;
             }
@@ -1107,17 +1108,12 @@ static StrBuf MakeLineFromTokens (TokNode* first)
         /* is it a string of some sort?*/
         unsigned len = SB_GetLen (&token->SVal);
         if (len > 0) {
-            token_string = xmalloc (len + 1);
-            memcpy (token_string, SB_GetBuf (&token->SVal), len);
-            token_string[len] = 0;
-            SB_AppendStr (&T, token_string);
-            xfree (token_string);
+            SB_Append (&T, &token->SVal);
         } else if (token->Tok == TOK_INTCON) {
             char ival[12]; // max size a long can be
             snprintf (ival, sizeof(ival), "%ld", token->IVal);
             SB_AppendStr (&T, ival);
-        } else if ((token_string = GetTokenString (token)) != NULL)
-        {
+        } else if ((token_string = GetTokenString (token)) != NULL)   {
             SB_AppendStr (&T, token_string);
         }
         SB_Append (&S, &T);

--- a/src/ca65/macro.c
+++ b/src/ca65/macro.c
@@ -53,6 +53,7 @@
 #include "pseudo.h"
 #include "toklist.h"
 #include "macro.h"
+#include "listing.h"
 
 
 
@@ -74,7 +75,8 @@ static int HT_Compare (const void* Key1, const void* Key2);
 ** than zero if Key1 is greater then Key2.
 */
 
-
+static StrBuf MakeLineFromTokens (TokNode* first);
+static char* GetTokenString (Token* T);
 
 /*****************************************************************************/
 /*                                   Data                                    */
@@ -689,6 +691,8 @@ ExpandParam:
         Mac->ParamLI = 0;
 
     }
+    /* boolean to indicate that we need to start a new macro expansion line*/
+    static int new_expand_line = 1;
 
     /* We're not expanding macro parameters. Check if we have tokens left from
     ** the macro itself.
@@ -697,7 +701,16 @@ ExpandParam:
 
         /* Use next macro token */
         TokSet (Mac->Exp);
-
+        if (ExpandMacros) {
+            if (new_expand_line) {
+                StrBuf  mac_line = MakeLineFromTokens (Mac->Exp);
+                NewListingLine (&mac_line, 0, 0);
+                new_expand_line = 0;
+            }
+            if (CurTok.Tok == TOK_SEP) {
+                new_expand_line = 1;
+            }
+        }
         /* Create new line info for this token */
         if (Mac->LI) {
             EndLine (Mac->LI);
@@ -1064,4 +1077,128 @@ void EnableDefineStyleMacros (void)
 {
     PRECONDITION (DisableDefines > 0);
     --DisableDefines;
+}
+
+static StrBuf MakeLineFromTokens (TokNode* first)
+{
+    /* This code reconstitutes a Macro line from the 'compiled' tokens*/
+    unsigned I;
+    /* string to be returned */
+    StrBuf S = STATIC_STRBUF_INITIALIZER;
+
+
+    /* prepend depth indicator */
+    for (I = 0; I < GetStackDepth (); I++) {
+        SB_AppendStr (&S, ">");
+    }
+    SB_AppendStr (&S, " ");
+
+    TokNode* tn = first;
+    while (tn) {
+        /* per token string */
+        StrBuf T = STATIC_STRBUF_INITIALIZER;
+
+        Token* token = &tn->T;
+        tn = tn->Next;
+        char* token_string;
+        /* leading white space?*/
+        if (token->WS) SB_AppendChar (&T, ' ');
+        /* is it a string of some sort?*/
+        unsigned len = SB_GetLen (&token->SVal);
+        if (len > 0) {
+            token_string = xmalloc (len + 1);
+            memcpy (token_string, SB_GetBuf (&token->SVal), len);
+            token_string[len] = 0;
+            SB_AppendStr (&T, token_string);
+            xfree (token_string);
+        } else if (token->Tok == TOK_INTCON) {
+            char ival[11]; // max size a long can be
+            snprintf (ival, 11, "%d", token->IVal);
+            SB_AppendStr (&T, ival);
+        } else if ((token_string = GetTokenString (token)) != NULL)
+        {
+            SB_AppendStr (&T, token_string);
+        }
+        SB_Append (&S, &T);
+        if (token->Tok == TOK_SEP) {
+            return S;
+        }
+    }
+    return S;
+}
+
+static char* GetTokenString (Token* T)
+{
+    switch (T->Tok) {
+
+        case TOK_ASSIGN: return ":=";       /* := */
+        case TOK_ULABEL: return ":++";      /* :++ or :-- */
+
+        case TOK_EQ:return "=";             /* = */
+        case TOK_NE: return "<>";           /* <> */
+        case TOK_LT: return "<";            /* < */
+        case TOK_GT:return ">";             /* > */
+        case TOK_LE: return "<=";           /* <= */
+        case TOK_GE:return ">=";            /* >= */
+
+                //TOK_BOOLAND,        /* .and */
+                //TOK_BOOLOR,         /* .or */
+                ///TOK_BOOLXOR,        /* .xor */
+                //TOK_BOOLNOT,        /* .not */
+
+        case TOK_PLUS: return "+";          /* + */
+        case TOK_MINUS:return "-";          /* - */
+        case TOK_MUL: return "*";           /* * */
+        case TOK_DIV: return "/";           /* / */
+        case TOK_MOD:return "!";            /* ! */
+        case TOK_OR: return "|";            /* | */
+        case TOK_XOR: return "^";           /* ^ */
+        case TOK_AND:return "&";            /* & */
+        case TOK_SHL: return "<<";          /* << */
+        case TOK_SHR: return ">>";          /* >> */
+        case TOK_NOT:return "~";            /* ~ */
+
+        case TOK_PC: return "$";            /* $ if enabled */
+        case TOK_NAMESPACE:return "::";     /* :: */
+        case TOK_DOT:return ".";            /* . */
+        case TOK_COMMA:return ",";          /* , */
+        case TOK_HASH: return "#";          /* # */
+        case TOK_COLON:return ":";          /* : */
+        case TOK_LPAREN:return "(";         /* ( */
+        case TOK_RPAREN:return ")";         /* ) */
+        case TOK_LBRACK:return "[";         /* [ */
+        case TOK_RBRACK:return "]";         /* ] */
+        case TOK_LCURLY:return "{";         /* { */
+        case TOK_RCURLY:return "}";         /* } */
+        case TOK_AT:return "@";             /* @ - in Sweet16 mode */
+
+        case TOK_OVERRIDE_ZP:return "z:";    /* z: */
+        case TOK_OVERRIDE_ABS:return "a:";   /* a: */
+        case TOK_OVERRIDE_FAR:return "f:";   /* f: */
+        default: return NULL;
+    }
+}
+StrBuf xMakeLineFromTokens (TokNode* first)
+{
+    StrBuf S = STATIC_STRBUF_INITIALIZER;
+    StrBuf T = STATIC_STRBUF_INITIALIZER;
+    SB_AppendStr (&S, ">> ");
+    TokNode* tn = first;
+    while (tn) {
+        Token* t = &tn->T;
+        tn = tn->Next;
+        char str[100];
+        int len = SB_GetLen (&t->SVal);
+        if (len > 0) {
+            memcpy (str, SB_GetBuf (&t->SVal), len);
+            str[len] = 0;
+        } else str[0] = 0;
+        SB_Printf (&T, "%s ", str);
+        SB_Append (&S, &T);
+        if (t->Tok == TOK_SEP) {
+
+            return S;
+        }
+    }
+    return S;
 }

--- a/src/ca65/macro.c
+++ b/src/ca65/macro.c
@@ -705,6 +705,7 @@ ExpandParam:
             if (new_expand_line) {
                 StrBuf  mac_line = MakeLineFromTokens (Mac->Exp);
                 NewListingLine (&mac_line, 0, 0);
+                SB_Done (&mac_line);
                 new_expand_line = 0;
             }
             if (CurTok.Tok == TOK_SEP) {
@@ -1141,10 +1142,6 @@ static char* GetTokenString (Token* T)
         case TOK_LE: return "<=";           /* <= */
         case TOK_GE:return ">=";            /* >= */
 
-                //TOK_BOOLAND,        /* .and */
-                //TOK_BOOLOR,         /* .or */
-                ///TOK_BOOLXOR,        /* .xor */
-                //TOK_BOOLNOT,        /* .not */
 
         case TOK_PLUS: return "+";          /* + */
         case TOK_MINUS:return "-";          /* - */
@@ -1177,28 +1174,4 @@ static char* GetTokenString (Token* T)
         case TOK_OVERRIDE_FAR:return "f:";   /* f: */
         default: return NULL;
     }
-}
-StrBuf xMakeLineFromTokens (TokNode* first)
-{
-    StrBuf S = STATIC_STRBUF_INITIALIZER;
-    StrBuf T = STATIC_STRBUF_INITIALIZER;
-    SB_AppendStr (&S, ">> ");
-    TokNode* tn = first;
-    while (tn) {
-        Token* t = &tn->T;
-        tn = tn->Next;
-        char str[100];
-        int len = SB_GetLen (&t->SVal);
-        if (len > 0) {
-            memcpy (str, SB_GetBuf (&t->SVal), len);
-            str[len] = 0;
-        } else str[0] = 0;
-        SB_Printf (&T, "%s ", str);
-        SB_Append (&S, &T);
-        if (t->Tok == TOK_SEP) {
-
-            return S;
-        }
-    }
-    return S;
 }

--- a/src/ca65/macro.c
+++ b/src/ca65/macro.c
@@ -1132,7 +1132,7 @@ StrBuf MakeLineFromTokens (TokNode* first)
             SB_AppendStr (&T, ival);
         } else if ((token_string = GetTokenString (token)) != NULL)   {
             SB_AppendStr (&T, token_string);
-        } 
+        }
         SB_Append (&S, &T);
         if (token->Tok == TOK_SEP) {
             return S;

--- a/src/ca65/macro.h
+++ b/src/ca65/macro.h
@@ -36,7 +36,7 @@
 #ifndef MACRO_H
 #define MACRO_H
 
-
+#include "toklist.h"
 
 /*****************************************************************************/
 /*                                 Forwards                                  */
@@ -105,7 +105,7 @@ void EnableDefineStyleMacros (void);
 ** DisableDefineStyleMacros.
 */
 
-
+StrBuf MakeLineFromTokens (TokNode* first);
 
 /* End of macro.h */
 

--- a/src/ca65/main.c
+++ b/src/ca65/main.c
@@ -702,9 +702,11 @@ static void OneLine (void)
     int           Instr = -1;
 
     /* Initialize the new listing line if we are actually reading from file
-    ** and not from internally pushed input, unless expanding macros
+    ** and not from internally pushed input
     */
-    if (!HavePushedInput () || ExpandMacros) {
+
+    
+    if (!HavePushedInput () ) {
         InitListingLine ();
     }
 

--- a/src/ca65/main.c
+++ b/src/ca65/main.c
@@ -676,7 +676,7 @@ static void OptExpandMacros (const char* Opt attribute ((unused)),
     const char* Arg attribute ((unused)))
     /* Expand macros in listing
     ** one -m means short listing
-    ** two means full listing 
+    ** two means full listing
     */
 {
 
@@ -709,7 +709,6 @@ static void OneLine (void)
     ** and not from internally pushed input
     */
 
-    
     if (!HavePushedInput () ) {
         InitListingLine ();
     }
@@ -899,7 +898,7 @@ static void Assemble (void)
     while (CurTok.Tok != TOK_EOF) {
         OneLine ();
     }
- 
+
 }
 
 

--- a/src/ca65/main.c
+++ b/src/ca65/main.c
@@ -131,7 +131,7 @@ static void Usage (void)
             "  --target sys\t\t\tSet the target system\n"
             "  --verbose\t\t\tIncrease verbosity\n"
             "  --version\t\t\tPrint the assembler version\n"
-            "  --expand_macros\t\tExpand macros in the listing\n",
+            "  --expand-macros\t\tExpand macros in the listing\n",
             ProgName);
 }
 
@@ -975,7 +975,7 @@ int main (int argc, char* argv [])
         { "--verbose",             0,      OptVerbose              },
         { "--version",             0,      OptVersion              },
         { "--warnings-as-errors",  0,      OptWarningsAsErrors     },
-        { "--expand_macros",       0,      OptExpandMacros         },
+        { "--expand-macros",       0,      OptExpandMacros         },
     };
 
     /* Name of the global name space */

--- a/src/ca65/main.c
+++ b/src/ca65/main.c
@@ -674,9 +674,13 @@ static void OptWarningsAsErrors (const char* Opt attribute ((unused)),
 
 static void OptExpandMacros (const char* Opt attribute ((unused)),
     const char* Arg attribute ((unused)))
-    /* Exapnd macros in listing */
+    /* Expand macros in listing
+    ** one -m means short listing
+    ** two means full listing 
+    */
 {
-    ExpandMacros = 1;
+
+    ExpandMacros++;
 }
 
 static void DoPCAssign (void)
@@ -895,6 +899,7 @@ static void Assemble (void)
     while (CurTok.Tok != TOK_EOF) {
         OneLine ();
     }
+ 
 }
 
 
@@ -1080,7 +1085,7 @@ int main (int argc, char* argv [])
                     WarnLevel = atoi (GetArg (&I, 2));
                     break;
                 case 'x':
-                    ExpandMacros = 1;
+                    ExpandMacros++;
                     break;
 
 

--- a/src/ca65/main.c
+++ b/src/ca65/main.c
@@ -107,6 +107,7 @@ static void Usage (void)
             "  -s\t\t\t\tEnable smart mode\n"
             "  -t sys\t\t\tSet the target system\n"
             "  -v\t\t\t\tIncrease verbosity\n"
+            "  -x\t\t\t\tExpand macros\n"
             "\n"
             "Long options:\n"
             "  --auto-import\t\t\tMark unresolved symbols as import\n"
@@ -129,7 +130,8 @@ static void Usage (void)
             "  --smart\t\t\tEnable smart mode\n"
             "  --target sys\t\t\tSet the target system\n"
             "  --verbose\t\t\tIncrease verbosity\n"
-            "  --version\t\t\tPrint the assembler version\n",
+            "  --version\t\t\tPrint the assembler version\n"
+            "  --expand_macros\t\tExpand macros in the listing\n",
             ProgName);
 }
 
@@ -670,7 +672,12 @@ static void OptWarningsAsErrors (const char* Opt attribute ((unused)),
     WarningsAsErrors = 1;
 }
 
-
+static void OptExpandMacros (const char* Opt attribute ((unused)),
+    const char* Arg attribute ((unused)))
+    /* Exapnd macros in listing */
+{
+    ExpandMacros = 1;
+}
 
 static void DoPCAssign (void)
 /* Start absolute code */
@@ -695,9 +702,9 @@ static void OneLine (void)
     int           Instr = -1;
 
     /* Initialize the new listing line if we are actually reading from file
-    ** and not from internally pushed input.
+    ** and not from internally pushed input, unless expanding macros
     */
-    if (!HavePushedInput ()) {
+    if (!HavePushedInput () || ExpandMacros) {
         InitListingLine ();
     }
 
@@ -962,6 +969,7 @@ int main (int argc, char* argv [])
         { "--verbose",             0,      OptVerbose              },
         { "--version",             0,      OptVersion              },
         { "--warnings-as-errors",  0,      OptWarningsAsErrors     },
+        { "--expand_macros",       0,      OptExpandMacros         },
     };
 
     /* Name of the global name space */
@@ -1069,6 +1077,10 @@ int main (int argc, char* argv [])
                 case 'W':
                     WarnLevel = atoi (GetArg (&I, 2));
                     break;
+                case 'x':
+                    ExpandMacros = 1;
+                    break;
+
 
                 default:
                     UnknownOption (Arg);

--- a/src/ca65/scanner.c
+++ b/src/ca65/scanner.c
@@ -378,6 +378,16 @@ static void IFMarkStart (CharSource* S)
 static void IFNextChar (CharSource* S)
 /* Read the next character from the input file */
 {
+    /* if expanding macros the next input line gets pushed too early
+    ** to the output. So defer the push.
+    ** Its harmless to do it regardless of expansion or not
+    */
+    static int pending_line = 0;
+    if (pending_line) {
+        NewListingLine (&S->V.File.Line, S->V.File.Pos.Name, FCount);
+        pending_line = 0;
+    };
+
     /* Check for end of line, read the next line if needed */
     while (SB_GetIndex (&S->V.File.Line) >= SB_GetLen (&S->V.File.Line)) {
 
@@ -443,7 +453,8 @@ static void IFNextChar (CharSource* S)
         S->V.File.Pos.Line++;
 
         /* Remember the new line for the listing */
-        NewListingLine (&S->V.File.Line, S->V.File.Pos.Name, FCount);
+
+        pending_line = 1;
 
     }
 


### PR DESCRIPTION
This code expands macros in the listing. This is extremely useful for macros that include segment switches (its what made me do this) but is also generally useful.

adds command line switches
 - -x
 - --expand_macros

It does not try to save to macro source code, instead the macro is 'disassembled' when it is expanded. This was, I felt, less invasive on the internal data structures. This does mean that the expansion is not 100% like the input but is certainly sufficient to work out what line generated what code, and importantly what segment it went into.

Here is sample from msbasic.s (from https://github.com/mist64/msbasic) with and without expansion, it target 3 different segments

without

```
000000r 2  rr rr 45 4E  		keyword_rts "END", END
000004r 2  C4 xx 
```

with expansion

```
000000r 2               		keyword_rts "END", END
000000r 0               >  .SEGMENT VECTORS
000000r 0  rr rr        >  .WORD vec-1
000002r 0               >  keyword key, token
000002r 0               >>  .SEGMENT KEYWORDS
000000r 0               >>  htasc key
000000r 0               >>>  .REPEAT .STRLEN(str)-1,I
000000r 0               >>>  .BYTE .STRAT(str,I)
000001r 0  45 4E        >>>  .ENDREP
000002r 0  C4           >>>  .BYTE .STRAT(str,.STRLEN(str)-1) | 128
000003r 0               >>  define_token token
000003r 0               >>>  .SEGMENT DUMMY
000000r 0               >>>  .IFNBLANK token
000000r 0               >>>  token := <(*-DUMMY_START)+128
000000r 0               >>>  .ENDIF
000000r 0  xx           >>>  .RES 1
```

these macros are nested 3 deep (thats what the > characters show)