### PR TITLE
Add segment ID to assembler listing for reloc code

### DIFF
--- a/l.txt
+++ b/l.txt
@@ -1,0 +1,9046 @@
+ca65 V2.19
+Main file   : C:\work\msbasic65\msbasic.s
+Current file: C:\work\msbasic65\msbasic.s
+
+00.000000r 1               ; Microsoft BASIC for 6502
+00.000000r 1               ;
+00.000000r 1               ; (first revision of this distribution, 20 Oct 2008, Michael Steil www.pagetable.com)
+00.000000r 1               ;
+00.000000r 1               ; This is a single integrated assembly source tree that can generate seven different versions of
+00.000000r 1               ; Microsoft BASIC for 6502.
+00.000000r 1               ;
+00.000000r 1               ; By running ./make.sh, this will generate all versions and compare them to the original files
+00.000000r 1               ; byte by byte. The CC65 compiler suite is need to build this project.
+00.000000r 1               ;
+00.000000r 1               ; These are the first eight (known) versions of Microsoft BASIC for 6502:
+00.000000r 1               ;
+00.000000r 1               ; Name                 Release   MS Version    ROM   9digit  INPUTBUFFER   extensions   .define
+00.000000r 1               ;---------------------------------------------------------------------------------------------------
+00.000000r 1               ; Commodore BASIC 1     1977                    Y      Y          ZP          CBM
+00.000000r 1               ; OSI BASIC             1977     1.0 REV 3.2    Y      N          ZP            -        CONFIG_10A
+00.000000r 1               ; AppleSoft I           1977     1.1            N      Y        $0200         Apple      CONFIG_11
+00.000000r 1               ; KIM BASIC             1977     1.1            N      Y          ZP            -        CONFIG_11A
+00.000000r 1               ; AppleSoft II          1978                    Y      Y        $0200         Apple      CONFIG_2
+00.000000r 1               ; Commodore BASIC 2     1979                    Y      Y        $0200          CBM       CONFIG_2A
+00.000000r 1               ; KBD BASIC             1982                    Y      N        $0700          KBD       CONFIG_2B
+00.000000r 1               ; MicroTAN              1980                    Y      Y          ZP            -        CONFIG_2C
+00.000000r 1               ;
+00.000000r 1               ; (Note that this assembly source cannot (yet) build AppleSoft II.)
+00.000000r 1               ;
+00.000000r 1               ; This lists the versions in the order in which they were forked from the Microsoft source base.
+00.000000r 1               ; Commodore BASIC 1, as used on the original PET is the oldest known version of Microsoft BASIC
+00.000000r 1               ; for 6502. It contains some additions to Microsoft's version, like Commodore-style file I/O.
+00.000000r 1               ;
+00.000000r 1               ; The CONFIG_n defines specify what Microsoft-version the OEM version is based on. If CONFIG_2B
+00.000000r 1               ; is defined, for example, CONFIG_2A, CONFIG_2, CONFIG_11A, CONFIG_11 and CONFIG_10A will be
+00.000000r 1               ; defined as well, and all bugfixes up to version 2B will be enabled.
+00.000000r 1               ;
+00.000000r 1               ; The following symbols can be defined in addition:
+00.000000r 1               ;
+00.000000r 1               ; CONFIG_CBM1_PATCHES				jump out into CBM1's binary patches instead of doing the right thing inline
+00.000000r 1               ; CONFIG_CBM_ALL					add all Commodore-specific additions except file I/O
+00.000000r 1               ; CONFIG_DATAFLG					?
+00.000000r 1               ; CONFIG_EASTER_EGG					include the CBM2 "WAIT 6502" easter egg
+00.000000r 1               ; CONFIG_FILE						support Commodore PRINT#, INPUT#, GET#, CMD
+00.000000r 1               ; CONFIG_IO_MSB						all I/O has bit #7 set
+00.000000r 1               ; CONFIG_MONCOUT_DESTROYS_Y			Y needs to be preserved when calling MONCOUT
+00.000000r 1               ; CONFIG_NO_CR						terminal doesn't need explicit CRs on line ends
+00.000000r 1               ; CONFIG_NO_LINE_EDITING			disable support for Microsoft-style "@", "_", BEL etc.
+00.000000r 1               ; CONFIG_NO_POKE					don't support PEEK, POKE and WAIT
+00.000000r 1               ; CONFIG_NO_READ_Y_IS_ZERO_HACK		don't do a very volatile trick that saves one byte
+00.000000r 1               ; CONFIG_NULL						support for the NULL statement
+00.000000r 1               ; CONFIG_PEEK_SAVE_LINNUM			preserve LINNUM on a PEEK
+00.000000r 1               ; CONFIG_PRINTNULLS					whether PRINTNULLS does anything
+00.000000r 1               ; CONFIG_PRINT_CR					print CR when line end reached
+00.000000r 1               ; CONFIG_RAM						optimizations for RAM version of BASIC, only use on 1.x
+00.000000r 1               ; CONFIG_ROR_WORKAROUND				use workaround for buggy 6502s from 1975/1976; not safe for CONFIG_SMALL!
+00.000000r 1               ; CONFIG_SAFE_NAMENOTFOUND			check both bytes of the caller's address in NAMENOTFOUND
+00.000000r 1               ; CONFIG_SCRTCH_ORDER				where in the init code to call SCRTCH
+00.000000r 1               ; CONFIG_SMALL						use 6 digit FP instead of 9 digit, use 2 character error messages, don't have GET
+00.000000r 1               ;
+00.000000r 1               ; Changing symbol definitions can alter an existing base configuration, but it not guaranteed to assemble
+00.000000r 1               ; or work correctly.
+00.000000r 1               ;
+00.000000r 1               ; Credits:
+00.000000r 1               ; * main work by Michael Steil
+00.000000r 1               ; * function names and all uppercase comments taken from Bob Sander-Cederlof's excellent AppleSoft II disassembly:
+00.000000r 1               ;   http://www.txbobsc.com/scsc/scdocumentor/
+00.000000r 1               ; * Applesoft lite by Tom Greene http://cowgod.org/replica1/applesoft/ helped a lot, too.
+00.000000r 1               ; * Thanks to Joe Zbicak for help with Intellision Keyboard BASIC
+00.000000r 1               ; * This work is dedicated to the memory of my dear hacking pal Michael "acidity" Kollmann.
+00.000000r 1               
+00.000000r 1               .debuginfo +
+00.000000r 1               
+00.000000r 1               .setcpu "6502"
+00.000000r 1               .macpack longbranch
+00.000000r 2               .macro  jeq     Target
+00.000000r 2                       .if     .match(Target, 0)
+00.000000r 2                       bne     *+5
+00.000000r 2                       jmp     Target
+00.000000r 2                       .elseif .def(Target) .and .const((*-2)-(Target)) .and ((*+2)-(Target) <= 127)
+00.000000r 2                               beq     Target
+00.000000r 2                       .else
+00.000000r 2                               bne     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .endif
+00.000000r 2               .endmacro
+00.000000r 2               .macro  jne     Target
+00.000000r 2                       .if     .match(Target, 0)
+00.000000r 2                               beq     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .elseif .def(Target) .and .const((*-2)-(Target)) .and ((*+2)-(Target) <= 127)
+00.000000r 2                               bne     Target
+00.000000r 2                       .else
+00.000000r 2                               beq     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .endif
+00.000000r 2               .endmacro
+00.000000r 2               .macro  jmi     Target
+00.000000r 2                       .if     .match(Target, 0)
+00.000000r 2                               bpl     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .elseif .def(Target) .and .const((*-2)-(Target)) .and ((*+2)-(Target) <= 127)
+00.000000r 2                               bmi     Target
+00.000000r 2                       .else
+00.000000r 2                               bpl     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .endif
+00.000000r 2               .endmacro
+00.000000r 2               .macro  jpl     Target
+00.000000r 2                       .if     .match(Target, 0)
+00.000000r 2                               bmi     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .elseif .def(Target) .and .const((*-2)-(Target)) .and ((*+2)-(Target) <= 127)
+00.000000r 2                               bpl     Target
+00.000000r 2                       .else
+00.000000r 2                               bmi     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .endif
+00.000000r 2               .endmacro
+00.000000r 2               .macro  jcs     Target
+00.000000r 2                       .if     .match(Target, 0)
+00.000000r 2                               bcc     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .elseif .def(Target) .and .const((*-2)-(Target)) .and ((*+2)-(Target) <= 127)
+00.000000r 2                               bcs     Target
+00.000000r 2                       .else
+00.000000r 2                               bcc     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .endif
+00.000000r 2               .endmacro
+00.000000r 2               .macro  jcc     Target
+00.000000r 2                       .if     .match(Target, 0)
+00.000000r 2                               bcs     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .elseif .def(Target) .and .const((*-2)-(Target)) .and ((*+2)-(Target) <= 127)
+00.000000r 2                               bcc     Target
+00.000000r 2                       .else
+00.000000r 2                               bcs     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .endif
+00.000000r 2               .endmacro
+00.000000r 2               .macro  jvs     Target
+00.000000r 2                       .if     .match(Target, 0)
+00.000000r 2                               bvc     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .elseif .def(Target) .and .const((*-2)-(Target)) .and ((*+2)-(Target) <= 127)
+00.000000r 2                               bvs     Target
+00.000000r 2                       .else
+00.000000r 2                               bvc     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .endif
+00.000000r 2               .endmacro
+00.000000r 2               .macro  jvc     Target
+00.000000r 2                       .if     .match(Target, 0)
+00.000000r 2                               bvs     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .elseif .def(Target) .and .const((*-2)-(Target)) .and ((*+2)-(Target) <= 127)
+00.000000r 2                               bvc     Target
+00.000000r 2                       .else
+00.000000r 2                               bvs     *+5
+00.000000r 2                               jmp     Target
+00.000000r 2                       .endif
+00.000000r 2               .endmacro
+00.000000r 2               
+00.000000r 1               
+00.000000r 1               .include "defines.s"
+00.000000r 2               .if .def(cbmbasic1)
+00.000000r 2               CBM1 := 1
+00.000000r 2               .include "defines_cbm1.s"
+00.000000r 2               .elseif .def(osi)
+00.000000r 2               OSI := 1
+00.000000r 2               .include "defines_osi.s"
+00.000000r 2               .elseif .def(applesoft)
+00.000000r 2               APPLE := 1
+00.000000r 2               .include "defines_apple.s"
+00.000000r 2               .elseif .def(kb9)
+00.000000r 2               KIM := 1
+00.000000r 2               .include "defines_kim.s"
+00.000000r 3               ; configuration
+00.000000r 3               CONFIG_11A := 1
+00.000000r 3               
+00.000000r 3               CONFIG_MONCOUT_DESTROYS_Y := 1
+00.000000r 3               CONFIG_NULL := 1
+00.000000r 3               CONFIG_PRINT_CR := 1 ; print CR when line end reached
+00.000000r 3               CONFIG_RAM := 1
+00.000000r 3               CONFIG_ROR_WORKAROUND := 1
+00.000000r 3               CONFIG_SAFE_NAMENOTFOUND := 1
+00.000000r 3               CONFIG_SCRTCH_ORDER := 2
+00.000000r 3               
+00.000000r 3               ; zero page
+00.000000r 3               ZP_START1 = $00
+00.000000r 3               ZP_START2 = $15
+00.000000r 3               ZP_START3 = $0A
+00.000000r 3               ZP_START4 = $63
+00.000000r 3               
+00.000000r 3               ; constants
+00.000000r 3               STACK_TOP		:= $FC
+00.000000r 3               SPACE_FOR_GOSUB := $36
+00.000000r 3               NULL_MAX		:= $F2 ; probably different in original version; the image I have seems to be modified; see PDF
+00.000000r 3               WIDTH			:= 72
+00.000000r 3               WIDTH2			:= 56
+00.000000r 3               
+00.000000r 3               ; magic memory locations
+00.000000r 3               L1800           := $1800
+00.000000r 3               L1873           := $1873
+00.000000r 3               
+00.000000r 3               ; monitor functions
+00.000000r 3               MONRDKEY        := $1E5A
+00.000000r 3               MONCOUT         := $1EA0
+00.000000r 3               
+00.000000r 3               
+00.000000r 2               .elseif .def(cbmbasic2)
+00.000000r 2               CBM2 := 1
+00.000000r 2               .include "defines_cbm2.s"
+00.000000r 2               .elseif .def(kbdbasic)
+00.000000r 2               KBD := 1
+00.000000r 2               .include "defines_kbd.s"
+00.000000r 2               .elseif .def(microtan)
+00.000000r 2               MICROTAN := 1
+00.000000r 2               .include "defines_microtan.s"
+00.000000r 2               .endif
+00.000000r 2               
+00.000000r 2               .ifdef CONFIG_2C
+00.000000r 2               CONFIG_2B := 1
+00.000000r 2               .endif
+00.000000r 2               .ifdef CONFIG_2B
+00.000000r 2               CONFIG_2A := 1
+00.000000r 2               .endif
+00.000000r 2               .ifdef CONFIG_2A
+00.000000r 2               CONFIG_2 := 1
+00.000000r 2               .endif
+00.000000r 2               .ifdef CONFIG_2
+00.000000r 2               CONFIG_11A := 1
+00.000000r 2               .endif
+00.000000r 2               .ifdef CONFIG_11A
+00.000000r 2               CONFIG_11 := 1
+00.000000r 2               .endif
+00.000000r 2               .ifdef CONFIG_11
+00.000000r 2               CONFIG_10A := 1
+00.000000r 2               .endif
+00.000000r 2               
+00.000000r 2               .ifdef CONFIG_SMALL
+00.000000r 2               BYTES_FP		:= 4
+00.000000r 2               .else
+00.000000r 2               BYTES_FP		:= 5
+00.000000r 2               .endif
+00.000000r 2               
+00.000000r 2               .ifndef BYTES_PER_ELEMENT
+00.000000r 2               BYTES_PER_ELEMENT := BYTES_FP
+00.000000r 2               .endif
+00.000000r 2               BYTES_PER_VARIABLE := BYTES_FP+2
+00.000000r 2               MANTISSA_BYTES	:= BYTES_FP-1
+00.000000r 2               BYTES_PER_FRAME := 2*BYTES_FP+8
+00.000000r 2               FOR_STACK1		:= 2*BYTES_FP+5
+00.000000r 2               FOR_STACK2		:= BYTES_FP+4
+00.000000r 2               
+00.000000r 2               .ifndef MAX_EXPON
+00.000000r 2               MAX_EXPON = 10
+00.000000r 2               .endif
+00.000000r 2               
+00.000000r 2               STACK           := $0100
+00.000000r 2               
+00.000000r 2               .ifdef INPUTBUFFER
+00.000000r 2                 .if INPUTBUFFER >= $0100
+00.000000r 2               CONFIG_NO_INPUTBUFFER_ZP := 1
+00.000000r 2                 .endif
+00.000000r 2                 .if INPUTBUFFER = $0200
+00.000000r 2               CONFIG_INPUTBUFFER_0200 := 1
+00.000000r 2                 .endif
+00.000000r 2               .endif
+00.000000r 2               INPUTBUFFERX = INPUTBUFFER & $FF00
+00.000000r 2               
+00.000000r 2               CR=13
+00.000000r 2               LF=10
+00.000000r 2               
+00.000000r 2               .ifndef CRLF_1
+00.000000r 2               CRLF_1 := CR
+00.000000r 2               CRLF_2 := LF
+00.000000r 2               .endif
+00.000000r 2               
+00.000000r 2               
+00.000000r 2               
+00.000000r 2               
+00.000000r 1               .include "macros.s"
+00.000000r 2               ; htasc - set the hi bit on the last byte of a string for termination
+00.000000r 2               ; (by Tom Greene)
+00.000000r 2               .macro htasc str
+00.000000r 2               	.repeat	.strlen(str)-1,I
+00.000000r 2               		.byte	.strat(str,I)
+00.000000r 2               	.endrep
+00.000000r 2               	.byte	.strat(str,.strlen(str)-1) | $80
+00.000000r 2               .endmacro
+00.000000r 2               
+00.000000r 2               ; For every token, a byte gets put into segment "DUMMY".
+00.000000r 2               ; This way, we count up with every token. The DUMMY segment
+00.000000r 2               ; doesn't get linked into the binary.
+00.000000r 2               .macro init_token_tables
+00.000000r 2                       .segment "VECTORS"
+00.000000r 2               TOKEN_ADDRESS_TABLE:
+00.000000r 2                       .segment "KEYWORDS"
+00.000000r 2               TOKEN_NAME_TABLE:
+00.000000r 2               		.segment "DUMMY"
+00.000000r 2               DUMMY_START:
+00.000000r 2               .endmacro
+00.000000r 2               
+00.000000r 2               ; optionally define token symbol
+00.000000r 2               ; count up token number
+00.000000r 2               .macro define_token token
+00.000000r 2                       .segment "DUMMY"
+00.000000r 2               		.ifnblank token
+00.000000r 2               			token := <(*-DUMMY_START)+$80
+00.000000r 2               		.endif
+00.000000r 2               		.res 1; count up in any case
+00.000000r 2               .endmacro
+00.000000r 2               
+00.000000r 2               ; lay down a keyword, optionally define a token symbol
+00.000000r 2               .macro keyword key, token
+00.000000r 2               		.segment "KEYWORDS"
+00.000000r 2               		htasc	key
+00.000000r 2               		define_token token
+00.000000r 2               .endmacro
+00.000000r 2               
+00.000000r 2               ; lay down a keyword and an address (RTS style),
+00.000000r 2               ; optionally define a token symbol
+00.000000r 2               .macro keyword_rts key, vec, token
+00.000000r 2                       .segment "VECTORS"
+00.000000r 2               		.word	vec-1
+00.000000r 2               		keyword key, token
+00.000000r 2               .endmacro
+00.000000r 2               
+00.000000r 2               ; lay down a keyword and an address,
+00.000000r 2               ; optionally define a token symbol
+00.000000r 2               .macro keyword_addr key, vec, token
+00.000000r 2                       .segment "VECTORS"
+00.000000r 2               		.addr	vec
+00.000000r 2               		keyword key, token
+00.000000r 2               .endmacro
+00.000000r 2               
+00.000000r 2               .macro count_tokens
+00.000000r 2                       .segment "DUMMY"
+00.000000r 2               		NUM_TOKENS := <(*-DUMMY_START)
+00.000000r 2               .endmacro
+00.000000r 2               
+00.000000r 2               .macro init_error_table
+00.000000r 2                       .segment "ERROR"
+00.000000r 2               ERROR_MESSAGES:
+00.000000r 2               .endmacro
+00.000000r 2               
+00.000000r 2               .macro define_error error, msg
+00.000000r 2                       .segment "ERROR"
+00.000000r 2               		error := <(*-ERROR_MESSAGES)
+00.000000r 2               		htasc msg
+00.000000r 2               .endmacro
+00.000000r 2               
+00.000000r 2               ;---------------------------------------------
+00.000000r 2               ; set the MSB of every byte of a string
+00.000000r 2               .macro asc80 str
+00.000000r 2               	.repeat	.strlen(str),I
+00.000000r 2               		.byte	.strat(str,I)+$80
+00.000000r 2               	.endrep
+00.000000r 2               .endmacro
+00.000000r 2               
+00.000000r 2               
+00.000000r 1               .include "zeropage.s"
+00.000000r 2               
+00.000000r 2               .feature org_per_seg
+00.000000r 2               .zeropage
+04.000000r 2               
+04.000000r 2               .org ZP_START1
+   000000  2               
+   000000  2               GORESTART:
+   000000  2  xx xx xx     	.res 3
+   000003  2               GOSTROUT:
+   000003  2  xx xx xx     	.res 3
+   000006  2               GOAYINT:
+   000006  2  xx xx        	.res 2
+   000008  2               GOGIVEAYF:
+   000008  2  xx xx        	.res 2
+   00000A  2               
+   00000A  2               .org ZP_START2
+   000015  2               Z15:
+   000015  2  xx           	.res 1
+   000016  2               .ifndef POSX; allow override
+   000016  2               POSX:
+   000016  2               .endif
+   000016  2  xx           	.res 1
+   000017  2               .ifndef Z17; allow override
+   000017  2               Z17:
+   000017  2               .endif
+   000017  2  xx           	.res 1
+   000018  2               .ifndef Z18; allow override
+   000018  2               Z18:
+   000018  2               .endif
+   000018  2  xx           	.res 1
+   000019  2               LINNUM:
+   000019  2               .ifndef TXPSV; allow override
+   000019  2               TXPSV:
+   000019  2               .endif
+   000019  2  xx xx        	.res 2
+   00001B  2               .ifndef INPUTBUFFER; allow override
+   00001B  2               INPUTBUFFER:
+   00001B  2               .endif
+   00001B  2               
+   00001B  2               .org ZP_START3
+   00000A  2               
+   00000A  2               CHARAC:
+   00000A  2  xx           	.res 1
+   00000B  2               ENDCHR:
+   00000B  2  xx           	.res 1
+   00000C  2               EOLPNTR:
+   00000C  2  xx           	.res 1
+   00000D  2               DIMFLG:
+   00000D  2  xx           	.res 1
+   00000E  2               VALTYP:
+   00000E  2               .ifdef CONFIG_SMALL
+   00000E  2               	.res 1
+   00000E  2               .else
+   00000E  2  xx xx        	.res 2
+   000010  2               .endif
+   000010  2               DATAFLG:
+   000010  2  xx           	.res 1
+   000011  2               SUBFLG:
+   000011  2  xx           	.res 1
+   000012  2               INPUTFLG:
+   000012  2  xx           	.res 1
+   000013  2               CPRMASK:
+   000013  2  xx           	.res 1
+   000014  2               Z14:
+   000014  2  xx           	.res 1
+   000015  2               
+   000015  2               .org ZP_START4
+   000063  2               
+   000063  2               TEMPPT:
+   000063  2  xx           	.res 1
+   000064  2               LASTPT:
+   000064  2  xx xx        	.res 2
+   000066  2               TEMPST:
+   000066  2  xx xx xx xx  	.res 9
+   00006A  2  xx xx xx xx  
+   00006E  2  xx           
+   00006F  2               INDEX:
+   00006F  2  xx xx        	.res 2
+   000071  2               DEST:
+   000071  2  xx xx        	.res 2
+   000073  2               RESULT:
+   000073  2  xx xx xx xx  	.res BYTES_FP
+   000077  2  xx           
+   000078  2               RESULT_LAST = RESULT + BYTES_FP-1
+   000078  2               TXTTAB:
+   000078  2  xx xx        	.res 2
+   00007A  2               VARTAB:
+   00007A  2  xx xx        	.res 2
+   00007C  2               ARYTAB:
+   00007C  2  xx xx        	.res 2
+   00007E  2               STREND:
+   00007E  2  xx xx        	.res 2
+   000080  2               FRETOP:
+   000080  2  xx xx        	.res 2
+   000082  2               FRESPC:
+   000082  2  xx xx        	.res 2
+   000084  2               MEMSIZ:
+   000084  2  xx xx        	.res 2
+   000086  2               CURLIN:
+   000086  2  xx xx        	.res 2
+   000088  2               OLDLIN:
+   000088  2  xx xx        	.res 2
+   00008A  2               OLDTEXT:
+   00008A  2  xx xx        	.res 2
+   00008C  2               Z8C:
+   00008C  2  xx xx        	.res 2
+   00008E  2               DATPTR:
+   00008E  2  xx xx        	.res 2
+   000090  2               INPTR:
+   000090  2  xx xx        	.res 2
+   000092  2               VARNAM:
+   000092  2  xx xx        	.res 2
+   000094  2               VARPNT:
+   000094  2  xx xx        	.res 2
+   000096  2               FORPNT:
+   000096  2  xx xx        	.res 2
+   000098  2               LASTOP:
+   000098  2  xx xx        	.res 2
+   00009A  2               CPRTYP:
+   00009A  2  xx           	.res 1
+   00009B  2               FNCNAM:
+   00009B  2               TEMP3:
+   00009B  2  xx xx        	.res 2
+   00009D  2               DSCPTR:
+   00009D  2               .ifdef CONFIG_SMALL
+   00009D  2               		.res 2
+   00009D  2               .else
+   00009D  2  xx xx xx     		.res 3
+   0000A0  2               .endif
+   0000A0  2               DSCLEN:
+   0000A0  2  xx xx        	.res 2
+   0000A2  2               .ifndef JMPADRS ; allow override
+   0000A2  2               JMPADRS			:= DSCLEN + 1
+   0000A2  2               .endif
+   0000A2  2               Z52:
+   0000A2  2  xx           	.res 1
+   0000A3  2               ARGEXTENSION:
+   0000A3  2               .ifndef CONFIG_SMALL
+   0000A3  2  xx           	.res 1
+   0000A4  2               .endif
+   0000A4  2               TEMP1:
+   0000A4  2  xx           	.res 1
+   0000A5  2               HIGHDS:
+   0000A5  2  xx xx        	.res 2
+   0000A7  2               HIGHTR:
+   0000A7  2  xx xx        	.res 2
+   0000A9  2               .ifndef CONFIG_SMALL
+   0000A9  2               TEMP2:
+   0000A9  2  xx           	.res 1
+   0000AA  2               .endif
+   0000AA  2               INDX:
+   0000AA  2               TMPEXP:
+   0000AA  2               .ifdef CONFIG_SMALL
+   0000AA  2               TEMP2:
+   0000AA  2               .endif
+   0000AA  2  xx           	.res 1
+   0000AB  2               EXPON:
+   0000AB  2  xx           	.res 1
+   0000AC  2               LOWTR:
+   0000AC  2               .ifndef LOWTRX ; allow override
+   0000AC  2               LOWTRX:
+   0000AC  2               .endif
+   0000AC  2  xx           	.res 1
+   0000AD  2               EXPSGN:
+   0000AD  2  xx           	.res 1
+   0000AE  2               FAC:
+   0000AE  2  xx xx xx xx  	.res BYTES_FP
+   0000B2  2  xx           
+   0000B3  2               FAC_LAST = FAC + BYTES_FP-1
+   0000B3  2               FACSIGN:
+   0000B3  2  xx           	.res 1
+   0000B4  2               SERLEN:
+   0000B4  2  xx           	.res 1
+   0000B5  2               SHIFTSIGNEXT:
+   0000B5  2  xx           	.res 1
+   0000B6  2               ARG:
+   0000B6  2  xx xx xx xx  	.res BYTES_FP
+   0000BA  2  xx           
+   0000BB  2               ARG_LAST = ARG + BYTES_FP-1
+   0000BB  2               ARGSIGN:
+   0000BB  2  xx           	.res 1
+   0000BC  2               STRNG1:
+   0000BC  2  xx xx        	.res 2
+   0000BE  2               SGNCPR = STRNG1
+   0000BE  2               FACEXTENSION = STRNG1+1
+   0000BE  2               STRNG2:
+   0000BE  2  xx xx        	.res 2
+   0000C0  2               CHRGET:
+   0000C0  2               TXTPTR = <(GENERIC_TXTPTR-GENERIC_CHRGET + CHRGET)
+   0000C0  2               CHRGOT = <(GENERIC_CHRGOT-GENERIC_CHRGET + CHRGET)
+   0000C0  2               CHRGOT2 = <(GENERIC_CHRGOT2-GENERIC_CHRGET + CHRGET)
+   0000C0  2               RNDSEED = <(GENERIC_RNDSEED-GENERIC_CHRGET + CHRGET)
+   0000C0  2               
+   0000C0  2               
+   0000C0  2               
+   0000C0  1               
+   0000C0  1               .include "header.s"
+   0000C0  2               		.segment "HEADER"
+06.000000r 2               .ifdef KBD
+06.000000r 2                       jmp     LE68C
+06.000000r 2                       .byte   $00,$13,$56
+06.000000r 2               .endif
+06.000000r 2               
+06.000000r 1               .include "token.s"
+06.000000r 2               		init_token_tables
+09.000000r 2               
+09.000000r 2  rr rr 45 4E  		keyword_rts "END", END
+09.000004r 2  C4 xx        
+09.000001r 2  rr rr 46 4F  		keyword_rts "FOR", FOR
+09.000005r 2  D2 xx        
+09.000002r 2  rr rr 4E 45  		keyword_rts "NEXT", NEXT
+09.000006r 2  58 D4 xx     
+09.000003r 2  rr rr 44 41  		keyword_rts "DATA", DATA
+09.000007r 2  54 C1 xx     
+09.000004r 2               .ifdef CONFIG_FILE
+09.000004r 2               		keyword_rts "INPUT#", INPUTH
+09.000004r 2               .endif
+09.000004r 2  rr rr 49 4E  		keyword_rts "INPUT", INPUT
+09.000008r 2  50 55 D4 xx  
+09.000005r 2  rr rr 44 49  		keyword_rts "DIM", DIM
+09.000009r 2  CD xx        
+09.000006r 2  rr rr 52 45  		keyword_rts "READ", READ
+09.00000Ar 2  41 C4 xx     
+09.000007r 2               .ifdef APPLE
+09.000007r 2               		keyword_rts "PLT", PLT
+09.000007r 2               .else
+09.000007r 2  rr rr 4C 45  		keyword_rts "LET", LET
+09.00000Br 2  D4 xx        
+09.000008r 2               .endif
+09.000008r 2  rr rr 47 4F  		keyword_rts "GOTO", GOTO, TOKEN_GOTO
+09.00000Cr 2  54 CF xx     
+09.000009r 2  rr rr 52 55  		keyword_rts "RUN", RUN
+09.00000Dr 2  CE xx        
+09.00000Ar 2  rr rr 49 C6  		keyword_rts "IF", IF
+09.00000Er 2  xx           
+09.00000Br 2  rr rr 52 45  		keyword_rts "RESTORE", RESTORE
+09.00000Fr 2  53 54 4F 52  
+09.000013r 2  C5 xx        
+09.00000Cr 2  rr rr 47 4F  		keyword_rts "GOSUB", GOSUB, TOKEN_GOSUB
+09.000010r 2  53 55 C2 xx  
+09.00000Dr 2  rr rr 52 45  		keyword_rts "RETURN", POP
+09.000011r 2  54 55 52 CE  
+09.000015r 2  xx           
+09.00000Er 2               .ifdef APPLE
+09.00000Er 2               		keyword_rts "TEX", TEX, TOKEN_REM
+09.00000Er 2               .else
+09.00000Er 2  rr rr 52 45  		keyword_rts "REM", REM, TOKEN_REM
+09.000012r 2  CD xx        
+09.00000Fr 2               .endif
+09.00000Fr 2  rr rr 53 54  		keyword_rts "STOP", STOP
+09.000013r 2  4F D0 xx     
+09.000010r 2  rr rr 4F CE  		keyword_rts "ON", ON
+09.000014r 2  xx           
+09.000011r 2               .ifdef CONFIG_NULL
+09.000011r 2  rr rr 4E 55  		keyword_rts "NULL", NULL
+09.000015r 2  4C CC xx     
+09.000012r 2               .endif
+09.000012r 2               .ifdef KBD
+09.000012r 2               		keyword_rts "PLOD", PLOD
+09.000012r 2               		keyword_rts "PSAV", PSAV
+09.000012r 2               		keyword_rts "VLOD", VLOD
+09.000012r 2               		keyword_rts "VSAV", VSAV
+09.000012r 2               .endif
+09.000012r 2               .ifndef CONFIG_NO_POKE
+09.000012r 2  rr rr 57 41  		keyword_rts "WAIT", WAIT
+09.000016r 2  49 D4 xx     
+09.000013r 2               .endif
+09.000013r 2               .ifndef KBD
+09.000013r 2  rr rr 4C 4F  		keyword_rts "LOAD", LOAD
+09.000017r 2  41 C4 xx     
+09.000014r 2  rr rr 53 41  		keyword_rts "SAVE", SAVE
+09.000018r 2  56 C5 xx     
+09.000015r 2               .endif
+09.000015r 2               .ifdef CONFIG_CBM_ALL
+09.000015r 2               		keyword_rts "VERIFY", VERIFY
+09.000015r 2               .endif
+09.000015r 2  rr rr 44 45  		keyword_rts "DEF", DEF
+09.000019r 2  C6 xx        
+09.000016r 2               .ifdef KBD
+09.000016r 2               		keyword_rts "SLOD", SLOD
+09.000016r 2               .endif
+09.000016r 2               .ifndef CONFIG_NO_POKE
+09.000016r 2  rr rr 50 4F  		keyword_rts "POKE", POKE
+09.00001Ar 2  4B C5 xx     
+09.000017r 2               .endif
+09.000017r 2               .ifdef CONFIG_FILE
+09.000017r 2               		keyword_rts "PRINT#", PRINTH
+09.000017r 2               .endif
+09.000017r 2  rr rr 50 52  		keyword_rts "PRINT", PRINT, TOKEN_PRINT
+09.00001Br 2  49 4E D4 xx  
+09.000018r 2  rr rr 43 4F  		keyword_rts "CONT", CONT
+09.00001Cr 2  4E D4 xx     
+09.000019r 2  rr rr 4C 49  		keyword_rts "LIST", LIST
+09.00001Dr 2  53 D4 xx     
+09.00001Ar 2               .ifdef CONFIG_CBM_ALL
+09.00001Ar 2               		keyword_rts "CLR", CLEAR
+09.00001Ar 2               .else
+09.00001Ar 2  rr rr 43 4C  		keyword_rts "CLEAR", CLEAR
+09.00001Er 2  45 41 D2 xx  
+09.00001Br 2               .endif
+09.00001Br 2               .ifdef CONFIG_FILE
+09.00001Br 2               		keyword_rts "CMD", CMD
+09.00001Br 2               		keyword_rts "SYS", SYS
+09.00001Br 2               		keyword_rts "OPEN", OPEN
+09.00001Br 2               		keyword_rts "CLOSE", CLOSE
+09.00001Br 2               .endif
+09.00001Br 2               .ifndef CONFIG_SMALL
+09.00001Br 2  rr rr 47 45  		keyword_rts "GET", GET
+09.00001Fr 2  D4 xx        
+09.00001Cr 2               .endif
+09.00001Cr 2               .ifdef KBD
+09.00001Cr 2               		keyword_rts "PRT", PRT
+09.00001Cr 2               .endif
+09.00001Cr 2  rr rr 4E 45  		keyword_rts "NEW", NEW
+09.000020r 2  D7 xx        
+09.00001Dr 2               
+09.00001Dr 2               		count_tokens
+09.00001Dr 2               
+09.00001Dr 2  54 41 42 A8  		keyword	"TAB(", TOKEN_TAB
+09.000021r 2  xx           
+09.00001Er 2  54 CF xx     		keyword	"TO", TOKEN_TO
+09.00001Fr 2  46 CE xx     		keyword	"FN", TOKEN_FN
+09.000020r 2  53 50 43 A8  		keyword	"SPC(", TOKEN_SPC
+09.000024r 2  xx           
+09.000021r 2  54 48 45 CE  		keyword	"THEN", TOKEN_THEN
+09.000025r 2  xx           
+09.000022r 2  4E 4F D4 xx  		keyword	"NOT", TOKEN_NOT
+09.000023r 2  53 54 45 D0  		keyword	"STEP", TOKEN_STEP
+09.000027r 2  xx           
+09.000024r 2  AB xx        		keyword	"+", TOKEN_PLUS
+09.000025r 2  AD xx        		keyword	"-", TOKEN_MINUS
+09.000026r 2  AA xx        		keyword	"*"
+09.000027r 2  AF xx        		keyword	"/"
+09.000028r 2               .ifdef KBD
+09.000028r 2               		keyword	"#"
+09.000028r 2               .else
+09.000028r 2  DE xx        		keyword	"^"
+09.000029r 2               .endif
+09.000029r 2  41 4E C4 xx  		keyword	"AND"
+09.00002Ar 2  4F D2 xx     		keyword	"OR"
+09.00002Br 2  BE xx        		keyword	">", TOKEN_GREATER
+09.00002Cr 2  BD xx        		keyword	"=", TOKEN_EQUAL
+09.00002Dr 2  BC xx        		keyword	"<"
+09.00002Er 2               
+09.00002Er 2                       .segment "VECTORS"
+07.00003Ar 2               UNFNC:
+07.00003Ar 2               
+07.00003Ar 2  rr rr 53 47  		keyword_addr "SGN", SGN, TOKEN_SGN
+07.00003Er 2  CE xx        
+09.00002Fr 2  rr rr 49 4E  		keyword_addr "INT", INT
+09.000033r 2  D4 xx        
+09.000030r 2  rr rr 41 42  		keyword_addr "ABS", ABS
+09.000034r 2  D3 xx        
+09.000031r 2               .ifdef KBD
+09.000031r 2               		keyword_addr "VER", VER
+09.000031r 2               .endif
+09.000031r 2               .ifndef CONFIG_NO_POKE
+09.000031r 2                 .ifdef CONFIG_RAM
+09.000031r 2  rr rr 55 53  		keyword_addr "USR", IQERR
+09.000035r 2  D2 xx        
+09.000032r 2                 .else
+09.000032r 2               		keyword_addr "USR", USR
+09.000032r 2                 .endif
+09.000032r 2               .endif
+09.000032r 2  rr rr 46 52  		keyword_addr "FRE", FRE
+09.000036r 2  C5 xx        
+09.000033r 2  rr rr 50 4F  		keyword_addr "POS", POS
+09.000037r 2  D3 xx        
+09.000034r 2  rr rr 53 51  		keyword_addr "SQR", SQR
+09.000038r 2  D2 xx        
+09.000035r 2  rr rr 52 4E  		keyword_addr "RND", RND
+09.000039r 2  C4 xx        
+09.000036r 2  rr rr 4C 4F  		keyword_addr "LOG", LOG
+09.00003Ar 2  C7 xx        
+09.000037r 2  rr rr 45 58  		keyword_addr "EXP", EXP
+09.00003Br 2  D0 xx        
+09.000038r 2               .segment "VECTORS"
+07.00004Er 2               UNFNC_COS:
+07.00004Er 2  rr rr 43 4F  		keyword_addr "COS", COS
+07.000052r 2  D3 xx        
+09.000039r 2               .segment "VECTORS"
+07.000050r 2               UNFNC_SIN:
+07.000050r 2  rr rr 53 49  		keyword_addr "SIN", SIN
+07.000054r 2  CE xx        
+09.00003Ar 2               .segment "VECTORS"
+07.000052r 2               UNFNC_TAN:
+07.000052r 2  rr rr 54 41  		keyword_addr "TAN", TAN
+07.000056r 2  CE xx        
+09.00003Br 2               .segment "VECTORS"
+07.000054r 2               UNFNC_ATN:
+07.000054r 2  rr rr 41 54  		keyword_addr "ATN", ATN
+07.000058r 2  CE xx        
+09.00003Cr 2               .ifdef KBD
+09.00003Cr 2               		keyword_addr "GETC", GETC
+09.00003Cr 2               .endif
+09.00003Cr 2               .ifndef CONFIG_NO_POKE
+09.00003Cr 2  rr rr 50 45  		keyword_addr "PEEK", PEEK
+09.000040r 2  45 CB xx     
+09.00003Dr 2               .endif
+09.00003Dr 2  rr rr 4C 45  		keyword_addr "LEN", LEN
+09.000041r 2  CE xx        
+09.00003Er 2  rr rr 53 54  		keyword_addr "STR$", STR
+09.000042r 2  52 A4 xx     
+09.00003Fr 2  rr rr 56 41  		keyword_addr "VAL", VAL
+09.000043r 2  CC xx        
+09.000040r 2  rr rr 41 53  		keyword_addr "ASC", ASC
+09.000044r 2  C3 xx        
+09.000041r 2  rr rr 43 48  		keyword_addr "CHR$", CHRSTR
+09.000045r 2  52 A4 xx     
+09.000042r 2  rr rr 4C 45  		keyword_addr "LEFT$", LEFTSTR, TOKEN_LEFTSTR
+09.000046r 2  46 54 A4 xx  
+09.000043r 2  rr rr 52 49  		keyword_addr "RIGHT$", RIGHTSTR
+09.000047r 2  47 48 54 A4  
+09.00004Br 2  xx           
+09.000044r 2  rr rr 4D 49  		keyword_addr "MID$", MIDSTR
+09.000048r 2  44 A4 xx     
+09.000045r 2               .ifdef CONFIG_2
+09.000045r 2               		keyword	"GO", TOKEN_GO
+09.000045r 2               .endif
+09.000045r 2                       .segment "KEYWORDS"
+08.0000E2r 2  00           		.byte   0
+08.0000E3r 2               
+08.0000E3r 2                       .segment "VECTORS"
+07.000068r 2               MATHTBL:
+07.000068r 2  79                   .byte   $79
+07.000069r 2  rr rr                .word   FADDT-1
+07.00006Br 2  79                   .byte   $79
+07.00006Cr 2  rr rr                .word   FSUBT-1
+07.00006Er 2  7B                   .byte   $7B
+07.00006Fr 2  rr rr                .word   FMULTT-1
+07.000071r 2  7B                   .byte   $7B
+07.000072r 2  rr rr                .word   FDIVT-1
+07.000074r 2  7F                   .byte   $7F
+07.000075r 2  rr rr                .word   FPWRT-1
+07.000077r 2  50                   .byte   $50
+07.000078r 2  rr rr                .word   TAND-1
+07.00007Ar 2  46                   .byte   $46
+07.00007Br 2  rr rr                .word   OR-1
+07.00007Dr 2  7D                   .byte   $7D
+07.00007Er 2  rr rr                .word   NEGOP-1
+07.000080r 2  5A                   .byte   $5A
+07.000081r 2  rr rr                .word   EQUOP-1
+07.000083r 2  64                   .byte   $64
+07.000084r 2  rr rr                .word   RELOPS-1
+07.000086r 2               
+07.000086r 1               .include "error.s"
+07.000086r 2               init_error_table
+0A.000000r 2               
+0A.000000r 2               .ifdef CONFIG_SMALL
+0A.000000r 2               define_error ERR_NOFOR, "NF"
+0A.000000r 2               define_error ERR_SYNTAX, "SN"
+0A.000000r 2               define_error ERR_NOGOSUB, "RG"
+0A.000000r 2               define_error ERR_NODATA, "OD"
+0A.000000r 2               define_error ERR_ILLQTY, "FC"
+0A.000000r 2               define_error ERR_OVERFLOW, "OV"
+0A.000000r 2               define_error ERR_MEMFULL, "OM"
+0A.000000r 2               define_error ERR_UNDEFSTAT, "US"
+0A.000000r 2               define_error ERR_BADSUBS, "BS"
+0A.000000r 2               define_error ERR_REDIMD, "DD"
+0A.000000r 2               define_error ERR_ZERODIV, "/0"
+0A.000000r 2               define_error ERR_ILLDIR, "ID"
+0A.000000r 2               define_error ERR_BADTYPE, "TM"
+0A.000000r 2               define_error ERR_STRLONG, "LS"
+0A.000000r 2               define_error ERR_FRMCPX, "ST"
+0A.000000r 2               define_error ERR_CANTCONT, "CN"
+0A.000000r 2               define_error ERR_UNDEFFN, "UF"
+0A.000000r 2               .else
+0A.000000r 2  4E 45 58 54  define_error ERR_NOFOR, "NEXT WITHOUT FOR"
+0A.000004r 2  20 57 49 54  
+0A.000008r 2  48 4F 55 54  
+0A.000010r 2  53 59 4E 54  define_error ERR_SYNTAX, "SYNTAX"
+0A.000014r 2  41 D8        
+0A.000016r 2  52 45 54 55  define_error ERR_NOGOSUB, "RETURN WITHOUT GOSUB"
+0A.00001Ar 2  52 4E 20 57  
+0A.00001Er 2  49 54 48 4F  
+0A.00002Ar 2  4F 55 54 20  define_error ERR_NODATA, "OUT OF DATA"
+0A.00002Er 2  4F 46 20 44  
+0A.000032r 2  41 54 C1     
+0A.000035r 2  49 4C 4C 45  define_error ERR_ILLQTY, "ILLEGAL QUANTITY"
+0A.000039r 2  47 41 4C 20  
+0A.00003Dr 2  51 55 41 4E  
+0A.000045r 2               .ifdef CBM1
+0A.000045r 2               	.byte 0,0,0,0,0
+0A.000045r 2               .endif
+0A.000045r 2  4F 56 45 52  define_error ERR_OVERFLOW, "OVERFLOW"
+0A.000049r 2  46 4C 4F D7  
+0A.00004Dr 2  4F 55 54 20  define_error ERR_MEMFULL, "OUT OF MEMORY"
+0A.000051r 2  4F 46 20 4D  
+0A.000055r 2  45 4D 4F 52  
+0A.00005Ar 2  55 4E 44 45  define_error ERR_UNDEFSTAT, "UNDEF'D STATEMENT"
+0A.00005Er 2  46 27 44 20  
+0A.000062r 2  53 54 41 54  
+0A.00006Br 2  42 41 44 20  define_error ERR_BADSUBS, "BAD SUBSCRIPT"
+0A.00006Fr 2  53 55 42 53  
+0A.000073r 2  43 52 49 50  
+0A.000078r 2  52 45 44 49  define_error ERR_REDIMD, "REDIM'D ARRAY"
+0A.00007Cr 2  4D 27 44 20  
+0A.000080r 2  41 52 52 41  
+0A.000085r 2  44 49 56 49  define_error ERR_ZERODIV, "DIVISION BY ZERO"
+0A.000089r 2  53 49 4F 4E  
+0A.00008Dr 2  20 42 59 20  
+0A.000095r 2  49 4C 4C 45  define_error ERR_ILLDIR, "ILLEGAL DIRECT"
+0A.000099r 2  47 41 4C 20  
+0A.00009Dr 2  44 49 52 45  
+0A.0000A3r 2  54 59 50 45  define_error ERR_BADTYPE, "TYPE MISMATCH"
+0A.0000A7r 2  20 4D 49 53  
+0A.0000ABr 2  4D 41 54 43  
+0A.0000B0r 2  53 54 52 49  define_error ERR_STRLONG, "STRING TOO LONG"
+0A.0000B4r 2  4E 47 20 54  
+0A.0000B8r 2  4F 4F 20 4C  
+0A.0000BFr 2               .ifdef CONFIG_FILE
+0A.0000BFr 2                 .ifdef CBM1
+0A.0000BFr 2               define_error ERR_BADDATA, "BAD DATA"
+0A.0000BFr 2                 .else
+0A.0000BFr 2               define_error ERR_BADDATA, "FILE DATA"
+0A.0000BFr 2                 .endif
+0A.0000BFr 2               .endif
+0A.0000BFr 2  46 4F 52 4D  define_error ERR_FRMCPX, "FORMULA TOO COMPLEX"
+0A.0000C3r 2  55 4C 41 20  
+0A.0000C7r 2  54 4F 4F 20  
+0A.0000D2r 2  43 41 4E 27  define_error ERR_CANTCONT, "CAN'T CONTINUE"
+0A.0000D6r 2  54 20 43 4F  
+0A.0000DAr 2  4E 54 49 4E  
+0A.0000E0r 2  55 4E 44 45  define_error ERR_UNDEFFN, "UNDEF'D FUNCTION"
+0A.0000E4r 2  46 27 44 20  
+0A.0000E8r 2  46 55 4E 43  
+0A.0000F0r 2               .endif
+0A.0000F0r 2               
+0A.0000F0r 1               .include "message.s"
+0A.0000F0r 2               ; global messages: "error", "in", "ready", "break"
+0A.0000F0r 2               
+0A.0000F0r 2               .segment "CODE"
+00.000000r 2               
+00.000000r 2               QT_ERROR:
+00.000000r 2               .ifdef KBD
+00.000000r 2                       .byte   " err"
+00.000000r 2               .else
+00.000000r 2                 .ifdef APPLE
+00.000000r 2                       .byte   " ERR"
+00.000000r 2               		.byte	$07,$07
+00.000000r 2                 .else
+00.000000r 2  20 45 52 52          .byte   " ERROR"
+00.000004r 2  4F 52        
+00.000006r 2                 .endif
+00.000006r 2               .endif
+00.000006r 2  00                   .byte   0
+00.000007r 2               
+00.000007r 2               .ifndef KBD
+00.000007r 2               QT_IN:
+00.000007r 2  20 49 4E 20          .byte   " IN "
+00.00000Br 2  00                   .byte   $00
+00.00000Cr 2               .endif
+00.00000Cr 2               
+00.00000Cr 2               .ifdef KBD
+00.00000Cr 2               		.byte	$54,$D2 ; ???
+00.00000Cr 2               OKPRT:
+00.00000Cr 2               		jsr     PRIMM
+00.00000Cr 2                       .byte   CR,CR,">>",CR,LF
+00.00000Cr 2               		.byte	0
+00.00000Cr 2                       rts
+00.00000Cr 2                       nop
+00.00000Cr 2               .else
+00.00000Cr 2               QT_OK:
+00.00000Cr 2                 .ifdef CONFIG_CBM_ALL
+00.00000Cr 2               		.byte   CR,LF,"READY.",CR,LF
+00.00000Cr 2                 .else
+00.00000Cr 2                   .ifdef APPLE
+00.00000Cr 2               		; binary patch!
+00.00000Cr 2                       .byte   CR,0,0,"K",CR,LF
+00.00000Cr 2                   .else
+00.00000Cr 2  0D 0A 4F 4B  		.byte   CR,LF,"OK",CR,LF
+00.000010r 2  0D 0A        
+00.000012r 2                   .endif
+00.000012r 2                 .endif
+00.000012r 2  00           		.byte	0
+00.000013r 2               .endif
+00.000013r 2               
+00.000013r 2               QT_BREAK:
+00.000013r 2               
+00.000013r 2               .ifdef KBD
+00.000013r 2               		.byte	CR,LF," Brk"
+00.000013r 2                       .byte   0
+00.000013r 2                       .byte   $54,$D0 ; ???
+00.000013r 2               .elseif .def(MICROTAN)
+00.000013r 2               		.byte CR,LF," BREAK"
+00.000013r 2                       .byte   0
+00.000013r 2               .else
+00.000013r 2  0D 0A 42 52  		.byte CR,LF,"BREAK"
+00.000017r 2  45 41 4B     
+00.00001Ar 2  00                   .byte   0
+00.00001Br 2               .endif
+00.00001Br 2               
+00.00001Br 1               .include "memory.s"
+00.00001Br 2               ; generic stack and memory management code
+00.00001Br 2               ; this code is identical across all versions of
+00.00001Br 2               ; BASIC
+00.00001Br 2               
+00.00001Br 2               .segment "CODE"
+00.00001Br 2               
+00.00001Br 2               ; ----------------------------------------------------------------------------
+00.00001Br 2               ; CALLED BY "NEXT" AND "FOR" TO SCAN THROUGH
+00.00001Br 2               ; THE STACK FOR A FRAME WITH THE SAME VARIABLE.
+00.00001Br 2               ;
+00.00001Br 2               ; (FORPNT) = ADDRESS OF VARIABLE IF "FOR" OR "NEXT"
+00.00001Br 2               ; 	= $XXFF IF CALLED FROM "RETURN"
+00.00001Br 2               ; 	<<< BUG: SHOULD BE $FFXX >>>
+00.00001Br 2               ;
+00.00001Br 2               ;	RETURNS .NE. IF VARIABLE NOT FOUND,
+00.00001Br 2               ;	(X) = STACK PNTR AFTER SKIPPING ALL FRAMES
+00.00001Br 2               ;
+00.00001Br 2               ;	.EQ. IF FOUND
+00.00001Br 2               ;	(X) = STACK PNTR OF FRAME FOUND
+00.00001Br 2               ; ----------------------------------------------------------------------------
+00.00001Br 2               GTFORPNT:
+00.00001Br 2  BA                   tsx
+00.00001Cr 2  E8                   inx
+00.00001Dr 2  E8                   inx
+00.00001Er 2  E8                   inx
+00.00001Fr 2  E8                   inx
+00.000020r 2               L2279:
+00.000020r 2  BD 01 01             lda     STACK+1,x
+00.000023r 2  C9 81                cmp     #$81
+00.000025r 2  D0 21                bne     L22A1
+00.000027r 2  A5 97                lda     FORPNT+1
+00.000029r 2  D0 0A                bne     L228E
+00.00002Br 2  BD 02 01             lda     STACK+2,x
+00.00002Er 2  85 96                sta     FORPNT
+00.000030r 2  BD 03 01             lda     STACK+3,x
+00.000033r 2  85 97                sta     FORPNT+1
+00.000035r 2               L228E:
+00.000035r 2  DD 03 01             cmp     STACK+3,x
+00.000038r 2  D0 07                bne     L229A
+00.00003Ar 2  A5 96                lda     FORPNT
+00.00003Cr 2  DD 02 01             cmp     STACK+2,x
+00.00003Fr 2  F0 07                beq     L22A1
+00.000041r 2               L229A:
+00.000041r 2  8A                   txa
+00.000042r 2  18                   clc
+00.000043r 2  69 12                adc     #BYTES_PER_FRAME
+00.000045r 2  AA                   tax
+00.000046r 2  D0 D8                bne     L2279
+00.000048r 2               L22A1:
+00.000048r 2  60                   rts
+00.000049r 2               
+00.000049r 2               ; ----------------------------------------------------------------------------
+00.000049r 2               ; MOVE BLOCK OF MEMORY UP
+00.000049r 2               ;
+00.000049r 2               ; ON ENTRY:
+00.000049r 2               ;	(Y,A) = (HIGHDS) = DESTINATION END+1
+00.000049r 2               ;	(LOWTR) = LOWEST ADDRESS OF SOURCE
+00.000049r 2               ;	(HIGHTR) = HIGHEST SOURCE ADDRESS+1
+00.000049r 2               ; ----------------------------------------------------------------------------
+00.000049r 2               BLTU:
+00.000049r 2  20 rr rr             jsr     REASON
+00.00004Cr 2  85 7E                sta     STREND
+00.00004Er 2  84 7F                sty     STREND+1
+00.000050r 2               BLTU2:
+00.000050r 2  38                   sec
+00.000051r 2  A5 A7                lda     HIGHTR
+00.000053r 2  E5 AC                sbc     LOWTR
+00.000055r 2  85 6F                sta     INDEX
+00.000057r 2  A8                   tay
+00.000058r 2  A5 A8                lda     HIGHTR+1
+00.00005Ar 2  E5 AD                sbc     LOWTR+1
+00.00005Cr 2  AA                   tax
+00.00005Dr 2  E8                   inx
+00.00005Er 2  98                   tya
+00.00005Fr 2  F0 23                beq     L22DD
+00.000061r 2  A5 A7                lda     HIGHTR
+00.000063r 2  38                   sec
+00.000064r 2  E5 6F                sbc     INDEX
+00.000066r 2  85 A7                sta     HIGHTR
+00.000068r 2  B0 03                bcs     L22C6
+00.00006Ar 2  C6 A8                dec     HIGHTR+1
+00.00006Cr 2  38                   sec
+00.00006Dr 2               L22C6:
+00.00006Dr 2  A5 A5                lda     HIGHDS
+00.00006Fr 2  E5 6F                sbc     INDEX
+00.000071r 2  85 A5                sta     HIGHDS
+00.000073r 2  B0 08                bcs     L22D6
+00.000075r 2  C6 A6                dec     HIGHDS+1
+00.000077r 2  90 04                bcc     L22D6
+00.000079r 2               L22D2:
+00.000079r 2  B1 A7                lda     (HIGHTR),y
+00.00007Br 2  91 A5                sta     (HIGHDS),y
+00.00007Dr 2               L22D6:
+00.00007Dr 2  88                   dey
+00.00007Er 2  D0 F9                bne     L22D2
+00.000080r 2  B1 A7                lda     (HIGHTR),y
+00.000082r 2  91 A5                sta     (HIGHDS),y
+00.000084r 2               L22DD:
+00.000084r 2  C6 A8                dec     HIGHTR+1
+00.000086r 2  C6 A6                dec     HIGHDS+1
+00.000088r 2  CA                   dex
+00.000089r 2  D0 F2                bne     L22D6
+00.00008Br 2  60                   rts
+00.00008Cr 2               
+00.00008Cr 2               ; ----------------------------------------------------------------------------
+00.00008Cr 2               ; CHECK IF ENOUGH ROOM LEFT ON STACK
+00.00008Cr 2               ; FOR "FOR", "GOSUB", OR EXPRESSION EVALUATION
+00.00008Cr 2               ; ----------------------------------------------------------------------------
+00.00008Cr 2               CHKMEM:
+00.00008Cr 2  0A                   asl     a
+00.00008Dr 2  69 36                adc     #SPACE_FOR_GOSUB
+00.00008Fr 2  B0 35                bcs     MEMERR
+00.000091r 2  85 6F                sta     INDEX
+00.000093r 2  BA                   tsx
+00.000094r 2  E4 6F                cpx     INDEX
+00.000096r 2  90 2E                bcc     MEMERR
+00.000098r 2  60                   rts
+00.000099r 2               
+00.000099r 2               ; ----------------------------------------------------------------------------
+00.000099r 2               ; CHECK IF ENOUGH ROOM BETWEEN ARRAYS AND STRINGS
+00.000099r 2               ; (Y,A) = ADDR ARRAYS NEED TO GROW TO
+00.000099r 2               ; ----------------------------------------------------------------------------
+00.000099r 2               REASON:
+00.000099r 2  C4 81                cpy     FRETOP+1
+00.00009Br 2  90 28                bcc     L231E
+00.00009Dr 2  D0 04                bne     L22FC
+00.00009Fr 2  C5 80                cmp     FRETOP
+00.0000A1r 2  90 22                bcc     L231E
+00.0000A3r 2               L22FC:
+00.0000A3r 2  48                   pha
+00.0000A4r 2  A2 09                ldx     #FAC-TEMP1-1
+00.0000A6r 2  98                   tya
+00.0000A7r 2               L2300:
+00.0000A7r 2  48                   pha
+00.0000A8r 2  B5 A4                lda     TEMP1,x
+00.0000AAr 2  CA                   dex
+00.0000ABr 2  10 FA                bpl     L2300
+00.0000ADr 2  20 rr rr             jsr     GARBAG
+00.0000B0r 2  A2 F7                ldx     #<(TEMP1-FAC+1)
+00.0000B2r 2               L230B:
+00.0000B2r 2  68                   pla
+00.0000B3r 2  95 AE                sta     FAC,x
+00.0000B5r 2  E8                   inx
+00.0000B6r 2  30 FA                bmi     L230B
+00.0000B8r 2  68                   pla
+00.0000B9r 2  A8                   tay
+00.0000BAr 2  68                   pla
+00.0000BBr 2  C4 81                cpy     FRETOP+1
+00.0000BDr 2  90 06                bcc     L231E
+00.0000BFr 2  D0 05                bne     MEMERR
+00.0000C1r 2  C5 80                cmp     FRETOP
+00.0000C3r 2  B0 01                bcs     MEMERR
+00.0000C5r 2               L231E:
+00.0000C5r 2  60                   rts
+00.0000C6r 2               
+00.0000C6r 1               .include "program.s"
+00.0000C6r 2               ; error
+00.0000C6r 2               ; line input, line editing
+00.0000C6r 2               ; tokenize
+00.0000C6r 2               ; detokenize
+00.0000C6r 2               ; BASIC program memory management
+00.0000C6r 2               
+00.0000C6r 2               ; MICROTAN has some nonstandard extension to LIST here
+00.0000C6r 2               
+00.0000C6r 2               .segment "CODE"
+00.0000C6r 2               
+00.0000C6r 2               MEMERR:
+00.0000C6r 2  A2 4D                ldx     #ERR_MEMFULL
+00.0000C8r 2               
+00.0000C8r 2               ; ----------------------------------------------------------------------------
+00.0000C8r 2               ; HANDLE AN ERROR
+00.0000C8r 2               ;
+00.0000C8r 2               ; (X)=OFFSET IN ERROR MESSAGE TABLE
+00.0000C8r 2               ; (ERRFLG) > 128 IF "ON ERR" TURNED ON
+00.0000C8r 2               ; (CURLIN+1) = $FF IF IN DIRECT MODE
+00.0000C8r 2               ; ----------------------------------------------------------------------------
+00.0000C8r 2               ERROR:
+00.0000C8r 2  46 14                lsr     Z14
+00.0000CAr 2               .ifdef CONFIG_FILE
+00.0000CAr 2                       lda     CURDVC    ; output
+00.0000CAr 2                       beq     LC366     ; is screen
+00.0000CAr 2                       jsr     CLRCH     ; otherwise redirect output back to screen
+00.0000CAr 2                       lda     #$00
+00.0000CAr 2                       sta     CURDVC
+00.0000CAr 2               LC366:
+00.0000CAr 2               .endif
+00.0000CAr 2  20 rr rr             jsr     CRDO
+00.0000CDr 2  20 rr rr             jsr     OUTQUES
+00.0000D0r 2               L2329:
+00.0000D0r 2  BD rr rr             lda     ERROR_MESSAGES,x
+00.0000D3r 2               .ifndef CONFIG_SMALL
+00.0000D3r 2  48                   pha
+00.0000D4r 2  29 7F                and     #$7F
+00.0000D6r 2               .endif
+00.0000D6r 2  20 rr rr             jsr     OUTDO
+00.0000D9r 2               .ifdef CONFIG_SMALL
+00.0000D9r 2                       lda     ERROR_MESSAGES+1,x
+00.0000D9r 2                 .ifdef KBD
+00.0000D9r 2                       and     #$7F
+00.0000D9r 2                 .endif
+00.0000D9r 2                       jsr     OUTDO
+00.0000D9r 2               .else
+00.0000D9r 2  E8                   inx
+00.0000DAr 2  68                   pla
+00.0000DBr 2  10 F3                bpl     L2329
+00.0000DDr 2               .endif
+00.0000DDr 2  20 rr rr             jsr     STKINI
+00.0000E0r 2  A9 rr                lda     #<QT_ERROR
+00.0000E2r 2  A0 rr                ldy     #>QT_ERROR
+00.0000E4r 2               
+00.0000E4r 2               ; ----------------------------------------------------------------------------
+00.0000E4r 2               ; PRINT STRING AT (Y,A)
+00.0000E4r 2               ; PRINT CURRENT LINE # UNLESS IN DIRECT MODE
+00.0000E4r 2               ; FALL INTO WARM RESTART
+00.0000E4r 2               ; ----------------------------------------------------------------------------
+00.0000E4r 2               PRINT_ERROR_LINNUM:
+00.0000E4r 2  20 rr rr             jsr     STROUT
+00.0000E7r 2  A4 87                ldy     CURLIN+1
+00.0000E9r 2  C8                   iny
+00.0000EAr 2  F0 03                beq     RESTART
+00.0000ECr 2  20 rr rr             jsr     INPRT
+00.0000EFr 2               
+00.0000EFr 2               ; ----------------------------------------------------------------------------
+00.0000EFr 2               ; WARM RESTART ENTRY
+00.0000EFr 2               ; ----------------------------------------------------------------------------
+00.0000EFr 2               RESTART:
+00.0000EFr 2               .ifdef KBD
+00.0000EFr 2                       jsr     CRDO
+00.0000EFr 2                       nop
+00.0000EFr 2               L2351X:
+00.0000EFr 2                       jsr     OKPRT
+00.0000EFr 2               L2351:
+00.0000EFr 2                       jsr     INLIN
+00.0000EFr 2               LE28E:
+00.0000EFr 2                       bpl     RESTART
+00.0000EFr 2               .else
+00.0000EFr 2  46 14                lsr     Z14
+00.0000F1r 2  A9 rr                lda     #<QT_OK
+00.0000F3r 2  A0 rr                ldy     #>QT_OK
+00.0000F5r 2                 .ifdef CONFIG_CBM_ALL
+00.0000F5r 2                       jsr     STROUT
+00.0000F5r 2                 .else
+00.0000F5r 2  20 03 00             jsr     GOSTROUT
+00.0000F8r 2                 .endif
+00.0000F8r 2               L2351:
+00.0000F8r 2  20 rr rr             jsr     INLIN
+00.0000FBr 2               .endif
+00.0000FBr 2  86 C7                stx     TXTPTR
+00.0000FDr 2  84 C8                sty     TXTPTR+1
+00.0000FFr 2  20 C0 00             jsr     CHRGET
+00.000102r 2               .ifdef CONFIG_11
+00.000102r 2               ; bug in pre-1.1: CHRGET sets Z on '\0'
+00.000102r 2               ; and ':' - a line starting with ':' in
+00.000102r 2               ; direct mode gets ignored
+00.000102r 2  AA                   tax
+00.000103r 2               .endif
+00.000103r 2               .ifdef KBD
+00.000103r 2                       beq     L2351X
+00.000103r 2               .else
+00.000103r 2  F0 F3                beq     L2351
+00.000105r 2               .endif
+00.000105r 2  A2 FF                ldx     #$FF
+00.000107r 2  86 87                stx     CURLIN+1
+00.000109r 2  90 06                bcc     NUMBERED_LINE
+00.00010Br 2  20 rr rr             jsr     PARSE_INPUT_LINE
+00.00010Er 2  4C rr rr             jmp     NEWSTT2
+00.000111r 2               
+00.000111r 2               ; ----------------------------------------------------------------------------
+00.000111r 2               ; HANDLE NUMBERED LINE
+00.000111r 2               ; ----------------------------------------------------------------------------
+00.000111r 2               NUMBERED_LINE:
+00.000111r 2  20 rr rr             jsr     LINGET
+00.000114r 2  20 rr rr             jsr     PARSE_INPUT_LINE
+00.000117r 2  84 0C                sty     EOLPNTR
+00.000119r 2               .ifdef KBD
+00.000119r 2                       jsr     FNDLIN2
+00.000119r 2                       lda     JMPADRS+1
+00.000119r 2                       sta     LOWTR
+00.000119r 2                       sta     Z96
+00.000119r 2                       lda     JMPADRS+2
+00.000119r 2                       sta     LOWTR+1
+00.000119r 2                       sta     Z96+1
+00.000119r 2                       lda     LINNUM
+00.000119r 2                       sta     L06FE
+00.000119r 2                       lda     LINNUM+1
+00.000119r 2                       sta     L06FE+1
+00.000119r 2                       inc     LINNUM
+00.000119r 2                       bne     LE2D2
+00.000119r 2                       inc     LINNUM+1
+00.000119r 2                       bne     LE2D2
+00.000119r 2                       jmp     SYNERR
+00.000119r 2               LE2D2:
+00.000119r 2                       jsr     LF457
+00.000119r 2                       ldx     #Z96
+00.000119r 2                       jsr     CMPJMPADRS
+00.000119r 2                       bcs     LE2FD
+00.000119r 2               LE2DC:
+00.000119r 2                       ldx     #$00
+00.000119r 2                       lda     (JMPADRS+1,x)
+00.000119r 2                       sta     (Z96,x)
+00.000119r 2                       inc     JMPADRS+1
+00.000119r 2                       bne     LE2E8
+00.000119r 2                       inc     JMPADRS+2
+00.000119r 2               LE2E8:
+00.000119r 2                       inc     Z96
+00.000119r 2                       bne     LE2EE
+00.000119r 2                       inc     Z96+1
+00.000119r 2               LE2EE:
+00.000119r 2                       ldx     #VARTAB
+00.000119r 2                       jsr     CMPJMPADRS
+00.000119r 2                       bne     LE2DC
+00.000119r 2                       lda     Z96
+00.000119r 2                       sta     VARTAB
+00.000119r 2                       lda     Z96+1
+00.000119r 2                       sta     VARTAB+1
+00.000119r 2               LE2FD:
+00.000119r 2                       jsr     SETPTRS
+00.000119r 2                       jsr     LE33D
+00.000119r 2                       lda     INPUTBUFFER
+00.000119r 2               LE306:
+00.000119r 2                       beq     LE28E
+00.000119r 2                       cmp     #$A5
+00.000119r 2                       beq     LE306
+00.000119r 2                       clc
+00.000119r 2               .else
+00.000119r 2  20 rr rr             jsr     FNDLIN
+00.00011Cr 2  90 44                bcc     PUT_NEW_LINE
+00.00011Er 2  A0 01                ldy     #$01
+00.000120r 2  B1 AC                lda     (LOWTR),y
+00.000122r 2  85 70                sta     INDEX+1
+00.000124r 2  A5 7A                lda     VARTAB
+00.000126r 2  85 6F                sta     INDEX
+00.000128r 2  A5 AD                lda     LOWTR+1
+00.00012Ar 2  85 72                sta     DEST+1
+00.00012Cr 2  A5 AC                lda     LOWTR
+00.00012Er 2  88                   dey
+00.00012Fr 2  F1 AC                sbc     (LOWTR),y
+00.000131r 2  18                   clc
+00.000132r 2  65 7A                adc     VARTAB
+00.000134r 2  85 7A                sta     VARTAB
+00.000136r 2  85 71                sta     DEST
+00.000138r 2  A5 7B                lda     VARTAB+1
+00.00013Ar 2  69 FF                adc     #$FF
+00.00013Cr 2  85 7B                sta     VARTAB+1
+00.00013Er 2  E5 AD                sbc     LOWTR+1
+00.000140r 2  AA                   tax
+00.000141r 2  38                   sec
+00.000142r 2  A5 AC                lda     LOWTR
+00.000144r 2  E5 7A                sbc     VARTAB
+00.000146r 2  A8                   tay
+00.000147r 2  B0 03                bcs     L23A5
+00.000149r 2  E8                   inx
+00.00014Ar 2  C6 72                dec     DEST+1
+00.00014Cr 2               L23A5:
+00.00014Cr 2  18                   clc
+00.00014Dr 2  65 6F                adc     INDEX
+00.00014Fr 2  90 03                bcc     L23AD
+00.000151r 2  C6 70                dec     INDEX+1
+00.000153r 2  18                   clc
+00.000154r 2               L23AD:
+00.000154r 2  B1 6F                lda     (INDEX),y
+00.000156r 2  91 71                sta     (DEST),y
+00.000158r 2  C8                   iny
+00.000159r 2  D0 F9                bne     L23AD
+00.00015Br 2  E6 70                inc     INDEX+1
+00.00015Dr 2  E6 72                inc     DEST+1
+00.00015Fr 2  CA                   dex
+00.000160r 2  D0 F2                bne     L23AD
+00.000162r 2               .endif
+00.000162r 2               ; ----------------------------------------------------------------------------
+00.000162r 2               PUT_NEW_LINE:
+00.000162r 2               .ifndef KBD
+00.000162r 2                 .ifdef CONFIG_2
+00.000162r 2                       jsr     SETPTRS
+00.000162r 2                       jsr     LE33D
+00.000162r 2                       lda     INPUTBUFFER
+00.000162r 2                       beq     L2351
+00.000162r 2                       clc
+00.000162r 2                 .else
+00.000162r 2  A5 1B                lda     INPUTBUFFER
+00.000164r 2  F0 2F                beq     FIX_LINKS
+00.000166r 2  A5 84                lda     MEMSIZ
+00.000168r 2  A4 85                ldy     MEMSIZ+1
+00.00016Ar 2  85 80                sta     FRETOP
+00.00016Cr 2  84 81                sty     FRETOP+1
+00.00016Er 2                 .endif
+00.00016Er 2               .endif
+00.00016Er 2  A5 7A                lda     VARTAB
+00.000170r 2  85 A7                sta     HIGHTR
+00.000172r 2  65 0C                adc     EOLPNTR
+00.000174r 2  85 A5                sta     HIGHDS
+00.000176r 2  A4 7B                ldy     VARTAB+1
+00.000178r 2  84 A8                sty     HIGHTR+1
+00.00017Ar 2  90 01                bcc     L23D6
+00.00017Cr 2  C8                   iny
+00.00017Dr 2               L23D6:
+00.00017Dr 2  84 A6                sty     HIGHDS+1
+00.00017Fr 2  20 rr rr             jsr     BLTU
+00.000182r 2               .ifdef CONFIG_INPUTBUFFER_0200
+00.000182r 2                       lda     LINNUM
+00.000182r 2                       ldy     LINNUM+1
+00.000182r 2                       sta     INPUTBUFFER-2
+00.000182r 2                       sty     INPUTBUFFER-1
+00.000182r 2               .endif
+00.000182r 2  A5 7E                lda     STREND
+00.000184r 2  A4 7F                ldy     STREND+1
+00.000186r 2  85 7A                sta     VARTAB
+00.000188r 2  84 7B                sty     VARTAB+1
+00.00018Ar 2  A4 0C                ldy     EOLPNTR
+00.00018Cr 2  88                   dey
+00.00018Dr 2               ; ---COPY LINE INTO PROGRAM-------
+00.00018Dr 2               L23E6:
+00.00018Dr 2  B9 17 00             lda     INPUTBUFFER-4,y
+00.000190r 2  91 AC                sta     (LOWTR),y
+00.000192r 2  88                   dey
+00.000193r 2  10 F8                bpl     L23E6
+00.000195r 2               
+00.000195r 2               ; ----------------------------------------------------------------------------
+00.000195r 2               ; CLEAR ALL VARIABLES
+00.000195r 2               ; RE-ESTABLISH ALL FORWARD LINKS
+00.000195r 2               ; ----------------------------------------------------------------------------
+00.000195r 2               FIX_LINKS:
+00.000195r 2  20 rr rr             jsr     SETPTRS
+00.000198r 2               .ifdef CONFIG_2
+00.000198r 2                       jsr     LE33D
+00.000198r 2                       jmp     L2351
+00.000198r 2               LE33D:
+00.000198r 2               .endif
+00.000198r 2  A5 78                lda     TXTTAB
+00.00019Ar 2  A4 79                ldy     TXTTAB+1
+00.00019Cr 2  85 6F                sta     INDEX
+00.00019Er 2  84 70                sty     INDEX+1
+00.0001A0r 2  18                   clc
+00.0001A1r 2               L23FA:
+00.0001A1r 2  A0 01                ldy     #$01
+00.0001A3r 2  B1 6F                lda     (INDEX),y
+00.0001A5r 2               .ifdef CONFIG_2
+00.0001A5r 2                       beq     RET3
+00.0001A5r 2               .else
+00.0001A5r 2  D0 03 4C rr          jeq     L2351
+00.0001A9r 2  rr           
+00.0001AAr 2               .endif
+00.0001AAr 2  A0 04                ldy     #$04
+00.0001ACr 2               L2405:
+00.0001ACr 2  C8                   iny
+00.0001ADr 2  B1 6F                lda     (INDEX),y
+00.0001AFr 2  D0 FB                bne     L2405
+00.0001B1r 2  C8                   iny
+00.0001B2r 2  98                   tya
+00.0001B3r 2  65 6F                adc     INDEX
+00.0001B5r 2  AA                   tax
+00.0001B6r 2  A0 00                ldy     #$00
+00.0001B8r 2  91 6F                sta     (INDEX),y
+00.0001BAr 2  A5 70                lda     INDEX+1
+00.0001BCr 2  69 00                adc     #$00
+00.0001BEr 2  C8                   iny
+00.0001BFr 2  91 6F                sta     (INDEX),y
+00.0001C1r 2  86 6F                stx     INDEX
+00.0001C3r 2  85 70                sta     INDEX+1
+00.0001C5r 2  90 DA                bcc     L23FA	; always
+00.0001C7r 2               
+00.0001C7r 2               ; ----------------------------------------------------------------------------
+00.0001C7r 2               .ifdef KBD
+00.0001C7r 2               .include "kbd_loadsave.s"
+00.0001C7r 2               .endif
+00.0001C7r 2               
+00.0001C7r 2               .ifdef CONFIG_2
+00.0001C7r 2               ; !!! kbd_loadsave.s requires an RTS here!
+00.0001C7r 2               RET3:
+00.0001C7r 2               		rts
+00.0001C7r 2               .endif
+00.0001C7r 2               
+00.0001C7r 2               .include "inline.s"
+00.0001C7r 3               .segment "CODE"
+00.0001C7r 3               
+00.0001C7r 3               .ifndef CONFIG_NO_INPUTBUFFER_ZP
+00.0001C7r 3               L2420:
+00.0001C7r 3                 .ifdef OSI
+00.0001C7r 3                       jsr     OUTDO
+00.0001C7r 3                 .endif
+00.0001C7r 3  CA                   dex
+00.0001C8r 3  10 05                bpl     INLIN2
+00.0001CAr 3               L2423:
+00.0001CAr 3                 .ifdef OSI
+00.0001CAr 3                       jsr     OUTDO
+00.0001CAr 3                 .endif
+00.0001CAr 3  20 rr rr             jsr     CRDO
+00.0001CDr 3               .endif
+00.0001CDr 3               
+00.0001CDr 3               ; ----------------------------------------------------------------------------
+00.0001CDr 3               ; READ A LINE, AND STRIP OFF SIGN BITS
+00.0001CDr 3               ; ----------------------------------------------------------------------------
+00.0001CDr 3               .ifndef KBD
+00.0001CDr 3               INLIN:
+00.0001CDr 3                 .ifdef APPLE
+00.0001CDr 3                       ldx     #$DD
+00.0001CDr 3               INLIN1:
+00.0001CDr 3                       stx     $33
+00.0001CDr 3                       jsr     L2900
+00.0001CDr 3                       cpx     #$EF
+00.0001CDr 3                       bcs     L0C32
+00.0001CDr 3                       ldx     #$EF
+00.0001CDr 3               L0C32:
+00.0001CDr 3                       lda     #$00
+00.0001CDr 3                       sta     INPUTBUFFER,x
+00.0001CDr 3                       ldx     #<INPUTBUFFER-1
+00.0001CDr 3                       ldy     #>INPUTBUFFER-1
+00.0001CDr 3                       rts
+00.0001CDr 3                 .endif
+00.0001CDr 3               
+00.0001CDr 3                 .ifndef APPLE
+00.0001CDr 3  A2 00                ldx     #$00
+00.0001CFr 3               INLIN2:
+00.0001CFr 3  20 rr rr             jsr     GETLN
+00.0001D2r 3                   .ifndef CONFIG_NO_LINE_EDITING
+00.0001D2r 3  C9 07                cmp     #$07
+00.0001D4r 3  F0 14                beq     L2443
+00.0001D6r 3                   .endif
+00.0001D6r 3  C9 0D                cmp     #$0D
+00.0001D8r 3  F0 20                beq     L2453
+00.0001DAr 3                   .ifndef CONFIG_NO_LINE_EDITING
+00.0001DAr 3  C9 20                cmp     #$20
+00.0001DCr 3  90 F1                bcc     INLIN2
+00.0001DEr 3                     .ifdef MICROTAN
+00.0001DEr 3                       cmp     #$80
+00.0001DEr 3                     .else
+00.0001DEr 3  C9 7D                cmp     #$7D
+00.0001E0r 3                     .endif
+00.0001E0r 3  B0 ED                bcs     INLIN2
+00.0001E2r 3  C9 40                cmp     #$40 ; @
+00.0001E4r 3  F0 E4                beq     L2423
+00.0001E6r 3                     .ifdef MICROTAN
+00.0001E6r 3                       cmp     #$7F ; DEL
+00.0001E6r 3                     .else
+00.0001E6r 3  C9 5F                cmp     #$5F ; _
+00.0001E8r 3                     .endif
+00.0001E8r 3  F0 DD                beq     L2420
+00.0001EAr 3               L2443:
+00.0001EAr 3                     .ifdef MICROTAN
+00.0001EAr 3                       cpx     #$4F
+00.0001EAr 3                     .else
+00.0001EAr 3  E0 47                cpx     #$47
+00.0001ECr 3                     .endif
+00.0001ECr 3  B0 05                bcs     L244C
+00.0001EEr 3                   .endif
+00.0001EEr 3  95 1B                sta     INPUTBUFFER,x
+00.0001F0r 3  E8                   inx
+00.0001F1r 3                   .ifdef OSI
+00.0001F1r 3                       .byte   $2C
+00.0001F1r 3                   .else
+00.0001F1r 3  D0 DC                bne     INLIN2
+00.0001F3r 3                   .endif
+00.0001F3r 3               L244C:
+00.0001F3r 3                   .ifndef CONFIG_NO_LINE_EDITING
+00.0001F3r 3  A9 07                lda     #$07 ; BEL
+00.0001F5r 3  20 rr rr             jsr     OUTDO
+00.0001F8r 3  D0 D5                bne     INLIN2
+00.0001FAr 3                   .endif
+00.0001FAr 3               L2453:
+00.0001FAr 3  4C rr rr             jmp     L29B9
+00.0001FDr 3                 .endif
+00.0001FDr 3               .endif
+00.0001FDr 3               
+00.0001FDr 3               .ifndef KBD
+00.0001FDr 3                 .ifndef APPLE
+00.0001FDr 3               GETLN:
+00.0001FDr 3                   .ifdef CONFIG_FILE
+00.0001FDr 3                       jsr     CHRIN
+00.0001FDr 3                       ldy     CURDVC
+00.0001FDr 3                       bne     L2465
+00.0001FDr 3                   .else
+00.0001FDr 3  20 5A 1E             jsr     MONRDKEY
+00.000200r 3                   .endif
+00.000200r 3                   .ifdef OSI
+00.000200r 3                       nop
+00.000200r 3                       nop
+00.000200r 3                       nop
+00.000200r 3                       nop
+00.000200r 3                       nop
+00.000200r 3                       nop
+00.000200r 3                       nop
+00.000200r 3                       nop
+00.000200r 3                       nop
+00.000200r 3                       nop
+00.000200r 3                       nop
+00.000200r 3                       nop
+00.000200r 3                       nop
+00.000200r 3                       nop
+00.000200r 3                       and     #$7F
+00.000200r 3                   .endif
+00.000200r 3                 .endif ; APPLE
+00.000200r 3                 .ifdef APPLE
+00.000200r 3               RDKEY:
+00.000200r 3                       jsr     LFD0C
+00.000200r 3                       and     #$7F
+00.000200r 3                 .endif
+00.000200r 3  C9 0F                cmp     #$0F
+00.000202r 3  D0 08                bne     L2465
+00.000204r 3  48                   pha
+00.000205r 3  A5 14                lda     Z14
+00.000207r 3  49 FF                eor     #$FF
+00.000209r 3  85 14                sta     Z14
+00.00020Br 3  68                   pla
+00.00020Cr 3               L2465:
+00.00020Cr 3  60                   rts
+00.00020Dr 3               .endif ; KBD
+00.00020Dr 3               
+00.00020Dr 2               
+00.00020Dr 2               ; ----------------------------------------------------------------------------
+00.00020Dr 2               ; TOKENIZE THE INPUT LINE
+00.00020Dr 2               ; ----------------------------------------------------------------------------
+00.00020Dr 2               PARSE_INPUT_LINE:
+00.00020Dr 2  A6 C7                ldx     TXTPTR
+00.00020Fr 2  A0 04                ldy     #$04
+00.000211r 2  84 10                sty     DATAFLG
+00.000213r 2               L246C:
+00.000213r 2  BD 00 00             lda     INPUTBUFFERX,x
+00.000216r 2               .ifdef CONFIG_CBM_ALL
+00.000216r 2                       bpl     LC49E
+00.000216r 2                       cmp     #$FF
+00.000216r 2                       beq     L24AC
+00.000216r 2                       inx
+00.000216r 2                       bne     L246C
+00.000216r 2               LC49E:
+00.000216r 2               .endif
+00.000216r 2  C9 20                cmp     #$20
+00.000218r 2  F0 3B                beq     L24AC
+00.00021Ar 2  85 0B                sta     ENDCHR
+00.00021Cr 2  C9 22                cmp     #$22
+00.00021Er 2  F0 5A                beq     L24D0
+00.000220r 2  24 10                bit     DATAFLG
+00.000222r 2  70 31                bvs     L24AC
+00.000224r 2  C9 3F                cmp     #$3F
+00.000226r 2  D0 04                bne     L2484
+00.000228r 2  A9 97                lda     #TOKEN_PRINT
+00.00022Ar 2  D0 29                bne     L24AC
+00.00022Cr 2               L2484:
+00.00022Cr 2  C9 30                cmp     #$30
+00.00022Er 2  90 04                bcc     L248C
+00.000230r 2  C9 3C                cmp     #$3C
+00.000232r 2  90 21                bcc     L24AC
+00.000234r 2               ; ----------------------------------------------------------------------------
+00.000234r 2               ; SEARCH TOKEN NAME TABLE FOR MATCH STARTING
+00.000234r 2               ; WITH CURRENT CHAR FROM INPUT LINE
+00.000234r 2               ; ----------------------------------------------------------------------------
+00.000234r 2               L248C:
+00.000234r 2  84 BE                sty     STRNG2
+00.000236r 2  A0 00                ldy     #$00
+00.000238r 2  84 0C                sty     EOLPNTR
+00.00023Ar 2  88                   dey
+00.00023Br 2  86 C7                stx     TXTPTR
+00.00023Dr 2  CA                   dex
+00.00023Er 2               L2496:
+00.00023Er 2  C8                   iny
+00.00023Fr 2               L2497:
+00.00023Fr 2  E8                   inx
+00.000240r 2               L2498:
+00.000240r 2               .ifdef KBD
+00.000240r 2                       jsr     GET_UPPER
+00.000240r 2               .else
+00.000240r 2  BD 00 00             lda     INPUTBUFFERX,x
+00.000243r 2                 .ifndef CONFIG_2
+00.000243r 2  C9 20                cmp     #$20
+00.000245r 2  F0 F8                beq     L2497
+00.000247r 2                 .endif
+00.000247r 2               .endif
+00.000247r 2  38                   sec
+00.000248r 2  F9 rr rr             sbc     TOKEN_NAME_TABLE,y
+00.00024Br 2  F0 F1                beq     L2496
+00.00024Dr 2  C9 80                cmp     #$80
+00.00024Fr 2  D0 30                bne     L24D7
+00.000251r 2  05 0C                ora     EOLPNTR
+00.000253r 2               ; ----------------------------------------------------------------------------
+00.000253r 2               ; STORE CHARACTER OR TOKEN IN OUTPUT LINE
+00.000253r 2               ; ----------------------------------------------------------------------------
+00.000253r 2               L24AA:
+00.000253r 2  A4 BE                ldy     STRNG2
+00.000255r 2               L24AC:
+00.000255r 2  E8                   inx
+00.000256r 2  C8                   iny
+00.000257r 2  99 16 00             sta     INPUTBUFFER-5,y
+00.00025Ar 2  B9 16 00             lda     INPUTBUFFER-5,y
+00.00025Dr 2  F0 36                beq     L24EA
+00.00025Fr 2  38                   sec
+00.000260r 2  E9 3A                sbc     #$3A
+00.000262r 2  F0 04                beq     L24BF
+00.000264r 2  C9 49                cmp     #$49
+00.000266r 2  D0 02                bne     L24C1
+00.000268r 2               L24BF:
+00.000268r 2  85 10                sta     DATAFLG
+00.00026Ar 2               L24C1:
+00.00026Ar 2  38                   sec
+00.00026Br 2  E9 54                sbc     #TOKEN_REM-':'
+00.00026Dr 2  D0 A4                bne     L246C
+00.00026Fr 2  85 0B                sta     ENDCHR
+00.000271r 2               ; ----------------------------------------------------------------------------
+00.000271r 2               ; HANDLE LITERAL (BETWEEN QUOTES) OR REMARK,
+00.000271r 2               ; BY COPYING CHARS UP TO ENDCHR.
+00.000271r 2               ; ----------------------------------------------------------------------------
+00.000271r 2               L24C8:
+00.000271r 2  BD 00 00             lda     INPUTBUFFERX,x
+00.000274r 2  F0 DF                beq     L24AC
+00.000276r 2  C5 0B                cmp     ENDCHR
+00.000278r 2  F0 DB                beq     L24AC
+00.00027Ar 2               L24D0:
+00.00027Ar 2  C8                   iny
+00.00027Br 2  99 16 00             sta     INPUTBUFFER-5,y
+00.00027Er 2  E8                   inx
+00.00027Fr 2  D0 F0                bne     L24C8
+00.000281r 2               ; ----------------------------------------------------------------------------
+00.000281r 2               ; ADVANCE POINTER TO NEXT TOKEN NAME
+00.000281r 2               ; ----------------------------------------------------------------------------
+00.000281r 2               L24D7:
+00.000281r 2  A6 C7                ldx     TXTPTR
+00.000283r 2  E6 0C                inc     EOLPNTR
+00.000285r 2               L24DB:
+00.000285r 2  C8                   iny
+00.000286r 2  B9 rr rr             lda     MATHTBL+28+1,y
+00.000289r 2  10 FA                bpl     L24DB
+00.00028Br 2  B9 rr rr             lda     TOKEN_NAME_TABLE,y
+00.00028Er 2  D0 B0                bne     L2498
+00.000290r 2  BD 00 00             lda     INPUTBUFFERX,x
+00.000293r 2  10 BE                bpl     L24AA
+00.000295r 2               ; ---END OF LINE------------------
+00.000295r 2               L24EA:
+00.000295r 2  99 18 00             sta     INPUTBUFFER-3,y
+00.000298r 2               .ifdef CONFIG_NO_INPUTBUFFER_ZP
+00.000298r 2                       dec     TXTPTR+1
+00.000298r 2               .endif
+00.000298r 2  A9 1A                lda     #<INPUTBUFFER-1
+00.00029Ar 2  85 C7                sta     TXTPTR
+00.00029Cr 2  60                   rts
+00.00029Dr 2               
+00.00029Dr 2               ; ----------------------------------------------------------------------------
+00.00029Dr 2               ; SEARCH FOR LINE
+00.00029Dr 2               ;
+00.00029Dr 2               ; (LINNUM) = LINE # TO FIND
+00.00029Dr 2               ; IF NOT FOUND:  CARRY = 0
+00.00029Dr 2               ;	LOWTR POINTS AT NEXT LINE
+00.00029Dr 2               ; IF FOUND:      CARRY = 1
+00.00029Dr 2               ;	LOWTR POINTS AT LINE
+00.00029Dr 2               ; ----------------------------------------------------------------------------
+00.00029Dr 2               FNDLIN:
+00.00029Dr 2               .ifdef KBD
+00.00029Dr 2                       jsr     CHRGET
+00.00029Dr 2                       jmp     LE444
+00.00029Dr 2               LE440:
+00.00029Dr 2                       php
+00.00029Dr 2                       jsr     LINGET
+00.00029Dr 2               LE444:
+00.00029Dr 2                       jsr     LF457
+00.00029Dr 2                       ldx     #$FF
+00.00029Dr 2                       plp
+00.00029Dr 2                       beq     LE464
+00.00029Dr 2                       jsr     CHRGOT
+00.00029Dr 2                       beq     L2520
+00.00029Dr 2                       cmp     #$A5
+00.00029Dr 2                       bne     L2520
+00.00029Dr 2                       jsr     CHRGET
+00.00029Dr 2                       beq     LE464
+00.00029Dr 2                       bcs     LE461
+00.00029Dr 2                       jsr     LINGET
+00.00029Dr 2                       beq     L2520
+00.00029Dr 2               LE461:
+00.00029Dr 2                       jmp     SYNERR
+00.00029Dr 2               LE464:
+00.00029Dr 2                       stx     LINNUM
+00.00029Dr 2                       stx     LINNUM+1
+00.00029Dr 2               .else
+00.00029Dr 2  A5 78                lda     TXTTAB
+00.00029Fr 2  A6 79                ldx     TXTTAB+1
+00.0002A1r 2               FL1:
+00.0002A1r 2  A0 01                ldy     #$01
+00.0002A3r 2  85 AC                sta     LOWTR
+00.0002A5r 2  86 AD                stx     LOWTR+1
+00.0002A7r 2  B1 AC                lda     (LOWTR),y
+00.0002A9r 2  F0 1F                beq     L251F
+00.0002ABr 2  C8                   iny
+00.0002ACr 2  C8                   iny
+00.0002ADr 2  A5 1A                lda     LINNUM+1
+00.0002AFr 2  D1 AC                cmp     (LOWTR),y
+00.0002B1r 2  90 18                bcc     L2520
+00.0002B3r 2  F0 03                beq     L250D
+00.0002B5r 2  88                   dey
+00.0002B6r 2  D0 09                bne     L2516
+00.0002B8r 2               L250D:
+00.0002B8r 2  A5 19                lda     LINNUM
+00.0002BAr 2  88                   dey
+00.0002BBr 2  D1 AC                cmp     (LOWTR),y
+00.0002BDr 2  90 0C                bcc     L2520
+00.0002BFr 2  F0 0A                beq     L2520
+00.0002C1r 2               L2516:
+00.0002C1r 2  88                   dey
+00.0002C2r 2  B1 AC                lda     (LOWTR),y
+00.0002C4r 2  AA                   tax
+00.0002C5r 2  88                   dey
+00.0002C6r 2  B1 AC                lda     (LOWTR),y
+00.0002C8r 2  B0 D7                bcs     FL1
+00.0002CAr 2               L251F:
+00.0002CAr 2  18                   clc
+00.0002CBr 2               .endif
+00.0002CBr 2               L2520:
+00.0002CBr 2  60                   rts
+00.0002CCr 2               
+00.0002CCr 2               ; ----------------------------------------------------------------------------
+00.0002CCr 2               ; "NEW" STATEMENT
+00.0002CCr 2               ; ----------------------------------------------------------------------------
+00.0002CCr 2               NEW:
+00.0002CCr 2  D0 FD                bne     L2520
+00.0002CEr 2               SCRTCH:
+00.0002CEr 2  A9 00                lda     #$00
+00.0002D0r 2  A8                   tay
+00.0002D1r 2  91 78                sta     (TXTTAB),y
+00.0002D3r 2  C8                   iny
+00.0002D4r 2  91 78                sta     (TXTTAB),y
+00.0002D6r 2  A5 78                lda     TXTTAB
+00.0002D8r 2               .ifdef CONFIG_2
+00.0002D8r 2               		clc
+00.0002D8r 2               .endif
+00.0002D8r 2  69 02                adc     #$02
+00.0002DAr 2  85 7A                sta     VARTAB
+00.0002DCr 2  A5 79                lda     TXTTAB+1
+00.0002DEr 2  69 00                adc     #$00
+00.0002E0r 2  85 7B                sta     VARTAB+1
+00.0002E2r 2               ; ----------------------------------------------------------------------------
+00.0002E2r 2               SETPTRS:
+00.0002E2r 2  20 rr rr             jsr     STXTPT
+00.0002E5r 2               .ifdef CONFIG_11A
+00.0002E5r 2  A9 00                lda     #$00
+00.0002E7r 2               
+00.0002E7r 2               ; ----------------------------------------------------------------------------
+00.0002E7r 2               ; "CLEAR" STATEMENT
+00.0002E7r 2               ; ----------------------------------------------------------------------------
+00.0002E7r 2               CLEAR:
+00.0002E7r 2  D0 2C                bne     L256A
+00.0002E9r 2               .endif
+00.0002E9r 2               CLEARC:
+00.0002E9r 2               .ifdef KBD
+00.0002E9r 2                       lda     #<CONST_MEMSIZ
+00.0002E9r 2                       ldy     #>CONST_MEMSIZ
+00.0002E9r 2               .else
+00.0002E9r 2  A5 84                lda     MEMSIZ
+00.0002EBr 2  A4 85                ldy     MEMSIZ+1
+00.0002EDr 2               .endif
+00.0002EDr 2  85 80                sta     FRETOP
+00.0002EFr 2  84 81                sty     FRETOP+1
+00.0002F1r 2               .ifdef CONFIG_CBM_ALL
+00.0002F1r 2                       jsr     CLALL
+00.0002F1r 2               .endif
+00.0002F1r 2  A5 7A                lda     VARTAB
+00.0002F3r 2  A4 7B                ldy     VARTAB+1
+00.0002F5r 2  85 7C                sta     ARYTAB
+00.0002F7r 2  84 7D                sty     ARYTAB+1
+00.0002F9r 2  85 7E                sta     STREND
+00.0002FBr 2  84 7F                sty     STREND+1
+00.0002FDr 2  20 rr rr             jsr     RESTORE
+00.000300r 2               ; ----------------------------------------------------------------------------
+00.000300r 2               STKINI:
+00.000300r 2  A2 66                ldx     #TEMPST
+00.000302r 2  86 63                stx     TEMPPT
+00.000304r 2  68                   pla
+00.000305r 2               .ifdef CONFIG_2
+00.000305r 2               		tay
+00.000305r 2               .else
+00.000305r 2  8D FD 01             sta     STACK+STACK_TOP+1
+00.000308r 2               .endif
+00.000308r 2  68                   pla
+00.000309r 2               .ifndef CONFIG_2
+00.000309r 2  8D FE 01             sta     STACK+STACK_TOP+2
+00.00030Cr 2               .endif
+00.00030Cr 2  A2 FC                ldx     #STACK_TOP
+00.00030Er 2  9A                   txs
+00.00030Fr 2               .ifdef CONFIG_2
+00.00030Fr 2                       pha
+00.00030Fr 2                       tya
+00.00030Fr 2                       pha
+00.00030Fr 2               .endif
+00.00030Fr 2  A9 00                lda     #$00
+00.000311r 2  85 8B                sta     OLDTEXT+1
+00.000313r 2  85 11                sta     SUBFLG
+00.000315r 2               L256A:
+00.000315r 2  60                   rts
+00.000316r 2               
+00.000316r 2               ; ----------------------------------------------------------------------------
+00.000316r 2               ; SET TXTPTR TO BEGINNING OF PROGRAM
+00.000316r 2               ; ----------------------------------------------------------------------------
+00.000316r 2               STXTPT:
+00.000316r 2  18                   clc
+00.000317r 2  A5 78                lda     TXTTAB
+00.000319r 2  69 FF                adc     #$FF
+00.00031Br 2  85 C7                sta     TXTPTR
+00.00031Dr 2  A5 79                lda     TXTTAB+1
+00.00031Fr 2  69 FF                adc     #$FF
+00.000321r 2  85 C8                sta     TXTPTR+1
+00.000323r 2  60                   rts
+00.000324r 2               
+00.000324r 2               ; ----------------------------------------------------------------------------
+00.000324r 2               .ifdef KBD
+00.000324r 2               LE4C0:
+00.000324r 2                       ldy     #<LE444
+00.000324r 2                       ldx     #>LE444
+00.000324r 2               LE4C4:
+00.000324r 2                       jsr     LFFD6
+00.000324r 2                       jsr     LFFED
+00.000324r 2                       lda     $0504
+00.000324r 2                       clc
+00.000324r 2                       adc     #$08
+00.000324r 2                       sta     $0504
+00.000324r 2                       rts
+00.000324r 2               
+00.000324r 2               CMPJMPADRS:
+00.000324r 2                       lda     1,x
+00.000324r 2                       cmp     JMPADRS+2
+00.000324r 2                       bne     LE4DE
+00.000324r 2                       lda     0,x
+00.000324r 2                       cmp     JMPADRS+1
+00.000324r 2               LE4DE:
+00.000324r 2                       rts
+00.000324r 2               .endif
+00.000324r 2               
+00.000324r 2               ; ----------------------------------------------------------------------------
+00.000324r 2               ; "LIST" STATEMENT
+00.000324r 2               ; ----------------------------------------------------------------------------
+00.000324r 2               LIST:
+00.000324r 2               .ifdef KBD
+00.000324r 2                       jsr     LE440
+00.000324r 2                       bne     LE4DE
+00.000324r 2                       pla
+00.000324r 2                       pla
+00.000324r 2               L25A6:
+00.000324r 2                       jsr     CRDO
+00.000324r 2               .else
+00.000324r 2                 .ifdef MICROTAN
+00.000324r 2                       php
+00.000324r 2                       jmp     LE21C ; patch
+00.000324r 2               LC57E:
+00.000324r 2                 .else
+00.000324r 2  90 06                bcc     L2581
+00.000326r 2  F0 04                beq     L2581
+00.000328r 2  C9 A5                cmp     #TOKEN_MINUS
+00.00032Ar 2  D0 E9                bne     L256A
+00.00032Cr 2               L2581:
+00.00032Cr 2  20 rr rr             jsr     LINGET
+00.00032Fr 2                 .endif
+00.00032Fr 2  20 rr rr             jsr     FNDLIN
+00.000332r 2                 .ifdef MICROTAN
+00.000332r 2                       plp
+00.000332r 2                       beq     L2598
+00.000332r 2                 .endif
+00.000332r 2  20 C6 00             jsr     CHRGOT
+00.000335r 2                 .ifdef MICROTAN
+00.000335r 2                       beq     L25A6
+00.000335r 2                 .else
+00.000335r 2  F0 0C                beq     L2598
+00.000337r 2                 .endif
+00.000337r 2  C9 A5                cmp     #TOKEN_MINUS
+00.000339r 2  D0 90                bne     L2520
+00.00033Br 2  20 C0 00             jsr     CHRGET
+00.00033Er 2                 .ifdef MICROTAN
+00.00033Er 2                       beq     L2598
+00.00033Er 2                       jsr     LINGET
+00.00033Er 2                       beq     L25A6
+00.00033Er 2                       rts
+00.00033Er 2                 .else
+00.00033Er 2  20 rr rr             jsr     LINGET
+00.000341r 2  D0 88                bne     L2520
+00.000343r 2                 .endif
+00.000343r 2               L2598:
+00.000343r 2                 .ifndef MICROTAN
+00.000343r 2  68                   pla
+00.000344r 2  68                   pla
+00.000345r 2  A5 19                lda     LINNUM
+00.000347r 2  05 1A                ora     LINNUM+1
+00.000349r 2  D0 06                bne     L25A6
+00.00034Br 2                 .endif
+00.00034Br 2  A9 FF                lda     #$FF
+00.00034Dr 2  85 19                sta     LINNUM
+00.00034Fr 2  85 1A                sta     LINNUM+1
+00.000351r 2               L25A6:
+00.000351r 2                 .ifdef MICROTAN
+00.000351r 2                       pla
+00.000351r 2                       pla
+00.000351r 2                 .endif
+00.000351r 2               L25A6X:
+00.000351r 2               .endif
+00.000351r 2  A0 01                ldy     #$01
+00.000353r 2               .ifdef CONFIG_DATAFLG
+00.000353r 2                       sty     DATAFLG
+00.000353r 2               .endif
+00.000353r 2  B1 AC                lda     (LOWTRX),y
+00.000355r 2  F0 39                beq     L25E5
+00.000357r 2               .ifdef MICROTAN
+00.000357r 2                       jmp     LE21F
+00.000357r 2               LC5A9:
+00.000357r 2               .else
+00.000357r 2  20 rr rr             jsr     ISCNTC
+00.00035Ar 2               .endif
+00.00035Ar 2               .ifndef KBD
+00.00035Ar 2  20 rr rr             jsr     CRDO
+00.00035Dr 2               .endif
+00.00035Dr 2  C8                   iny
+00.00035Er 2  B1 AC                lda     (LOWTRX),y
+00.000360r 2  AA                   tax
+00.000361r 2  C8                   iny
+00.000362r 2  B1 AC                lda     (LOWTRX),y
+00.000364r 2  C5 1A                cmp     LINNUM+1
+00.000366r 2  D0 04                bne     L25C1
+00.000368r 2  E4 19                cpx     LINNUM
+00.00036Ar 2  F0 02                beq     L25C3
+00.00036Cr 2               L25C1:
+00.00036Cr 2  B0 22                bcs     L25E5
+00.00036Er 2               ; ---LIST ONE LINE----------------
+00.00036Er 2               L25C3:
+00.00036Er 2  84 96                sty     FORPNT
+00.000370r 2  20 rr rr             jsr     LINPRT
+00.000373r 2  A9 20                lda     #$20
+00.000375r 2               L25CA:
+00.000375r 2  A4 96                ldy     FORPNT
+00.000377r 2  29 7F                and     #$7F
+00.000379r 2               L25CE:
+00.000379r 2  20 rr rr             jsr     OUTDO
+00.00037Cr 2               .ifdef CONFIG_DATAFLG
+00.00037Cr 2                       cmp     #$22
+00.00037Cr 2                       bne     LA519
+00.00037Cr 2                       lda     DATAFLG
+00.00037Cr 2                       eor     #$FF
+00.00037Cr 2                       sta     DATAFLG
+00.00037Cr 2               LA519:
+00.00037Cr 2               .endif
+00.00037Cr 2  C8                   iny
+00.00037Dr 2               .ifdef CONFIG_11
+00.00037Dr 2  F0 11                beq     L25E5
+00.00037Fr 2               .endif
+00.00037Fr 2  B1 AC                lda     (LOWTRX),y
+00.000381r 2  D0 10                bne     L25E8
+00.000383r 2  A8                   tay
+00.000384r 2  B1 AC                lda     (LOWTRX),y
+00.000386r 2  AA                   tax
+00.000387r 2  C8                   iny
+00.000388r 2  B1 AC                lda     (LOWTRX),y
+00.00038Ar 2  86 AC                stx     LOWTRX
+00.00038Cr 2  85 AD                sta     LOWTRX+1
+00.00038Er 2               .ifdef MICROTAN
+00.00038Er 2                       bne     L25A6X
+00.00038Er 2               .else
+00.00038Er 2  D0 C1                bne     L25A6
+00.000390r 2               .endif
+00.000390r 2               L25E5:
+00.000390r 2  4C rr rr             jmp     RESTART
+00.000393r 2               L25E8:
+00.000393r 2  10 E4                bpl     L25CE
+00.000395r 2               .ifdef CONFIG_DATAFLG
+00.000395r 2                       cmp     #$FF
+00.000395r 2                       beq     L25CE
+00.000395r 2                       bit     DATAFLG
+00.000395r 2                       bmi     L25CE
+00.000395r 2               .endif
+00.000395r 2  38                   sec
+00.000396r 2  E9 7F                sbc     #$7F
+00.000398r 2  AA                   tax
+00.000399r 2  84 96                sty     FORPNT
+00.00039Br 2  A0 FF                ldy     #$FF
+00.00039Dr 2               L25F2:
+00.00039Dr 2  CA                   dex
+00.00039Er 2  F0 08                beq     L25FD
+00.0003A0r 2               L25F5:
+00.0003A0r 2  C8                   iny
+00.0003A1r 2  B9 rr rr             lda     TOKEN_NAME_TABLE,y
+00.0003A4r 2  10 FA                bpl     L25F5
+00.0003A6r 2  30 F5                bmi     L25F2
+00.0003A8r 2               L25FD:
+00.0003A8r 2  C8                   iny
+00.0003A9r 2  B9 rr rr             lda     TOKEN_NAME_TABLE,y
+00.0003ACr 2  30 C7                bmi     L25CA
+00.0003AEr 2  20 rr rr             jsr     OUTDO
+00.0003B1r 2  D0 F5                bne     L25FD	; always
+00.0003B3r 2               
+00.0003B3r 2               
+00.0003B3r 1               .include "flow1.s"
+00.0003B3r 2               .segment "CODE"
+00.0003B3r 2               
+00.0003B3r 2               ; ----------------------------------------------------------------------------
+00.0003B3r 2               ; "FOR" STATEMENT
+00.0003B3r 2               ;
+00.0003B3r 2               ; FOR PUSHES 18 BYTES ON THE STACK:
+00.0003B3r 2               ; 2 -- TXTPTR
+00.0003B3r 2               ; 2 -- LINE NUMBER
+00.0003B3r 2               ; 5 -- INITIAL (CURRENT)  FOR VARIABLE VALUE
+00.0003B3r 2               ; 1 -- STEP SIGN
+00.0003B3r 2               ; 5 -- STEP VALUE
+00.0003B3r 2               ; 2 -- ADDRESS OF FOR VARIABLE IN VARTAB
+00.0003B3r 2               ; 1 -- FOR TOKEN ($81)
+00.0003B3r 2               ; ----------------------------------------------------------------------------
+00.0003B3r 2               FOR:
+00.0003B3r 2  A9 80                lda     #$80
+00.0003B5r 2  85 11                sta     SUBFLG
+00.0003B7r 2  20 rr rr             jsr     LET
+00.0003BAr 2  20 rr rr             jsr     GTFORPNT
+00.0003BDr 2  D0 05                bne     L2619
+00.0003BFr 2  8A                   txa
+00.0003C0r 2  69 0F                adc     #FOR_STACK1
+00.0003C2r 2  AA                   tax
+00.0003C3r 2  9A                   txs
+00.0003C4r 2               L2619:
+00.0003C4r 2  68                   pla
+00.0003C5r 2  68                   pla
+00.0003C6r 2  A9 09                lda     #FOR_STACK2
+00.0003C8r 2  20 rr rr             jsr     CHKMEM
+00.0003CBr 2  20 rr rr             jsr     DATAN
+00.0003CEr 2  18                   clc
+00.0003CFr 2  98                   tya
+00.0003D0r 2  65 C7                adc     TXTPTR
+00.0003D2r 2  48                   pha
+00.0003D3r 2  A5 C8                lda     TXTPTR+1
+00.0003D5r 2  69 00                adc     #$00
+00.0003D7r 2  48                   pha
+00.0003D8r 2  A5 87                lda     CURLIN+1
+00.0003DAr 2  48                   pha
+00.0003DBr 2  A5 86                lda     CURLIN
+00.0003DDr 2  48                   pha
+00.0003DEr 2  A9 9E                lda     #TOKEN_TO
+00.0003E0r 2  20 rr rr             jsr     SYNCHR
+00.0003E3r 2  20 rr rr             jsr     CHKNUM
+00.0003E6r 2  20 rr rr             jsr     FRMNUM
+00.0003E9r 2  A5 B3                lda     FACSIGN
+00.0003EBr 2  09 7F                ora     #$7F
+00.0003EDr 2  25 AF                and     FAC+1
+00.0003EFr 2  85 AF                sta     FAC+1
+00.0003F1r 2  A9 rr                lda     #<STEP
+00.0003F3r 2  A0 rr                ldy     #>STEP
+00.0003F5r 2  85 6F                sta     INDEX
+00.0003F7r 2  84 70                sty     INDEX+1
+00.0003F9r 2  4C rr rr             jmp     FRM_STACK3
+00.0003FCr 2               
+00.0003FCr 2               ; ----------------------------------------------------------------------------
+00.0003FCr 2               ; "STEP" PHRASE OF "FOR" STATEMENT
+00.0003FCr 2               ; ----------------------------------------------------------------------------
+00.0003FCr 2               STEP:
+00.0003FCr 2  A9 rr                lda     #<CON_ONE
+00.0003FEr 2  A0 rr                ldy     #>CON_ONE
+00.000400r 2  20 rr rr             jsr     LOAD_FAC_FROM_YA
+00.000403r 2  20 C6 00             jsr     CHRGOT
+00.000406r 2  C9 A3                cmp     #TOKEN_STEP
+00.000408r 2  D0 06                bne     L2665
+00.00040Ar 2  20 C0 00             jsr     CHRGET
+00.00040Dr 2  20 rr rr             jsr     FRMNUM
+00.000410r 2               L2665:
+00.000410r 2  20 rr rr             jsr     SIGN
+00.000413r 2  20 rr rr             jsr     FRM_STACK2
+00.000416r 2  A5 97                lda     FORPNT+1
+00.000418r 2  48                   pha
+00.000419r 2  A5 96                lda     FORPNT
+00.00041Br 2  48                   pha
+00.00041Cr 2  A9 81                lda     #$81
+00.00041Er 2  48                   pha
+00.00041Fr 2               
+00.00041Fr 2               ; ----------------------------------------------------------------------------
+00.00041Fr 2               ; PERFORM NEXT STATEMENT
+00.00041Fr 2               ; ----------------------------------------------------------------------------
+00.00041Fr 2               NEWSTT:
+00.00041Fr 2  20 rr rr             jsr     ISCNTC
+00.000422r 2  A5 C7                lda     TXTPTR
+00.000424r 2  A4 C8                ldy     TXTPTR+1
+00.000426r 2               .if .def(CONFIG_NO_INPUTBUFFER_ZP) && .def(CONFIG_2)
+00.000426r 2                       cpy     #>INPUTBUFFER
+00.000426r 2                 .ifdef CBM2
+00.000426r 2                       nop
+00.000426r 2                 .endif
+00.000426r 2                       beq     LC6D4
+00.000426r 2               .else
+00.000426r 2               ; BUG on AppleSoft I,
+00.000426r 2               ; fixed differently on AppleSoft II (ldx/inx)
+00.000426r 2  F0 06                beq     L2683
+00.000428r 2               .endif
+00.000428r 2  85 8A                sta     OLDTEXT
+00.00042Ar 2  84 8B                sty     OLDTEXT+1
+00.00042Cr 2               LC6D4:
+00.00042Cr 2  A0 00                ldy     #$00
+00.00042Er 2               L2683:
+00.00042Er 2  B1 C7                lda     (TXTPTR),y
+00.000430r 2               .ifndef CONFIG_11
+00.000430r 2                       beq     LA5DC	; old: 1 cycle more on generic case
+00.000430r 2                       cmp     #$3A
+00.000430r 2                       beq     NEWSTT2
+00.000430r 2               SYNERR1:
+00.000430r 2                       jmp     SYNERR
+00.000430r 2               LA5DC:
+00.000430r 2               .else
+00.000430r 2  D0 3D                bne     COLON; new: 1 cycle more on ":" case
+00.000432r 2               .endif
+00.000432r 2  A0 02                ldy     #$02
+00.000434r 2  B1 C7                lda     (TXTPTR),y
+00.000436r 2  18                   clc
+00.000437r 2               .ifdef CONFIG_2
+00.000437r 2                       jeq     L2701
+00.000437r 2               .else
+00.000437r 2  F0 73                beq     L2701
+00.000439r 2               .endif
+00.000439r 2  C8                   iny
+00.00043Ar 2  B1 C7                lda     (TXTPTR),y
+00.00043Cr 2  85 86                sta     CURLIN
+00.00043Er 2  C8                   iny
+00.00043Fr 2  B1 C7                lda     (TXTPTR),y
+00.000441r 2  85 87                sta     CURLIN+1
+00.000443r 2  98                   tya
+00.000444r 2  65 C7                adc     TXTPTR
+00.000446r 2  85 C7                sta     TXTPTR
+00.000448r 2  90 02                bcc     NEWSTT2
+00.00044Ar 2  E6 C8                inc     TXTPTR+1
+00.00044Cr 2               NEWSTT2:
+00.00044Cr 2  20 C0 00             jsr     CHRGET
+00.00044Fr 2  20 rr rr             jsr     EXECUTE_STATEMENT
+00.000452r 2  4C rr rr             jmp     NEWSTT
+00.000455r 2               
+00.000455r 2               ; ----------------------------------------------------------------------------
+00.000455r 2               ; EXECUTE A STATEMENT
+00.000455r 2               ;
+00.000455r 2               ; (A) IS FIRST CHAR OF STATEMENT
+00.000455r 2               ; CARRY IS SET
+00.000455r 2               ; ----------------------------------------------------------------------------
+00.000455r 2               EXECUTE_STATEMENT:
+00.000455r 2               .ifndef CONFIG_11A
+00.000455r 2                       beq     RET1
+00.000455r 2               .else
+00.000455r 2  F0 2D                beq     RET2
+00.000457r 2               .endif
+00.000457r 2               .ifndef CONFIG_11
+00.000457r 2                       sec
+00.000457r 2               .endif
+00.000457r 2               EXECUTE_STATEMENT1:
+00.000457r 2  E9 80                sbc     #$80
+00.000459r 2               .ifndef CONFIG_11
+00.000459r 2                       jcc     LET	; old: 1 cycle more on instr.
+00.000459r 2               .else
+00.000459r 2  90 11                bcc     LET1; new: 1 cycle more on assignment
+00.00045Br 2               .endif
+00.00045Br 2  C9 1D                cmp     #NUM_TOKENS
+00.00045Dr 2               .ifdef CONFIG_2
+00.00045Dr 2                       bcs     LC721
+00.00045Dr 2               .else
+00.00045Dr 2  B0 14                bcs     SYNERR1
+00.00045Fr 2               .endif
+00.00045Fr 2  0A                   asl     a
+00.000460r 2  A8                   tay
+00.000461r 2  B9 rr rr             lda     TOKEN_ADDRESS_TABLE+1,y
+00.000464r 2  48                   pha
+00.000465r 2  B9 rr rr             lda     TOKEN_ADDRESS_TABLE,y
+00.000468r 2  48                   pha
+00.000469r 2  4C C0 00             jmp     CHRGET
+00.00046Cr 2               
+00.00046Cr 2               .ifdef CONFIG_11
+00.00046Cr 2               LET1:
+00.00046Cr 2  4C rr rr             jmp     LET
+00.00046Fr 2               
+00.00046Fr 2               COLON:
+00.00046Fr 2  C9 3A                cmp     #$3A
+00.000471r 2  F0 D9                beq     NEWSTT2
+00.000473r 2               SYNERR1:
+00.000473r 2  4C rr rr             jmp     SYNERR
+00.000476r 2               .endif
+00.000476r 2               
+00.000476r 2               .ifdef CONFIG_2; GO TO
+00.000476r 2               LC721:
+00.000476r 2                       cmp     #TOKEN_GO-$80
+00.000476r 2                       bne     SYNERR1
+00.000476r 2                       jsr     CHRGET
+00.000476r 2                       lda     #TOKEN_TO
+00.000476r 2                       jsr     SYNCHR
+00.000476r 2                       jmp     GOTO
+00.000476r 2               .endif
+00.000476r 2               
+00.000476r 2               ; ----------------------------------------------------------------------------
+00.000476r 2               ; "RESTORE" STATEMENT
+00.000476r 2               ; ----------------------------------------------------------------------------
+00.000476r 2               RESTORE:
+00.000476r 2  38                   sec
+00.000477r 2  A5 78                lda     TXTTAB
+00.000479r 2  E9 01                sbc     #$01
+00.00047Br 2  A4 79                ldy     TXTTAB+1
+00.00047Dr 2  B0 01                bcs     SETDA
+00.00047Fr 2  88                   dey
+00.000480r 2               SETDA:
+00.000480r 2  85 8E                sta     DATPTR
+00.000482r 2  84 8F                sty     DATPTR+1
+00.000484r 2               RET2:
+00.000484r 2  60                   rts
+00.000485r 2               
+00.000485r 2               .include "iscntc.s"
+00.000485r 3               .segment "CODE"
+00.000485r 3               ; ----------------------------------------------------------------------------
+00.000485r 3               ; SEE IF CONTROL-C TYPED
+00.000485r 3               ; ----------------------------------------------------------------------------
+00.000485r 3               .ifndef CONFIG_CBM_ALL
+00.000485r 3               .include "cbm_iscntc.s"
+00.000485r 4               ; nothing - ISCNTC is a KERNAL function
+00.000485r 4               
+00.000485r 3               .endif
+00.000485r 3               .ifdef KBD
+00.000485r 3               .include "kbd_iscntc.s"
+00.000485r 3               .endif
+00.000485r 3               .ifdef OSI
+00.000485r 3               .include "osi_iscntc.s"
+00.000485r 3               .endif
+00.000485r 3               .ifdef APPLE
+00.000485r 3               .include "apple_iscntc.s"
+00.000485r 3               .endif
+00.000485r 3               .ifdef KIM
+00.000485r 3               .include "kim_iscntc.s"
+00.000485r 4               .segment "CODE"
+00.000485r 4               ISCNTC:
+00.000485r 4  A9 01                lda     #$01
+00.000487r 4  2C 40 17             bit     $1740
+00.00048Ar 4  30 F8                bmi     RET2
+00.00048Cr 4  A2 08                ldx     #$08
+00.00048Er 4  A9 03                lda     #$03
+00.000490r 4  18                   clc
+00.000491r 4  C9 03                cmp     #$03
+00.000493r 4               ;!!! runs into "STOP"
+00.000493r 4               
+00.000493r 3               .endif
+00.000493r 3               .ifdef MICROTAN
+00.000493r 3               .include "microtan_iscntc.s"
+00.000493r 3               .endif
+00.000493r 3               ;!!! runs into "STOP"
+00.000493r 3               
+00.000493r 2               ;!!! runs into "STOP"
+00.000493r 2               ; ----------------------------------------------------------------------------
+00.000493r 2               ; "STOP" STATEMENT
+00.000493r 2               ; ----------------------------------------------------------------------------
+00.000493r 2               STOP:
+00.000493r 2  B0 01                bcs     END2
+00.000495r 2               
+00.000495r 2               ; ----------------------------------------------------------------------------
+00.000495r 2               ; "END" STATEMENT
+00.000495r 2               ; ----------------------------------------------------------------------------
+00.000495r 2               END:
+00.000495r 2  18                   clc
+00.000496r 2               END2:
+00.000496r 2  D0 3D                bne     RET1
+00.000498r 2  A5 C7                lda     TXTPTR
+00.00049Ar 2  A4 C8                ldy     TXTPTR+1
+00.00049Cr 2               .if .def(CONFIG_NO_INPUTBUFFER_ZP) && .def(CONFIG_2)
+00.00049Cr 2               ; BUG on AppleSoft I
+00.00049Cr 2               ; fix exists on AppleSoft II
+00.00049Cr 2               ; TXTPTR+1 will always be > 0
+00.00049Cr 2                       ldx     CURLIN+1
+00.00049Cr 2                       inx
+00.00049Cr 2               .endif
+00.00049Cr 2  F0 0C                beq     END4
+00.00049Er 2  85 8A                sta     OLDTEXT
+00.0004A0r 2  84 8B                sty     OLDTEXT+1
+00.0004A2r 2               CONTROL_C_TYPED:
+00.0004A2r 2  A5 86                lda     CURLIN
+00.0004A4r 2  A4 87                ldy     CURLIN+1
+00.0004A6r 2  85 88                sta     OLDLIN
+00.0004A8r 2  84 89                sty     OLDLIN+1
+00.0004AAr 2               END4:
+00.0004AAr 2  68                   pla
+00.0004ABr 2  68                   pla
+00.0004ACr 2               L2701:
+00.0004ACr 2  A9 rr                lda     #<QT_BREAK
+00.0004AEr 2  A0 rr                ldy     #>QT_BREAK
+00.0004B0r 2               .ifndef KBD
+00.0004B0r 2  A2 00                ldx     #$00
+00.0004B2r 2  86 14                stx     Z14
+00.0004B4r 2               .endif
+00.0004B4r 2  90 03                bcc     L270E
+00.0004B6r 2  4C rr rr             jmp     PRINT_ERROR_LINNUM
+00.0004B9r 2               L270E:
+00.0004B9r 2  4C rr rr             jmp     RESTART
+00.0004BCr 2               .ifdef KBD
+00.0004BCr 2               LE664:
+00.0004BCr 2                       tay
+00.0004BCr 2                       jmp     SNGFLT
+00.0004BCr 2               .endif
+00.0004BCr 2               
+00.0004BCr 2               ; ----------------------------------------------------------------------------
+00.0004BCr 2               ; "CONT" COMMAND
+00.0004BCr 2               ; ----------------------------------------------------------------------------
+00.0004BCr 2               CONT:
+00.0004BCr 2  D0 17                bne     RET1
+00.0004BEr 2  A2 D2                ldx     #ERR_CANTCONT
+00.0004C0r 2  A4 8B                ldy     OLDTEXT+1
+00.0004C2r 2  D0 03                bne     L271C
+00.0004C4r 2  4C rr rr             jmp     ERROR
+00.0004C7r 2               L271C:
+00.0004C7r 2  A5 8A                lda     OLDTEXT
+00.0004C9r 2  85 C7                sta     TXTPTR
+00.0004CBr 2  84 C8                sty     TXTPTR+1
+00.0004CDr 2  A5 88                lda     OLDLIN
+00.0004CFr 2  A4 89                ldy     OLDLIN+1
+00.0004D1r 2  85 86                sta     CURLIN
+00.0004D3r 2  84 87                sty     CURLIN+1
+00.0004D5r 2               RET1:
+00.0004D5r 2  60                   rts
+00.0004D6r 2               
+00.0004D6r 2               .ifdef KBD
+00.0004D6r 2               PRT:
+00.0004D6r 2                       jsr     GETBYT
+00.0004D6r 2                       txa
+00.0004D6r 2               ; not ROR bug safe
+00.0004D6r 2                       ror     a
+00.0004D6r 2                       ror     a
+00.0004D6r 2                       ror     a
+00.0004D6r 2                       sta     $8F
+00.0004D6r 2                       rts
+00.0004D6r 2               
+00.0004D6r 2               LE68C:
+00.0004D6r 2                       ldy     #$12
+00.0004D6r 2               LE68E:
+00.0004D6r 2                       lda     LEA30,y
+00.0004D6r 2                       sta     $03A2,y
+00.0004D6r 2                       dey
+00.0004D6r 2                       bpl     LE68E
+00.0004D6r 2                       rts
+00.0004D6r 2               .endif
+00.0004D6r 2               
+00.0004D6r 2               .if .def(CONFIG_NULL) || .def(CONFIG_PRINTNULLS)
+00.0004D6r 2               ; CBM1 has the keyword removed,
+00.0004D6r 2               ; but the code is still here
+00.0004D6r 2               NULL:
+00.0004D6r 2  20 rr rr             jsr     GETBYT
+00.0004D9r 2  D0 FA                bne     RET1
+00.0004DBr 2  E8                   inx
+00.0004DCr 2  E0 F2                cpx     #NULL_MAX
+00.0004DEr 2  B0 04                bcs     L2739
+00.0004E0r 2  CA                   dex
+00.0004E1r 2  86 15                stx     Z15
+00.0004E3r 2  60                   rts
+00.0004E4r 2               L2739:
+00.0004E4r 2  4C rr rr             jmp     IQERR
+00.0004E7r 2               .endif
+00.0004E7r 2               .ifndef CONFIG_11A
+00.0004E7r 2               CLEAR:
+00.0004E7r 2                       bne     RET1
+00.0004E7r 2                       jmp     CLEARC
+00.0004E7r 2               .endif
+00.0004E7r 2               
+00.0004E7r 1               .include "loadsave.s"
+00.0004E7r 2               .segment "CODE"
+00.0004E7r 2               
+00.0004E7r 2               .ifdef APPLE
+00.0004E7r 2               .include "apple_loadsave.s"
+00.0004E7r 2               .endif
+00.0004E7r 2               .ifdef KIM
+00.0004E7r 2               .include "kim_loadsave.s"
+00.0004E7r 3               .segment "CODE"
+00.0004E7r 3               SAVE:
+00.0004E7r 3  BA                   tsx
+00.0004E8r 3  86 12                stx     INPUTFLG
+00.0004EAr 3  A9 37                lda     #$37
+00.0004ECr 3  85 F2                sta     $F2
+00.0004EEr 3  A9 FE                lda     #$FE
+00.0004F0r 3  8D F9 17             sta     $17F9
+00.0004F3r 3  A5 78                lda     TXTTAB
+00.0004F5r 3  A4 79                ldy     TXTTAB+1
+00.0004F7r 3  8D F5 17             sta     $17F5
+00.0004FAr 3  8C F6 17             sty     $17F6
+00.0004FDr 3  A5 7A                lda     VARTAB
+00.0004FFr 3  A4 7B                ldy     VARTAB+1
+00.000501r 3  8D F7 17             sta     $17F7
+00.000504r 3  8C F8 17             sty     $17F8
+00.000507r 3  4C 00 18             jmp     L1800
+00.00050Ar 3  A6 12                ldx     INPUTFLG
+00.00050Cr 3  9A                   txs
+00.00050Dr 3  A9 rr                lda     #<QT_SAVED
+00.00050Fr 3  A0 rr                ldy     #>QT_SAVED
+00.000511r 3  4C rr rr             jmp     STROUT
+00.000514r 3               QT_LOADED:
+00.000514r 3  4C 4F 41 44          .byte   "LOADED"
+00.000518r 3  45 44        
+00.00051Ar 3  00                   .byte   $00
+00.00051Br 3               QT_SAVED:
+00.00051Br 3  53 41 56 45          .byte   "SAVED"
+00.00051Fr 3  44           
+00.000520r 3  0D 0A 00 00          .byte   $0D,$0A,$00,$00,$00,$00,$00,$00
+00.000524r 3  00 00 00 00  
+00.000528r 3  00 00 00 00          .byte   $00,$00,$00,$00,$00,$00,$00,$00
+00.00052Cr 3  00 00 00 00  
+00.000530r 3  00 00 00 00          .byte   $00,$00,$00,$00,$00,$00,$00
+00.000534r 3  00 00 00     
+00.000537r 3               LOAD:
+00.000537r 3  A5 78                lda     TXTTAB
+00.000539r 3  A4 79                ldy     TXTTAB+1
+00.00053Br 3  8D F5 17             sta     $17F5
+00.00053Er 3  8C F6 17             sty     $17F6
+00.000541r 3  A9 FF                lda     #$FF
+00.000543r 3  8D F9 17             sta     $17F9
+00.000546r 3  A9 rr                lda     #<L27A6
+00.000548r 3  A0 rr                ldy     #>L27A6
+00.00054Ar 3  85 01                sta     GORESTART+1
+00.00054Cr 3  84 02                sty     GORESTART+2
+00.00054Er 3  4C 73 18             jmp     L1873
+00.000551r 3               L27A6:
+00.000551r 3  A2 FF                ldx     #$FF
+00.000553r 3  9A                   txs
+00.000554r 3  A9 rr                lda     #<RESTART
+00.000556r 3  A0 rr                ldy     #>RESTART
+00.000558r 3  85 01                sta     GORESTART+1
+00.00055Ar 3  84 02                sty     GORESTART+2
+00.00055Cr 3  A9 rr                lda     #<QT_LOADED
+00.00055Er 3  A0 rr                ldy     #>QT_LOADED
+00.000560r 3  20 rr rr             jsr     STROUT
+00.000563r 3  AE ED 17             ldx     $17ED
+00.000566r 3  AC EE 17             ldy     $17EE
+00.000569r 3  8A                   txa
+00.00056Ar 3  D0 01                bne     L27C2
+00.00056Cr 3  EA                   nop
+00.00056Dr 3               L27C2:
+00.00056Dr 3  EA                   nop
+00.00056Er 3  86 7A                stx     VARTAB
+00.000570r 3  84 7B                sty     VARTAB+1
+00.000572r 3  4C rr rr             jmp     FIX_LINKS
+00.000575r 3               
+00.000575r 2               .endif
+00.000575r 2               .ifdef MICROTAN
+00.000575r 2               .include "microtan_loadsave.s"
+00.000575r 2               .endif
+00.000575r 2               
+00.000575r 1               .include "flow2.s"
+00.000575r 2               .segment "CODE"
+00.000575r 2               ; ----------------------------------------------------------------------------
+00.000575r 2               ; "RUN" COMMAND
+00.000575r 2               ; ----------------------------------------------------------------------------
+00.000575r 2               RUN:
+00.000575r 2  D0 03                bne     L27CF
+00.000577r 2  4C rr rr             jmp     SETPTRS
+00.00057Ar 2               L27CF:
+00.00057Ar 2  20 rr rr             jsr     CLEARC
+00.00057Dr 2  4C rr rr             jmp     L27E9
+00.000580r 2               
+00.000580r 2               ; ----------------------------------------------------------------------------
+00.000580r 2               ; "GOSUB" STATEMENT
+00.000580r 2               ;
+00.000580r 2               ; LEAVES 7 BYTES ON STACK:
+00.000580r 2               ; 2 -- RETURN ADDRESS (NEWSTT)
+00.000580r 2               ; 2 -- TXTPTR
+00.000580r 2               ; 2 -- LINE #
+00.000580r 2               ; 1 -- GOSUB TOKEN
+00.000580r 2               ; ----------------------------------------------------------------------------
+00.000580r 2               GOSUB:
+00.000580r 2  A9 03                lda     #$03
+00.000582r 2  20 rr rr             jsr     CHKMEM
+00.000585r 2  A5 C8                lda     TXTPTR+1
+00.000587r 2  48                   pha
+00.000588r 2  A5 C7                lda     TXTPTR
+00.00058Ar 2  48                   pha
+00.00058Br 2  A5 87                lda     CURLIN+1
+00.00058Dr 2  48                   pha
+00.00058Er 2  A5 86                lda     CURLIN
+00.000590r 2  48                   pha
+00.000591r 2  A9 8C                lda     #TOKEN_GOSUB
+00.000593r 2  48                   pha
+00.000594r 2               L27E9:
+00.000594r 2  20 C6 00             jsr     CHRGOT
+00.000597r 2  20 rr rr             jsr     GOTO
+00.00059Ar 2  4C rr rr             jmp     NEWSTT
+00.00059Dr 2               
+00.00059Dr 2               ; ----------------------------------------------------------------------------
+00.00059Dr 2               ; "GOTO" STATEMENT
+00.00059Dr 2               ; ALSO USED BY "RUN" AND "GOSUB"
+00.00059Dr 2               ; ----------------------------------------------------------------------------
+00.00059Dr 2               GOTO:
+00.00059Dr 2  20 rr rr             jsr     LINGET
+00.0005A0r 2  20 rr rr             jsr     REMN
+00.0005A3r 2  A5 87                lda     CURLIN+1
+00.0005A5r 2  C5 1A                cmp     LINNUM+1
+00.0005A7r 2  B0 0B                bcs     L2809
+00.0005A9r 2  98                   tya
+00.0005AAr 2  38                   sec
+00.0005ABr 2  65 C7                adc     TXTPTR
+00.0005ADr 2  A6 C8                ldx     TXTPTR+1
+00.0005AFr 2  90 07                bcc     L280D
+00.0005B1r 2  E8                   inx
+00.0005B2r 2  B0 04                bcs     L280D
+00.0005B4r 2               L2809:
+00.0005B4r 2  A5 78                lda     TXTTAB
+00.0005B6r 2  A6 79                ldx     TXTTAB+1
+00.0005B8r 2               L280D:
+00.0005B8r 2               .ifdef KBD
+00.0005B8r 2                       jsr     LF457
+00.0005B8r 2                       bne     UNDERR
+00.0005B8r 2               .else
+00.0005B8r 2  20 rr rr             jsr     FL1
+00.0005BBr 2  90 1E                bcc     UNDERR
+00.0005BDr 2               .endif
+00.0005BDr 2  A5 AC                lda     LOWTRX
+00.0005BFr 2  E9 01                sbc     #$01
+00.0005C1r 2  85 C7                sta     TXTPTR
+00.0005C3r 2  A5 AD                lda     LOWTRX+1
+00.0005C5r 2  E9 00                sbc     #$00
+00.0005C7r 2  85 C8                sta     TXTPTR+1
+00.0005C9r 2               L281E:
+00.0005C9r 2  60                   rts
+00.0005CAr 2               
+00.0005CAr 2               ; ----------------------------------------------------------------------------
+00.0005CAr 2               ; "POP" AND "RETURN" STATEMENTS
+00.0005CAr 2               ; ----------------------------------------------------------------------------
+00.0005CAr 2               POP:
+00.0005CAr 2  D0 FD                bne     L281E
+00.0005CCr 2  A9 FF                lda     #$FF
+00.0005CEr 2               .ifdef CONFIG_2A
+00.0005CEr 2                       sta     FORPNT+1 ; bugfix, wrong in AppleSoft II
+00.0005CEr 2               .else
+00.0005CEr 2  85 96                sta     FORPNT
+00.0005D0r 2               .endif
+00.0005D0r 2  20 rr rr             jsr     GTFORPNT
+00.0005D3r 2  9A                   txs
+00.0005D4r 2  C9 8C                cmp     #TOKEN_GOSUB
+00.0005D6r 2  F0 0B                beq     RETURN
+00.0005D8r 2  A2 16                ldx     #ERR_NOGOSUB
+00.0005DAr 2  2C                   .byte   $2C
+00.0005DBr 2               UNDERR:
+00.0005DBr 2  A2 5A                ldx     #ERR_UNDEFSTAT
+00.0005DDr 2  4C rr rr             jmp     ERROR
+00.0005E0r 2               ; ----------------------------------------------------------------------------
+00.0005E0r 2               SYNERR2:
+00.0005E0r 2  4C rr rr             jmp     SYNERR
+00.0005E3r 2               ; ----------------------------------------------------------------------------
+00.0005E3r 2               RETURN:
+00.0005E3r 2  68                   pla
+00.0005E4r 2  68                   pla
+00.0005E5r 2  85 86                sta     CURLIN
+00.0005E7r 2  68                   pla
+00.0005E8r 2  85 87                sta     CURLIN+1
+00.0005EAr 2  68                   pla
+00.0005EBr 2  85 C7                sta     TXTPTR
+00.0005EDr 2  68                   pla
+00.0005EEr 2  85 C8                sta     TXTPTR+1
+00.0005F0r 2               
+00.0005F0r 2               ; ----------------------------------------------------------------------------
+00.0005F0r 2               ; "DATA" STATEMENT
+00.0005F0r 2               ; EXECUTED BY SKIPPING TO NEXT COLON OR EOL
+00.0005F0r 2               ; ----------------------------------------------------------------------------
+00.0005F0r 2               DATA:
+00.0005F0r 2  20 rr rr             jsr     DATAN
+00.0005F3r 2               
+00.0005F3r 2               ; ----------------------------------------------------------------------------
+00.0005F3r 2               ; ADD (Y) TO TXTPTR
+00.0005F3r 2               ; ----------------------------------------------------------------------------
+00.0005F3r 2               ADDON:
+00.0005F3r 2  98                   tya
+00.0005F4r 2  18                   clc
+00.0005F5r 2  65 C7                adc     TXTPTR
+00.0005F7r 2  85 C7                sta     TXTPTR
+00.0005F9r 2  90 02                bcc     L2852
+00.0005FBr 2  E6 C8                inc     TXTPTR+1
+00.0005FDr 2               L2852:
+00.0005FDr 2  60                   rts
+00.0005FEr 2               
+00.0005FEr 2               ; ----------------------------------------------------------------------------
+00.0005FEr 2               ; SCAN AHEAD TO NEXT ":" OR EOL
+00.0005FEr 2               ; ----------------------------------------------------------------------------
+00.0005FEr 2               DATAN:
+00.0005FEr 2  A2 3A                ldx     #$3A
+00.000600r 2  2C                   .byte   $2C
+00.000601r 2               REMN:
+00.000601r 2  A2 00                ldx     #$00
+00.000603r 2  86 0A                stx     CHARAC
+00.000605r 2  A0 00                ldy     #$00
+00.000607r 2  84 0B                sty     ENDCHR
+00.000609r 2               L285E:
+00.000609r 2  A5 0B                lda     ENDCHR
+00.00060Br 2  A6 0A                ldx     CHARAC
+00.00060Dr 2  85 0A                sta     CHARAC
+00.00060Fr 2  86 0B                stx     ENDCHR
+00.000611r 2               L2866:
+00.000611r 2  B1 C7                lda     (TXTPTR),y
+00.000613r 2  F0 E8                beq     L2852
+00.000615r 2  C5 0B                cmp     ENDCHR
+00.000617r 2  F0 E4                beq     L2852
+00.000619r 2  C8                   iny
+00.00061Ar 2  C9 22                cmp     #$22
+00.00061Cr 2               .ifndef CONFIG_11
+00.00061Cr 2                       beq     L285E; old: swap & cont is faster
+00.00061Cr 2                       bne     L2866
+00.00061Cr 2               .else
+00.00061Cr 2  D0 F3                bne     L2866; new: cont is faster
+00.00061Er 2  F0 E9                beq     L285E
+00.000620r 2               .endif
+00.000620r 2               
+00.000620r 2               ; ----------------------------------------------------------------------------
+00.000620r 2               ; "IF" STATEMENT
+00.000620r 2               ; ----------------------------------------------------------------------------
+00.000620r 2               IF:
+00.000620r 2  20 rr rr             jsr     FRMEVL
+00.000623r 2  20 C6 00             jsr     CHRGOT
+00.000626r 2  C9 88                cmp     #TOKEN_GOTO
+00.000628r 2  F0 05                beq     L2884
+00.00062Ar 2  A9 A1                lda     #TOKEN_THEN
+00.00062Cr 2  20 rr rr             jsr     SYNCHR
+00.00062Fr 2               L2884:
+00.00062Fr 2  A5 AE                lda     FAC
+00.000631r 2  D0 05                bne     L288D
+00.000633r 2               
+00.000633r 2               ; ----------------------------------------------------------------------------
+00.000633r 2               ; "REM" STATEMENT, OR FALSE "IF" STATEMENT
+00.000633r 2               ; ----------------------------------------------------------------------------
+00.000633r 2               REM:
+00.000633r 2  20 rr rr             jsr     REMN
+00.000636r 2  F0 BB                beq     ADDON
+00.000638r 2               L288D:
+00.000638r 2  20 C6 00             jsr     CHRGOT
+00.00063Br 2  B0 03                bcs     L2895
+00.00063Dr 2  4C rr rr             jmp     GOTO
+00.000640r 2               L2895:
+00.000640r 2  4C rr rr             jmp     EXECUTE_STATEMENT
+00.000643r 2               
+00.000643r 2               ; ----------------------------------------------------------------------------
+00.000643r 2               ; "ON" STATEMENT
+00.000643r 2               ;
+00.000643r 2               ; ON <EXP> GOTO <LIST>
+00.000643r 2               ; ON <EXP> GOSUB <LIST>
+00.000643r 2               ; ----------------------------------------------------------------------------
+00.000643r 2               ON:
+00.000643r 2  20 rr rr             jsr     GETBYT
+00.000646r 2  48                   pha
+00.000647r 2  C9 8C                cmp     #TOKEN_GOSUB
+00.000649r 2  F0 04                beq     L28A4
+00.00064Br 2               L28A0:
+00.00064Br 2  C9 88                cmp     #TOKEN_GOTO
+00.00064Dr 2  D0 91                bne     SYNERR2
+00.00064Fr 2               L28A4:
+00.00064Fr 2  C6 B2                dec     FAC_LAST
+00.000651r 2  D0 04                bne     L28AC
+00.000653r 2  68                   pla
+00.000654r 2  4C rr rr             jmp     EXECUTE_STATEMENT1
+00.000657r 2               L28AC:
+00.000657r 2  20 C0 00             jsr     CHRGET
+00.00065Ar 2  20 rr rr             jsr     LINGET
+00.00065Dr 2  C9 2C                cmp     #$2C
+00.00065Fr 2  F0 EE                beq     L28A4
+00.000661r 2  68                   pla
+00.000662r 2               L28B7:
+00.000662r 2  60                   rts
+00.000663r 2               
+00.000663r 1               .include "misc1.s"
+00.000663r 2               .segment "CODE"
+00.000663r 2               
+00.000663r 2               ; ----------------------------------------------------------------------------
+00.000663r 2               ; CONVERT LINE NUMBER
+00.000663r 2               ; ----------------------------------------------------------------------------
+00.000663r 2               LINGET:
+00.000663r 2  A2 00                ldx     #$00
+00.000665r 2  86 19                stx     LINNUM
+00.000667r 2  86 1A                stx     LINNUM+1
+00.000669r 2               L28BE:
+00.000669r 2  B0 F7                bcs     L28B7
+00.00066Br 2  E9 2F                sbc     #$2F
+00.00066Dr 2  85 0A                sta     CHARAC
+00.00066Fr 2  A5 1A                lda     LINNUM+1
+00.000671r 2  85 6F                sta     INDEX
+00.000673r 2  C9 19                cmp     #$19
+00.000675r 2  B0 D4                bcs     L28A0
+00.000677r 2               ; <<<<<DANGEROUS CODE>>>>>
+00.000677r 2               ; NOTE THAT IF (A) = $AB ON THE LINE ABOVE,
+00.000677r 2               ; ON.1 WILL COMPARE = AND CAUSE A CATASTROPHIC
+00.000677r 2               ; JUMP TO $22D9 (FOR GOTO), OR OTHER LOCATIONS
+00.000677r 2               ; FOR OTHER CALLS TO LINGET.
+00.000677r 2               ;
+00.000677r 2               ; YOU CAN SEE THIS IS YOU FIRST PUT "BRK" IN $22D9,
+00.000677r 2               ; THEN TYPE "GO TO 437761".
+00.000677r 2               ;
+00.000677r 2               ; ANY VALUE FROM 437760 THROUGH 440319 WILL CAUSE
+00.000677r 2               ; THE PROBLEM.  ($AB00 - $ABFF)
+00.000677r 2               ; <<<<<DANGEROUS CODE>>>>>
+00.000677r 2  A5 19                lda     LINNUM
+00.000679r 2  0A                   asl     a
+00.00067Ar 2  26 6F                rol     INDEX
+00.00067Cr 2  0A                   asl     a
+00.00067Dr 2  26 6F                rol     INDEX
+00.00067Fr 2  65 19                adc     LINNUM
+00.000681r 2  85 19                sta     LINNUM
+00.000683r 2  A5 6F                lda     INDEX
+00.000685r 2  65 1A                adc     LINNUM+1
+00.000687r 2  85 1A                sta     LINNUM+1
+00.000689r 2  06 19                asl     LINNUM
+00.00068Br 2  26 1A                rol     LINNUM+1
+00.00068Dr 2  A5 19                lda     LINNUM
+00.00068Fr 2  65 0A                adc     CHARAC
+00.000691r 2  85 19                sta     LINNUM
+00.000693r 2  90 02                bcc     L28EC
+00.000695r 2  E6 1A                inc     LINNUM+1
+00.000697r 2               L28EC:
+00.000697r 2  20 C0 00             jsr     CHRGET
+00.00069Ar 2  4C rr rr             jmp     L28BE
+00.00069Dr 2               
+00.00069Dr 2               ; ----------------------------------------------------------------------------
+00.00069Dr 2               ; "LET" STATEMENT
+00.00069Dr 2               ;
+00.00069Dr 2               ; LET <VAR> = <EXP>
+00.00069Dr 2               ; <VAR> = <EXP>
+00.00069Dr 2               ; ----------------------------------------------------------------------------
+00.00069Dr 2               LET:
+00.00069Dr 2  20 rr rr             jsr     PTRGET
+00.0006A0r 2  85 96                sta     FORPNT
+00.0006A2r 2  84 97                sty     FORPNT+1
+00.0006A4r 2  A9 AC                lda     #TOKEN_EQUAL
+00.0006A6r 2  20 rr rr             jsr     SYNCHR
+00.0006A9r 2               .ifndef CONFIG_SMALL
+00.0006A9r 2  A5 0F                lda     VALTYP+1
+00.0006ABr 2  48                   pha
+00.0006ACr 2               .endif
+00.0006ACr 2  A5 0E                lda     VALTYP
+00.0006AEr 2  48                   pha
+00.0006AFr 2  20 rr rr             jsr     FRMEVL
+00.0006B2r 2  68                   pla
+00.0006B3r 2  2A                   rol     a
+00.0006B4r 2  20 rr rr             jsr     CHKVAL
+00.0006B7r 2  D0 18                bne     LETSTRING
+00.0006B9r 2               .ifndef CONFIG_SMALL
+00.0006B9r 2  68                   pla
+00.0006BAr 2               LET2:
+00.0006BAr 2  10 12                bpl     L2923
+00.0006BCr 2  20 rr rr             jsr     ROUND_FAC
+00.0006BFr 2  20 rr rr             jsr     AYINT
+00.0006C2r 2  A0 00                ldy     #$00
+00.0006C4r 2  A5 B1                lda     FAC+3
+00.0006C6r 2  91 96                sta     (FORPNT),y
+00.0006C8r 2  C8                   iny
+00.0006C9r 2  A5 B2                lda     FAC+4
+00.0006CBr 2  91 96                sta     (FORPNT),y
+00.0006CDr 2  60                   rts
+00.0006CEr 2               L2923:
+00.0006CEr 2               .endif
+00.0006CEr 2               
+00.0006CEr 2               ; ----------------------------------------------------------------------------
+00.0006CEr 2               ; REAL VARIABLE = EXPRESSION
+00.0006CEr 2               ; ----------------------------------------------------------------------------
+00.0006CEr 2  4C rr rr             jmp     SETFOR
+00.0006D1r 2               LETSTRING:
+00.0006D1r 2               .ifndef CONFIG_SMALL
+00.0006D1r 2  68                   pla
+00.0006D2r 2               .endif
+00.0006D2r 2               
+00.0006D2r 2               ; ----------------------------------------------------------------------------
+00.0006D2r 2               ; INSTALL STRING, DESCRIPTOR ADDRESS IS AT FAC+3,4
+00.0006D2r 2               ; ----------------------------------------------------------------------------
+00.0006D2r 2               PUTSTR:
+00.0006D2r 2               .ifdef CONFIG_CBM_ALL
+00.0006D2r 2                       ldy     FORPNT+1
+00.0006D2r 2                 .ifdef CBM1
+00.0006D2r 2                       cpy     #$D0	; TI$
+00.0006D2r 2                 .else
+00.0006D2r 2                       cpy     #$DE
+00.0006D2r 2                 .endif
+00.0006D2r 2                       bne     LC92B
+00.0006D2r 2                       jsr     FREFAC
+00.0006D2r 2                       cmp     #$06
+00.0006D2r 2                 .ifdef CBM2
+00.0006D2r 2                       bne     IQERR1
+00.0006D2r 2                 .else
+00.0006D2r 2                       jne     IQERR
+00.0006D2r 2                 .endif
+00.0006D2r 2                       ldy     #$00
+00.0006D2r 2                       sty     FAC
+00.0006D2r 2                       sty     FACSIGN
+00.0006D2r 2               LC8E8:
+00.0006D2r 2                       sty     STRNG2
+00.0006D2r 2                       jsr     LC91C
+00.0006D2r 2                       jsr     MUL10
+00.0006D2r 2                       inc     STRNG2
+00.0006D2r 2                       ldy     STRNG2
+00.0006D2r 2                       jsr     LC91C
+00.0006D2r 2                       jsr     COPY_FAC_TO_ARG_ROUNDED
+00.0006D2r 2                       tax
+00.0006D2r 2                       beq     LC902
+00.0006D2r 2                       inx
+00.0006D2r 2                       txa
+00.0006D2r 2                       jsr     LD9BF
+00.0006D2r 2               LC902:
+00.0006D2r 2                       ldy     STRNG2
+00.0006D2r 2                       iny
+00.0006D2r 2                       cpy     #$06
+00.0006D2r 2                       bne     LC8E8
+00.0006D2r 2                       jsr     MUL10
+00.0006D2r 2                       jsr     QINT
+00.0006D2r 2                       ldx     #$02
+00.0006D2r 2                       sei
+00.0006D2r 2               LC912:
+00.0006D2r 2                       lda     FAC+2,x
+00.0006D2r 2                       sta     TISTR,x
+00.0006D2r 2                       dex
+00.0006D2r 2                       bpl     LC912
+00.0006D2r 2                       cli
+00.0006D2r 2                       rts
+00.0006D2r 2               LC91C:
+00.0006D2r 2                       lda     (INDEX),y
+00.0006D2r 2                       jsr     CHRGOT2
+00.0006D2r 2                       bcc     LC926
+00.0006D2r 2               IQERR1:
+00.0006D2r 2                       jmp     IQERR
+00.0006D2r 2               LC926:
+00.0006D2r 2                       sbc     #$2F
+00.0006D2r 2                       jmp     ADDACC
+00.0006D2r 2               LC92B:
+00.0006D2r 2               .endif
+00.0006D2r 2  A0 02                ldy     #$02
+00.0006D4r 2  B1 B1                lda     (FAC_LAST-1),y
+00.0006D6r 2  C5 81                cmp     FRETOP+1
+00.0006D8r 2  90 17                bcc     L2946
+00.0006DAr 2  D0 07                bne     L2938
+00.0006DCr 2  88                   dey
+00.0006DDr 2  B1 B1                lda     (FAC_LAST-1),y
+00.0006DFr 2  C5 80                cmp     FRETOP
+00.0006E1r 2  90 0E                bcc     L2946
+00.0006E3r 2               L2938:
+00.0006E3r 2  A4 B2                ldy     FAC_LAST
+00.0006E5r 2  C4 7B                cpy     VARTAB+1
+00.0006E7r 2  90 08                bcc     L2946
+00.0006E9r 2  D0 0D                bne     L294D
+00.0006EBr 2  A5 B1                lda     FAC_LAST-1
+00.0006EDr 2  C5 7A                cmp     VARTAB
+00.0006EFr 2  B0 07                bcs     L294D
+00.0006F1r 2               L2946:
+00.0006F1r 2  A5 B1                lda     FAC_LAST-1
+00.0006F3r 2  A4 B2                ldy     FAC_LAST
+00.0006F5r 2  4C rr rr             jmp     L2963
+00.0006F8r 2               L294D:
+00.0006F8r 2  A0 00                ldy     #$00
+00.0006FAr 2  B1 B1                lda     (FAC_LAST-1),y
+00.0006FCr 2  20 rr rr             jsr     STRINI
+00.0006FFr 2  A5 9D                lda     DSCPTR
+00.000701r 2  A4 9E                ldy     DSCPTR+1
+00.000703r 2  85 BC                sta     STRNG1
+00.000705r 2  84 BD                sty     STRNG1+1
+00.000707r 2  20 rr rr             jsr     MOVINS
+00.00070Ar 2  A9 AE                lda     #FAC
+00.00070Cr 2  A0 00                ldy     #$00
+00.00070Er 2               L2963:
+00.00070Er 2  85 9D                sta     DSCPTR
+00.000710r 2  84 9E                sty     DSCPTR+1
+00.000712r 2  20 rr rr             jsr     FRETMS
+00.000715r 2  A0 00                ldy     #$00
+00.000717r 2  B1 9D                lda     (DSCPTR),y
+00.000719r 2  91 96                sta     (FORPNT),y
+00.00071Br 2  C8                   iny
+00.00071Cr 2  B1 9D                lda     (DSCPTR),y
+00.00071Er 2  91 96                sta     (FORPNT),y
+00.000720r 2  C8                   iny
+00.000721r 2  B1 9D                lda     (DSCPTR),y
+00.000723r 2  91 96                sta     (FORPNT),y
+00.000725r 2  60                   rts
+00.000726r 2               .ifdef CONFIG_FILE
+00.000726r 2               PRINTH:
+00.000726r 2                       jsr     CMD
+00.000726r 2                       jmp     LCAD6
+00.000726r 2               CMD:
+00.000726r 2                       jsr     GETBYT
+00.000726r 2                       beq     LC98F
+00.000726r 2                       lda     #$2C
+00.000726r 2                       jsr     SYNCHR
+00.000726r 2               LC98F:
+00.000726r 2                       php
+00.000726r 2                       jsr     CHKOUT
+00.000726r 2                       stx     CURDVC
+00.000726r 2                       plp
+00.000726r 2                       jmp     PRINT
+00.000726r 2               .endif
+00.000726r 2               
+00.000726r 2               
+00.000726r 1               .include "print.s"
+00.000726r 2               .segment "CODE"
+00.000726r 2               
+00.000726r 2               PRSTRING:
+00.000726r 2  20 rr rr             jsr     STRPRT
+00.000729r 2               L297E:
+00.000729r 2  20 C6 00             jsr     CHRGOT
+00.00072Cr 2               
+00.00072Cr 2               ; ----------------------------------------------------------------------------
+00.00072Cr 2               ; "PRINT" STATEMENT
+00.00072Cr 2               ; ----------------------------------------------------------------------------
+00.00072Cr 2               PRINT:
+00.00072Cr 2  F0 3C                beq     CRDO
+00.00072Er 2               PRINT2:
+00.00072Er 2  F0 58                beq     L29DD
+00.000730r 2  C9 9D                cmp     #TOKEN_TAB
+00.000732r 2  F0 6C                beq     L29F5
+00.000734r 2  C9 A0                cmp     #TOKEN_SPC
+00.000736r 2               .ifdef CONFIG_2
+00.000736r 2                       clc	; also AppleSoft II
+00.000736r 2               .endif
+00.000736r 2  F0 68                beq     L29F5
+00.000738r 2  C9 2C                cmp     #','
+00.00073Ar 2               ; Pre-KIM had no CLC. KIM added the CLC
+00.00073Ar 2               ; here. Post-KIM moved the CLC up...
+00.00073Ar 2               ; (makes no sense on KIM, liveness = 0)
+00.00073Ar 2               .if .def(CONFIG_11A) && (!.def(CONFIG_2))
+00.00073Ar 2  18                   clc
+00.00073Br 2               .endif
+00.00073Br 2  F0 4C                beq     L29DE
+00.00073Dr 2  C9 3B                cmp     #$3B
+00.00073Fr 2  F0 77                beq     L2A0D
+00.000741r 2  20 rr rr             jsr     FRMEVL
+00.000744r 2  24 0E                bit     VALTYP
+00.000746r 2  30 DE                bmi     PRSTRING
+00.000748r 2  20 rr rr             jsr     FOUT
+00.00074Br 2  20 rr rr             jsr     STRLIT
+00.00074Er 2               .ifndef CONFIG_NO_CR
+00.00074Er 2  A0 00                ldy     #$00
+00.000750r 2  B1 B1                lda     (FAC_LAST-1),y
+00.000752r 2  18                   clc
+00.000753r 2  65 16                adc     POSX
+00.000755r 2                 .ifdef KBD
+00.000755r 2                       cmp     #$28
+00.000755r 2                 .else
+00.000755r 2  C5 17                cmp     Z17
+00.000757r 2                 .endif
+00.000757r 2  90 03                bcc     L29B1
+00.000759r 2  20 rr rr             jsr     CRDO
+00.00075Cr 2               L29B1:
+00.00075Cr 2               .endif
+00.00075Cr 2  20 rr rr             jsr     STRPRT
+00.00075Fr 2               .ifdef KBD
+00.00075Fr 2                       jmp     L297E
+00.00075Fr 2               .else
+00.00075Fr 2  20 rr rr             jsr     OUTSP
+00.000762r 2  D0 C5                bne     L297E ; branch always
+00.000764r 2               .endif
+00.000764r 2               
+00.000764r 2               .ifdef KBD
+00.000764r 2               ; PATCHES
+00.000764r 2               LE86C:
+00.000764r 2                       pla
+00.000764r 2                       jmp     CONTROL_C_TYPED
+00.000764r 2               LE870:
+00.000764r 2                       jsr     GETBYT
+00.000764r 2                       txa
+00.000764r 2               LE874:
+00.000764r 2                       beq     LE878
+00.000764r 2                       bpl     LE8F2
+00.000764r 2               LE878:
+00.000764r 2                       jmp     IQERR
+00.000764r 2               ; PATCHES
+00.000764r 2               .endif
+00.000764r 2               
+00.000764r 2               
+00.000764r 2               
+00.000764r 2               .ifndef KBD
+00.000764r 2               L29B9:
+00.000764r 2                 .ifdef CBM2
+00.000764r 2                       lda     #$00
+00.000764r 2                       sta     INPUTBUFFER,x
+00.000764r 2                       ldx     #<(INPUTBUFFER-1)
+00.000764r 2                       ldy     #>(INPUTBUFFER-1)
+00.000764r 2                 .else
+00.000764r 2                   .ifndef APPLE
+00.000764r 2  A0 00                ldy     #$00
+00.000766r 2  94 1B                sty     INPUTBUFFER,x
+00.000768r 2  A2 1A                ldx     #LINNUM+1
+00.00076Ar 2                   .endif
+00.00076Ar 2                   .ifdef MICROTAN
+00.00076Ar 2                       bne     CRDO2
+00.00076Ar 2               	.endif
+00.00076Ar 2                 .endif
+00.00076Ar 2                 .ifdef CONFIG_FILE
+00.00076Ar 2                       lda     CURDVC
+00.00076Ar 2                       bne     L29DD
+00.00076Ar 2                 .endif
+00.00076Ar 2               .endif
+00.00076Ar 2               
+00.00076Ar 2               
+00.00076Ar 2               CRDO:
+00.00076Ar 2               .if .def(CONFIG_PRINTNULLS) && .def(CONFIG_FILE)
+00.00076Ar 2                       lda     CURDVC
+00.00076Ar 2                       bne     LC9D8
+00.00076Ar 2                       sta     POSX
+00.00076Ar 2               LC9D8:
+00.00076Ar 2               .endif
+00.00076Ar 2  A9 0D                lda     #CRLF_1
+00.00076Cr 2               .ifndef CONFIG_CBM_ALL
+00.00076Cr 2  85 16                sta     POSX
+00.00076Er 2               .endif
+00.00076Er 2  20 rr rr             jsr     OUTDO
+00.000771r 2               CRDO2:
+00.000771r 2  A9 0A                lda     #CRLF_2
+00.000773r 2  20 rr rr             jsr     OUTDO
+00.000776r 2               
+00.000776r 2               PRINTNULLS:
+00.000776r 2               .ifdef KBD
+00.000776r 2                       lda     #$00
+00.000776r 2                       sta     POSX
+00.000776r 2                       eor     #$FF
+00.000776r 2               .else
+00.000776r 2                 .if .def(CONFIG_NULL) || .def(CONFIG_PRINTNULLS)
+00.000776r 2                   .ifdef CONFIG_FILE
+00.000776r 2                   ; Although there is no statement for it,
+00.000776r 2                   ; CBM1 had NULL support and ignores
+00.000776r 2                   ; it when not targeting the screen,
+00.000776r 2                   ; CBM2 dropped it completely.
+00.000776r 2                       lda     CURDVC
+00.000776r 2                       bne     L29DD
+00.000776r 2                   .endif
+00.000776r 2  8A                   txa
+00.000777r 2  48                   pha
+00.000778r 2  A6 15                ldx     Z15
+00.00077Ar 2  F0 08                beq     L29D9
+00.00077Cr 2  A9 00                lda     #$00
+00.00077Er 2               L29D3:
+00.00077Er 2  20 rr rr             jsr     OUTDO
+00.000781r 2  CA                   dex
+00.000782r 2  D0 FA                bne     L29D3
+00.000784r 2               L29D9:
+00.000784r 2  86 16                stx     POSX
+00.000786r 2  68                   pla
+00.000787r 2  AA                   tax
+00.000788r 2                 .else
+00.000788r 2                   .ifndef CONFIG_2
+00.000788r 2                       lda     #$00
+00.000788r 2                       sta     POSX
+00.000788r 2                   .endif
+00.000788r 2                       eor     #$FF
+00.000788r 2                 .endif
+00.000788r 2               .endif
+00.000788r 2               L29DD:
+00.000788r 2  60                   rts
+00.000789r 2               L29DE:
+00.000789r 2  A5 16                lda     POSX
+00.00078Br 2               .ifndef CONFIG_NO_CR
+00.00078Br 2                 .ifdef KBD
+00.00078Br 2                       cmp     #$1A
+00.00078Br 2                 .else
+00.00078Br 2  C5 18                cmp     Z18
+00.00078Dr 2                 .endif
+00.00078Dr 2  90 06                bcc     L29EA
+00.00078Fr 2  20 rr rr             jsr     CRDO
+00.000792r 2  4C rr rr             jmp     L2A0D
+00.000795r 2               L29EA:
+00.000795r 2               .endif
+00.000795r 2  38                   sec
+00.000796r 2               L29EB:
+00.000796r 2               .ifdef CONFIG_CBM_ALL
+00.000796r 2                       sbc     #$0A
+00.000796r 2               .else
+00.000796r 2                 .ifdef KBD
+00.000796r 2                       sbc     #$0D
+00.000796r 2                 .else
+00.000796r 2  E9 0E                sbc     #$0E
+00.000798r 2                 .endif
+00.000798r 2               .endif
+00.000798r 2  B0 FC                bcs     L29EB
+00.00079Ar 2  49 FF                eor     #$FF
+00.00079Cr 2  69 01                adc     #$01
+00.00079Er 2  D0 13                bne     L2A08
+00.0007A0r 2               L29F5:
+00.0007A0r 2               .ifdef CONFIG_11A
+00.0007A0r 2  08                   php
+00.0007A1r 2               .else
+00.0007A1r 2                       pha
+00.0007A1r 2               .endif
+00.0007A1r 2  20 rr rr             jsr     GTBYTC
+00.0007A4r 2  C9 29                cmp     #')'
+00.0007A6r 2               .ifdef CONFIG_11A
+00.0007A6r 2                 .ifdef CONFIG_2
+00.0007A6r 2                       bne     SYNERR4
+00.0007A6r 2                 .else
+00.0007A6r 2  F0 03 4C rr          jne     SYNERR
+00.0007AAr 2  rr           
+00.0007ABr 2                 .endif
+00.0007ABr 2  28                   plp
+00.0007ACr 2  90 06                bcc     L2A09
+00.0007AEr 2               .else
+00.0007AEr 2                 .ifdef CONFIG_11
+00.0007AEr 2                       jne     SYNERR
+00.0007AEr 2                 .else
+00.0007AEr 2                       bne     SYNERR4
+00.0007AEr 2                 .endif
+00.0007AEr 2                       pla
+00.0007AEr 2                       cmp     #TOKEN_TAB
+00.0007AEr 2                 .ifdef CONFIG_11
+00.0007AEr 2                       bne     L2A09
+00.0007AEr 2                 .else
+00.0007AEr 2                       bne     L2A0A
+00.0007AEr 2                 .endif
+00.0007AEr 2               .endif
+00.0007AEr 2  8A                   txa
+00.0007AFr 2  E5 16                sbc     POSX
+00.0007B1r 2  90 05                bcc     L2A0D
+00.0007B3r 2               .ifndef CONFIG_11
+00.0007B3r 2                       beq     L2A0D
+00.0007B3r 2               .endif
+00.0007B3r 2               L2A08:
+00.0007B3r 2  AA                   tax
+00.0007B4r 2               .ifdef CONFIG_11
+00.0007B4r 2               L2A09:
+00.0007B4r 2  E8                   inx
+00.0007B5r 2               .endif
+00.0007B5r 2               L2A0A:
+00.0007B5r 2               .ifndef CONFIG_11
+00.0007B5r 2                       jsr     OUTSP
+00.0007B5r 2               .endif
+00.0007B5r 2  CA                   dex
+00.0007B6r 2               .ifndef CONFIG_11
+00.0007B6r 2                       bne     L2A0A
+00.0007B6r 2               .else
+00.0007B6r 2  D0 06                bne     L2A13
+00.0007B8r 2               .endif
+00.0007B8r 2               L2A0D:
+00.0007B8r 2  20 C0 00             jsr     CHRGET
+00.0007BBr 2  4C rr rr             jmp     PRINT2
+00.0007BEr 2               .ifdef CONFIG_11
+00.0007BEr 2               L2A13:
+00.0007BEr 2  20 rr rr             jsr     OUTSP
+00.0007C1r 2  D0 F2                bne     L2A0A
+00.0007C3r 2               .endif
+00.0007C3r 2               
+00.0007C3r 2               ; ----------------------------------------------------------------------------
+00.0007C3r 2               ; PRINT STRING AT (Y,A)
+00.0007C3r 2               ; ----------------------------------------------------------------------------
+00.0007C3r 2               STROUT:
+00.0007C3r 2  20 rr rr             jsr     STRLIT
+00.0007C6r 2               
+00.0007C6r 2               ; ----------------------------------------------------------------------------
+00.0007C6r 2               ; PRINT STRING AT (FACMO,FACLO)
+00.0007C6r 2               ; ----------------------------------------------------------------------------
+00.0007C6r 2               STRPRT:
+00.0007C6r 2  20 rr rr             jsr     FREFAC
+00.0007C9r 2  AA                   tax
+00.0007CAr 2  A0 00                ldy     #$00
+00.0007CCr 2  E8                   inx
+00.0007CDr 2               L2A22:
+00.0007CDr 2  CA                   dex
+00.0007CEr 2  F0 B8                beq     L29DD
+00.0007D0r 2  B1 6F                lda     (INDEX),y
+00.0007D2r 2  20 rr rr             jsr     OUTDO
+00.0007D5r 2  C8                   iny
+00.0007D6r 2  C9 0D                cmp     #$0D
+00.0007D8r 2  D0 F3                bne     L2A22
+00.0007DAr 2  20 rr rr             jsr     PRINTNULLS
+00.0007DDr 2  4C rr rr             jmp     L2A22
+00.0007E0r 2               ; ----------------------------------------------------------------------------
+00.0007E0r 2               OUTSP:
+00.0007E0r 2               .ifdef CONFIG_FILE
+00.0007E0r 2                 .ifndef CBM1
+00.0007E0r 2               ; on non-screen devices, print SPACE
+00.0007E0r 2               ; instead of CRSR RIGHT
+00.0007E0r 2                       lda     CURDVC
+00.0007E0r 2                       beq     LCA40
+00.0007E0r 2                       lda     #$20
+00.0007E0r 2                       .byte   $2C
+00.0007E0r 2               LCA40:
+00.0007E0r 2                 .endif
+00.0007E0r 2                       lda     #$1D ; CRSR RIGHT
+00.0007E0r 2               .else
+00.0007E0r 2  A9 20                lda     #$20
+00.0007E2r 2               .endif
+00.0007E2r 2  2C                   .byte   $2C
+00.0007E3r 2               OUTQUES:
+00.0007E3r 2  A9 3F                lda     #$3F
+00.0007E5r 2               
+00.0007E5r 2               ; ----------------------------------------------------------------------------
+00.0007E5r 2               ; PRINT CHAR FROM (A)
+00.0007E5r 2               ; ----------------------------------------------------------------------------
+00.0007E5r 2               OUTDO:
+00.0007E5r 2               .ifndef KBD
+00.0007E5r 2  24 14                bit     Z14
+00.0007E7r 2  30 18                bmi     L2A56
+00.0007E9r 2               .endif
+00.0007E9r 2               .if .def(CONFIG_PRINT_CR) || .def(CBM1)
+00.0007E9r 2               ; Commodore forgot to remove this in CBM1
+00.0007E9r 2  48                   pha
+00.0007EAr 2               .endif
+00.0007EAr 2               .ifdef CBM1
+00.0007EAr 2                       cmp     #$1D ; CRSR RIGHT
+00.0007EAr 2                       beq     LCA6A
+00.0007EAr 2                       cmp     #$9D ; CRSR LEFT
+00.0007EAr 2                       beq     LCA5A
+00.0007EAr 2                       cmp     #$14 ; DEL
+00.0007EAr 2                       bne     LCA64
+00.0007EAr 2               LCA5A:
+00.0007EAr 2                       lda     POSX
+00.0007EAr 2                       beq     L2A4E
+00.0007EAr 2                       lda     CURDVC
+00.0007EAr 2                       bne     L2A4E
+00.0007EAr 2                       dec     POSX
+00.0007EAr 2               LCA64:
+00.0007EAr 2                       and     #$7F
+00.0007EAr 2               .endif
+00.0007EAr 2               .ifndef CBM2
+00.0007EAr 2  C9 20                cmp     #$20
+00.0007ECr 2  90 0B                bcc     L2A4E
+00.0007EEr 2               .endif
+00.0007EEr 2               LCA6A:
+00.0007EEr 2               .ifdef CONFIG_CBM1_PATCHES
+00.0007EEr 2                       lda     CURDVC
+00.0007EEr 2                       jsr     PATCH6
+00.0007EEr 2                       nop
+00.0007EEr 2               .endif
+00.0007EEr 2               .ifdef CONFIG_PRINT_CR
+00.0007EEr 2  A5 16                lda     POSX
+00.0007F0r 2  C5 17                cmp     Z17
+00.0007F2r 2  D0 03                bne     L2A4C
+00.0007F4r 2                 .ifdef APPLE
+00.0007F4r 2                       nop ; PATCH!
+00.0007F4r 2                       nop ; don't print CR
+00.0007F4r 2                       nop
+00.0007F4r 2                 .else
+00.0007F4r 2  20 rr rr             jsr     CRDO
+00.0007F7r 2                 .endif
+00.0007F7r 2               L2A4C:
+00.0007F7r 2               .endif
+00.0007F7r 2               .ifndef CONFIG_CBM_ALL
+00.0007F7r 2  E6 16                inc     POSX
+00.0007F9r 2               .endif
+00.0007F9r 2               L2A4E:
+00.0007F9r 2               .if .def(CONFIG_PRINT_CR) || .def(CBM1)
+00.0007F9r 2               ; Commodore forgot to remove this in CBM1
+00.0007F9r 2  68                   pla
+00.0007FAr 2               .endif
+00.0007FAr 2               .ifdef CONFIG_MONCOUT_DESTROYS_Y
+00.0007FAr 2  84 0D                sty     DIMFLG
+00.0007FCr 2               .endif
+00.0007FCr 2               .ifdef CONFIG_IO_MSB
+00.0007FCr 2                       ora     #$80
+00.0007FCr 2               .endif
+00.0007FCr 2  20 A0 1E             jsr     MONCOUT
+00.0007FFr 2               .ifdef CONFIG_IO_MSB
+00.0007FFr 2                       and     #$7F
+00.0007FFr 2               .endif
+00.0007FFr 2               .ifdef CONFIG_MONCOUT_DESTROYS_Y
+00.0007FFr 2  A4 0D                ldy     DIMFLG
+00.000801r 2               .endif
+00.000801r 2               .ifdef OSI
+00.000801r 2                       nop
+00.000801r 2                       nop
+00.000801r 2                       nop
+00.000801r 2                       nop
+00.000801r 2               .endif
+00.000801r 2               L2A56:
+00.000801r 2  29 FF                and     #$FF
+00.000803r 2               LE8F2:
+00.000803r 2  60                   rts
+00.000804r 2               
+00.000804r 2               ; ----------------------------------------------------------------------------
+00.000804r 2               ; ???
+00.000804r 2               ; ----------------------------------------------------------------------------
+00.000804r 2               .ifdef KBD
+00.000804r 2               LE8F3:
+00.000804r 2                       pha
+00.000804r 2                       lda     $047F
+00.000804r 2                       clc
+00.000804r 2                       beq     LE900
+00.000804r 2                       lda     #$00
+00.000804r 2                       sta     $047F
+00.000804r 2                       sec
+00.000804r 2               LE900:
+00.000804r 2                       pla
+00.000804r 2                       rts
+00.000804r 2               .endif
+00.000804r 2               
+00.000804r 1               .include "input.s"
+00.000804r 2               .segment "CODE"
+00.000804r 2               
+00.000804r 2               ; ----------------------------------------------------------------------------
+00.000804r 2               ; INPUT CONVERSION ERROR:  ILLEGAL CHARACTER
+00.000804r 2               ; IN NUMERIC FIELD.  MUST DISTINGUISH
+00.000804r 2               ; BETWEEN INPUT, READ, AND GET
+00.000804r 2               ; ----------------------------------------------------------------------------
+00.000804r 2               INPUTERR:
+00.000804r 2  A5 12                lda     INPUTFLG
+00.000806r 2  F0 11                beq     RESPERR	; INPUT
+00.000808r 2               .ifndef CONFIG_SMALL
+00.000808r 2               .ifdef CONFIG_10A
+00.000808r 2               ; without this, it treats GET errors
+00.000808r 2               ; like READ errors
+00.000808r 2  30 04                bmi     L2A63	; READ
+00.00080Ar 2  A0 FF                ldy     #$FF	; GET
+00.00080Cr 2  D0 04                bne     L2A67
+00.00080Er 2               L2A63:
+00.00080Er 2               .endif
+00.00080Er 2               .endif
+00.00080Er 2               .ifdef CONFIG_CBM1_PATCHES
+00.00080Er 2                       jsr     PATCH5
+00.00080Er 2               		nop
+00.00080Er 2               .else
+00.00080Er 2  A5 8C                lda     Z8C
+00.000810r 2  A4 8D                ldy     Z8C+1
+00.000812r 2               .endif
+00.000812r 2               L2A67:
+00.000812r 2  85 86                sta     CURLIN
+00.000814r 2  84 87                sty     CURLIN+1
+00.000816r 2               SYNERR4:
+00.000816r 2  4C rr rr             jmp     SYNERR
+00.000819r 2               RESPERR:
+00.000819r 2               .ifdef CONFIG_FILE
+00.000819r 2                       lda     CURDVC
+00.000819r 2                       beq     LCA8F
+00.000819r 2                       ldx     #ERR_BADDATA
+00.000819r 2                       jmp     ERROR
+00.000819r 2               LCA8F:
+00.000819r 2               .endif
+00.000819r 2  A9 rr                lda     #<ERRREENTRY
+00.00081Br 2  A0 rr                ldy     #>ERRREENTRY
+00.00081Dr 2  20 rr rr             jsr     STROUT
+00.000820r 2  A5 8A                lda     OLDTEXT
+00.000822r 2  A4 8B                ldy     OLDTEXT+1
+00.000824r 2  85 C7                sta     TXTPTR
+00.000826r 2  84 C8                sty     TXTPTR+1
+00.000828r 2               RTS20:
+00.000828r 2  60                   rts
+00.000829r 2               
+00.000829r 2               ; ----------------------------------------------------------------------------
+00.000829r 2               ; "GET" STATEMENT
+00.000829r 2               ; ----------------------------------------------------------------------------
+00.000829r 2               .ifndef CONFIG_SMALL
+00.000829r 2               GET:
+00.000829r 2  20 rr rr             jsr     ERRDIR
+00.00082Cr 2               ; CBM: if GET#, then switch input
+00.00082Cr 2               .ifdef CONFIG_FILE
+00.00082Cr 2                       cmp     #'#'
+00.00082Cr 2                       bne     LCAB6
+00.00082Cr 2                       jsr     CHRGET
+00.00082Cr 2                       jsr     GETBYT
+00.00082Cr 2                       lda     #','
+00.00082Cr 2                       jsr     SYNCHR
+00.00082Cr 2                       jsr     CHKIN
+00.00082Cr 2                       stx     CURDVC
+00.00082Cr 2               LCAB6:
+00.00082Cr 2               .endif
+00.00082Cr 2  A2 1C                ldx     #<(INPUTBUFFER+1)
+00.00082Er 2  A0 00                ldy     #>(INPUTBUFFER+1)
+00.000830r 2               .ifdef CONFIG_NO_INPUTBUFFER_ZP
+00.000830r 2                       lda     #$00
+00.000830r 2                       sta     INPUTBUFFER+1
+00.000830r 2               .else
+00.000830r 2  84 1C                sty     INPUTBUFFER+1
+00.000832r 2               .endif
+00.000832r 2  A9 40                lda     #$40
+00.000834r 2  20 rr rr             jsr     PROCESS_INPUT_LIST
+00.000837r 2               ; CBM: if GET#, then switch input back
+00.000837r 2               .ifdef CONFIG_FILE
+00.000837r 2                       ldx     CURDVC
+00.000837r 2                       bne     LCAD8
+00.000837r 2               .endif
+00.000837r 2  60                   rts
+00.000838r 2               .endif
+00.000838r 2               
+00.000838r 2               ; ----------------------------------------------------------------------------
+00.000838r 2               ; "INPUT#" STATEMENT
+00.000838r 2               ; ----------------------------------------------------------------------------
+00.000838r 2               .ifdef CONFIG_FILE
+00.000838r 2               INPUTH:
+00.000838r 2                       jsr     GETBYT
+00.000838r 2                       lda     #$2C
+00.000838r 2                       jsr     SYNCHR
+00.000838r 2                       jsr     CHKIN
+00.000838r 2                       stx     CURDVC
+00.000838r 2                       jsr     L2A9E
+00.000838r 2               LCAD6:
+00.000838r 2                       lda     CURDVC
+00.000838r 2               LCAD8:
+00.000838r 2                       jsr     CLRCH
+00.000838r 2                       ldx     #$00
+00.000838r 2                       stx     CURDVC
+00.000838r 2                       rts
+00.000838r 2               LCAE0:
+00.000838r 2               .endif
+00.000838r 2               
+00.000838r 2               ; ----------------------------------------------------------------------------
+00.000838r 2               ; "INPUT" STATEMENT
+00.000838r 2               ; ----------------------------------------------------------------------------
+00.000838r 2               INPUT:
+00.000838r 2               .ifndef KBD
+00.000838r 2  46 14                lsr     Z14
+00.00083Ar 2               .endif
+00.00083Ar 2  C9 22                cmp     #$22
+00.00083Cr 2  D0 0B                bne     L2A9E
+00.00083Er 2  20 rr rr             jsr     STRTXT
+00.000841r 2  A9 3B                lda     #$3B
+00.000843r 2  20 rr rr             jsr     SYNCHR
+00.000846r 2  20 rr rr             jsr     STRPRT
+00.000849r 2               L2A9E:
+00.000849r 2  20 rr rr             jsr     ERRDIR
+00.00084Cr 2  A9 2C                lda     #$2C
+00.00084Er 2  85 1A                sta     INPUTBUFFER-1
+00.000850r 2               LCAF8:
+00.000850r 2               .ifdef APPLE
+00.000850r 2                       jsr     INLINX
+00.000850r 2               .else
+00.000850r 2  20 rr rr             jsr     NXIN
+00.000853r 2               .endif
+00.000853r 2               .ifdef KBD
+00.000853r 2                       bmi     L2ABE
+00.000853r 2               .else
+00.000853r 2                 .ifdef CONFIG_FILE
+00.000853r 2                       lda     CURDVC
+00.000853r 2                       beq     LCB0C
+00.000853r 2                       lda     Z96
+00.000853r 2                       and     #$02
+00.000853r 2                       beq     LCB0C
+00.000853r 2                       jsr     LCAD6
+00.000853r 2                       jmp     DATA
+00.000853r 2               LCB0C:
+00.000853r 2                 .endif
+00.000853r 2  A5 1B                lda     INPUTBUFFER
+00.000855r 2  D0 12                bne     L2ABE
+00.000857r 2                 .ifdef CONFIG_FILE
+00.000857r 2                       lda     CURDVC
+00.000857r 2                       bne     LCAF8
+00.000857r 2                 .endif
+00.000857r 2                 .ifdef CONFIG_CBM1_PATCHES
+00.000857r 2                       jmp     PATCH1
+00.000857r 2                 .else
+00.000857r 2  18                   clc
+00.000858r 2  4C rr rr             jmp     CONTROL_C_TYPED
+00.00085Br 2                 .endif
+00.00085Br 2               .endif
+00.00085Br 2               
+00.00085Br 2               NXIN:
+00.00085Br 2               .ifdef KBD
+00.00085Br 2                       jsr     INLIN
+00.00085Br 2                       bmi     RTS20
+00.00085Br 2                       pla
+00.00085Br 2                       jmp     LE86C
+00.00085Br 2               .else
+00.00085Br 2                 .ifdef CONFIG_FILE
+00.00085Br 2                       lda     CURDVC
+00.00085Br 2                       bne     LCB21
+00.00085Br 2                 .endif
+00.00085Br 2  20 rr rr             jsr     OUTQUES	; '?'
+00.00085Er 2  20 rr rr             jsr     OUTSP
+00.000861r 2               LCB21:
+00.000861r 2  4C rr rr             jmp     INLIN
+00.000864r 2               .endif
+00.000864r 2               
+00.000864r 2               ; ----------------------------------------------------------------------------
+00.000864r 2               ; "GETC" STATEMENT
+00.000864r 2               ; ----------------------------------------------------------------------------
+00.000864r 2               .ifdef KBD
+00.000864r 2               GETC:
+00.000864r 2                       jsr     CONINT
+00.000864r 2                       jsr     LF43D
+00.000864r 2                       jmp     LE664
+00.000864r 2               .endif
+00.000864r 2               
+00.000864r 2               ; ----------------------------------------------------------------------------
+00.000864r 2               ; "READ" STATEMENT
+00.000864r 2               ; ----------------------------------------------------------------------------
+00.000864r 2               READ:
+00.000864r 2  A6 8E                ldx     DATPTR
+00.000866r 2  A4 8F                ldy     DATPTR+1
+00.000868r 2               .ifdef CONFIG_NO_READ_Y_IS_ZERO_HACK
+00.000868r 2               ; AppleSoft II, too
+00.000868r 2                       lda     #$98	; READ
+00.000868r 2                       .byte   $2C
+00.000868r 2               L2ABE:
+00.000868r 2                       lda     #$00	; INPUT
+00.000868r 2               .else
+00.000868r 2  A9                   .byte   $A9	; LDA #$98
+00.000869r 2               L2ABE:
+00.000869r 2  98                   tya
+00.00086Ar 2               .endif
+00.00086Ar 2               
+00.00086Ar 2               ; ----------------------------------------------------------------------------
+00.00086Ar 2               ; PROCESS INPUT LIST
+00.00086Ar 2               ;
+00.00086Ar 2               ; (Y,X) IS ADDRESS OF INPUT DATA STRING
+00.00086Ar 2               ; (A) = VALUE FOR INPUTFLG:  $00 FOR INPUT
+00.00086Ar 2               ; 				$40 FOR GET
+00.00086Ar 2               ;				$98 FOR READ
+00.00086Ar 2               ; ----------------------------------------------------------------------------
+00.00086Ar 2               PROCESS_INPUT_LIST:
+00.00086Ar 2  85 12                sta     INPUTFLG
+00.00086Cr 2  86 90                stx     INPTR
+00.00086Er 2  84 91                sty     INPTR+1
+00.000870r 2               PROCESS_INPUT_ITEM:
+00.000870r 2  20 rr rr             jsr     PTRGET
+00.000873r 2  85 96                sta     FORPNT
+00.000875r 2  84 97                sty     FORPNT+1
+00.000877r 2  A5 C7                lda     TXTPTR
+00.000879r 2  A4 C8                ldy     TXTPTR+1
+00.00087Br 2  85 19                sta     TXPSV
+00.00087Dr 2  84 1A                sty     TXPSV+1
+00.00087Fr 2  A6 90                ldx     INPTR
+00.000881r 2  A4 91                ldy     INPTR+1
+00.000883r 2  86 C7                stx     TXTPTR
+00.000885r 2  84 C8                sty     TXTPTR+1
+00.000887r 2  20 C6 00             jsr     CHRGOT
+00.00088Ar 2  D0 1B                bne     INSTART
+00.00088Cr 2  24 12                bit     INPUTFLG
+00.00088Er 2               .ifndef CONFIG_SMALL ; GET
+00.00088Er 2  50 0B                bvc     L2AF0
+00.000890r 2                 .ifdef MICROTAN
+00.000890r 2                       jsr     MONRDKEY2
+00.000890r 2                 .else
+00.000890r 2  20 5A 1E             jsr     MONRDKEY
+00.000893r 2                 .endif
+00.000893r 2                 .ifdef CONFIG_IO_MSB
+00.000893r 2                       and     #$7F
+00.000893r 2                 .endif
+00.000893r 2  85 1B                sta     INPUTBUFFER
+00.000895r 2               ; BUG: The beq/bne L2AF8 below is supposed
+00.000895r 2               ; to be always taken. For this to happen,
+00.000895r 2               ; the last load must be a 0 for beq
+00.000895r 2               ; and != 0 for bne. The original Microsoft
+00.000895r 2               ; code had ldx/ldy/bne here, which was only
+00.000895r 2               ; correct for a non-ZP INPUTBUFFER. Commodore
+00.000895r 2               ; fixed it in CBMBASIC V1 by swapping the
+00.000895r 2               ; ldx and the ldy. It was broken on KIM,
+00.000895r 2               ; but okay on APPLE and CBM2, because
+00.000895r 2               ; these used a non-ZP INPUTBUFFER.
+00.000895r 2               ; Microsoft fixed this somewhere after KIM
+00.000895r 2               ; and before MICROTAN, by using beq instead
+00.000895r 2               ; of bne in the ZP case.
+00.000895r 2                 .ifdef CBM1
+00.000895r 2                       ldy     #>(INPUTBUFFER-1)
+00.000895r 2                       ldx     #<(INPUTBUFFER-1)
+00.000895r 2                 .else
+00.000895r 2  A2 1A                ldx     #<(INPUTBUFFER-1)
+00.000897r 2  A0 00                ldy     #>(INPUTBUFFER-1)
+00.000899r 2                 .endif
+00.000899r 2                 .if .def(CONFIG_2) && (!.def(CONFIG_NO_INPUTBUFFER_ZP))
+00.000899r 2                       beq     L2AF8	; always
+00.000899r 2                 .else
+00.000899r 2  D0 08                bne     L2AF8	; always
+00.00089Br 2                 .endif
+00.00089Br 2               L2AF0:
+00.00089Br 2               .endif
+00.00089Br 2  30 71                bmi     FINDATA
+00.00089Dr 2               .ifdef CONFIG_FILE
+00.00089Dr 2                       lda     CURDVC
+00.00089Dr 2                       bne     LCB64
+00.00089Dr 2               .endif
+00.00089Dr 2               .ifdef KBD
+00.00089Dr 2                       jsr     OUTQUESSP
+00.00089Dr 2               .else
+00.00089Dr 2  20 rr rr             jsr     OUTQUES
+00.0008A0r 2               .endif
+00.0008A0r 2               LCB64:
+00.0008A0r 2  20 rr rr             jsr     NXIN
+00.0008A3r 2               L2AF8:
+00.0008A3r 2  86 C7                stx     TXTPTR
+00.0008A5r 2  84 C8                sty     TXTPTR+1
+00.0008A7r 2               
+00.0008A7r 2               ; ----------------------------------------------------------------------------
+00.0008A7r 2               INSTART:
+00.0008A7r 2  20 C0 00             jsr     CHRGET
+00.0008AAr 2  24 0E                bit     VALTYP
+00.0008ACr 2  10 31                bpl     L2B34
+00.0008AEr 2               .ifndef CONFIG_SMALL ; GET
+00.0008AEr 2  24 12                bit     INPUTFLG
+00.0008B0r 2  50 09                bvc     L2B10
+00.0008B2r 2                 .ifdef CONFIG_CBM1_PATCHES
+00.0008B2r 2                       lda     #$00
+00.0008B2r 2                       jsr     PATCH4
+00.0008B2r 2                       nop
+00.0008B2r 2                 .else
+00.0008B2r 2  E8                   inx
+00.0008B3r 2  86 C7                stx     TXTPTR
+00.0008B5r 2  A9 00                lda     #$00
+00.0008B7r 2  85 0A                sta     CHARAC
+00.0008B9r 2  F0 0C                beq     L2B1C
+00.0008BBr 2                 .endif
+00.0008BBr 2               L2B10:
+00.0008BBr 2               .endif
+00.0008BBr 2  85 0A                sta     CHARAC
+00.0008BDr 2  C9 22                cmp     #$22
+00.0008BFr 2  F0 07                beq     L2B1D
+00.0008C1r 2  A9 3A                lda     #$3A
+00.0008C3r 2  85 0A                sta     CHARAC
+00.0008C5r 2  A9 2C                lda     #$2C
+00.0008C7r 2               L2B1C:
+00.0008C7r 2  18                   clc
+00.0008C8r 2               L2B1D:
+00.0008C8r 2  85 0B                sta     ENDCHR
+00.0008CAr 2  A5 C7                lda     TXTPTR
+00.0008CCr 2  A4 C8                ldy     TXTPTR+1
+00.0008CEr 2  69 00                adc     #$00
+00.0008D0r 2  90 01                bcc     L2B28
+00.0008D2r 2  C8                   iny
+00.0008D3r 2               L2B28:
+00.0008D3r 2  20 rr rr             jsr     STRLT2
+00.0008D6r 2  20 rr rr             jsr     POINT
+00.0008D9r 2               .ifdef CONFIG_SMALL
+00.0008D9r 2                       jsr     LETSTRING
+00.0008D9r 2               .else
+00.0008D9r 2  20 rr rr             jsr     PUTSTR
+00.0008DCr 2               .endif
+00.0008DCr 2  4C rr rr             jmp     INPUT_MORE
+00.0008DFr 2               ; ----------------------------------------------------------------------------
+00.0008DFr 2               L2B34:
+00.0008DFr 2  20 rr rr             jsr     FIN
+00.0008E2r 2               .ifdef CONFIG_SMALL
+00.0008E2r 2                       jsr     SETFOR
+00.0008E2r 2               .else
+00.0008E2r 2  A5 0F                lda     VALTYP+1
+00.0008E4r 2  20 rr rr             jsr     LET2
+00.0008E7r 2               .endif
+00.0008E7r 2               ; ----------------------------------------------------------------------------
+00.0008E7r 2               INPUT_MORE:
+00.0008E7r 2  20 C6 00             jsr     CHRGOT
+00.0008EAr 2  F0 07                beq     L2B48
+00.0008ECr 2  C9 2C                cmp     #$2C
+00.0008EEr 2  F0 03                beq     L2B48
+00.0008F0r 2  4C rr rr             jmp     INPUTERR
+00.0008F3r 2               L2B48:
+00.0008F3r 2  A5 C7                lda     TXTPTR
+00.0008F5r 2  A4 C8                ldy     TXTPTR+1
+00.0008F7r 2  85 90                sta     INPTR
+00.0008F9r 2  84 91                sty     INPTR+1
+00.0008FBr 2  A5 19                lda     TXPSV
+00.0008FDr 2  A4 1A                ldy     TXPSV+1
+00.0008FFr 2  85 C7                sta     TXTPTR
+00.000901r 2  84 C8                sty     TXTPTR+1
+00.000903r 2  20 C6 00             jsr     CHRGOT
+00.000906r 2  F0 2C                beq     INPDONE
+00.000908r 2  20 rr rr             jsr     CHKCOM
+00.00090Br 2  4C rr rr             jmp     PROCESS_INPUT_ITEM
+00.00090Er 2               ; ----------------------------------------------------------------------------
+00.00090Er 2               FINDATA:
+00.00090Er 2  20 rr rr             jsr     DATAN
+00.000911r 2  C8                   iny
+00.000912r 2  AA                   tax
+00.000913r 2  D0 12                bne     L2B7C
+00.000915r 2  A2 2A                ldx     #ERR_NODATA
+00.000917r 2  C8                   iny
+00.000918r 2  B1 C7                lda     (TXTPTR),y
+00.00091Ar 2  F0 69                beq     GERR
+00.00091Cr 2  C8                   iny
+00.00091Dr 2  B1 C7                lda     (TXTPTR),y
+00.00091Fr 2  85 8C                sta     Z8C
+00.000921r 2  C8                   iny
+00.000922r 2  B1 C7                lda     (TXTPTR),y
+00.000924r 2  C8                   iny
+00.000925r 2  85 8D                sta     Z8C+1
+00.000927r 2               L2B7C:
+00.000927r 2  B1 C7                lda     (TXTPTR),y
+00.000929r 2  AA                   tax
+00.00092Ar 2  20 rr rr             jsr     ADDON
+00.00092Dr 2  E0 83                cpx     #$83
+00.00092Fr 2  D0 DD                bne     FINDATA
+00.000931r 2  4C rr rr             jmp     INSTART
+00.000934r 2               ; ---NO MORE INPUT REQUESTED------
+00.000934r 2               INPDONE:
+00.000934r 2  A5 90                lda     INPTR
+00.000936r 2  A4 91                ldy     INPTR+1
+00.000938r 2  A6 12                ldx     INPUTFLG
+00.00093Ar 2               .if .def(CONFIG_SMALL) && (!.def(CONFIG_11))
+00.00093Ar 2                       beq     L2B94 ; INPUT
+00.00093Ar 2               .else
+00.00093Ar 2  10 03                bpl     L2B94; INPUT or GET
+00.00093Cr 2               .endif
+00.00093Cr 2  4C rr rr             jmp     SETDA
+00.00093Fr 2               L2B94:
+00.00093Fr 2  A0 00                ldy     #$00
+00.000941r 2  B1 90                lda     (INPTR),y
+00.000943r 2  F0 07                beq     L2BA1
+00.000945r 2               .ifdef CONFIG_FILE
+00.000945r 2                       lda     CURDVC
+00.000945r 2                       bne     L2BA1
+00.000945r 2               .endif
+00.000945r 2  A9 rr                lda     #<ERREXTRA
+00.000947r 2  A0 rr                ldy     #>ERREXTRA
+00.000949r 2  4C rr rr             jmp     STROUT
+00.00094Cr 2               L2BA1:
+00.00094Cr 2  60                   rts
+00.00094Dr 2               
+00.00094Dr 2               ; ----------------------------------------------------------------------------
+00.00094Dr 2               ERREXTRA:
+00.00094Dr 2               .ifdef KBD
+00.00094Dr 2                       .byte   "?Extra"
+00.00094Dr 2               .else
+00.00094Dr 2  3F 45 58 54          .byte   "?EXTRA IGNORED"
+00.000951r 2  52 41 20 49  
+00.000955r 2  47 4E 4F 52  
+00.00095Br 2               .endif
+00.00095Br 2  0D 0A 00             .byte   $0D,$0A,$00
+00.00095Er 2               ERRREENTRY:
+00.00095Er 2               .ifdef KBD
+00.00095Er 2                       .byte   "What?"
+00.00095Er 2               .else
+00.00095Er 2  3F 52 45 44          .byte   "?REDO FROM START"
+00.000962r 2  4F 20 46 52  
+00.000966r 2  4F 4D 20 53  
+00.00096Er 2               .endif
+00.00096Er 2  0D 0A 00             .byte   $0D,$0A,$00
+00.000971r 2               .ifdef KBD
+00.000971r 2               LEA30:
+00.000971r 2                       .byte   "B"
+00.000971r 2                       .byte   $FD
+00.000971r 2                       .byte   "GsBASIC"
+00.000971r 2                       .byte   $00,$1B,$0D,$13
+00.000971r 2                       .byte   " BASIC"
+00.000971r 2               .endif
+00.000971r 2               
+00.000971r 1               .include "eval.s"
+00.000971r 2               .segment "CODE"
+00.000971r 2               
+00.000971r 2               ; ----------------------------------------------------------------------------
+00.000971r 2               ; "NEXT" STATEMENT
+00.000971r 2               ; ----------------------------------------------------------------------------
+00.000971r 2               NEXT:
+00.000971r 2  D0 04                bne     NEXT1
+00.000973r 2  A0 00                ldy     #$00
+00.000975r 2  F0 03                beq     NEXT2
+00.000977r 2               NEXT1:
+00.000977r 2  20 rr rr             jsr     PTRGET
+00.00097Ar 2               NEXT2:
+00.00097Ar 2  85 96                sta     FORPNT
+00.00097Cr 2  84 97                sty     FORPNT+1
+00.00097Er 2  20 rr rr             jsr     GTFORPNT
+00.000981r 2  F0 04                beq     NEXT3
+00.000983r 2  A2 00                ldx     #$00
+00.000985r 2               GERR:
+00.000985r 2  F0 69                beq     JERROR
+00.000987r 2               NEXT3:
+00.000987r 2  9A                   txs
+00.000988r 2               .ifndef CONFIG_2
+00.000988r 2  E8                   inx
+00.000989r 2  E8                   inx
+00.00098Ar 2  E8                   inx
+00.00098Br 2  E8                   inx
+00.00098Cr 2               .endif
+00.00098Cr 2  8A                   txa
+00.00098Dr 2               .ifdef CONFIG_2
+00.00098Dr 2                       clc
+00.00098Dr 2                       adc     #$04
+00.00098Dr 2                       pha
+00.00098Dr 2                       adc     #BYTES_FP+1
+00.00098Dr 2                       sta     DEST
+00.00098Dr 2                       pla
+00.00098Dr 2               .else
+00.00098Dr 2  E8                   inx
+00.00098Er 2  E8                   inx
+00.00098Fr 2  E8                   inx
+00.000990r 2  E8                   inx
+00.000991r 2  E8                   inx
+00.000992r 2               .ifndef CONFIG_SMALL
+00.000992r 2  E8                   inx
+00.000993r 2               .endif
+00.000993r 2  86 71                stx     DEST
+00.000995r 2               .endif
+00.000995r 2  A0 01                ldy     #>STACK
+00.000997r 2  20 rr rr             jsr     LOAD_FAC_FROM_YA
+00.00099Ar 2  BA                   tsx
+00.00099Br 2  BD 09 01             lda     STACK+BYTES_FP+4,x
+00.00099Er 2  85 B3                sta     FACSIGN
+00.0009A0r 2  A5 96                lda     FORPNT
+00.0009A2r 2  A4 97                ldy     FORPNT+1
+00.0009A4r 2  20 rr rr             jsr     FADD
+00.0009A7r 2  20 rr rr             jsr     SETFOR
+00.0009AAr 2  A0 01                ldy     #>STACK
+00.0009ACr 2  20 rr rr             jsr     FCOMP2
+00.0009AFr 2  BA                   tsx
+00.0009B0r 2  38                   sec
+00.0009B1r 2  FD 09 01             sbc     STACK+BYTES_FP+4,x
+00.0009B4r 2  F0 17                beq     L2C22
+00.0009B6r 2  BD 0F 01             lda     STACK+2*BYTES_FP+5,x
+00.0009B9r 2  85 86                sta     CURLIN
+00.0009BBr 2  BD 10 01             lda     STACK+2*BYTES_FP+6,x
+00.0009BEr 2  85 87                sta     CURLIN+1
+00.0009C0r 2  BD 12 01             lda     STACK+2*BYTES_FP+8,x
+00.0009C3r 2  85 C7                sta     TXTPTR
+00.0009C5r 2  BD 11 01             lda     STACK+2*BYTES_FP+7,x
+00.0009C8r 2  85 C8                sta     TXTPTR+1
+00.0009CAr 2               L2C1F:
+00.0009CAr 2  4C rr rr             jmp     NEWSTT
+00.0009CDr 2               L2C22:
+00.0009CDr 2  8A                   txa
+00.0009CEr 2  69 11                adc     #2*BYTES_FP+7
+00.0009D0r 2  AA                   tax
+00.0009D1r 2  9A                   txs
+00.0009D2r 2  20 C6 00             jsr     CHRGOT
+00.0009D5r 2  C9 2C                cmp     #$2C
+00.0009D7r 2  D0 F1                bne     L2C1F
+00.0009D9r 2  20 C0 00             jsr     CHRGET
+00.0009DCr 2  20 rr rr             jsr     NEXT1
+00.0009DFr 2               
+00.0009DFr 2               ; ----------------------------------------------------------------------------
+00.0009DFr 2               ; EVALUATE EXPRESSION, MAKE SURE IT IS NUMERIC
+00.0009DFr 2               ; ----------------------------------------------------------------------------
+00.0009DFr 2               FRMNUM:
+00.0009DFr 2  20 rr rr             jsr     FRMEVL
+00.0009E2r 2               
+00.0009E2r 2               ; ----------------------------------------------------------------------------
+00.0009E2r 2               ; MAKE SURE (FAC) IS NUMERIC
+00.0009E2r 2               ; ----------------------------------------------------------------------------
+00.0009E2r 2               CHKNUM:
+00.0009E2r 2  18                   clc
+00.0009E3r 2  24                   .byte   $24
+00.0009E4r 2               
+00.0009E4r 2               ; ----------------------------------------------------------------------------
+00.0009E4r 2               ; MAKE SURE (FAC) IS STRING
+00.0009E4r 2               ; ----------------------------------------------------------------------------
+00.0009E4r 2               CHKSTR:
+00.0009E4r 2  38                   sec
+00.0009E5r 2               
+00.0009E5r 2               ; ----------------------------------------------------------------------------
+00.0009E5r 2               ; MAKE SURE (FAC) IS CORRECT TYPE
+00.0009E5r 2               ; IF C=0, TYPE MUST BE NUMERIC
+00.0009E5r 2               ; IF C=1, TYPE MUST BE STRING
+00.0009E5r 2               ; ----------------------------------------------------------------------------
+00.0009E5r 2               CHKVAL:
+00.0009E5r 2  24 0E                bit     VALTYP
+00.0009E7r 2  30 03                bmi     L2C41
+00.0009E9r 2  B0 03                bcs     L2C43
+00.0009EBr 2               L2C40:
+00.0009EBr 2  60                   rts
+00.0009ECr 2               L2C41:
+00.0009ECr 2  B0 FD                bcs     L2C40
+00.0009EEr 2               L2C43:
+00.0009EEr 2  A2 A3                ldx     #ERR_BADTYPE
+00.0009F0r 2               JERROR:
+00.0009F0r 2  4C rr rr             jmp     ERROR
+00.0009F3r 2               
+00.0009F3r 2               ; ----------------------------------------------------------------------------
+00.0009F3r 2               ; EVALUATE THE EXPRESSION AT TXTPTR, LEAVING THE
+00.0009F3r 2               ; RESULT IN FAC.  WORKS FOR BOTH STRING AND NUMERIC
+00.0009F3r 2               ; EXPRESSIONS.
+00.0009F3r 2               ; ----------------------------------------------------------------------------
+00.0009F3r 2               FRMEVL:
+00.0009F3r 2  A6 C7                ldx     TXTPTR
+00.0009F5r 2  D0 02                bne     L2C4E
+00.0009F7r 2  C6 C8                dec     TXTPTR+1
+00.0009F9r 2               L2C4E:
+00.0009F9r 2  C6 C7                dec     TXTPTR
+00.0009FBr 2  A2 00                ldx     #$00
+00.0009FDr 2  24                   .byte   $24
+00.0009FEr 2               FRMEVL1:
+00.0009FEr 2  48                   pha
+00.0009FFr 2  8A                   txa
+00.000A00r 2  48                   pha
+00.000A01r 2  A9 01                lda     #$01
+00.000A03r 2  20 rr rr             jsr     CHKMEM
+00.000A06r 2  20 rr rr             jsr     FRM_ELEMENT
+00.000A09r 2  A9 00                lda     #$00
+00.000A0Br 2  85 9A                sta     CPRTYP
+00.000A0Dr 2               FRMEVL2:
+00.000A0Dr 2  20 C6 00             jsr     CHRGOT
+00.000A10r 2               L2C65:
+00.000A10r 2  38                   sec
+00.000A11r 2  E9 AB                sbc     #TOKEN_GREATER
+00.000A13r 2  90 17                bcc     L2C81
+00.000A15r 2  C9 03                cmp     #$03
+00.000A17r 2  B0 13                bcs     L2C81
+00.000A19r 2  C9 01                cmp     #$01
+00.000A1Br 2  2A                   rol     a
+00.000A1Cr 2  49 01                eor     #$01
+00.000A1Er 2  45 9A                eor     CPRTYP
+00.000A20r 2  C5 9A                cmp     CPRTYP
+00.000A22r 2  90 61                bcc     SNTXERR
+00.000A24r 2  85 9A                sta     CPRTYP
+00.000A26r 2  20 C0 00             jsr     CHRGET
+00.000A29r 2  4C rr rr             jmp     L2C65
+00.000A2Cr 2               L2C81:
+00.000A2Cr 2  A6 9A                ldx     CPRTYP
+00.000A2Er 2  D0 2C                bne     FRM_RELATIONAL
+00.000A30r 2  B0 7B                bcs     L2D02
+00.000A32r 2  69 07                adc     #$07
+00.000A34r 2  90 77                bcc     L2D02
+00.000A36r 2  65 0E                adc     VALTYP
+00.000A38r 2  D0 03                bne     L2C92
+00.000A3Ar 2  4C rr rr             jmp     CAT
+00.000A3Dr 2               L2C92:
+00.000A3Dr 2  69 FF                adc     #$FF
+00.000A3Fr 2  85 6F                sta     INDEX
+00.000A41r 2  0A                   asl     a
+00.000A42r 2  65 6F                adc     INDEX
+00.000A44r 2  A8                   tay
+00.000A45r 2               FRM_PRECEDENCE_TEST:
+00.000A45r 2  68                   pla
+00.000A46r 2  D9 rr rr             cmp     MATHTBL,y
+00.000A49r 2  B0 67                bcs     FRM_PERFORM1
+00.000A4Br 2  20 rr rr             jsr     CHKNUM
+00.000A4Er 2               L2CA3:
+00.000A4Er 2  48                   pha
+00.000A4Fr 2               L2CA4:
+00.000A4Fr 2  20 rr rr             jsr     FRM_RECURSE
+00.000A52r 2  68                   pla
+00.000A53r 2  A4 98                ldy     LASTOP
+00.000A55r 2  10 17                bpl     PREFNC
+00.000A57r 2  AA                   tax
+00.000A58r 2  F0 56                beq     GOEX
+00.000A5Ar 2  D0 5F                bne     FRM_PERFORM2
+00.000A5Cr 2               
+00.000A5Cr 2               ; ----------------------------------------------------------------------------
+00.000A5Cr 2               ; FOUND ONE OR MORE RELATIONAL OPERATORS <,=,>
+00.000A5Cr 2               ; ----------------------------------------------------------------------------
+00.000A5Cr 2               FRM_RELATIONAL:
+00.000A5Cr 2  46 0E                lsr     VALTYP
+00.000A5Er 2  8A                   txa
+00.000A5Fr 2  2A                   rol     a
+00.000A60r 2  A6 C7                ldx     TXTPTR
+00.000A62r 2  D0 02                bne     L2CBB
+00.000A64r 2  C6 C8                dec     TXTPTR+1
+00.000A66r 2               L2CBB:
+00.000A66r 2  C6 C7                dec     TXTPTR
+00.000A68r 2  A0 1B                ldy     #$1B
+00.000A6Ar 2  85 9A                sta     CPRTYP
+00.000A6Cr 2  D0 D7                bne     FRM_PRECEDENCE_TEST
+00.000A6Er 2               PREFNC:
+00.000A6Er 2  D9 rr rr             cmp     MATHTBL,y
+00.000A71r 2  B0 48                bcs     FRM_PERFORM2
+00.000A73r 2  90 D9                bcc     L2CA3
+00.000A75r 2               
+00.000A75r 2               ; ----------------------------------------------------------------------------
+00.000A75r 2               ; STACK THIS OPERATION AND CALL FRMEVL FOR
+00.000A75r 2               ; ANOTHER ONE
+00.000A75r 2               ; ----------------------------------------------------------------------------
+00.000A75r 2               FRM_RECURSE:
+00.000A75r 2  B9 rr rr             lda     MATHTBL+2,y
+00.000A78r 2  48                   pha
+00.000A79r 2  B9 rr rr             lda     MATHTBL+1,y
+00.000A7Cr 2  48                   pha
+00.000A7Dr 2  20 rr rr             jsr     FRM_STACK1
+00.000A80r 2  A5 9A                lda     CPRTYP
+00.000A82r 2  4C rr rr             jmp     FRMEVL1
+00.000A85r 2               SNTXERR:
+00.000A85r 2  4C rr rr             jmp     SYNERR
+00.000A88r 2               
+00.000A88r 2               ; ----------------------------------------------------------------------------
+00.000A88r 2               ; STACK (FAC)
+00.000A88r 2               ; THREE ENTRY POINTS:
+00.000A88r 2               ; 	1, FROM FRMEVL
+00.000A88r 2               ;	2, FROM "STEP"
+00.000A88r 2               ;	3, FROM "FOR"
+00.000A88r 2               ; ----------------------------------------------------------------------------
+00.000A88r 2               FRM_STACK1:
+00.000A88r 2  A5 B3                lda     FACSIGN
+00.000A8Ar 2  BE rr rr             ldx     MATHTBL,y
+00.000A8Dr 2               
+00.000A8Dr 2               ; ----------------------------------------------------------------------------
+00.000A8Dr 2               ; ENTER HERE FROM "STEP", TO PUSH STEP SIGN AND VALUE
+00.000A8Dr 2               ; ----------------------------------------------------------------------------
+00.000A8Dr 2               FRM_STACK2:
+00.000A8Dr 2  A8                   tay
+00.000A8Er 2  68                   pla
+00.000A8Fr 2  85 6F                sta     INDEX
+00.000A91r 2               .ifndef CONFIG_2B
+00.000A91r 2  E6 6F                inc     INDEX ; bug: assumes not on page boundary
+00.000A93r 2               ; bug exists on AppleSoft II
+00.000A93r 2               .endif
+00.000A93r 2  68                   pla
+00.000A94r 2  85 70                sta     INDEX+1
+00.000A96r 2               .ifdef CONFIG_2B
+00.000A96r 2                       inc     INDEX
+00.000A96r 2                       bne     LEB69
+00.000A96r 2                       inc     INDEX+1
+00.000A96r 2               LEB69:
+00.000A96r 2               .endif
+00.000A96r 2  98                   tya
+00.000A97r 2  48                   pha
+00.000A98r 2               
+00.000A98r 2               ; ----------------------------------------------------------------------------
+00.000A98r 2               ; ENTER HERE FROM "FOR", WITH (INDEX) = STEP,
+00.000A98r 2               ; TO PUSH INITIAL VALUE OF "FOR" VARIABLE
+00.000A98r 2               ; ----------------------------------------------------------------------------
+00.000A98r 2               FRM_STACK3:
+00.000A98r 2  20 rr rr             jsr     ROUND_FAC
+00.000A9Br 2               .ifndef CONFIG_SMALL
+00.000A9Br 2  A5 B2                lda     FAC+4
+00.000A9Dr 2  48                   pha
+00.000A9Er 2               .endif
+00.000A9Er 2  A5 B1                lda     FAC+3
+00.000AA0r 2  48                   pha
+00.000AA1r 2  A5 B0                lda     FAC+2
+00.000AA3r 2  48                   pha
+00.000AA4r 2  A5 AF                lda     FAC+1
+00.000AA6r 2  48                   pha
+00.000AA7r 2  A5 AE                lda     FAC
+00.000AA9r 2  48                   pha
+00.000AAAr 2  6C 6F 00             jmp     (INDEX)
+00.000AADr 2               L2D02:
+00.000AADr 2  A0 FF                ldy     #$FF
+00.000AAFr 2  68                   pla
+00.000AB0r 2               GOEX:
+00.000AB0r 2  F0 23                beq     EXIT
+00.000AB2r 2               
+00.000AB2r 2               ; ----------------------------------------------------------------------------
+00.000AB2r 2               ; PERFORM STACKED OPERATION
+00.000AB2r 2               ;
+00.000AB2r 2               ; (A) = PRECEDENCE BYTE
+00.000AB2r 2               ; STACK:  1 -- CPRMASK
+00.000AB2r 2               ;	5 -- (ARG)
+00.000AB2r 2               ;	2 -- ADDR OF PERFORMER
+00.000AB2r 2               ; ----------------------------------------------------------------------------
+00.000AB2r 2               FRM_PERFORM1:
+00.000AB2r 2  C9 64                cmp     #$64
+00.000AB4r 2  F0 03                beq     L2D0E
+00.000AB6r 2  20 rr rr             jsr     CHKNUM
+00.000AB9r 2               L2D0E:
+00.000AB9r 2  84 98                sty     LASTOP
+00.000ABBr 2               FRM_PERFORM2:
+00.000ABBr 2  68                   pla
+00.000ABCr 2  4A                   lsr     a
+00.000ABDr 2  85 13                sta     CPRMASK
+00.000ABFr 2  68                   pla
+00.000AC0r 2  85 B6                sta     ARG
+00.000AC2r 2  68                   pla
+00.000AC3r 2  85 B7                sta     ARG+1
+00.000AC5r 2  68                   pla
+00.000AC6r 2  85 B8                sta     ARG+2
+00.000AC8r 2  68                   pla
+00.000AC9r 2  85 B9                sta     ARG+3
+00.000ACBr 2  68                   pla
+00.000ACCr 2               .ifndef CONFIG_SMALL
+00.000ACCr 2  85 BA                sta     ARG+4
+00.000ACEr 2  68                   pla
+00.000ACFr 2               .endif
+00.000ACFr 2  85 BB                sta     ARGSIGN
+00.000AD1r 2  45 B3                eor     FACSIGN
+00.000AD3r 2  85 BC                sta     SGNCPR
+00.000AD5r 2               EXIT:
+00.000AD5r 2  A5 AE                lda     FAC
+00.000AD7r 2  60                   rts
+00.000AD8r 2               
+00.000AD8r 2               ; ----------------------------------------------------------------------------
+00.000AD8r 2               ; GET ELEMENT IN EXPRESSION
+00.000AD8r 2               ;
+00.000AD8r 2               ; GET VALUE OF VARIABLE OR NUMBER AT TXTPNT, OR POINT
+00.000AD8r 2               ; TO STRING DESCRIPTOR IF A STRING, AND PUT IN FAC.
+00.000AD8r 2               ; ----------------------------------------------------------------------------
+00.000AD8r 2               FRM_ELEMENT:
+00.000AD8r 2  A9 00                lda     #$00
+00.000ADAr 2  85 0E                sta     VALTYP
+00.000ADCr 2               L2D31:
+00.000ADCr 2  20 C0 00             jsr     CHRGET
+00.000ADFr 2  B0 03                bcs     L2D39
+00.000AE1r 2               L2D36:
+00.000AE1r 2  4C rr rr             jmp     FIN
+00.000AE4r 2               L2D39:
+00.000AE4r 2  20 rr rr             jsr     ISLETC
+00.000AE7r 2  B0 67                bcs     FRM_VARIABLE
+00.000AE9r 2               .ifdef CONFIG_CBM_ALL
+00.000AE9r 2                       cmp     #$FF
+00.000AE9r 2                       bne     LCDC1
+00.000AE9r 2                       lda     #<CON_PI
+00.000AE9r 2                       ldy     #>CON_PI
+00.000AE9r 2                       jsr     LOAD_FAC_FROM_YA
+00.000AE9r 2                       jmp     CHRGET
+00.000AE9r 2               CON_PI:
+00.000AE9r 2                       .byte   $82,$49,$0f,$DA,$A1
+00.000AE9r 2               LCDC1:
+00.000AE9r 2               .endif
+00.000AE9r 2  C9 2E                cmp     #$2E
+00.000AEBr 2  F0 F4                beq     L2D36
+00.000AEDr 2  C9 A5                cmp     #TOKEN_MINUS
+00.000AEFr 2  F0 58                beq     MIN
+00.000AF1r 2  C9 A4                cmp     #TOKEN_PLUS
+00.000AF3r 2  F0 E7                beq     L2D31
+00.000AF5r 2  C9 22                cmp     #$22
+00.000AF7r 2  D0 0F                bne     NOT_
+00.000AF9r 2               
+00.000AF9r 2               ; ----------------------------------------------------------------------------
+00.000AF9r 2               ; STRING CONSTANT ELEMENT
+00.000AF9r 2               ;
+00.000AF9r 2               ; SET Y,A = (TXTPTR)+CARRY
+00.000AF9r 2               ; ----------------------------------------------------------------------------
+00.000AF9r 2               STRTXT:
+00.000AF9r 2  A5 C7                lda     TXTPTR
+00.000AFBr 2  A4 C8                ldy     TXTPTR+1
+00.000AFDr 2  69 00                adc     #$00
+00.000AFFr 2  90 01                bcc     L2D57
+00.000B01r 2  C8                   iny
+00.000B02r 2               L2D57:
+00.000B02r 2  20 rr rr             jsr     STRLIT
+00.000B05r 2  4C rr rr             jmp     POINT
+00.000B08r 2               
+00.000B08r 2               ; ----------------------------------------------------------------------------
+00.000B08r 2               ; "NOT" FUNCTION
+00.000B08r 2               ; IF FAC=0, RETURN FAC=1
+00.000B08r 2               ; IF FAC<>0, RETURN FAC=0
+00.000B08r 2               ; ----------------------------------------------------------------------------
+00.000B08r 2               NOT_:
+00.000B08r 2  C9 A2                cmp     #TOKEN_NOT
+00.000B0Ar 2  D0 13                bne     L2D74
+00.000B0Cr 2  A0 18                ldy     #$18
+00.000B0Er 2  D0 3B                bne     EQUL
+00.000B10r 2               
+00.000B10r 2               ; ----------------------------------------------------------------------------
+00.000B10r 2               ; COMPARISON FOR EQUALITY (= OPERATOR)
+00.000B10r 2               ; ALSO USED TO EVALUATE "NOT" FUNCTION
+00.000B10r 2               ; ----------------------------------------------------------------------------
+00.000B10r 2               EQUOP:
+00.000B10r 2  20 rr rr             jsr     AYINT
+00.000B13r 2  A5 B2                lda     FAC_LAST
+00.000B15r 2  49 FF                eor     #$FF
+00.000B17r 2  A8                   tay
+00.000B18r 2  A5 B1                lda     FAC_LAST-1
+00.000B1Ar 2  49 FF                eor     #$FF
+00.000B1Cr 2  4C rr rr             jmp     GIVAYF
+00.000B1Fr 2               L2D74:
+00.000B1Fr 2  C9 9F                cmp     #TOKEN_FN
+00.000B21r 2  D0 03                bne     L2D7B
+00.000B23r 2  4C rr rr             jmp     L31F3
+00.000B26r 2               L2D7B:
+00.000B26r 2  C9 AE                cmp     #TOKEN_SGN
+00.000B28r 2  90 03                bcc     PARCHK
+00.000B2Ar 2  4C rr rr             jmp     UNARY
+00.000B2Dr 2               
+00.000B2Dr 2               ; ----------------------------------------------------------------------------
+00.000B2Dr 2               ; EVALUATE "(EXPRESSION)"
+00.000B2Dr 2               ; ----------------------------------------------------------------------------
+00.000B2Dr 2               PARCHK:
+00.000B2Dr 2  20 rr rr             jsr     CHKOPN
+00.000B30r 2  20 rr rr             jsr     FRMEVL
+00.000B33r 2               CHKCLS:
+00.000B33r 2  A9 29                lda     #$29
+00.000B35r 2  2C                   .byte   $2C
+00.000B36r 2               CHKOPN:
+00.000B36r 2  A9 28                lda     #$28
+00.000B38r 2  2C                   .byte   $2C
+00.000B39r 2               CHKCOM:
+00.000B39r 2  A9 2C                lda     #$2C
+00.000B3Br 2               
+00.000B3Br 2               ; ----------------------------------------------------------------------------
+00.000B3Br 2               ; UNLESS CHAR AT TXTPTR = (A), SYNTAX ERROR
+00.000B3Br 2               ; ----------------------------------------------------------------------------
+00.000B3Br 2               SYNCHR:	; XXX all CBM code calls SYNCHR instead of CHKCOM
+00.000B3Br 2  A0 00                ldy     #$00
+00.000B3Dr 2  D1 C7                cmp     (TXTPTR),y
+00.000B3Fr 2  D0 03                bne     SYNERR
+00.000B41r 2  4C C0 00             jmp     CHRGET
+00.000B44r 2               ; ----------------------------------------------------------------------------
+00.000B44r 2               SYNERR:
+00.000B44r 2  A2 10                ldx     #ERR_SYNTAX
+00.000B46r 2  4C rr rr             jmp     ERROR
+00.000B49r 2               ; ----------------------------------------------------------------------------
+00.000B49r 2               MIN:
+00.000B49r 2  A0 15                ldy     #$15
+00.000B4Br 2               EQUL:
+00.000B4Br 2  68                   pla
+00.000B4Cr 2  68                   pla
+00.000B4Dr 2  4C rr rr             jmp     L2CA4
+00.000B50r 2               ; ----------------------------------------------------------------------------
+00.000B50r 2               FRM_VARIABLE:
+00.000B50r 2  20 rr rr             jsr     PTRGET
+00.000B53r 2               FRM_VARIABLE_CALL	= *-1
+00.000B53r 2  85 B1                sta     FAC_LAST-1
+00.000B55r 2  84 B2                sty     FAC_LAST
+00.000B57r 2               .ifdef CONFIG_CBM_ALL
+00.000B57r 2                       lda     VARNAM
+00.000B57r 2                       ldy     VARNAM+1
+00.000B57r 2               .endif
+00.000B57r 2  A6 0E                ldx     VALTYP
+00.000B59r 2  F0 01                beq     L2DB1
+00.000B5Br 2               .ifdef CONFIG_CBM_ALL
+00.000B5Br 2                 .ifdef CONFIG_CBM1_PATCHES
+00.000B5Br 2                       jmp     PATCH2
+00.000B5Br 2                       clc
+00.000B5Br 2               LCE3B:
+00.000B5Br 2                 .else
+00.000B5Br 2                       ldx     #$00
+00.000B5Br 2                       stx     STRNG1+1
+00.000B5Br 2                       bit     FAC+4
+00.000B5Br 2                       bpl     LCE53
+00.000B5Br 2                       cmp     #$54	; T
+00.000B5Br 2                       bne     LCE53
+00.000B5Br 2                 .endif
+00.000B5Br 2                       cpy     #$C9	; I$
+00.000B5Br 2                       bne     LCE53
+00.000B5Br 2                       jsr     LCE76
+00.000B5Br 2                       sty     EXPON
+00.000B5Br 2                       dey
+00.000B5Br 2                       sty     STRNG2
+00.000B5Br 2                       ldy     #$06
+00.000B5Br 2                       sty     INDX
+00.000B5Br 2                       ldy     #$24
+00.000B5Br 2                       jsr     LDD3A
+00.000B5Br 2                       jmp     LD353
+00.000B5Br 2               LCE53:
+00.000B5Br 2               .endif
+00.000B5Br 2               .ifdef CONFIG_2
+00.000B5Br 2                 .ifndef CBM2
+00.000B5Br 2               ; bugfix?
+00.000B5Br 2               ; fixed on AppleSoft II, not on any CBM
+00.000B5Br 2                       ldx     #$00
+00.000B5Br 2                       stx     STRNG1+1
+00.000B5Br 2                 .endif
+00.000B5Br 2               .endif
+00.000B5Br 2  60                   rts
+00.000B5Cr 2               L2DB1:
+00.000B5Cr 2               .ifndef CONFIG_SMALL
+00.000B5Cr 2  A6 0F                ldx     VALTYP+1
+00.000B5Er 2  10 0D                bpl     L2DC2
+00.000B60r 2  A0 00                ldy     #$00
+00.000B62r 2  B1 B1                lda     (FAC+3),y
+00.000B64r 2  AA                   tax
+00.000B65r 2  C8                   iny
+00.000B66r 2  B1 B1                lda     (FAC+3),y
+00.000B68r 2  A8                   tay
+00.000B69r 2  8A                   txa
+00.000B6Ar 2  4C rr rr             jmp     GIVAYF
+00.000B6Dr 2               L2DC2:
+00.000B6Dr 2               .endif
+00.000B6Dr 2               .ifdef CONFIG_CBM1_PATCHES
+00.000B6Dr 2                       jmp     PATCH3
+00.000B6Dr 2                       .byte   $19
+00.000B6Dr 2               .endif
+00.000B6Dr 2               .ifdef CBM2
+00.000B6Dr 2                       bit     FAC+4
+00.000B6Dr 2                       bpl     LCE90
+00.000B6Dr 2                       cmp     #$54
+00.000B6Dr 2                       bne     LCE82
+00.000B6Dr 2               .endif
+00.000B6Dr 2               .ifndef CONFIG_CBM_ALL
+00.000B6Dr 2  4C rr rr             jmp     LOAD_FAC_FROM_YA
+00.000B70r 2               .endif
+00.000B70r 2               .ifdef CONFIG_CBM_ALL
+00.000B70r 2               LCE69:
+00.000B70r 2                       cpy     #$49
+00.000B70r 2               .ifdef CBM1
+00.000B70r 2                       bne     LCE82
+00.000B70r 2               .else
+00.000B70r 2                       bne     LCE90
+00.000B70r 2               .endif
+00.000B70r 2                       jsr     LCE76
+00.000B70r 2                       tya
+00.000B70r 2                       ldx     #$A0
+00.000B70r 2                       jmp     LDB21
+00.000B70r 2               LCE76:
+00.000B70r 2               .ifdef CBM1
+00.000B70r 2                       lda     #$FE
+00.000B70r 2                       ldy     #$01
+00.000B70r 2               .else
+00.000B70r 2                       lda     #$8B
+00.000B70r 2                       ldy     #$00
+00.000B70r 2               .endif
+00.000B70r 2                       sei
+00.000B70r 2                       jsr     LOAD_FAC_FROM_YA
+00.000B70r 2                       cli
+00.000B70r 2                       sty     FAC+1
+00.000B70r 2                       rts
+00.000B70r 2               LCE82:
+00.000B70r 2                       cmp     #$53
+00.000B70r 2                       bne     LCE90
+00.000B70r 2                       cpy     #$54
+00.000B70r 2                       bne     LCE90
+00.000B70r 2                       lda     Z96
+00.000B70r 2                       jmp     FLOAT
+00.000B70r 2               LCE90:
+00.000B70r 2                       lda     FAC+3
+00.000B70r 2                       ldy     FAC+4
+00.000B70r 2                       jmp     LOAD_FAC_FROM_YA
+00.000B70r 2               .endif
+00.000B70r 2               
+00.000B70r 2               ; ----------------------------------------------------------------------------
+00.000B70r 2               UNARY:
+00.000B70r 2  0A                   asl     a
+00.000B71r 2  48                   pha
+00.000B72r 2  AA                   tax
+00.000B73r 2  20 C0 00             jsr     CHRGET
+00.000B76r 2  E0 83                cpx     #<(TOKEN_LEFTSTR*2-1)
+00.000B78r 2  90 20                bcc     L2DEF
+00.000B7Ar 2  20 rr rr             jsr     CHKOPN
+00.000B7Dr 2  20 rr rr             jsr     FRMEVL
+00.000B80r 2  20 rr rr             jsr     CHKCOM
+00.000B83r 2  20 rr rr             jsr     CHKSTR
+00.000B86r 2  68                   pla
+00.000B87r 2  AA                   tax
+00.000B88r 2  A5 B2                lda     FAC_LAST
+00.000B8Ar 2  48                   pha
+00.000B8Br 2  A5 B1                lda     FAC_LAST-1
+00.000B8Dr 2  48                   pha
+00.000B8Er 2  8A                   txa
+00.000B8Fr 2  48                   pha
+00.000B90r 2  20 rr rr             jsr     GETBYT
+00.000B93r 2  68                   pla
+00.000B94r 2  A8                   tay
+00.000B95r 2  8A                   txa
+00.000B96r 2  48                   pha
+00.000B97r 2  4C rr rr             jmp     L2DF4
+00.000B9Ar 2               L2DEF:
+00.000B9Ar 2  20 rr rr             jsr     PARCHK
+00.000B9Dr 2  68                   pla
+00.000B9Er 2  A8                   tay
+00.000B9Fr 2               L2DF4:
+00.000B9Fr 2  B9 rr rr             lda     UNFNC-TOKEN_SGN-TOKEN_SGN+$100,y
+00.000BA2r 2  85 A2                sta     JMPADRS+1
+00.000BA4r 2  B9 rr rr             lda     UNFNC-TOKEN_SGN-TOKEN_SGN+$101,y
+00.000BA7r 2  85 A3                sta     JMPADRS+2
+00.000BA9r 2               .ifdef KBD
+00.000BA9r 2                       jsr     LF47D
+00.000BA9r 2               .else
+00.000BA9r 2  20 A1 00             jsr     JMPADRS
+00.000BACr 2               .endif
+00.000BACr 2  4C rr rr             jmp     CHKNUM
+00.000BAFr 2               
+00.000BAFr 2               ; ----------------------------------------------------------------------------
+00.000BAFr 2               OR:
+00.000BAFr 2  A0 FF                ldy     #$FF
+00.000BB1r 2  2C                   .byte   $2C
+00.000BB2r 2               ; ----------------------------------------------------------------------------
+00.000BB2r 2               TAND:
+00.000BB2r 2  A0 00                ldy     #$00
+00.000BB4r 2  84 0C                sty     EOLPNTR
+00.000BB6r 2  20 rr rr             jsr     AYINT
+00.000BB9r 2  A5 B1                lda     FAC_LAST-1
+00.000BBBr 2  45 0C                eor     EOLPNTR
+00.000BBDr 2  85 0A                sta     CHARAC
+00.000BBFr 2  A5 B2                lda     FAC_LAST
+00.000BC1r 2  45 0C                eor     EOLPNTR
+00.000BC3r 2  85 0B                sta     ENDCHR
+00.000BC5r 2  20 rr rr             jsr     COPY_ARG_TO_FAC
+00.000BC8r 2  20 rr rr             jsr     AYINT
+00.000BCBr 2  A5 B2                lda     FAC_LAST
+00.000BCDr 2  45 0C                eor     EOLPNTR
+00.000BCFr 2  25 0B                and     ENDCHR
+00.000BD1r 2  45 0C                eor     EOLPNTR
+00.000BD3r 2  A8                   tay
+00.000BD4r 2  A5 B1                lda     FAC_LAST-1
+00.000BD6r 2  45 0C                eor     EOLPNTR
+00.000BD8r 2  25 0A                and     CHARAC
+00.000BDAr 2  45 0C                eor     EOLPNTR
+00.000BDCr 2  4C rr rr             jmp     GIVAYF
+00.000BDFr 2               
+00.000BDFr 2               ; ----------------------------------------------------------------------------
+00.000BDFr 2               ; PERFORM RELATIONAL OPERATIONS
+00.000BDFr 2               ; ----------------------------------------------------------------------------
+00.000BDFr 2               RELOPS:
+00.000BDFr 2  20 rr rr             jsr     CHKVAL
+00.000BE2r 2  B0 13                bcs     STRCMP
+00.000BE4r 2  A5 BB                lda     ARGSIGN
+00.000BE6r 2  09 7F                ora     #$7F
+00.000BE8r 2  25 B7                and     ARG+1
+00.000BEAr 2  85 B7                sta     ARG+1
+00.000BECr 2  A9 B6                lda     #<ARG
+00.000BEEr 2  A0 00                ldy     #$00
+00.000BF0r 2  20 rr rr             jsr     FCOMP
+00.000BF3r 2  AA                   tax
+00.000BF4r 2  4C rr rr             jmp     NUMCMP
+00.000BF7r 2               
+00.000BF7r 2               ; ----------------------------------------------------------------------------
+00.000BF7r 2               ; STRING COMPARISON
+00.000BF7r 2               ; ----------------------------------------------------------------------------
+00.000BF7r 2               STRCMP:
+00.000BF7r 2  A9 00                lda     #$00
+00.000BF9r 2  85 0E                sta     VALTYP
+00.000BFBr 2  C6 9A                dec     CPRTYP
+00.000BFDr 2  20 rr rr             jsr     FREFAC
+00.000C00r 2  85 AE                sta     FAC
+00.000C02r 2  86 AF                stx     FAC+1
+00.000C04r 2  84 B0                sty     FAC+2
+00.000C06r 2  A5 B9                lda     ARG_LAST-1
+00.000C08r 2  A4 BA                ldy     ARG_LAST
+00.000C0Ar 2  20 rr rr             jsr     FRETMP
+00.000C0Dr 2  86 B9                stx     ARG_LAST-1
+00.000C0Fr 2  84 BA                sty     ARG_LAST
+00.000C11r 2  AA                   tax
+00.000C12r 2  38                   sec
+00.000C13r 2  E5 AE                sbc     FAC
+00.000C15r 2  F0 08                beq     L2E74
+00.000C17r 2  A9 01                lda     #$01
+00.000C19r 2  90 04                bcc     L2E74
+00.000C1Br 2  A6 AE                ldx     FAC
+00.000C1Dr 2  A9 FF                lda     #$FF
+00.000C1Fr 2               L2E74:
+00.000C1Fr 2  85 B3                sta     FACSIGN
+00.000C21r 2  A0 FF                ldy     #$FF
+00.000C23r 2  E8                   inx
+00.000C24r 2               STRCMP1:
+00.000C24r 2  C8                   iny
+00.000C25r 2  CA                   dex
+00.000C26r 2  D0 07                bne     L2E84
+00.000C28r 2  A6 B3                ldx     FACSIGN
+00.000C2Ar 2               NUMCMP:
+00.000C2Ar 2  30 0F                bmi     CMPDONE
+00.000C2Cr 2  18                   clc
+00.000C2Dr 2  90 0C                bcc     CMPDONE
+00.000C2Fr 2               L2E84:
+00.000C2Fr 2  B1 B9                lda     (ARG_LAST-1),y
+00.000C31r 2  D1 AF                cmp     (FAC+1),y
+00.000C33r 2  F0 EF                beq     STRCMP1
+00.000C35r 2  A2 FF                ldx     #$FF
+00.000C37r 2  B0 02                bcs     CMPDONE
+00.000C39r 2  A2 01                ldx     #$01
+00.000C3Br 2               CMPDONE:
+00.000C3Br 2  E8                   inx
+00.000C3Cr 2  8A                   txa
+00.000C3Dr 2  2A                   rol     a
+00.000C3Er 2  25 13                and     CPRMASK
+00.000C40r 2  F0 02                beq     L2E99
+00.000C42r 2  A9 FF                lda     #$FF
+00.000C44r 2               L2E99:
+00.000C44r 2  4C rr rr             jmp     FLOAT
+00.000C47r 2               
+00.000C47r 1               .include "var.s"
+00.000C47r 2               .segment "CODE"
+00.000C47r 2               
+00.000C47r 2               ; ----------------------------------------------------------------------------
+00.000C47r 2               ; "DIM" STATEMENT
+00.000C47r 2               ; ----------------------------------------------------------------------------
+00.000C47r 2               NXDIM:
+00.000C47r 2  20 rr rr             jsr     CHKCOM
+00.000C4Ar 2               DIM:
+00.000C4Ar 2  AA                   tax
+00.000C4Br 2  20 rr rr             jsr     PTRGET2
+00.000C4Er 2  20 C6 00             jsr     CHRGOT
+00.000C51r 2  D0 F4                bne     NXDIM
+00.000C53r 2  60                   rts
+00.000C54r 2               
+00.000C54r 2               ; ----------------------------------------------------------------------------
+00.000C54r 2               ; PTRGET -- GENERAL VARIABLE SCAN
+00.000C54r 2               ;
+00.000C54r 2               ; SCANS VARIABLE NAME AT TXTPTR, AND SEARCHES THE
+00.000C54r 2               ; VARTAB AND ARYTAB FOR THE NAME.
+00.000C54r 2               ; IF NOT FOUND, CREATE VARIABLE OF APPROPRIATE TYPE.
+00.000C54r 2               ; RETURN WITH ADDRESS IN VARPNT AND Y,A
+00.000C54r 2               ;
+00.000C54r 2               ; ACTUAL ACTIVITY CONTROLLED SOMEWHAT BY TWO FLAGS:
+00.000C54r 2               ;	DIMFLG -- NONZERO IF CALLED FROM "DIM"
+00.000C54r 2               ;		ELSE = 0
+00.000C54r 2               ;
+00.000C54r 2               ;	SUBFLG -- = $00
+00.000C54r 2               ;		= $40 IF CALLED FROM "GETARYPT"
+00.000C54r 2               ; ----------------------------------------------------------------------------
+00.000C54r 2               PTRGET:
+00.000C54r 2  A2 00                ldx     #$00
+00.000C56r 2  20 C6 00             jsr     CHRGOT
+00.000C59r 2               PTRGET2:
+00.000C59r 2  86 0D                stx     DIMFLG
+00.000C5Br 2               PTRGET3:
+00.000C5Br 2  85 92                sta     VARNAM
+00.000C5Dr 2  20 C6 00             jsr     CHRGOT
+00.000C60r 2  20 rr rr             jsr     ISLETC
+00.000C63r 2  B0 03                bcs     NAMOK
+00.000C65r 2               SYNERR3:
+00.000C65r 2  4C rr rr             jmp     SYNERR
+00.000C68r 2               NAMOK:
+00.000C68r 2  A2 00                ldx     #$00
+00.000C6Ar 2  86 0E                stx     VALTYP
+00.000C6Cr 2               .ifndef CONFIG_SMALL
+00.000C6Cr 2  86 0F                stx     VALTYP+1
+00.000C6Er 2               .endif
+00.000C6Er 2  20 C0 00             jsr     CHRGET
+00.000C71r 2  90 05                bcc     L2ECD
+00.000C73r 2  20 rr rr             jsr     ISLETC
+00.000C76r 2  90 0B                bcc     L2ED8
+00.000C78r 2               L2ECD:
+00.000C78r 2  AA                   tax
+00.000C79r 2               L2ECE:
+00.000C79r 2  20 C0 00             jsr     CHRGET
+00.000C7Cr 2  90 FB                bcc     L2ECE
+00.000C7Er 2  20 rr rr             jsr     ISLETC
+00.000C81r 2  B0 F6                bcs     L2ECE
+00.000C83r 2               L2ED8:
+00.000C83r 2  C9 24                cmp     #$24
+00.000C85r 2               .ifdef CONFIG_SMALL
+00.000C85r 2                       bne     L2EF9
+00.000C85r 2               .else
+00.000C85r 2  D0 06                bne     L2EE2
+00.000C87r 2               .endif
+00.000C87r 2  A9 FF                lda     #$FF
+00.000C89r 2  85 0E                sta     VALTYP
+00.000C8Br 2               .ifndef CONFIG_SMALL
+00.000C8Br 2  D0 10                bne     L2EF2
+00.000C8Dr 2               L2EE2:
+00.000C8Dr 2  C9 25                cmp     #$25
+00.000C8Fr 2  D0 13                bne     L2EF9
+00.000C91r 2  A5 11                lda     SUBFLG
+00.000C93r 2  D0 D0                bne     SYNERR3
+00.000C95r 2  A9 80                lda     #$80
+00.000C97r 2  85 0F                sta     VALTYP+1
+00.000C99r 2  05 92                ora     VARNAM
+00.000C9Br 2  85 92                sta     VARNAM
+00.000C9Dr 2               L2EF2:
+00.000C9Dr 2               .endif
+00.000C9Dr 2  8A                   txa
+00.000C9Er 2  09 80                ora     #$80
+00.000CA0r 2  AA                   tax
+00.000CA1r 2  20 C0 00             jsr     CHRGET
+00.000CA4r 2               L2EF9:
+00.000CA4r 2  86 93                stx     VARNAM+1
+00.000CA6r 2  38                   sec
+00.000CA7r 2  05 11                ora     SUBFLG
+00.000CA9r 2  E9 28                sbc     #$28
+00.000CABr 2  D0 03                bne     L2F05
+00.000CADr 2  4C rr rr             jmp     ARRAY
+00.000CB0r 2               L2F05:
+00.000CB0r 2  A9 00                lda     #$00
+00.000CB2r 2  85 11                sta     SUBFLG
+00.000CB4r 2  A5 7A                lda     VARTAB
+00.000CB6r 2  A6 7B                ldx     VARTAB+1
+00.000CB8r 2  A0 00                ldy     #$00
+00.000CBAr 2               L2F0F:
+00.000CBAr 2  86 AD                stx     LOWTR+1
+00.000CBCr 2               L2F11:
+00.000CBCr 2  85 AC                sta     LOWTR
+00.000CBEr 2  E4 7D                cpx     ARYTAB+1
+00.000CC0r 2  D0 04                bne     L2F1B
+00.000CC2r 2  C5 7C                cmp     ARYTAB
+00.000CC4r 2  F0 22                beq     NAMENOTFOUND
+00.000CC6r 2               L2F1B:
+00.000CC6r 2  A5 92                lda     VARNAM
+00.000CC8r 2  D1 AC                cmp     (LOWTR),y
+00.000CCAr 2  D0 08                bne     L2F29
+00.000CCCr 2  A5 93                lda     VARNAM+1
+00.000CCEr 2  C8                   iny
+00.000CCFr 2  D1 AC                cmp     (LOWTR),y
+00.000CD1r 2  F0 6C                beq     SET_VARPNT_AND_YA
+00.000CD3r 2  88                   dey
+00.000CD4r 2               L2F29:
+00.000CD4r 2  18                   clc
+00.000CD5r 2  A5 AC                lda     LOWTR
+00.000CD7r 2  69 07                adc     #BYTES_PER_VARIABLE
+00.000CD9r 2  90 E1                bcc     L2F11
+00.000CDBr 2  E8                   inx
+00.000CDCr 2  D0 DC                bne     L2F0F
+00.000CDEr 2               
+00.000CDEr 2               ; ----------------------------------------------------------------------------
+00.000CDEr 2               ; CHECK IF (A) IS ASCII LETTER A-Z
+00.000CDEr 2               ;
+00.000CDEr 2               ; RETURN CARRY = 1 IF A-Z
+00.000CDEr 2               ;	= 0 IF NOT
+00.000CDEr 2               ; ----------------------------------------------------------------------------
+00.000CDEr 2               ISLETC:
+00.000CDEr 2  C9 41                cmp     #$41
+00.000CE0r 2  90 05                bcc     L2F3C
+00.000CE2r 2  E9 5B                sbc     #$5B
+00.000CE4r 2  38                   sec
+00.000CE5r 2  E9 A5                sbc     #$A5
+00.000CE7r 2               L2F3C:
+00.000CE7r 2  60                   rts
+00.000CE8r 2               
+00.000CE8r 2               ; ----------------------------------------------------------------------------
+00.000CE8r 2               ; VARIABLE NOT FOUND, SO MAKE ONE
+00.000CE8r 2               ; ----------------------------------------------------------------------------
+00.000CE8r 2               NAMENOTFOUND:
+00.000CE8r 2  68                   pla
+00.000CE9r 2  48                   pha
+00.000CEAr 2  C9 rr                cmp     #<FRM_VARIABLE_CALL
+00.000CECr 2  D0 0F                bne     MAKENEWVARIABLE
+00.000CEEr 2               .ifdef CONFIG_SAFE_NAMENOTFOUND
+00.000CEEr 2  BA                   tsx
+00.000CEFr 2  BD 02 01             lda     STACK+2,x
+00.000CF2r 2  C9 rr                cmp     #>FRM_VARIABLE_CALL
+00.000CF4r 2  D0 07                bne     MAKENEWVARIABLE
+00.000CF6r 2               .endif
+00.000CF6r 2               LD015:
+00.000CF6r 2  A9 rr                lda     #<C_ZERO
+00.000CF8r 2  A0 rr                ldy     #>C_ZERO
+00.000CFAr 2  60                   rts
+00.000CFBr 2               
+00.000CFBr 2               ; ----------------------------------------------------------------------------
+00.000CFBr 2               .ifndef CONFIG_2
+00.000CFBr 2               C_ZERO:
+00.000CFBr 2  00 00                .byte   $00,$00
+00.000CFDr 2               .endif
+00.000CFDr 2               
+00.000CFDr 2               ; ----------------------------------------------------------------------------
+00.000CFDr 2               ; MAKE A NEW SIMPLE VARIABLE
+00.000CFDr 2               ;
+00.000CFDr 2               ; MOVE ARRAYS UP 7 BYTES TO MAKE ROOM FOR NEW VARIABLE
+00.000CFDr 2               ; ENTER 7-BYTE VARIABLE DATA IN THE HOLE
+00.000CFDr 2               ; ----------------------------------------------------------------------------
+00.000CFDr 2               MAKENEWVARIABLE:
+00.000CFDr 2               .ifdef CONFIG_CBM_ALL
+00.000CFDr 2                       lda     VARNAM
+00.000CFDr 2                       ldy     VARNAM+1
+00.000CFDr 2                       cmp     #$54
+00.000CFDr 2                       bne     LD02F
+00.000CFDr 2                       cpy     #$C9
+00.000CFDr 2                       beq     LD015
+00.000CFDr 2                       cpy     #$49
+00.000CFDr 2                       bne     LD02F
+00.000CFDr 2               LD02C:
+00.000CFDr 2                       jmp     SYNERR
+00.000CFDr 2               LD02F:
+00.000CFDr 2                       cmp     #$53
+00.000CFDr 2                       bne     LD037
+00.000CFDr 2                       cpy     #$54
+00.000CFDr 2                       beq     LD02C
+00.000CFDr 2               LD037:
+00.000CFDr 2               .endif
+00.000CFDr 2  A5 7C                lda     ARYTAB
+00.000CFFr 2  A4 7D                ldy     ARYTAB+1
+00.000D01r 2  85 AC                sta     LOWTR
+00.000D03r 2  84 AD                sty     LOWTR+1
+00.000D05r 2  A5 7E                lda     STREND
+00.000D07r 2  A4 7F                ldy     STREND+1
+00.000D09r 2  85 A7                sta     HIGHTR
+00.000D0Br 2  84 A8                sty     HIGHTR+1
+00.000D0Dr 2  18                   clc
+00.000D0Er 2  69 07                adc     #BYTES_PER_VARIABLE
+00.000D10r 2  90 01                bcc     L2F68
+00.000D12r 2  C8                   iny
+00.000D13r 2               L2F68:
+00.000D13r 2  85 A5                sta     HIGHDS
+00.000D15r 2  84 A6                sty     HIGHDS+1
+00.000D17r 2  20 rr rr             jsr     BLTU
+00.000D1Ar 2  A5 A5                lda     HIGHDS
+00.000D1Cr 2  A4 A6                ldy     HIGHDS+1
+00.000D1Er 2  C8                   iny
+00.000D1Fr 2  85 7C                sta     ARYTAB
+00.000D21r 2  84 7D                sty     ARYTAB+1
+00.000D23r 2  A0 00                ldy     #$00
+00.000D25r 2  A5 92                lda     VARNAM
+00.000D27r 2  91 AC                sta     (LOWTR),y
+00.000D29r 2  C8                   iny
+00.000D2Ar 2  A5 93                lda     VARNAM+1
+00.000D2Cr 2  91 AC                sta     (LOWTR),y
+00.000D2Er 2  A9 00                lda     #$00
+00.000D30r 2  C8                   iny
+00.000D31r 2  91 AC                sta     (LOWTR),y
+00.000D33r 2  C8                   iny
+00.000D34r 2  91 AC                sta     (LOWTR),y
+00.000D36r 2  C8                   iny
+00.000D37r 2  91 AC                sta     (LOWTR),y
+00.000D39r 2  C8                   iny
+00.000D3Ar 2  91 AC                sta     (LOWTR),y
+00.000D3Cr 2               .ifndef CONFIG_SMALL
+00.000D3Cr 2  C8                   iny
+00.000D3Dr 2  91 AC                sta     (LOWTR),y
+00.000D3Fr 2               .endif
+00.000D3Fr 2               
+00.000D3Fr 2               ; ----------------------------------------------------------------------------
+00.000D3Fr 2               ; PUT ADDRESS OF VALUE OF VARIABLE IN VARPNT AND Y,A
+00.000D3Fr 2               ; ----------------------------------------------------------------------------
+00.000D3Fr 2               SET_VARPNT_AND_YA:
+00.000D3Fr 2  A5 AC                lda     LOWTR
+00.000D41r 2  18                   clc
+00.000D42r 2  69 02                adc     #$02
+00.000D44r 2  A4 AD                ldy     LOWTR+1
+00.000D46r 2  90 01                bcc     L2F9E
+00.000D48r 2  C8                   iny
+00.000D49r 2               L2F9E:
+00.000D49r 2  85 94                sta     VARPNT
+00.000D4Br 2  84 95                sty     VARPNT+1
+00.000D4Dr 2  60                   rts
+00.000D4Er 2               
+00.000D4Er 1               .include "array.s"
+00.000D4Er 2               .segment "CODE"
+00.000D4Er 2               
+00.000D4Er 2               ; ----------------------------------------------------------------------------
+00.000D4Er 2               ; COMPUTE ADDRESS OF FIRST VALUE IN ARRAY
+00.000D4Er 2               ; ARYPNT = (LOWTR) + #DIMS*2 + 5
+00.000D4Er 2               ; ----------------------------------------------------------------------------
+00.000D4Er 2               GETARY:
+00.000D4Er 2  A5 0C                lda     EOLPNTR
+00.000D50r 2  0A                   asl     a
+00.000D51r 2  69 05                adc     #$05
+00.000D53r 2  65 AC                adc     LOWTR
+00.000D55r 2  A4 AD                ldy     LOWTR+1
+00.000D57r 2  90 01                bcc     L2FAF
+00.000D59r 2  C8                   iny
+00.000D5Ar 2               L2FAF:
+00.000D5Ar 2  85 A5                sta     HIGHDS
+00.000D5Cr 2  84 A6                sty     HIGHDS+1
+00.000D5Er 2  60                   rts
+00.000D5Fr 2               
+00.000D5Fr 2               ; ----------------------------------------------------------------------------
+00.000D5Fr 2               NEG32768:
+00.000D5Fr 2  90 80 00 00          .byte   $90,$80,$00,$00
+00.000D63r 2               
+00.000D63r 2               .ifdef CONFIG_2C
+00.000D63r 2               		.byte	$00; bugfix: short number
+00.000D63r 2               .endif
+00.000D63r 2               
+00.000D63r 2               ; ----------------------------------------------------------------------------
+00.000D63r 2               ; EVALUATE NUMERIC FORMULA AT TXTPTR
+00.000D63r 2               ; CONVERTING RESULT TO INTEGER 0 <= X <= 32767
+00.000D63r 2               ; IN FAC+3,4
+00.000D63r 2               ; ----------------------------------------------------------------------------
+00.000D63r 2               MAKINT:
+00.000D63r 2  20 C0 00             jsr     CHRGET
+00.000D66r 2               .ifdef CONFIG_2
+00.000D66r 2                       jsr     FRMEVL
+00.000D66r 2               .else
+00.000D66r 2  20 rr rr             jsr     FRMNUM
+00.000D69r 2               .endif
+00.000D69r 2               
+00.000D69r 2               ; ----------------------------------------------------------------------------
+00.000D69r 2               ; CONVERT FAC TO INTEGER
+00.000D69r 2               ; MUST BE POSITIVE AND LESS THAN 32768
+00.000D69r 2               ; ----------------------------------------------------------------------------
+00.000D69r 2               MKINT:
+00.000D69r 2               .ifdef CONFIG_2
+00.000D69r 2                       jsr     CHKNUM
+00.000D69r 2               .endif
+00.000D69r 2  A5 B3                lda     FACSIGN
+00.000D6Br 2  30 0D                bmi     MI1
+00.000D6Dr 2               
+00.000D6Dr 2               ; ----------------------------------------------------------------------------
+00.000D6Dr 2               ; CONVERT FAC TO INTEGER
+00.000D6Dr 2               ; MUST BE -32767 <= FAC <= 32767
+00.000D6Dr 2               ; ----------------------------------------------------------------------------
+00.000D6Dr 2               AYINT:
+00.000D6Dr 2  A5 AE                lda     FAC
+00.000D6Fr 2  C9 90                cmp     #$90
+00.000D71r 2  90 09                bcc     MI2
+00.000D73r 2  A9 rr                lda     #<NEG32768
+00.000D75r 2  A0 rr                ldy     #>NEG32768
+00.000D77r 2  20 rr rr             jsr     FCOMP
+00.000D7Ar 2               MI1:
+00.000D7Ar 2  D0 7A                bne     IQERR
+00.000D7Cr 2               MI2:
+00.000D7Cr 2  4C rr rr             jmp     QINT
+00.000D7Fr 2               
+00.000D7Fr 2               ; ----------------------------------------------------------------------------
+00.000D7Fr 2               ; LOCATE ARRAY ELEMENT OR CREATE AN ARRAY
+00.000D7Fr 2               ; ----------------------------------------------------------------------------
+00.000D7Fr 2               ARRAY:
+00.000D7Fr 2  A5 0D                lda     DIMFLG
+00.000D81r 2               .ifndef CONFIG_SMALL
+00.000D81r 2  05 0F                ora     VALTYP+1
+00.000D83r 2               .endif
+00.000D83r 2  48                   pha
+00.000D84r 2  A5 0E                lda     VALTYP
+00.000D86r 2  48                   pha
+00.000D87r 2  A0 00                ldy     #$00
+00.000D89r 2               L2FDE:
+00.000D89r 2  98                   tya
+00.000D8Ar 2  48                   pha
+00.000D8Br 2  A5 93                lda     VARNAM+1
+00.000D8Dr 2  48                   pha
+00.000D8Er 2  A5 92                lda     VARNAM
+00.000D90r 2  48                   pha
+00.000D91r 2  20 rr rr             jsr     MAKINT
+00.000D94r 2  68                   pla
+00.000D95r 2  85 92                sta     VARNAM
+00.000D97r 2  68                   pla
+00.000D98r 2  85 93                sta     VARNAM+1
+00.000D9Ar 2  68                   pla
+00.000D9Br 2  A8                   tay
+00.000D9Cr 2  BA                   tsx
+00.000D9Dr 2  BD 02 01             lda     STACK+2,x
+00.000DA0r 2  48                   pha
+00.000DA1r 2  BD 01 01             lda     STACK+1,x
+00.000DA4r 2  48                   pha
+00.000DA5r 2  A5 B1                lda     FAC_LAST-1
+00.000DA7r 2  9D 02 01             sta     STACK+2,x
+00.000DAAr 2  A5 B2                lda     FAC_LAST
+00.000DACr 2  9D 01 01             sta     STACK+1,x
+00.000DAFr 2  C8                   iny
+00.000DB0r 2  20 C6 00             jsr     CHRGOT
+00.000DB3r 2  C9 2C                cmp     #$2C
+00.000DB5r 2  F0 D2                beq     L2FDE
+00.000DB7r 2  84 0C                sty     EOLPNTR
+00.000DB9r 2  20 rr rr             jsr     CHKCLS
+00.000DBCr 2  68                   pla
+00.000DBDr 2  85 0E                sta     VALTYP
+00.000DBFr 2  68                   pla
+00.000DC0r 2               .ifndef CONFIG_SMALL
+00.000DC0r 2  85 0F                sta     VALTYP+1
+00.000DC2r 2  29 7F                and     #$7F
+00.000DC4r 2               .endif
+00.000DC4r 2  85 0D                sta     DIMFLG
+00.000DC6r 2               ; ----------------------------------------------------------------------------
+00.000DC6r 2               ; SEARCH ARRAY TABLE FOR THIS ARRAY NAME
+00.000DC6r 2               ; ----------------------------------------------------------------------------
+00.000DC6r 2  A6 7C                ldx     ARYTAB
+00.000DC8r 2  A5 7D                lda     ARYTAB+1
+00.000DCAr 2               L301F:
+00.000DCAr 2  86 AC                stx     LOWTR
+00.000DCCr 2  85 AD                sta     LOWTR+1
+00.000DCEr 2  C5 7F                cmp     STREND+1
+00.000DD0r 2  D0 04                bne     L302B
+00.000DD2r 2  E4 7E                cpx     STREND
+00.000DD4r 2  F0 39                beq     MAKE_NEW_ARRAY
+00.000DD6r 2               L302B:
+00.000DD6r 2  A0 00                ldy     #$00
+00.000DD8r 2  B1 AC                lda     (LOWTR),y
+00.000DDAr 2  C8                   iny
+00.000DDBr 2  C5 92                cmp     VARNAM
+00.000DDDr 2  D0 06                bne     L303A
+00.000DDFr 2  A5 93                lda     VARNAM+1
+00.000DE1r 2  D1 AC                cmp     (LOWTR),y
+00.000DE3r 2  F0 16                beq     USE_OLD_ARRAY
+00.000DE5r 2               L303A:
+00.000DE5r 2  C8                   iny
+00.000DE6r 2  B1 AC                lda     (LOWTR),y
+00.000DE8r 2  18                   clc
+00.000DE9r 2  65 AC                adc     LOWTR
+00.000DEBr 2  AA                   tax
+00.000DECr 2  C8                   iny
+00.000DEDr 2  B1 AC                lda     (LOWTR),y
+00.000DEFr 2  65 AD                adc     LOWTR+1
+00.000DF1r 2  90 D7                bcc     L301F
+00.000DF3r 2               
+00.000DF3r 2               ; ----------------------------------------------------------------------------
+00.000DF3r 2               ; ERROR:  BAD SUBSCRIPTS
+00.000DF3r 2               ; ----------------------------------------------------------------------------
+00.000DF3r 2               SUBERR:
+00.000DF3r 2  A2 6B                ldx     #ERR_BADSUBS
+00.000DF5r 2  2C                   .byte   $2C
+00.000DF6r 2               
+00.000DF6r 2               ; ----------------------------------------------------------------------------
+00.000DF6r 2               ; ERROR:  ILLEGAL QUANTITY
+00.000DF6r 2               ; ----------------------------------------------------------------------------
+00.000DF6r 2               IQERR:
+00.000DF6r 2  A2 35                ldx     #ERR_ILLQTY
+00.000DF8r 2               JER:
+00.000DF8r 2  4C rr rr             jmp     ERROR
+00.000DFBr 2               
+00.000DFBr 2               ; ----------------------------------------------------------------------------
+00.000DFBr 2               ; FOUND THE ARRAY
+00.000DFBr 2               ; ----------------------------------------------------------------------------
+00.000DFBr 2               USE_OLD_ARRAY:
+00.000DFBr 2  A2 78                ldx     #ERR_REDIMD
+00.000DFDr 2  A5 0D                lda     DIMFLG
+00.000DFFr 2  D0 F7                bne     JER
+00.000E01r 2  20 rr rr             jsr     GETARY
+00.000E04r 2  A5 0C                lda     EOLPNTR
+00.000E06r 2  A0 04                ldy     #$04
+00.000E08r 2  D1 AC                cmp     (LOWTR),y
+00.000E0Ar 2  D0 E7                bne     SUBERR
+00.000E0Cr 2  4C rr rr             jmp     FIND_ARRAY_ELEMENT
+00.000E0Fr 2               
+00.000E0Fr 2               ; ----------------------------------------------------------------------------
+00.000E0Fr 2               ; CREATE A NEW ARRAY, UNLESS CALLED FROM GETARYPT
+00.000E0Fr 2               ; ----------------------------------------------------------------------------
+00.000E0Fr 2               MAKE_NEW_ARRAY:
+00.000E0Fr 2  20 rr rr             jsr     GETARY
+00.000E12r 2  20 rr rr             jsr     REASON
+00.000E15r 2  A9 00                lda     #$00
+00.000E17r 2  A8                   tay
+00.000E18r 2  85 BF                sta     STRNG2+1
+00.000E1Ar 2  A2 05                ldx     #BYTES_PER_ELEMENT
+00.000E1Cr 2               .if .def(CONFIG_SMALL) && (!.def(CONFIG_2))
+00.000E1Cr 2                       stx     STRNG2
+00.000E1Cr 2               .endif
+00.000E1Cr 2  A5 92                lda     VARNAM
+00.000E1Er 2  91 AC                sta     (LOWTR),y
+00.000E20r 2               .ifndef CONFIG_SMALL
+00.000E20r 2  10 01                bpl     L3078
+00.000E22r 2  CA                   dex
+00.000E23r 2               L3078:
+00.000E23r 2               .endif
+00.000E23r 2  C8                   iny
+00.000E24r 2  A5 93                lda     VARNAM+1
+00.000E26r 2  91 AC                sta     (LOWTR),y
+00.000E28r 2               .if (!.def(CONFIG_SMALL)) || .def(CONFIG_2)
+00.000E28r 2  10 02                bpl     L3081
+00.000E2Ar 2  CA                   dex
+00.000E2Br 2                 .if !(.def(CONFIG_SMALL) && .def(CONFIG_2))
+00.000E2Br 2  CA                   dex
+00.000E2Cr 2                 .endif
+00.000E2Cr 2               L3081:
+00.000E2Cr 2  86 BE                stx     STRNG2
+00.000E2Er 2               .endif
+00.000E2Er 2  A5 0C                lda     EOLPNTR
+00.000E30r 2  C8                   iny
+00.000E31r 2  C8                   iny
+00.000E32r 2  C8                   iny
+00.000E33r 2  91 AC                sta     (LOWTR),y
+00.000E35r 2               L308A:
+00.000E35r 2  A2 0B                ldx     #$0B
+00.000E37r 2  A9 00                lda     #$00
+00.000E39r 2  24 0D                bit     DIMFLG
+00.000E3Br 2  50 08                bvc     L309A
+00.000E3Dr 2  68                   pla
+00.000E3Er 2  18                   clc
+00.000E3Fr 2  69 01                adc     #$01
+00.000E41r 2  AA                   tax
+00.000E42r 2  68                   pla
+00.000E43r 2  69 00                adc     #$00
+00.000E45r 2               L309A:
+00.000E45r 2  C8                   iny
+00.000E46r 2  91 AC                sta     (LOWTR),y
+00.000E48r 2  C8                   iny
+00.000E49r 2  8A                   txa
+00.000E4Ar 2  91 AC                sta     (LOWTR),y
+00.000E4Cr 2  20 rr rr             jsr     MULTIPLY_SUBSCRIPT
+00.000E4Fr 2  86 BE                stx     STRNG2
+00.000E51r 2  85 BF                sta     STRNG2+1
+00.000E53r 2  A4 6F                ldy     INDEX
+00.000E55r 2  C6 0C                dec     EOLPNTR
+00.000E57r 2  D0 DC                bne     L308A
+00.000E59r 2  65 A6                adc     HIGHDS+1
+00.000E5Br 2  B0 5D                bcs     GME
+00.000E5Dr 2  85 A6                sta     HIGHDS+1
+00.000E5Fr 2  A8                   tay
+00.000E60r 2  8A                   txa
+00.000E61r 2  65 A5                adc     HIGHDS
+00.000E63r 2  90 03                bcc     L30BD
+00.000E65r 2  C8                   iny
+00.000E66r 2  F0 52                beq     GME
+00.000E68r 2               L30BD:
+00.000E68r 2  20 rr rr             jsr     REASON
+00.000E6Br 2  85 7E                sta     STREND
+00.000E6Dr 2  84 7F                sty     STREND+1
+00.000E6Fr 2  A9 00                lda     #$00
+00.000E71r 2  E6 BF                inc     STRNG2+1
+00.000E73r 2  A4 BE                ldy     STRNG2
+00.000E75r 2  F0 05                beq     L30D1
+00.000E77r 2               L30CC:
+00.000E77r 2  88                   dey
+00.000E78r 2  91 A5                sta     (HIGHDS),y
+00.000E7Ar 2  D0 FB                bne     L30CC
+00.000E7Cr 2               L30D1:
+00.000E7Cr 2  C6 A6                dec     HIGHDS+1
+00.000E7Er 2  C6 BF                dec     STRNG2+1
+00.000E80r 2  D0 F5                bne     L30CC
+00.000E82r 2  E6 A6                inc     HIGHDS+1
+00.000E84r 2  38                   sec
+00.000E85r 2  A5 7E                lda     STREND
+00.000E87r 2  E5 AC                sbc     LOWTR
+00.000E89r 2  A0 02                ldy     #$02
+00.000E8Br 2  91 AC                sta     (LOWTR),y
+00.000E8Dr 2  A5 7F                lda     STREND+1
+00.000E8Fr 2  C8                   iny
+00.000E90r 2  E5 AD                sbc     LOWTR+1
+00.000E92r 2  91 AC                sta     (LOWTR),y
+00.000E94r 2  A5 0D                lda     DIMFLG
+00.000E96r 2  D0 62                bne     RTS9
+00.000E98r 2  C8                   iny
+00.000E99r 2               
+00.000E99r 2               ; ----------------------------------------------------------------------------
+00.000E99r 2               ; FIND SPECIFIED ARRAY ELEMENT
+00.000E99r 2               ;
+00.000E99r 2               ; (LOWTR),Y POINTS AT # OF DIMS IN ARRAY DESCRIPTOR
+00.000E99r 2               ; THE SUBSCRIPTS ARE ALL ON THE STACK AS INTEGERS
+00.000E99r 2               ; ----------------------------------------------------------------------------
+00.000E99r 2               FIND_ARRAY_ELEMENT:
+00.000E99r 2  B1 AC                lda     (LOWTR),y
+00.000E9Br 2  85 0C                sta     EOLPNTR
+00.000E9Dr 2  A9 00                lda     #$00
+00.000E9Fr 2  85 BE                sta     STRNG2
+00.000EA1r 2               L30F6:
+00.000EA1r 2  85 BF                sta     STRNG2+1
+00.000EA3r 2  C8                   iny
+00.000EA4r 2  68                   pla
+00.000EA5r 2  AA                   tax
+00.000EA6r 2  85 B1                sta     FAC_LAST-1
+00.000EA8r 2  68                   pla
+00.000EA9r 2  85 B2                sta     FAC_LAST
+00.000EABr 2  D1 AC                cmp     (LOWTR),y
+00.000EADr 2  90 0E                bcc     FAE2
+00.000EAFr 2  D0 06                bne     GSE
+00.000EB1r 2  C8                   iny
+00.000EB2r 2  8A                   txa
+00.000EB3r 2  D1 AC                cmp     (LOWTR),y
+00.000EB5r 2  90 07                bcc     FAE3
+00.000EB7r 2               ; ----------------------------------------------------------------------------
+00.000EB7r 2               GSE:
+00.000EB7r 2  4C rr rr             jmp     SUBERR
+00.000EBAr 2               GME:
+00.000EBAr 2  4C rr rr             jmp     MEMERR
+00.000EBDr 2               ; ----------------------------------------------------------------------------
+00.000EBDr 2               FAE2:
+00.000EBDr 2  C8                   iny
+00.000EBEr 2               FAE3:
+00.000EBEr 2  A5 BF                lda     STRNG2+1
+00.000EC0r 2  05 BE                ora     STRNG2
+00.000EC2r 2  18                   clc
+00.000EC3r 2  F0 0A                beq     L3124
+00.000EC5r 2  20 rr rr             jsr     MULTIPLY_SUBSCRIPT
+00.000EC8r 2  8A                   txa
+00.000EC9r 2  65 B1                adc     FAC_LAST-1
+00.000ECBr 2  AA                   tax
+00.000ECCr 2  98                   tya
+00.000ECDr 2  A4 6F                ldy     INDEX
+00.000ECFr 2               L3124:
+00.000ECFr 2  65 B2                adc     FAC_LAST
+00.000ED1r 2  86 BE                stx     STRNG2
+00.000ED3r 2  C6 0C                dec     EOLPNTR
+00.000ED5r 2  D0 CA                bne     L30F6
+00.000ED7r 2               .if .def(CONFIG_SMALL) && (!.def(CONFIG_2))
+00.000ED7r 2                       asl     STRNG2
+00.000ED7r 2                       rol     a
+00.000ED7r 2                       bcs     GSE
+00.000ED7r 2                       asl     STRNG2
+00.000ED7r 2                       rol     a
+00.000ED7r 2                       bcs     GSE
+00.000ED7r 2                       tay
+00.000ED7r 2                       lda     STRNG2
+00.000ED7r 2               .else
+00.000ED7r 2                 .ifdef CONFIG_11A
+00.000ED7r 2  85 BF                sta     STRNG2+1
+00.000ED9r 2                 .endif
+00.000ED9r 2  A2 05                ldx     #BYTES_FP
+00.000EDBr 2                 .ifdef CONFIG_SMALL
+00.000EDBr 2                       lda     VARNAM+1
+00.000EDBr 2                 .else
+00.000EDBr 2  A5 92                lda     VARNAM
+00.000EDDr 2                 .endif
+00.000EDDr 2  10 01                bpl     L3135
+00.000EDFr 2  CA                   dex
+00.000EE0r 2               L3135:
+00.000EE0r 2                 .ifdef CONFIG_SMALL
+00.000EE0r 2                       stx     RESULT+1
+00.000EE0r 2                 .else
+00.000EE0r 2  A5 93                lda     VARNAM+1
+00.000EE2r 2  10 02                bpl     L313B
+00.000EE4r 2  CA                   dex
+00.000EE5r 2  CA                   dex
+00.000EE6r 2               L313B:
+00.000EE6r 2  86 75                stx     RESULT+2
+00.000EE8r 2                 .endif
+00.000EE8r 2  A9 00                lda     #$00
+00.000EEAr 2  20 rr rr             jsr     MULTIPLY_SUBS1
+00.000EEDr 2  8A                   txa
+00.000EEEr 2               .endif
+00.000EEEr 2  65 A5                adc     HIGHDS
+00.000EF0r 2  85 94                sta     VARPNT
+00.000EF2r 2  98                   tya
+00.000EF3r 2  65 A6                adc     HIGHDS+1
+00.000EF5r 2  85 95                sta     VARPNT+1
+00.000EF7r 2  A8                   tay
+00.000EF8r 2  A5 94                lda     VARPNT
+00.000EFAr 2               RTS9:
+00.000EFAr 2  60                   rts
+00.000EFBr 2               
+00.000EFBr 2               ; ----------------------------------------------------------------------------
+00.000EFBr 2               ; MULTIPLY (STRNG2) BY ((LOWTR),Y)
+00.000EFBr 2               ; LEAVING PRODUCT IN A,X.  (HI-BYTE ALSO IN Y.)
+00.000EFBr 2               ; USED ONLY BY ARRAY SUBSCRIPT ROUTINES
+00.000EFBr 2               ; ----------------------------------------------------------------------------
+00.000EFBr 2               MULTIPLY_SUBSCRIPT:
+00.000EFBr 2  84 6F                sty     INDEX
+00.000EFDr 2  B1 AC                lda     (LOWTR),y
+00.000EFFr 2  85 75                sta     RESULT_LAST-2
+00.000F01r 2  88                   dey
+00.000F02r 2  B1 AC                lda     (LOWTR),y
+00.000F04r 2               MULTIPLY_SUBS1:
+00.000F04r 2  85 76                sta     RESULT_LAST-1
+00.000F06r 2  A9 10                lda     #$10
+00.000F08r 2  85 AA                sta     INDX
+00.000F0Ar 2  A2 00                ldx     #$00
+00.000F0Cr 2  A0 00                ldy     #$00
+00.000F0Er 2               L3163:
+00.000F0Er 2  8A                   txa
+00.000F0Fr 2  0A                   asl     a
+00.000F10r 2  AA                   tax
+00.000F11r 2  98                   tya
+00.000F12r 2  2A                   rol     a
+00.000F13r 2  A8                   tay
+00.000F14r 2  B0 A4                bcs     GME
+00.000F16r 2  06 BE                asl     STRNG2
+00.000F18r 2  26 BF                rol     STRNG2+1
+00.000F1Ar 2  90 0B                bcc     L317C
+00.000F1Cr 2  18                   clc
+00.000F1Dr 2  8A                   txa
+00.000F1Er 2  65 75                adc     RESULT_LAST-2
+00.000F20r 2  AA                   tax
+00.000F21r 2  98                   tya
+00.000F22r 2  65 76                adc     RESULT_LAST-1
+00.000F24r 2  A8                   tay
+00.000F25r 2  B0 93                bcs     GME
+00.000F27r 2               L317C:
+00.000F27r 2  C6 AA                dec     INDX
+00.000F29r 2  D0 E3                bne     L3163
+00.000F2Br 2  60                   rts
+00.000F2Cr 2               
+00.000F2Cr 2               
+00.000F2Cr 1               .include "misc2.s"
+00.000F2Cr 2               .segment "CODE"
+00.000F2Cr 2               
+00.000F2Cr 2               ; ----------------------------------------------------------------------------
+00.000F2Cr 2               ; "FRE" FUNCTION
+00.000F2Cr 2               ;
+00.000F2Cr 2               ; COLLECTS GARBAGE AND RETURNS # BYTES OF MEMORY LEFT
+00.000F2Cr 2               ; ----------------------------------------------------------------------------
+00.000F2Cr 2               FRE:
+00.000F2Cr 2  A5 0E                lda     VALTYP
+00.000F2Er 2  F0 03                beq     L3188
+00.000F30r 2  20 rr rr             jsr     FREFAC
+00.000F33r 2               L3188:
+00.000F33r 2  20 rr rr             jsr     GARBAG
+00.000F36r 2  38                   sec
+00.000F37r 2  A5 80                lda     FRETOP
+00.000F39r 2  E5 7E                sbc     STREND
+00.000F3Br 2  A8                   tay
+00.000F3Cr 2  A5 81                lda     FRETOP+1
+00.000F3Er 2  E5 7F                sbc     STREND+1
+00.000F40r 2               ; FALL INTO GIVAYF TO FLOAT THE VALUE
+00.000F40r 2               ; NOTE THAT VALUES OVER 32767 WILL RETURN AS NEGATIVE
+00.000F40r 2               
+00.000F40r 2               ; ----------------------------------------------------------------------------
+00.000F40r 2               ; FLOAT THE SIGNED INTEGER IN A,Y
+00.000F40r 2               ; ----------------------------------------------------------------------------
+00.000F40r 2               GIVAYF:
+00.000F40r 2  A2 00                ldx     #$00
+00.000F42r 2  86 0E                stx     VALTYP
+00.000F44r 2  85 AF                sta     FAC+1
+00.000F46r 2  84 B0                sty     FAC+2
+00.000F48r 2  A2 90                ldx     #$90
+00.000F4Ar 2  4C rr rr             jmp     FLOAT1
+00.000F4Dr 2               POS:
+00.000F4Dr 2  A4 16                ldy     POSX
+00.000F4Fr 2               
+00.000F4Fr 2               ; ----------------------------------------------------------------------------
+00.000F4Fr 2               ; FLOAT (Y) INTO FAC, GIVING VALUE 0-255
+00.000F4Fr 2               ; ----------------------------------------------------------------------------
+00.000F4Fr 2               SNGFLT:
+00.000F4Fr 2  A9 00                lda     #$00
+00.000F51r 2  F0 ED                beq     GIVAYF
+00.000F53r 2               
+00.000F53r 2               ; ----------------------------------------------------------------------------
+00.000F53r 2               ; CHECK FOR DIRECT OR RUNNING MODE
+00.000F53r 2               ; GIVING ERROR IF DIRECT MODE
+00.000F53r 2               ; ----------------------------------------------------------------------------
+00.000F53r 2               ERRDIR:
+00.000F53r 2  A6 87                ldx     CURLIN+1
+00.000F55r 2  E8                   inx
+00.000F56r 2  D0 A2                bne     RTS9
+00.000F58r 2  A2 95                ldx     #ERR_ILLDIR
+00.000F5Ar 2               .ifdef CONFIG_2
+00.000F5Ar 2                       .byte   $2C
+00.000F5Ar 2               LD288:
+00.000F5Ar 2                       ldx     #ERR_UNDEFFN
+00.000F5Ar 2               .endif
+00.000F5Ar 2               L31AF:
+00.000F5Ar 2  4C rr rr             jmp     ERROR
+00.000F5Dr 2               DEF:
+00.000F5Dr 2  20 rr rr             jsr     FNC
+00.000F60r 2  20 rr rr             jsr     ERRDIR
+00.000F63r 2  20 rr rr             jsr     CHKOPN
+00.000F66r 2  A9 80                lda     #$80
+00.000F68r 2  85 11                sta     SUBFLG
+00.000F6Ar 2  20 rr rr             jsr     PTRGET
+00.000F6Dr 2  20 rr rr             jsr     CHKNUM
+00.000F70r 2  20 rr rr             jsr     CHKCLS
+00.000F73r 2  A9 AC                lda     #TOKEN_EQUAL
+00.000F75r 2  20 rr rr             jsr     SYNCHR
+00.000F78r 2               .ifndef CONFIG_SMALL
+00.000F78r 2  48                   pha
+00.000F79r 2               .endif
+00.000F79r 2  A5 95                lda     VARPNT+1
+00.000F7Br 2  48                   pha
+00.000F7Cr 2  A5 94                lda     VARPNT
+00.000F7Er 2  48                   pha
+00.000F7Fr 2  A5 C8                lda     TXTPTR+1
+00.000F81r 2  48                   pha
+00.000F82r 2  A5 C7                lda     TXTPTR
+00.000F84r 2  48                   pha
+00.000F85r 2  20 rr rr             jsr     DATA
+00.000F88r 2  4C rr rr             jmp     L3250
+00.000F8Br 2               FNC:
+00.000F8Br 2  A9 9F                lda     #TOKEN_FN
+00.000F8Dr 2  20 rr rr             jsr     SYNCHR
+00.000F90r 2  09 80                ora     #$80
+00.000F92r 2  85 11                sta     SUBFLG
+00.000F94r 2  20 rr rr             jsr     PTRGET3
+00.000F97r 2  85 9B                sta     FNCNAM
+00.000F99r 2  84 9C                sty     FNCNAM+1
+00.000F9Br 2  4C rr rr             jmp     CHKNUM
+00.000F9Er 2               L31F3:
+00.000F9Er 2  20 rr rr             jsr     FNC
+00.000FA1r 2  A5 9C                lda     FNCNAM+1
+00.000FA3r 2  48                   pha
+00.000FA4r 2  A5 9B                lda     FNCNAM
+00.000FA6r 2  48                   pha
+00.000FA7r 2  20 rr rr             jsr     PARCHK
+00.000FAAr 2  20 rr rr             jsr     CHKNUM
+00.000FADr 2  68                   pla
+00.000FAEr 2  85 9B                sta     FNCNAM
+00.000FB0r 2  68                   pla
+00.000FB1r 2  85 9C                sta     FNCNAM+1
+00.000FB3r 2  A0 02                ldy     #$02
+00.000FB5r 2               .ifndef CONFIG_2
+00.000FB5r 2  A2 E0                ldx     #ERR_UNDEFFN
+00.000FB7r 2               .endif
+00.000FB7r 2  B1 9B                lda     (FNCNAM),y
+00.000FB9r 2               .ifndef CONFIG_2
+00.000FB9r 2  F0 9F                beq     L31AF
+00.000FBBr 2               .endif
+00.000FBBr 2  85 94                sta     VARPNT
+00.000FBDr 2  AA                   tax
+00.000FBEr 2  C8                   iny
+00.000FBFr 2  B1 9B                lda     (FNCNAM),y
+00.000FC1r 2               .ifdef CONFIG_2
+00.000FC1r 2                       beq     LD288
+00.000FC1r 2               .endif
+00.000FC1r 2  85 95                sta     VARPNT+1
+00.000FC3r 2               .ifndef CONFIG_SMALL
+00.000FC3r 2  C8                   iny
+00.000FC4r 2               .endif
+00.000FC4r 2               L3219:
+00.000FC4r 2  B1 94                lda     (VARPNT),y
+00.000FC6r 2  48                   pha
+00.000FC7r 2  88                   dey
+00.000FC8r 2  10 FA                bpl     L3219
+00.000FCAr 2  A4 95                ldy     VARPNT+1
+00.000FCCr 2  20 rr rr             jsr     STORE_FAC_AT_YX_ROUNDED
+00.000FCFr 2  A5 C8                lda     TXTPTR+1
+00.000FD1r 2  48                   pha
+00.000FD2r 2  A5 C7                lda     TXTPTR
+00.000FD4r 2  48                   pha
+00.000FD5r 2  B1 9B                lda     (FNCNAM),y
+00.000FD7r 2  85 C7                sta     TXTPTR
+00.000FD9r 2  C8                   iny
+00.000FDAr 2  B1 9B                lda     (FNCNAM),y
+00.000FDCr 2  85 C8                sta     TXTPTR+1
+00.000FDEr 2  A5 95                lda     VARPNT+1
+00.000FE0r 2  48                   pha
+00.000FE1r 2  A5 94                lda     VARPNT
+00.000FE3r 2  48                   pha
+00.000FE4r 2  20 rr rr             jsr     FRMNUM
+00.000FE7r 2  68                   pla
+00.000FE8r 2  85 9B                sta     FNCNAM
+00.000FEAr 2  68                   pla
+00.000FEBr 2  85 9C                sta     FNCNAM+1
+00.000FEDr 2  20 C6 00             jsr     CHRGOT
+00.000FF0r 2  F0 03                beq     L324A
+00.000FF2r 2  4C rr rr             jmp     SYNERR
+00.000FF5r 2               L324A:
+00.000FF5r 2  68                   pla
+00.000FF6r 2  85 C7                sta     TXTPTR
+00.000FF8r 2  68                   pla
+00.000FF9r 2  85 C8                sta     TXTPTR+1
+00.000FFBr 2               L3250:
+00.000FFBr 2  A0 00                ldy     #$00
+00.000FFDr 2  68                   pla
+00.000FFEr 2  91 9B                sta     (FNCNAM),y
+00.001000r 2  68                   pla
+00.001001r 2  C8                   iny
+00.001002r 2  91 9B                sta     (FNCNAM),y
+00.001004r 2  68                   pla
+00.001005r 2  C8                   iny
+00.001006r 2  91 9B                sta     (FNCNAM),y
+00.001008r 2  68                   pla
+00.001009r 2  C8                   iny
+00.00100Ar 2  91 9B                sta     (FNCNAM),y
+00.00100Cr 2               .ifndef CONFIG_SMALL
+00.00100Cr 2  68                   pla
+00.00100Dr 2  C8                   iny
+00.00100Er 2  91 9B                sta     (FNCNAM),y
+00.001010r 2               .endif
+00.001010r 2  60                   rts
+00.001011r 2               
+00.001011r 1               .include "string.s"
+00.001011r 2               .segment "CODE"
+00.001011r 2               ; ----------------------------------------------------------------------------
+00.001011r 2               ; "STR$" FUNCTION
+00.001011r 2               ; ----------------------------------------------------------------------------
+00.001011r 2               STR:
+00.001011r 2  20 rr rr             jsr     CHKNUM
+00.001014r 2  A0 00                ldy     #$00
+00.001016r 2  20 rr rr             jsr     FOUT1
+00.001019r 2  68                   pla
+00.00101Ar 2  68                   pla
+00.00101Br 2               LD353:
+00.00101Br 2  A9 FF                lda     #$FF
+00.00101Dr 2  A0 00                ldy     #$00
+00.00101Fr 2  F0 12                beq     STRLIT
+00.001021r 2               
+00.001021r 2               ; ----------------------------------------------------------------------------
+00.001021r 2               ; GET SPACE AND MAKE DESCRIPTOR FOR STRING WHOSE
+00.001021r 2               ; ADDRESS IS IN FAC+3,4 AND WHOSE LENGTH IS IN A-REG
+00.001021r 2               ; ----------------------------------------------------------------------------
+00.001021r 2               STRINI:
+00.001021r 2  A6 B1                ldx     FAC_LAST-1
+00.001023r 2  A4 B2                ldy     FAC_LAST
+00.001025r 2  86 9D                stx     DSCPTR
+00.001027r 2  84 9E                sty     DSCPTR+1
+00.001029r 2               
+00.001029r 2               ; ----------------------------------------------------------------------------
+00.001029r 2               ; GET SPACE AND MAKE DESCRIPTOR FOR STRING WHOSE
+00.001029r 2               ; ADDRESS IS IN Y,X AND WHOSE LENGTH IS IN A-REG
+00.001029r 2               ; ----------------------------------------------------------------------------
+00.001029r 2               STRSPA:
+00.001029r 2  20 rr rr             jsr     GETSPA
+00.00102Cr 2  86 AF                stx     FAC+1
+00.00102Er 2  84 B0                sty     FAC+2
+00.001030r 2  85 AE                sta     FAC
+00.001032r 2  60                   rts
+00.001033r 2               
+00.001033r 2               ; ----------------------------------------------------------------------------
+00.001033r 2               ; BUILD A DESCRIPTOR FOR STRING STARTING AT Y,A
+00.001033r 2               ; AND TERMINATED BY $00 OR QUOTATION MARK
+00.001033r 2               ; RETURN WITH DESCRIPTOR IN A TEMPORARY
+00.001033r 2               ; AND ADDRESS OF DESCRIPTOR IN FAC+3,4
+00.001033r 2               ; ----------------------------------------------------------------------------
+00.001033r 2               STRLIT:
+00.001033r 2  A2 22                ldx     #$22
+00.001035r 2  86 0A                stx     CHARAC
+00.001037r 2  86 0B                stx     ENDCHR
+00.001039r 2               
+00.001039r 2               ; ----------------------------------------------------------------------------
+00.001039r 2               ; BUILD A DESCRIPTOR FOR STRING STARTING AT Y,A
+00.001039r 2               ; AND TERMINATED BY $00, (CHARAC), OR (ENDCHR)
+00.001039r 2               ;
+00.001039r 2               ; RETURN WITH DESCRIPTOR IN A TEMPORARY
+00.001039r 2               ; AND ADDRESS OF DESCRIPTOR IN FAC+3,4
+00.001039r 2               ; ----------------------------------------------------------------------------
+00.001039r 2               STRLT2:
+00.001039r 2  85 BC                sta     STRNG1
+00.00103Br 2  84 BD                sty     STRNG1+1
+00.00103Dr 2  85 AF                sta     FAC+1
+00.00103Fr 2  84 B0                sty     FAC+2
+00.001041r 2  A0 FF                ldy     #$FF
+00.001043r 2               L3298:
+00.001043r 2  C8                   iny
+00.001044r 2  B1 BC                lda     (STRNG1),y
+00.001046r 2  F0 0C                beq     L32A9
+00.001048r 2  C5 0A                cmp     CHARAC
+00.00104Ar 2  F0 04                beq     L32A5
+00.00104Cr 2  C5 0B                cmp     ENDCHR
+00.00104Er 2  D0 F3                bne     L3298
+00.001050r 2               L32A5:
+00.001050r 2  C9 22                cmp     #$22
+00.001052r 2  F0 01                beq     L32AA
+00.001054r 2               L32A9:
+00.001054r 2  18                   clc
+00.001055r 2               L32AA:
+00.001055r 2  84 AE                sty     FAC
+00.001057r 2  98                   tya
+00.001058r 2  65 BC                adc     STRNG1
+00.00105Ar 2  85 BE                sta     STRNG2
+00.00105Cr 2  A6 BD                ldx     STRNG1+1
+00.00105Er 2  90 01                bcc     L32B6
+00.001060r 2  E8                   inx
+00.001061r 2               L32B6:
+00.001061r 2  86 BF                stx     STRNG2+1
+00.001063r 2  A5 BD                lda     STRNG1+1
+00.001065r 2               .ifdef CONFIG_NO_INPUTBUFFER_ZP
+00.001065r 2                       beq     LD399
+00.001065r 2                       cmp     #>INPUTBUFFER
+00.001065r 2               .endif
+00.001065r 2  D0 0B                bne     PUTNEW
+00.001067r 2               LD399:
+00.001067r 2  98                   tya
+00.001068r 2  20 rr rr             jsr     STRINI
+00.00106Br 2  A6 BC                ldx     STRNG1
+00.00106Dr 2  A4 BD                ldy     STRNG1+1
+00.00106Fr 2  20 rr rr             jsr     MOVSTR
+00.001072r 2               
+00.001072r 2               ; ----------------------------------------------------------------------------
+00.001072r 2               ; STORE DESCRIPTOR IN TEMPORARY DESCRIPTOR STACK
+00.001072r 2               ;
+00.001072r 2               ; THE DESCRIPTOR IS NOW IN FAC, FAC+1, FAC+2
+00.001072r 2               ; PUT ADDRESS OF TEMP DESCRIPTOR IN FAC+3,4
+00.001072r 2               ; ----------------------------------------------------------------------------
+00.001072r 2               PUTNEW:
+00.001072r 2  A6 63                ldx     TEMPPT
+00.001074r 2  E0 6F                cpx     #TEMPST+9
+00.001076r 2  D0 05                bne     PUTEMP
+00.001078r 2  A2 BF                ldx     #ERR_FRMCPX
+00.00107Ar 2               JERR:
+00.00107Ar 2  4C rr rr             jmp     ERROR
+00.00107Dr 2               PUTEMP:
+00.00107Dr 2  A5 AE                lda     FAC
+00.00107Fr 2  95 00                sta     0,x
+00.001081r 2  A5 AF                lda     FAC+1
+00.001083r 2  95 01                sta     1,x
+00.001085r 2  A5 B0                lda     FAC+2
+00.001087r 2  95 02                sta     2,x
+00.001089r 2  A0 00                ldy     #$00
+00.00108Br 2  86 B1                stx     FAC_LAST-1
+00.00108Dr 2  84 B2                sty     FAC_LAST
+00.00108Fr 2               .ifdef CONFIG_2
+00.00108Fr 2                       sty     FACEXTENSION
+00.00108Fr 2               .endif
+00.00108Fr 2  88                   dey
+00.001090r 2  84 0E                sty     VALTYP
+00.001092r 2  86 64                stx     LASTPT
+00.001094r 2  E8                   inx
+00.001095r 2  E8                   inx
+00.001096r 2  E8                   inx
+00.001097r 2  86 63                stx     TEMPPT
+00.001099r 2  60                   rts
+00.00109Ar 2               
+00.00109Ar 2               ; ----------------------------------------------------------------------------
+00.00109Ar 2               ; MAKE SPACE FOR STRING AT BOTTOM OF STRING SPACE
+00.00109Ar 2               ; (A)=# BYTES SPACE TO MAKE
+00.00109Ar 2               ;
+00.00109Ar 2               ; RETURN WITH (A) SAME,
+00.00109Ar 2               ;	AND Y,X = ADDRESS OF SPACE ALLOCATED
+00.00109Ar 2               ; ----------------------------------------------------------------------------
+00.00109Ar 2               GETSPA:
+00.00109Ar 2  46 10                lsr     DATAFLG
+00.00109Cr 2               L32F1:
+00.00109Cr 2  48                   pha
+00.00109Dr 2  49 FF                eor     #$FF
+00.00109Fr 2  38                   sec
+00.0010A0r 2  65 80                adc     FRETOP
+00.0010A2r 2  A4 81                ldy     FRETOP+1
+00.0010A4r 2  B0 01                bcs     L32FC
+00.0010A6r 2  88                   dey
+00.0010A7r 2               L32FC:
+00.0010A7r 2  C4 7F                cpy     STREND+1
+00.0010A9r 2  90 11                bcc     L3311
+00.0010ABr 2  D0 04                bne     L3306
+00.0010ADr 2  C5 7E                cmp     STREND
+00.0010AFr 2  90 0B                bcc     L3311
+00.0010B1r 2               L3306:
+00.0010B1r 2  85 80                sta     FRETOP
+00.0010B3r 2  84 81                sty     FRETOP+1
+00.0010B5r 2  85 82                sta     FRESPC
+00.0010B7r 2  84 83                sty     FRESPC+1
+00.0010B9r 2  AA                   tax
+00.0010BAr 2  68                   pla
+00.0010BBr 2  60                   rts
+00.0010BCr 2               L3311:
+00.0010BCr 2  A2 4D                ldx     #ERR_MEMFULL
+00.0010BEr 2  A5 10                lda     DATAFLG
+00.0010C0r 2  30 B8                bmi     JERR
+00.0010C2r 2  20 rr rr             jsr     GARBAG
+00.0010C5r 2  A9 80                lda     #$80
+00.0010C7r 2  85 10                sta     DATAFLG
+00.0010C9r 2  68                   pla
+00.0010CAr 2  D0 D0                bne     L32F1
+00.0010CCr 2               
+00.0010CCr 2               ; ----------------------------------------------------------------------------
+00.0010CCr 2               ; SHOVE ALL REFERENCED STRINGS AS HIGH AS POSSIBLE
+00.0010CCr 2               ; IN MEMORY (AGAINST HIMEM), FREEING UP SPACE
+00.0010CCr 2               ; BELOW STRING AREA DOWN TO STREND.
+00.0010CCr 2               ; ----------------------------------------------------------------------------
+00.0010CCr 2               GARBAG:
+00.0010CCr 2               
+00.0010CCr 2               .ifdef CONST_MEMSIZ
+00.0010CCr 2                       ldx     #<CONST_MEMSIZ
+00.0010CCr 2                       lda     #>CONST_MEMSIZ
+00.0010CCr 2               .else
+00.0010CCr 2  A6 84                ldx     MEMSIZ
+00.0010CEr 2  A5 85                lda     MEMSIZ+1
+00.0010D0r 2               .endif
+00.0010D0r 2               FINDHIGHESTSTRING:
+00.0010D0r 2  86 80                stx     FRETOP
+00.0010D2r 2  85 81                sta     FRETOP+1
+00.0010D4r 2  A0 00                ldy     #$00
+00.0010D6r 2  84 9C                sty     FNCNAM+1
+00.0010D8r 2               .ifdef CONFIG_2
+00.0010D8r 2                       sty     FNCNAM	; GC bugfix!
+00.0010D8r 2               .endif
+00.0010D8r 2  A5 7E                lda     STREND
+00.0010DAr 2  A6 7F                ldx     STREND+1
+00.0010DCr 2  85 AC                sta     LOWTR
+00.0010DEr 2  86 AD                stx     LOWTR+1
+00.0010E0r 2  A9 66                lda     #TEMPST
+00.0010E2r 2  A2 00                ldx     #$00
+00.0010E4r 2  85 6F                sta     INDEX
+00.0010E6r 2  86 70                stx     INDEX+1
+00.0010E8r 2               L333D:
+00.0010E8r 2  C5 63                cmp     TEMPPT
+00.0010EAr 2  F0 05                beq     L3346
+00.0010ECr 2  20 rr rr             jsr     CHECK_VARIABLE
+00.0010EFr 2  F0 F7                beq     L333D
+00.0010F1r 2               L3346:
+00.0010F1r 2  A9 07                lda     #BYTES_PER_VARIABLE
+00.0010F3r 2  85 A0                sta     DSCLEN
+00.0010F5r 2  A5 7A                lda     VARTAB
+00.0010F7r 2  A6 7B                ldx     VARTAB+1
+00.0010F9r 2  85 6F                sta     INDEX
+00.0010FBr 2  86 70                stx     INDEX+1
+00.0010FDr 2               L3352:
+00.0010FDr 2  E4 7D                cpx     ARYTAB+1
+00.0010FFr 2  D0 04                bne     L335A
+00.001101r 2  C5 7C                cmp     ARYTAB
+00.001103r 2  F0 05                beq     L335F
+00.001105r 2               L335A:
+00.001105r 2  20 rr rr             jsr     CHECK_SIMPLE_VARIABLE
+00.001108r 2  F0 F3                beq     L3352
+00.00110Ar 2               L335F:
+00.00110Ar 2  85 A5                sta     HIGHDS
+00.00110Cr 2  86 A6                stx     HIGHDS+1
+00.00110Er 2  A9 03                lda     #$03	; OSI GC bugfix -> $04 ???
+00.001110r 2  85 A0                sta     DSCLEN
+00.001112r 2               L3367:
+00.001112r 2  A5 A5                lda     HIGHDS
+00.001114r 2  A6 A6                ldx     HIGHDS+1
+00.001116r 2               L336B:
+00.001116r 2  E4 7F                cpx     STREND+1
+00.001118r 2  D0 07                bne     L3376
+00.00111Ar 2  C5 7E                cmp     STREND
+00.00111Cr 2  D0 03                bne     L3376
+00.00111Er 2  4C rr rr             jmp     MOVE_HIGHEST_STRING_TO_TOP
+00.001121r 2               L3376:
+00.001121r 2  85 6F                sta     INDEX
+00.001123r 2  86 70                stx     INDEX+1
+00.001125r 2               .ifdef CONFIG_SMALL
+00.001125r 2                       ldy     #$01
+00.001125r 2               .else
+00.001125r 2  A0 00                ldy     #$00
+00.001127r 2  B1 6F                lda     (INDEX),y
+00.001129r 2  AA                   tax
+00.00112Ar 2  C8                   iny
+00.00112Br 2               .endif
+00.00112Br 2  B1 6F                lda     (INDEX),y
+00.00112Dr 2  08                   php
+00.00112Er 2  C8                   iny
+00.00112Fr 2  B1 6F                lda     (INDEX),y
+00.001131r 2  65 A5                adc     HIGHDS
+00.001133r 2  85 A5                sta     HIGHDS
+00.001135r 2  C8                   iny
+00.001136r 2  B1 6F                lda     (INDEX),y
+00.001138r 2  65 A6                adc     HIGHDS+1
+00.00113Ar 2  85 A6                sta     HIGHDS+1
+00.00113Cr 2  28                   plp
+00.00113Dr 2  10 D3                bpl     L3367
+00.00113Fr 2               .ifndef CONFIG_SMALL
+00.00113Fr 2  8A                   txa
+00.001140r 2  30 D0                bmi     L3367
+00.001142r 2               .endif
+00.001142r 2  C8                   iny
+00.001143r 2  B1 6F                lda     (INDEX),y
+00.001145r 2               .ifdef CONFIG_CBM1_PATCHES
+00.001145r 2                       jsr     LE7F3 ; XXX patch, call into screen editor
+00.001145r 2               .else
+00.001145r 2                 .ifdef CONFIG_11
+00.001145r 2  A0 00                ldy     #$00	; GC bugfix
+00.001147r 2                 .endif
+00.001147r 2  0A                   asl     a
+00.001148r 2  69 05                adc     #$05
+00.00114Ar 2               .endif
+00.00114Ar 2  65 6F                adc     INDEX
+00.00114Cr 2  85 6F                sta     INDEX
+00.00114Er 2  90 02                bcc     L33A7
+00.001150r 2  E6 70                inc     INDEX+1
+00.001152r 2               L33A7:
+00.001152r 2  A6 70                ldx     INDEX+1
+00.001154r 2               L33A9:
+00.001154r 2  E4 A6                cpx     HIGHDS+1
+00.001156r 2  D0 04                bne     L33B1
+00.001158r 2  C5 A5                cmp     HIGHDS
+00.00115Ar 2  F0 BA                beq     L336B
+00.00115Cr 2               L33B1:
+00.00115Cr 2  20 rr rr             jsr     CHECK_VARIABLE
+00.00115Fr 2  F0 F3                beq     L33A9
+00.001161r 2               
+00.001161r 2               ; ----------------------------------------------------------------------------
+00.001161r 2               ; PROCESS A SIMPLE VARIABLE
+00.001161r 2               ; ----------------------------------------------------------------------------
+00.001161r 2               CHECK_SIMPLE_VARIABLE:
+00.001161r 2               .ifndef CONFIG_SMALL
+00.001161r 2  B1 6F                lda     (INDEX),y
+00.001163r 2  30 35                bmi     CHECK_BUMP
+00.001165r 2               .endif
+00.001165r 2  C8                   iny
+00.001166r 2  B1 6F                lda     (INDEX),y
+00.001168r 2  10 30                bpl     CHECK_BUMP
+00.00116Ar 2  C8                   iny
+00.00116Br 2               
+00.00116Br 2               ; ----------------------------------------------------------------------------
+00.00116Br 2               ; IF STRING IS NOT EMPTY, CHECK IF IT IS HIGHEST
+00.00116Br 2               ; ----------------------------------------------------------------------------
+00.00116Br 2               CHECK_VARIABLE:
+00.00116Br 2  B1 6F                lda     (INDEX),y
+00.00116Dr 2  F0 2B                beq     CHECK_BUMP
+00.00116Fr 2  C8                   iny
+00.001170r 2  B1 6F                lda     (INDEX),y
+00.001172r 2  AA                   tax
+00.001173r 2  C8                   iny
+00.001174r 2  B1 6F                lda     (INDEX),y
+00.001176r 2  C5 81                cmp     FRETOP+1
+00.001178r 2  90 06                bcc     L33D5
+00.00117Ar 2  D0 1E                bne     CHECK_BUMP
+00.00117Cr 2  E4 80                cpx     FRETOP
+00.00117Er 2  B0 1A                bcs     CHECK_BUMP
+00.001180r 2               L33D5:
+00.001180r 2  C5 AD                cmp     LOWTR+1
+00.001182r 2  90 16                bcc     CHECK_BUMP
+00.001184r 2  D0 04                bne     L33DF
+00.001186r 2  E4 AC                cpx     LOWTR
+00.001188r 2  90 10                bcc     CHECK_BUMP
+00.00118Ar 2               L33DF:
+00.00118Ar 2  86 AC                stx     LOWTR
+00.00118Cr 2  85 AD                sta     LOWTR+1
+00.00118Er 2  A5 6F                lda     INDEX
+00.001190r 2  A6 70                ldx     INDEX+1
+00.001192r 2  85 9B                sta     FNCNAM
+00.001194r 2  86 9C                stx     FNCNAM+1
+00.001196r 2  A5 A0                lda     DSCLEN
+00.001198r 2  85 A2                sta     Z52
+00.00119Ar 2               
+00.00119Ar 2               ; ----------------------------------------------------------------------------
+00.00119Ar 2               ; ADD (DSCLEN) TO PNTR IN INDEX
+00.00119Ar 2               ; RETURN WITH Y=0, PNTR ALSO IN X,A
+00.00119Ar 2               ; ----------------------------------------------------------------------------
+00.00119Ar 2               CHECK_BUMP:
+00.00119Ar 2  A5 A0                lda     DSCLEN
+00.00119Cr 2  18                   clc
+00.00119Dr 2  65 6F                adc     INDEX
+00.00119Fr 2  85 6F                sta     INDEX
+00.0011A1r 2  90 02                bcc     L33FA
+00.0011A3r 2  E6 70                inc     INDEX+1
+00.0011A5r 2               L33FA:
+00.0011A5r 2  A6 70                ldx     INDEX+1
+00.0011A7r 2  A0 00                ldy     #$00
+00.0011A9r 2  60                   rts
+00.0011AAr 2               
+00.0011AAr 2               ; ----------------------------------------------------------------------------
+00.0011AAr 2               ; FOUND HIGHEST NON-EMPTY STRING, SO MOVE IT
+00.0011AAr 2               ; TO TOP AND GO BACK FOR ANOTHER
+00.0011AAr 2               ; ----------------------------------------------------------------------------
+00.0011AAr 2               MOVE_HIGHEST_STRING_TO_TOP:
+00.0011AAr 2               .ifdef CONFIG_2
+00.0011AAr 2                       lda     FNCNAM+1	; GC bugfix
+00.0011AAr 2                       ora     FNCNAM
+00.0011AAr 2               .else
+00.0011AAr 2  A6 9C                ldx     FNCNAM+1
+00.0011ACr 2               .endif
+00.0011ACr 2  F0 F7                beq     L33FA
+00.0011AEr 2  A5 A2                lda     Z52
+00.0011B0r 2               .ifndef CONFIG_10A
+00.0011B0r 2                       sbc     #$03
+00.0011B0r 2               .else
+00.0011B0r 2  29 04                and     #$04
+00.0011B2r 2               .endif
+00.0011B2r 2  4A                   lsr     a
+00.0011B3r 2  A8                   tay
+00.0011B4r 2  85 A2                sta     Z52
+00.0011B6r 2  B1 9B                lda     (FNCNAM),y
+00.0011B8r 2  65 AC                adc     LOWTR
+00.0011BAr 2  85 A7                sta     HIGHTR
+00.0011BCr 2  A5 AD                lda     LOWTR+1
+00.0011BEr 2  69 00                adc     #$00
+00.0011C0r 2  85 A8                sta     HIGHTR+1
+00.0011C2r 2  A5 80                lda     FRETOP
+00.0011C4r 2  A6 81                ldx     FRETOP+1
+00.0011C6r 2  85 A5                sta     HIGHDS
+00.0011C8r 2  86 A6                stx     HIGHDS+1
+00.0011CAr 2  20 rr rr             jsr     BLTU2
+00.0011CDr 2  A4 A2                ldy     Z52
+00.0011CFr 2  C8                   iny
+00.0011D0r 2  A5 A5                lda     HIGHDS
+00.0011D2r 2  91 9B                sta     (FNCNAM),y
+00.0011D4r 2  AA                   tax
+00.0011D5r 2  E6 A6                inc     HIGHDS+1
+00.0011D7r 2  A5 A6                lda     HIGHDS+1
+00.0011D9r 2  C8                   iny
+00.0011DAr 2  91 9B                sta     (FNCNAM),y
+00.0011DCr 2  4C rr rr             jmp     FINDHIGHESTSTRING
+00.0011DFr 2               
+00.0011DFr 2               ; ----------------------------------------------------------------------------
+00.0011DFr 2               ; CONCATENATE TWO STRINGS
+00.0011DFr 2               ; ----------------------------------------------------------------------------
+00.0011DFr 2               CAT:
+00.0011DFr 2  A5 B2                lda     FAC_LAST
+00.0011E1r 2  48                   pha
+00.0011E2r 2  A5 B1                lda     FAC_LAST-1
+00.0011E4r 2  48                   pha
+00.0011E5r 2  20 rr rr             jsr     FRM_ELEMENT
+00.0011E8r 2  20 rr rr             jsr     CHKSTR
+00.0011EBr 2  68                   pla
+00.0011ECr 2  85 BC                sta     STRNG1
+00.0011EEr 2  68                   pla
+00.0011EFr 2  85 BD                sta     STRNG1+1
+00.0011F1r 2  A0 00                ldy     #$00
+00.0011F3r 2  B1 BC                lda     (STRNG1),y
+00.0011F5r 2  18                   clc
+00.0011F6r 2  71 B1                adc     (FAC_LAST-1),y
+00.0011F8r 2  90 05                bcc     L3454
+00.0011FAr 2  A2 B0                ldx     #ERR_STRLONG
+00.0011FCr 2  4C rr rr             jmp     ERROR
+00.0011FFr 2               L3454:
+00.0011FFr 2  20 rr rr             jsr     STRINI
+00.001202r 2  20 rr rr             jsr     MOVINS
+00.001205r 2  A5 9D                lda     DSCPTR
+00.001207r 2  A4 9E                ldy     DSCPTR+1
+00.001209r 2  20 rr rr             jsr     FRETMP
+00.00120Cr 2  20 rr rr             jsr     MOVSTR1
+00.00120Fr 2  A5 BC                lda     STRNG1
+00.001211r 2  A4 BD                ldy     STRNG1+1
+00.001213r 2  20 rr rr             jsr     FRETMP
+00.001216r 2  20 rr rr             jsr     PUTNEW
+00.001219r 2  4C rr rr             jmp     FRMEVL2
+00.00121Cr 2               
+00.00121Cr 2               ; ----------------------------------------------------------------------------
+00.00121Cr 2               ; GET STRING DESCRIPTOR POINTED AT BY (STRNG1)
+00.00121Cr 2               ; AND MOVE DESCRIBED STRING TO (FRESPC)
+00.00121Cr 2               ; ----------------------------------------------------------------------------
+00.00121Cr 2               MOVINS:
+00.00121Cr 2  A0 00                ldy     #$00
+00.00121Er 2  B1 BC                lda     (STRNG1),y
+00.001220r 2  48                   pha
+00.001221r 2  C8                   iny
+00.001222r 2  B1 BC                lda     (STRNG1),y
+00.001224r 2  AA                   tax
+00.001225r 2  C8                   iny
+00.001226r 2  B1 BC                lda     (STRNG1),y
+00.001228r 2  A8                   tay
+00.001229r 2  68                   pla
+00.00122Ar 2               
+00.00122Ar 2               ; ----------------------------------------------------------------------------
+00.00122Ar 2               ; MOVE STRING AT (Y,X) WITH LENGTH (A)
+00.00122Ar 2               ; TO DESTINATION WHOSE ADDRESS IS IN FRESPC,FRESPC+1
+00.00122Ar 2               ; ----------------------------------------------------------------------------
+00.00122Ar 2               MOVSTR:
+00.00122Ar 2  86 6F                stx     INDEX
+00.00122Cr 2  84 70                sty     INDEX+1
+00.00122Er 2               MOVSTR1:
+00.00122Er 2  A8                   tay
+00.00122Fr 2  F0 0A                beq     L3490
+00.001231r 2  48                   pha
+00.001232r 2               L3487:
+00.001232r 2  88                   dey
+00.001233r 2  B1 6F                lda     (INDEX),y
+00.001235r 2  91 82                sta     (FRESPC),y
+00.001237r 2  98                   tya
+00.001238r 2  D0 F8                bne     L3487
+00.00123Ar 2  68                   pla
+00.00123Br 2               L3490:
+00.00123Br 2  18                   clc
+00.00123Cr 2  65 82                adc     FRESPC
+00.00123Er 2  85 82                sta     FRESPC
+00.001240r 2  90 02                bcc     L3499
+00.001242r 2  E6 83                inc     FRESPC+1
+00.001244r 2               L3499:
+00.001244r 2  60                   rts
+00.001245r 2               
+00.001245r 2               ; ----------------------------------------------------------------------------
+00.001245r 2               ; IF (FAC) IS A TEMPORARY STRING, RELEASE DESCRIPTOR
+00.001245r 2               ; ----------------------------------------------------------------------------
+00.001245r 2               FRESTR:
+00.001245r 2  20 rr rr             jsr     CHKSTR
+00.001248r 2               
+00.001248r 2               ; ----------------------------------------------------------------------------
+00.001248r 2               ; IF STRING DESCRIPTOR POINTED TO BY FAC+3,4 IS
+00.001248r 2               ; A TEMPORARY STRING, RELEASE IT.
+00.001248r 2               ; ----------------------------------------------------------------------------
+00.001248r 2               FREFAC:
+00.001248r 2  A5 B1                lda     FAC_LAST-1
+00.00124Ar 2  A4 B2                ldy     FAC_LAST
+00.00124Cr 2               
+00.00124Cr 2               ; ----------------------------------------------------------------------------
+00.00124Cr 2               ; IF STRING DESCRIPTOR WHOSE ADDRESS IS IN Y,A IS
+00.00124Cr 2               ; A TEMPORARY STRING, RELEASE IT.
+00.00124Cr 2               ; ----------------------------------------------------------------------------
+00.00124Cr 2               FRETMP:
+00.00124Cr 2  85 6F                sta     INDEX
+00.00124Er 2  84 70                sty     INDEX+1
+00.001250r 2  20 rr rr             jsr     FRETMS
+00.001253r 2  08                   php
+00.001254r 2  A0 00                ldy     #$00
+00.001256r 2  B1 6F                lda     (INDEX),y
+00.001258r 2  48                   pha
+00.001259r 2  C8                   iny
+00.00125Ar 2  B1 6F                lda     (INDEX),y
+00.00125Cr 2  AA                   tax
+00.00125Dr 2  C8                   iny
+00.00125Er 2  B1 6F                lda     (INDEX),y
+00.001260r 2  A8                   tay
+00.001261r 2  68                   pla
+00.001262r 2  28                   plp
+00.001263r 2  D0 13                bne     L34CD
+00.001265r 2  C4 81                cpy     FRETOP+1
+00.001267r 2  D0 0F                bne     L34CD
+00.001269r 2  E4 80                cpx     FRETOP
+00.00126Br 2  D0 0B                bne     L34CD
+00.00126Dr 2  48                   pha
+00.00126Er 2  18                   clc
+00.00126Fr 2  65 80                adc     FRETOP
+00.001271r 2  85 80                sta     FRETOP
+00.001273r 2  90 02                bcc     L34CC
+00.001275r 2  E6 81                inc     FRETOP+1
+00.001277r 2               L34CC:
+00.001277r 2  68                   pla
+00.001278r 2               L34CD:
+00.001278r 2  86 6F                stx     INDEX
+00.00127Ar 2  84 70                sty     INDEX+1
+00.00127Cr 2  60                   rts
+00.00127Dr 2               
+00.00127Dr 2               ; ----------------------------------------------------------------------------
+00.00127Dr 2               ; RELEASE TEMPORARY DESCRIPTOR IF Y,A = LASTPT
+00.00127Dr 2               ; ----------------------------------------------------------------------------
+00.00127Dr 2               FRETMS:
+00.00127Dr 2               .ifdef KBD
+00.00127Dr 2                       cpy     #$00
+00.00127Dr 2               .else
+00.00127Dr 2  C4 65                cpy     LASTPT+1
+00.00127Fr 2               .endif
+00.00127Fr 2  D0 0C                bne     L34E2
+00.001281r 2  C5 64                cmp     LASTPT
+00.001283r 2  D0 08                bne     L34E2
+00.001285r 2  85 63                sta     TEMPPT
+00.001287r 2  E9 03                sbc     #$03
+00.001289r 2  85 64                sta     LASTPT
+00.00128Br 2  A0 00                ldy     #$00
+00.00128Dr 2               L34E2:
+00.00128Dr 2  60                   rts
+00.00128Er 2               
+00.00128Er 2               ; ----------------------------------------------------------------------------
+00.00128Er 2               ; "CHR$" FUNCTION
+00.00128Er 2               ; ----------------------------------------------------------------------------
+00.00128Er 2               CHRSTR:
+00.00128Er 2  20 rr rr             jsr     CONINT
+00.001291r 2  8A                   txa
+00.001292r 2  48                   pha
+00.001293r 2  A9 01                lda     #$01
+00.001295r 2  20 rr rr             jsr     STRSPA
+00.001298r 2  68                   pla
+00.001299r 2  A0 00                ldy     #$00
+00.00129Br 2  91 AF                sta     (FAC+1),y
+00.00129Dr 2  68                   pla
+00.00129Er 2  68                   pla
+00.00129Fr 2  4C rr rr             jmp     PUTNEW
+00.0012A2r 2               
+00.0012A2r 2               ; ----------------------------------------------------------------------------
+00.0012A2r 2               ; "LEFT$" FUNCTION
+00.0012A2r 2               ; ----------------------------------------------------------------------------
+00.0012A2r 2               LEFTSTR:
+00.0012A2r 2  20 rr rr             jsr     SUBSTRING_SETUP
+00.0012A5r 2  D1 9D                cmp     (DSCPTR),y
+00.0012A7r 2  98                   tya
+00.0012A8r 2               SUBSTRING1:
+00.0012A8r 2  90 04                bcc     L3503
+00.0012AAr 2  B1 9D                lda     (DSCPTR),y
+00.0012ACr 2  AA                   tax
+00.0012ADr 2  98                   tya
+00.0012AEr 2               L3503:
+00.0012AEr 2  48                   pha
+00.0012AFr 2               SUBSTRING2:
+00.0012AFr 2  8A                   txa
+00.0012B0r 2               SUBSTRING3:
+00.0012B0r 2  48                   pha
+00.0012B1r 2  20 rr rr             jsr     STRSPA
+00.0012B4r 2  A5 9D                lda     DSCPTR
+00.0012B6r 2  A4 9E                ldy     DSCPTR+1
+00.0012B8r 2  20 rr rr             jsr     FRETMP
+00.0012BBr 2  68                   pla
+00.0012BCr 2  A8                   tay
+00.0012BDr 2  68                   pla
+00.0012BEr 2  18                   clc
+00.0012BFr 2  65 6F                adc     INDEX
+00.0012C1r 2  85 6F                sta     INDEX
+00.0012C3r 2  90 02                bcc     L351C
+00.0012C5r 2  E6 70                inc     INDEX+1
+00.0012C7r 2               L351C:
+00.0012C7r 2  98                   tya
+00.0012C8r 2  20 rr rr             jsr     MOVSTR1
+00.0012CBr 2  4C rr rr             jmp     PUTNEW
+00.0012CEr 2               
+00.0012CEr 2               ; ----------------------------------------------------------------------------
+00.0012CEr 2               ; "RIGHT$" FUNCTION
+00.0012CEr 2               ; ----------------------------------------------------------------------------
+00.0012CEr 2               RIGHTSTR:
+00.0012CEr 2  20 rr rr             jsr     SUBSTRING_SETUP
+00.0012D1r 2  18                   clc
+00.0012D2r 2  F1 9D                sbc     (DSCPTR),y
+00.0012D4r 2  49 FF                eor     #$FF
+00.0012D6r 2  4C rr rr             jmp     SUBSTRING1
+00.0012D9r 2               
+00.0012D9r 2               ; ----------------------------------------------------------------------------
+00.0012D9r 2               ; "MID$" FUNCTION
+00.0012D9r 2               ; ----------------------------------------------------------------------------
+00.0012D9r 2               MIDSTR:
+00.0012D9r 2  A9 FF                lda     #$FF
+00.0012DBr 2  85 B2                sta     FAC_LAST
+00.0012DDr 2  20 C6 00             jsr     CHRGOT
+00.0012E0r 2  C9 29                cmp     #$29
+00.0012E2r 2  F0 06                beq     L353F
+00.0012E4r 2  20 rr rr             jsr     CHKCOM
+00.0012E7r 2  20 rr rr             jsr     GETBYT
+00.0012EAr 2               L353F:
+00.0012EAr 2  20 rr rr             jsr     SUBSTRING_SETUP
+00.0012EDr 2               .ifdef CONFIG_2
+00.0012EDr 2                       beq     GOIQ
+00.0012EDr 2               .endif
+00.0012EDr 2  CA                   dex
+00.0012EEr 2  8A                   txa
+00.0012EFr 2  48                   pha
+00.0012F0r 2  18                   clc
+00.0012F1r 2  A2 00                ldx     #$00
+00.0012F3r 2  F1 9D                sbc     (DSCPTR),y
+00.0012F5r 2  B0 B8                bcs     SUBSTRING2
+00.0012F7r 2  49 FF                eor     #$FF
+00.0012F9r 2  C5 B2                cmp     FAC_LAST
+00.0012FBr 2  90 B3                bcc     SUBSTRING3
+00.0012FDr 2  A5 B2                lda     FAC_LAST
+00.0012FFr 2  B0 AF                bcs     SUBSTRING3
+00.001301r 2               
+00.001301r 2               ; ----------------------------------------------------------------------------
+00.001301r 2               ; COMMON SETUP ROUTINE FOR LEFT$, RIGHT$, MID$:
+00.001301r 2               ; REQUIRE ")"; POP RETURN ADRS, GET DESCRIPTOR
+00.001301r 2               ; ADDRESS, GET 1ST PARAMETER OF COMMAND
+00.001301r 2               ; ----------------------------------------------------------------------------
+00.001301r 2               SUBSTRING_SETUP:
+00.001301r 2  20 rr rr             jsr     CHKCLS
+00.001304r 2  68                   pla
+00.001305r 2               .ifndef CONFIG_11
+00.001305r 2                       sta     JMPADRS+1
+00.001305r 2                       pla
+00.001305r 2                       sta     JMPADRS+2
+00.001305r 2               .else
+00.001305r 2  A8                   tay
+00.001306r 2  68                   pla
+00.001307r 2  85 A2                sta     Z52
+00.001309r 2               .endif
+00.001309r 2  68                   pla
+00.00130Ar 2  68                   pla
+00.00130Br 2  68                   pla
+00.00130Cr 2  AA                   tax
+00.00130Dr 2  68                   pla
+00.00130Er 2  85 9D                sta     DSCPTR
+00.001310r 2  68                   pla
+00.001311r 2  85 9E                sta     DSCPTR+1
+00.001313r 2               .ifdef CONFIG_11
+00.001313r 2  A5 A2                lda     Z52
+00.001315r 2  48                   pha
+00.001316r 2  98                   tya
+00.001317r 2  48                   pha
+00.001318r 2               .endif
+00.001318r 2  A0 00                ldy     #$00
+00.00131Ar 2  8A                   txa
+00.00131Br 2               .ifndef CONFIG_2
+00.00131Br 2  F0 1D                beq     GOIQ
+00.00131Dr 2               .endif
+00.00131Dr 2               .ifndef CONFIG_11
+00.00131Dr 2                       inc     JMPADRS+1
+00.00131Dr 2                       jmp     (JMPADRS+1)
+00.00131Dr 2               .else
+00.00131Dr 2  60                   rts
+00.00131Er 2               .endif
+00.00131Er 2               
+00.00131Er 2               ; ----------------------------------------------------------------------------
+00.00131Er 2               ; "LEN" FUNCTION
+00.00131Er 2               ; ----------------------------------------------------------------------------
+00.00131Er 2               LEN:
+00.00131Er 2  20 rr rr             jsr     GETSTR
+00.001321r 2               SNGFLT1:
+00.001321r 2  4C rr rr             jmp     SNGFLT
+00.001324r 2               
+00.001324r 2               ; ----------------------------------------------------------------------------
+00.001324r 2               ; IF LAST RESULT IS A TEMPORARY STRING, FREE IT
+00.001324r 2               ; MAKE VALTYP NUMERIC, RETURN LENGTH IN Y-REG
+00.001324r 2               ; ----------------------------------------------------------------------------
+00.001324r 2               GETSTR:
+00.001324r 2  20 rr rr             jsr     FRESTR
+00.001327r 2  A2 00                ldx     #$00
+00.001329r 2  86 0E                stx     VALTYP
+00.00132Br 2  A8                   tay
+00.00132Cr 2  60                   rts
+00.00132Dr 2               
+00.00132Dr 2               ; ----------------------------------------------------------------------------
+00.00132Dr 2               ; "ASC" FUNCTION
+00.00132Dr 2               ; ----------------------------------------------------------------------------
+00.00132Dr 2               ASC:
+00.00132Dr 2  20 rr rr             jsr     GETSTR
+00.001330r 2  F0 08                beq     GOIQ
+00.001332r 2  A0 00                ldy     #$00
+00.001334r 2  B1 6F                lda     (INDEX),y
+00.001336r 2  A8                   tay
+00.001337r 2               .ifndef CONFIG_11A
+00.001337r 2                       jmp     SNGFLT1
+00.001337r 2               .else
+00.001337r 2  4C rr rr             jmp     SNGFLT
+00.00133Ar 2               .endif
+00.00133Ar 2               ; ----------------------------------------------------------------------------
+00.00133Ar 2               GOIQ:
+00.00133Ar 2  4C rr rr             jmp     IQERR
+00.00133Dr 2               
+00.00133Dr 2               ; ----------------------------------------------------------------------------
+00.00133Dr 2               ; SCAN TO NEXT CHARACTER AND CONVERT EXPRESSION
+00.00133Dr 2               ; TO SINGLE BYTE IN X-REG
+00.00133Dr 2               ; ----------------------------------------------------------------------------
+00.00133Dr 2               GTBYTC:
+00.00133Dr 2  20 C0 00             jsr     CHRGET
+00.001340r 2               
+00.001340r 2               ; ----------------------------------------------------------------------------
+00.001340r 2               ; EVALUATE EXPRESSION AT TXTPTR, AND
+00.001340r 2               ; CONVERT IT TO SINGLE BYTE IN X-REG
+00.001340r 2               ; ----------------------------------------------------------------------------
+00.001340r 2               GETBYT:
+00.001340r 2  20 rr rr             jsr     FRMNUM
+00.001343r 2               
+00.001343r 2               ; ----------------------------------------------------------------------------
+00.001343r 2               ; CONVERT (FAC) TO SINGLE BYTE INTEGER IN X-REG
+00.001343r 2               ; ----------------------------------------------------------------------------
+00.001343r 2               CONINT:
+00.001343r 2  20 rr rr             jsr     MKINT
+00.001346r 2  A6 B1                ldx     FAC_LAST-1
+00.001348r 2  D0 F0                bne     GOIQ
+00.00134Ar 2  A6 B2                ldx     FAC_LAST
+00.00134Cr 2  4C C6 00             jmp     CHRGOT
+00.00134Fr 2               
+00.00134Fr 2               ; ----------------------------------------------------------------------------
+00.00134Fr 2               ; "VAL" FUNCTION
+00.00134Fr 2               ; ----------------------------------------------------------------------------
+00.00134Fr 2               VAL:
+00.00134Fr 2  20 rr rr             jsr     GETSTR
+00.001352r 2  D0 03                bne     L35AC
+00.001354r 2  4C rr rr             jmp     ZERO_FAC
+00.001357r 2               L35AC:
+00.001357r 2  A6 C7                ldx     TXTPTR
+00.001359r 2  A4 C8                ldy     TXTPTR+1
+00.00135Br 2  86 BE                stx     STRNG2
+00.00135Dr 2  84 BF                sty     STRNG2+1
+00.00135Fr 2  A6 6F                ldx     INDEX
+00.001361r 2  86 C7                stx     TXTPTR
+00.001363r 2  18                   clc
+00.001364r 2  65 6F                adc     INDEX
+00.001366r 2  85 71                sta     DEST
+00.001368r 2  A6 70                ldx     INDEX+1
+00.00136Ar 2  86 C8                stx     TXTPTR+1
+00.00136Cr 2  90 01                bcc     L35C4
+00.00136Er 2  E8                   inx
+00.00136Fr 2               L35C4:
+00.00136Fr 2  86 72                stx     DEST+1
+00.001371r 2  A0 00                ldy     #$00
+00.001373r 2  B1 71                lda     (DEST),y
+00.001375r 2  48                   pha
+00.001376r 2  A9 00                lda     #$00
+00.001378r 2  91 71                sta     (DEST),y
+00.00137Ar 2  20 C6 00             jsr     CHRGOT
+00.00137Dr 2  20 rr rr             jsr     FIN
+00.001380r 2  68                   pla
+00.001381r 2  A0 00                ldy     #$00
+00.001383r 2  91 71                sta     (DEST),y
+00.001385r 2               
+00.001385r 2               ; ----------------------------------------------------------------------------
+00.001385r 2               ; COPY STRNG2 INTO TXTPTR
+00.001385r 2               ; ----------------------------------------------------------------------------
+00.001385r 2               POINT:
+00.001385r 2  A6 BE                ldx     STRNG2
+00.001387r 2  A4 BF                ldy     STRNG2+1
+00.001389r 2  86 C7                stx     TXTPTR
+00.00138Br 2  84 C8                sty     TXTPTR+1
+00.00138Dr 2  60                   rts
+00.00138Er 2               
+00.00138Er 2               
+00.00138Er 1               .include "misc3.s"
+00.00138Er 2               ; KBD specific patches
+00.00138Er 2               
+00.00138Er 2               .segment "CODE"
+00.00138Er 2               
+00.00138Er 2               .ifdef KBD
+00.00138Er 2               VARTAB_MINUS_2_TO_AY:
+00.00138Er 2                       lda     VARTAB
+00.00138Er 2                       sec
+00.00138Er 2                       sbc     #$02
+00.00138Er 2                       ldy     VARTAB+1
+00.00138Er 2                       bcs     LF42C
+00.00138Er 2                       dey
+00.00138Er 2               LF42C:
+00.00138Er 2                       rts
+00.00138Er 2               
+00.00138Er 2               ; ----------------------------------------------------------------------------
+00.00138Er 2               GET_UPPER:
+00.00138Er 2                       lda     INPUTBUFFERX,x
+00.00138Er 2               LF430:
+00.00138Er 2                       cmp     #'a'
+00.00138Er 2                       bcc     LF43A
+00.00138Er 2                       cmp     #'z'+1
+00.00138Er 2                       bcs     LF43A
+00.00138Er 2               LF438:
+00.00138Er 2                       sbc     #$1F
+00.00138Er 2               LF43A:
+00.00138Er 2                       rts
+00.00138Er 2               
+00.00138Er 2               ; ----------------------------------------------------------------------------
+00.00138Er 2               GETLN:
+00.00138Er 2                       ldx     #$5D
+00.00138Er 2               LF43D:
+00.00138Er 2                       txa
+00.00138Er 2                       and     #$7F
+00.00138Er 2                       cmp     $0340
+00.00138Er 2                       beq     LF44D
+00.00138Er 2                       sta     $0340
+00.00138Er 2                       lda     #$03
+00.00138Er 2                       jsr     LDE48
+00.00138Er 2               LF44D:
+00.00138Er 2                       jsr     LDE7F
+00.00138Er 2                       bne     RTS4
+00.00138Er 2                       cpx     #$80
+00.00138Er 2                       bcc     LF44D
+00.00138Er 2               RTS4:
+00.00138Er 2                       rts
+00.00138Er 2               
+00.00138Er 2               ; ----------------------------------------------------------------------------
+00.00138Er 2               LF457:
+00.00138Er 2                       lda     TXTTAB
+00.00138Er 2                       ldx     TXTTAB+1
+00.00138Er 2               LF45B:
+00.00138Er 2                       sta     JMPADRS+1
+00.00138Er 2                       stx     JMPADRS+2
+00.00138Er 2                       ldy     #$01
+00.00138Er 2                       lda     (JMPADRS+1),y
+00.00138Er 2                       beq     LF438
+00.00138Er 2                       iny
+00.00138Er 2                       iny
+00.00138Er 2                       lda     (JMPADRS+1),y
+00.00138Er 2                       dey
+00.00138Er 2                       cmp     LINNUM+1
+00.00138Er 2                       bne     LF472
+00.00138Er 2                       lda     (JMPADRS+1),y
+00.00138Er 2                       cmp     LINNUM
+00.00138Er 2               LF472:
+00.00138Er 2                       bcs     LF43A
+00.00138Er 2                       dey
+00.00138Er 2                       lda     (JMPADRS+1),y
+00.00138Er 2                       tax
+00.00138Er 2                       dey
+00.00138Er 2                       lda     (JMPADRS+1),y
+00.00138Er 2                       bcc     LF45B
+00.00138Er 2               LF47D:
+00.00138Er 2                       jmp     (JMPADRS+1)
+00.00138Er 2               .endif
+00.00138Er 2               
+00.00138Er 1               .include "poke.s"
+00.00138Er 2               .segment "CODE"
+00.00138Er 2               
+00.00138Er 2               .ifndef CONFIG_NO_POKE
+00.00138Er 2               ; ----------------------------------------------------------------------------
+00.00138Er 2               ; EVALUATE "EXP1,EXP2"
+00.00138Er 2               ;
+00.00138Er 2               ; CONVERT EXP1 TO 16-BIT NUMBER IN LINNUM
+00.00138Er 2               ; CONVERT EXP2 TO 8-BIT NUMBER IN X-REG
+00.00138Er 2               ; ----------------------------------------------------------------------------
+00.00138Er 2               GTNUM:
+00.00138Er 2  20 rr rr             jsr     FRMNUM
+00.001391r 2  20 rr rr             jsr     GETADR
+00.001394r 2               
+00.001394r 2               ; ----------------------------------------------------------------------------
+00.001394r 2               ; EVALUATE ",EXPRESSION"
+00.001394r 2               ; CONVERT EXPRESSION TO SINGLE BYTE IN X-REG
+00.001394r 2               ; ----------------------------------------------------------------------------
+00.001394r 2               COMBYTE:
+00.001394r 2  20 rr rr             jsr     CHKCOM
+00.001397r 2  4C rr rr             jmp     GETBYT
+00.00139Ar 2               
+00.00139Ar 2               ; ----------------------------------------------------------------------------
+00.00139Ar 2               ; CONVERT (FAC) TO A 16-BIT VALUE IN LINNUM
+00.00139Ar 2               ; ----------------------------------------------------------------------------
+00.00139Ar 2               GETADR:
+00.00139Ar 2  A5 B3                lda     FACSIGN
+00.00139Cr 2                 .ifdef APPLE
+00.00139Cr 2                       nop ; PATCH
+00.00139Cr 2                       nop
+00.00139Cr 2                 .else
+00.00139Cr 2  30 9C                bmi     GOIQ
+00.00139Er 2                 .endif
+00.00139Er 2  A5 AE                lda     FAC
+00.0013A0r 2  C9 91                cmp     #$91
+00.0013A2r 2  B0 96                bcs     GOIQ
+00.0013A4r 2  20 rr rr             jsr     QINT
+00.0013A7r 2  A5 B1                lda     FAC_LAST-1
+00.0013A9r 2  A4 B2                ldy     FAC_LAST
+00.0013ABr 2  84 19                sty     LINNUM
+00.0013ADr 2  85 1A                sta     LINNUM+1
+00.0013AFr 2  60                   rts
+00.0013B0r 2               
+00.0013B0r 2               ; ----------------------------------------------------------------------------
+00.0013B0r 2               ; "PEEK" FUNCTION
+00.0013B0r 2               ; ----------------------------------------------------------------------------
+00.0013B0r 2               PEEK:
+00.0013B0r 2               .ifdef CONFIG_PEEK_SAVE_LINNUM
+00.0013B0r 2                       lda     LINNUM+1
+00.0013B0r 2                       pha
+00.0013B0r 2                       lda     LINNUM
+00.0013B0r 2                       pha
+00.0013B0r 2               .endif
+00.0013B0r 2  20 rr rr             jsr     GETADR
+00.0013B3r 2  A0 00                ldy     #$00
+00.0013B5r 2               .ifdef CBM1
+00.0013B5r 2               ; disallow PEEK between $C000 and $DFFF
+00.0013B5r 2                       cmp     #$C0
+00.0013B5r 2                       bcc     LD6F3
+00.0013B5r 2                       cmp     #$E1
+00.0013B5r 2                       bcc     LD6F6
+00.0013B5r 2               LD6F3:
+00.0013B5r 2               .endif
+00.0013B5r 2               .ifdef CBM2
+00.0013B5r 2               		nop ; patch that disables the compares above
+00.0013B5r 2               		nop
+00.0013B5r 2               		nop
+00.0013B5r 2               		nop
+00.0013B5r 2               		nop
+00.0013B5r 2               		nop
+00.0013B5r 2               		nop
+00.0013B5r 2               		nop
+00.0013B5r 2               .endif
+00.0013B5r 2  B1 19                lda     (LINNUM),y
+00.0013B7r 2  A8                   tay
+00.0013B8r 2               .ifdef CONFIG_PEEK_SAVE_LINNUM
+00.0013B8r 2                       pla
+00.0013B8r 2                       sta     LINNUM
+00.0013B8r 2                       pla
+00.0013B8r 2                       sta     LINNUM+1
+00.0013B8r 2               .endif
+00.0013B8r 2               LD6F6:
+00.0013B8r 2  4C rr rr             jmp     SNGFLT
+00.0013BBr 2               
+00.0013BBr 2               ; ----------------------------------------------------------------------------
+00.0013BBr 2               ; "POKE" STATEMENT
+00.0013BBr 2               ; ----------------------------------------------------------------------------
+00.0013BBr 2               POKE:
+00.0013BBr 2  20 rr rr             jsr     GTNUM
+00.0013BEr 2  8A                   txa
+00.0013BFr 2  A0 00                ldy     #$00
+00.0013C1r 2  91 19                sta     (LINNUM),y
+00.0013C3r 2  60                   rts
+00.0013C4r 2               
+00.0013C4r 2               ; ----------------------------------------------------------------------------
+00.0013C4r 2               ; "WAIT" STATEMENT
+00.0013C4r 2               ; ----------------------------------------------------------------------------
+00.0013C4r 2               WAIT:
+00.0013C4r 2  20 rr rr             jsr     GTNUM
+00.0013C7r 2  86 96                stx     FORPNT
+00.0013C9r 2  A2 00                ldx     #$00
+00.0013CBr 2  20 C6 00             jsr     CHRGOT
+00.0013CEr 2               .ifdef CONFIG_EASTER_EGG
+00.0013CEr 2                       beq     EASTER_EGG
+00.0013CEr 2               .else
+00.0013CEr 2  F0 03                beq     L3628
+00.0013D0r 2               .endif
+00.0013D0r 2  20 rr rr             jsr     COMBYTE
+00.0013D3r 2               L3628:
+00.0013D3r 2  86 97                stx     FORPNT+1
+00.0013D5r 2  A0 00                ldy     #$00
+00.0013D7r 2               L362C:
+00.0013D7r 2  B1 19                lda     (LINNUM),y
+00.0013D9r 2  45 97                eor     FORPNT+1
+00.0013DBr 2  25 96                and     FORPNT
+00.0013DDr 2  F0 F8                beq     L362C
+00.0013DFr 2               RTS3:
+00.0013DFr 2  60                   rts
+00.0013E0r 2               .endif ; KBD
+00.0013E0r 2               
+00.0013E0r 1               .include "float.s"
+00.0013E0r 2               .segment "CODE"
+00.0013E0r 2               
+00.0013E0r 2               TEMP1X = TEMP1+(5-BYTES_FP)
+00.0013E0r 2               
+00.0013E0r 2               ; ----------------------------------------------------------------------------
+00.0013E0r 2               ; ADD 0.5 TO FAC
+00.0013E0r 2               ; ----------------------------------------------------------------------------
+00.0013E0r 2               FADDH:
+00.0013E0r 2  A9 rr                lda     #<CON_HALF
+00.0013E2r 2  A0 rr                ldy     #>CON_HALF
+00.0013E4r 2  4C rr rr             jmp     FADD
+00.0013E7r 2               
+00.0013E7r 2               ; ----------------------------------------------------------------------------
+00.0013E7r 2               ; FAC = (Y,A) - FAC
+00.0013E7r 2               ; ----------------------------------------------------------------------------
+00.0013E7r 2               FSUB:
+00.0013E7r 2  20 rr rr             jsr     LOAD_ARG_FROM_YA
+00.0013EAr 2               
+00.0013EAr 2               ; ----------------------------------------------------------------------------
+00.0013EAr 2               ; FAC = ARG - FAC
+00.0013EAr 2               ; ----------------------------------------------------------------------------
+00.0013EAr 2               FSUBT:
+00.0013EAr 2  A5 B3                lda     FACSIGN
+00.0013ECr 2  49 FF                eor     #$FF
+00.0013EEr 2  85 B3                sta     FACSIGN
+00.0013F0r 2  45 BB                eor     ARGSIGN
+00.0013F2r 2  85 BC                sta     SGNCPR
+00.0013F4r 2  A5 AE                lda     FAC
+00.0013F6r 2  4C rr rr             jmp     FADDT
+00.0013F9r 2               
+00.0013F9r 2               ; ----------------------------------------------------------------------------
+00.0013F9r 2               ; Commodore BASIC V2 Easter Egg
+00.0013F9r 2               ; ----------------------------------------------------------------------------
+00.0013F9r 2               .ifdef CONFIG_EASTER_EGG
+00.0013F9r 2               EASTER_EGG:
+00.0013F9r 2                       lda     LINNUM
+00.0013F9r 2                       cmp     #<6502
+00.0013F9r 2                       bne     L3628
+00.0013F9r 2                       lda     LINNUM+1
+00.0013F9r 2                       sbc     #>6502
+00.0013F9r 2                       bne     L3628
+00.0013F9r 2                       sta     LINNUM
+00.0013F9r 2                       tay
+00.0013F9r 2                       lda     #$80
+00.0013F9r 2                       sta     LINNUM+1
+00.0013F9r 2               LD758:
+00.0013F9r 2                       ldx     #$0A
+00.0013F9r 2               LD75A:
+00.0013F9r 2                       lda     MICROSOFT-1,x
+00.0013F9r 2                       and     #$3F
+00.0013F9r 2                       sta     (LINNUM),y
+00.0013F9r 2                       iny
+00.0013F9r 2                       bne     LD766
+00.0013F9r 2                       inc     LINNUM+1
+00.0013F9r 2               LD766:
+00.0013F9r 2                       dex
+00.0013F9r 2                       bne     LD75A
+00.0013F9r 2                       dec     FORPNT
+00.0013F9r 2                       bne     LD758
+00.0013F9r 2                       rts
+00.0013F9r 2               .endif
+00.0013F9r 2               
+00.0013F9r 2               ; ----------------------------------------------------------------------------
+00.0013F9r 2               ; SHIFT SMALLER ARGUMENT MORE THAN 7 BITS
+00.0013F9r 2               ; ----------------------------------------------------------------------------
+00.0013F9r 2               FADD1:
+00.0013F9r 2  20 rr rr             jsr     SHIFT_RIGHT
+00.0013FCr 2  90 3C                bcc     FADD3
+00.0013FEr 2               
+00.0013FEr 2               ; ----------------------------------------------------------------------------
+00.0013FEr 2               ; FAC = (Y,A) + FAC
+00.0013FEr 2               ; ----------------------------------------------------------------------------
+00.0013FEr 2               FADD:
+00.0013FEr 2  20 rr rr             jsr     LOAD_ARG_FROM_YA
+00.001401r 2               
+00.001401r 2               ; ----------------------------------------------------------------------------
+00.001401r 2               ; FAC = ARG + FAC
+00.001401r 2               ; ----------------------------------------------------------------------------
+00.001401r 2               FADDT:
+00.001401r 2  D0 03                bne     L365B
+00.001403r 2  4C rr rr             jmp     COPY_ARG_TO_FAC
+00.001406r 2               L365B:
+00.001406r 2  A6 BD                ldx     FACEXTENSION
+00.001408r 2  86 A3                stx     ARGEXTENSION
+00.00140Ar 2  A2 B6                ldx     #ARG
+00.00140Cr 2  A5 B6                lda     ARG
+00.00140Er 2               FADD2:
+00.00140Er 2  A8                   tay
+00.00140Fr 2               .ifdef KBD
+00.00140Fr 2                       beq     RTS4
+00.00140Fr 2               .else
+00.00140Fr 2  F0 CE                beq     RTS3
+00.001411r 2               .endif
+00.001411r 2  38                   sec
+00.001412r 2  E5 AE                sbc     FAC
+00.001414r 2  F0 24                beq     FADD3
+00.001416r 2  90 12                bcc     L367F
+00.001418r 2  84 AE                sty     FAC
+00.00141Ar 2  A4 BB                ldy     ARGSIGN
+00.00141Cr 2  84 B3                sty     FACSIGN
+00.00141Er 2  49 FF                eor     #$FF
+00.001420r 2  69 00                adc     #$00
+00.001422r 2  A0 00                ldy     #$00
+00.001424r 2  84 A3                sty     ARGEXTENSION
+00.001426r 2  A2 AE                ldx     #FAC
+00.001428r 2  D0 04                bne     L3683
+00.00142Ar 2               L367F:
+00.00142Ar 2  A0 00                ldy     #$00
+00.00142Cr 2  84 BD                sty     FACEXTENSION
+00.00142Er 2               L3683:
+00.00142Er 2  C9 F9                cmp     #$F9
+00.001430r 2  30 C7                bmi     FADD1
+00.001432r 2  A8                   tay
+00.001433r 2  A5 BD                lda     FACEXTENSION
+00.001435r 2  56 01                lsr     1,x
+00.001437r 2  20 rr rr             jsr     SHIFT_RIGHT4
+00.00143Ar 2               FADD3:
+00.00143Ar 2  24 BC                bit     SGNCPR
+00.00143Cr 2  10 57                bpl     FADD4
+00.00143Er 2  A0 AE                ldy     #FAC
+00.001440r 2  E0 B6                cpx     #ARG
+00.001442r 2  F0 02                beq     L369B
+00.001444r 2  A0 B6                ldy     #ARG
+00.001446r 2               L369B:
+00.001446r 2  38                   sec
+00.001447r 2  49 FF                eor     #$FF
+00.001449r 2  65 A3                adc     ARGEXTENSION
+00.00144Br 2  85 BD                sta     FACEXTENSION
+00.00144Dr 2               .ifndef CONFIG_SMALL
+00.00144Dr 2  B9 04 00             lda     4,y
+00.001450r 2  F5 04                sbc     4,x
+00.001452r 2  85 B2                sta     FAC+4
+00.001454r 2               .endif
+00.001454r 2  B9 03 00             lda     3,y
+00.001457r 2  F5 03                sbc     3,x
+00.001459r 2  85 B1                sta     FAC+3
+00.00145Br 2  B9 02 00             lda     2,y
+00.00145Er 2  F5 02                sbc     2,x
+00.001460r 2  85 B0                sta     FAC+2
+00.001462r 2  B9 01 00             lda     1,y
+00.001465r 2  F5 01                sbc     1,x
+00.001467r 2  85 AF                sta     FAC+1
+00.001469r 2               
+00.001469r 2               ; ----------------------------------------------------------------------------
+00.001469r 2               ; NORMALIZE VALUE IN FAC
+00.001469r 2               ; ----------------------------------------------------------------------------
+00.001469r 2               NORMALIZE_FAC1:
+00.001469r 2  B0 03                bcs     NORMALIZE_FAC2
+00.00146Br 2  20 rr rr             jsr     COMPLEMENT_FAC
+00.00146Er 2               NORMALIZE_FAC2:
+00.00146Er 2  A0 00                ldy     #$00
+00.001470r 2  98                   tya
+00.001471r 2  18                   clc
+00.001472r 2               L36C7:
+00.001472r 2  A6 AF                ldx     FAC+1
+00.001474r 2  D0 4A                bne     NORMALIZE_FAC4
+00.001476r 2  A6 B0                ldx     FAC+2
+00.001478r 2  86 AF                stx     FAC+1
+00.00147Ar 2  A6 B1                ldx     FAC+3
+00.00147Cr 2  86 B0                stx     FAC+2
+00.00147Er 2               .ifdef CONFIG_SMALL
+00.00147Er 2                       ldx     FACEXTENSION
+00.00147Er 2                       stx     FAC+3
+00.00147Er 2               .else
+00.00147Er 2  A6 B2                ldx     FAC+4
+00.001480r 2  86 B1                stx     FAC+3
+00.001482r 2  A6 BD                ldx     FACEXTENSION
+00.001484r 2  86 B2                stx     FAC+4
+00.001486r 2               .endif
+00.001486r 2  84 BD                sty     FACEXTENSION
+00.001488r 2  69 08                adc     #$08
+00.00148Ar 2               .ifdef CONFIG_2B
+00.00148Ar 2               ; bugfix?
+00.00148Ar 2               ; fix does not exist on AppleSoft 2
+00.00148Ar 2                       cmp     #(MANTISSA_BYTES+1)*8
+00.00148Ar 2               .else
+00.00148Ar 2  C9 20                cmp     #MANTISSA_BYTES*8
+00.00148Cr 2               .endif
+00.00148Cr 2  D0 E4                bne     L36C7
+00.00148Er 2               
+00.00148Er 2               ; ----------------------------------------------------------------------------
+00.00148Er 2               ; SET FAC = 0
+00.00148Er 2               ; (ONLY NECESSARY TO ZERO EXPONENT AND SIGN CELLS)
+00.00148Er 2               ; ----------------------------------------------------------------------------
+00.00148Er 2               ZERO_FAC:
+00.00148Er 2  A9 00                lda     #$00
+00.001490r 2               STA_IN_FAC_SIGN_AND_EXP:
+00.001490r 2  85 AE                sta     FAC
+00.001492r 2               STA_IN_FAC_SIGN:
+00.001492r 2  85 B3                sta     FACSIGN
+00.001494r 2  60                   rts
+00.001495r 2               
+00.001495r 2               ; ----------------------------------------------------------------------------
+00.001495r 2               ; ADD MANTISSAS OF FAC AND ARG INTO FAC
+00.001495r 2               ; ----------------------------------------------------------------------------
+00.001495r 2               FADD4:
+00.001495r 2  65 A3                adc     ARGEXTENSION
+00.001497r 2  85 BD                sta     FACEXTENSION
+00.001499r 2               .ifndef CONFIG_SMALL
+00.001499r 2  A5 B2                lda     FAC+4
+00.00149Br 2  65 BA                adc     ARG+4
+00.00149Dr 2  85 B2                sta     FAC+4
+00.00149Fr 2               .endif
+00.00149Fr 2  A5 B1                lda     FAC+3
+00.0014A1r 2  65 B9                adc     ARG+3
+00.0014A3r 2  85 B1                sta     FAC+3
+00.0014A5r 2  A5 B0                lda     FAC+2
+00.0014A7r 2  65 B8                adc     ARG+2
+00.0014A9r 2  85 B0                sta     FAC+2
+00.0014ABr 2  A5 AF                lda     FAC+1
+00.0014ADr 2  65 B7                adc     ARG+1
+00.0014AFr 2  85 AF                sta     FAC+1
+00.0014B1r 2  4C rr rr             jmp     NORMALIZE_FAC5
+00.0014B4r 2               
+00.0014B4r 2               ; ----------------------------------------------------------------------------
+00.0014B4r 2               ; FINISH NORMALIZING FAC
+00.0014B4r 2               ; ----------------------------------------------------------------------------
+00.0014B4r 2               NORMALIZE_FAC3:
+00.0014B4r 2  69 01                adc     #$01
+00.0014B6r 2  06 BD                asl     FACEXTENSION
+00.0014B8r 2               .ifndef CONFIG_SMALL
+00.0014B8r 2  26 B2                rol     FAC+4
+00.0014BAr 2               .endif
+00.0014BAr 2  26 B1                rol     FAC+3
+00.0014BCr 2  26 B0                rol     FAC+2
+00.0014BEr 2  26 AF                rol     FAC+1
+00.0014C0r 2               NORMALIZE_FAC4:
+00.0014C0r 2  10 F2                bpl     NORMALIZE_FAC3
+00.0014C2r 2  38                   sec
+00.0014C3r 2  E5 AE                sbc     FAC
+00.0014C5r 2  B0 C7                bcs     ZERO_FAC
+00.0014C7r 2  49 FF                eor     #$FF
+00.0014C9r 2  69 01                adc     #$01
+00.0014CBr 2  85 AE                sta     FAC
+00.0014CDr 2               NORMALIZE_FAC5:
+00.0014CDr 2  90 40                bcc     L3764
+00.0014CFr 2               NORMALIZE_FAC6:
+00.0014CFr 2  E6 AE                inc     FAC
+00.0014D1r 2  F0 74                beq     OVERFLOW
+00.0014D3r 2               .ifndef CONFIG_ROR_WORKAROUND
+00.0014D3r 2                       ror     FAC+1
+00.0014D3r 2                       ror     FAC+2
+00.0014D3r 2                       ror     FAC+3
+00.0014D3r 2                 .ifndef CONFIG_SMALL
+00.0014D3r 2                       ror     FAC+4
+00.0014D3r 2                 .endif
+00.0014D3r 2                       ror     FACEXTENSION
+00.0014D3r 2               .else
+00.0014D3r 2  A9 00                lda     #$00
+00.0014D5r 2  90 02                bcc     L372E
+00.0014D7r 2  A9 80                lda     #$80
+00.0014D9r 2               L372E:
+00.0014D9r 2  46 AF                lsr     FAC+1
+00.0014DBr 2  05 AF                ora     FAC+1
+00.0014DDr 2  85 AF                sta     FAC+1
+00.0014DFr 2  A9 00                lda     #$00
+00.0014E1r 2  90 02                bcc     L373A
+00.0014E3r 2  A9 80                lda     #$80
+00.0014E5r 2               L373A:
+00.0014E5r 2  46 B0                lsr     FAC+2
+00.0014E7r 2  05 B0                ora     FAC+2
+00.0014E9r 2  85 B0                sta     FAC+2
+00.0014EBr 2  A9 00                lda     #$00
+00.0014EDr 2  90 02                bcc     L3746
+00.0014EFr 2  A9 80                lda     #$80
+00.0014F1r 2               L3746:
+00.0014F1r 2  46 B1                lsr     FAC+3
+00.0014F3r 2  05 B1                ora     FAC+3
+00.0014F5r 2  85 B1                sta     FAC+3
+00.0014F7r 2  A9 00                lda     #$00
+00.0014F9r 2  90 02                bcc     L3752
+00.0014FBr 2  A9 80                lda     #$80
+00.0014FDr 2               L3752:
+00.0014FDr 2  46 B2                lsr     FAC+4
+00.0014FFr 2  05 B2                ora     FAC+4
+00.001501r 2  85 B2                sta     FAC+4
+00.001503r 2  A9 00                lda     #$00
+00.001505r 2  90 02                bcc     L375E
+00.001507r 2  A9 80                lda     #$80
+00.001509r 2               L375E:
+00.001509r 2  46 BD                lsr     FACEXTENSION
+00.00150Br 2  05 BD                ora     FACEXTENSION
+00.00150Dr 2  85 BD                sta     FACEXTENSION
+00.00150Fr 2               .endif
+00.00150Fr 2               L3764:
+00.00150Fr 2  60                   rts
+00.001510r 2               
+00.001510r 2               ; ----------------------------------------------------------------------------
+00.001510r 2               ; 2'S COMPLEMENT OF FAC
+00.001510r 2               ; ----------------------------------------------------------------------------
+00.001510r 2               COMPLEMENT_FAC:
+00.001510r 2  A5 B3                lda     FACSIGN
+00.001512r 2  49 FF                eor     #$FF
+00.001514r 2  85 B3                sta     FACSIGN
+00.001516r 2               
+00.001516r 2               ; ----------------------------------------------------------------------------
+00.001516r 2               ; 2'S COMPLEMENT OF FAC MANTISSA ONLY
+00.001516r 2               ; ----------------------------------------------------------------------------
+00.001516r 2               COMPLEMENT_FAC_MANTISSA:
+00.001516r 2  A5 AF                lda     FAC+1
+00.001518r 2  49 FF                eor     #$FF
+00.00151Ar 2  85 AF                sta     FAC+1
+00.00151Cr 2  A5 B0                lda     FAC+2
+00.00151Er 2  49 FF                eor     #$FF
+00.001520r 2  85 B0                sta     FAC+2
+00.001522r 2  A5 B1                lda     FAC+3
+00.001524r 2  49 FF                eor     #$FF
+00.001526r 2  85 B1                sta     FAC+3
+00.001528r 2               .ifndef CONFIG_SMALL
+00.001528r 2  A5 B2                lda     FAC+4
+00.00152Ar 2  49 FF                eor     #$FF
+00.00152Cr 2  85 B2                sta     FAC+4
+00.00152Er 2               .endif
+00.00152Er 2  A5 BD                lda     FACEXTENSION
+00.001530r 2  49 FF                eor     #$FF
+00.001532r 2  85 BD                sta     FACEXTENSION
+00.001534r 2  E6 BD                inc     FACEXTENSION
+00.001536r 2  D0 0E                bne     RTS12
+00.001538r 2               
+00.001538r 2               ; ----------------------------------------------------------------------------
+00.001538r 2               ; INCREMENT FAC MANTISSA
+00.001538r 2               ; ----------------------------------------------------------------------------
+00.001538r 2               INCREMENT_FAC_MANTISSA:
+00.001538r 2               .ifndef CONFIG_SMALL
+00.001538r 2  E6 B2                inc     FAC+4
+00.00153Ar 2  D0 0A                bne     RTS12
+00.00153Cr 2               .endif
+00.00153Cr 2  E6 B1                inc     FAC+3
+00.00153Er 2  D0 06                bne     RTS12
+00.001540r 2  E6 B0                inc     FAC+2
+00.001542r 2  D0 02                bne     RTS12
+00.001544r 2  E6 AF                inc     FAC+1
+00.001546r 2               RTS12:
+00.001546r 2  60                   rts
+00.001547r 2               OVERFLOW:
+00.001547r 2  A2 45                ldx     #ERR_OVERFLOW
+00.001549r 2  4C rr rr             jmp     ERROR
+00.00154Cr 2               
+00.00154Cr 2               ; ----------------------------------------------------------------------------
+00.00154Cr 2               ; SHIFT 1,X THRU 5,X RIGHT
+00.00154Cr 2               ; (A) = NEGATIVE OF SHIFT COUNT
+00.00154Cr 2               ; (X) = POINTER TO BYTES TO BE SHIFTED
+00.00154Cr 2               ;
+00.00154Cr 2               ; RETURN WITH (Y)=0, CARRY=0, EXTENSION BITS IN A-REG
+00.00154Cr 2               ; ----------------------------------------------------------------------------
+00.00154Cr 2               SHIFT_RIGHT1:
+00.00154Cr 2  A2 72                ldx     #RESULT-1
+00.00154Er 2               SHIFT_RIGHT2:
+00.00154Er 2               .ifdef CONFIG_SMALL
+00.00154Er 2                       ldy     3,x
+00.00154Er 2               .else
+00.00154Er 2  B4 04                ldy     4,x
+00.001550r 2               .endif
+00.001550r 2  84 BD                sty     FACEXTENSION
+00.001552r 2               .ifndef CONFIG_SMALL
+00.001552r 2  B4 03                ldy     3,x
+00.001554r 2  94 04                sty     4,x
+00.001556r 2               .endif
+00.001556r 2  B4 02                ldy     2,x
+00.001558r 2  94 03                sty     3,x
+00.00155Ar 2  B4 01                ldy     1,x
+00.00155Cr 2  94 02                sty     2,x
+00.00155Er 2  A4 B5                ldy     SHIFTSIGNEXT
+00.001560r 2  94 01                sty     1,x
+00.001562r 2               
+00.001562r 2               ; ----------------------------------------------------------------------------
+00.001562r 2               ; MAIN ENTRY TO RIGHT SHIFT SUBROUTINE
+00.001562r 2               ; ----------------------------------------------------------------------------
+00.001562r 2               SHIFT_RIGHT:
+00.001562r 2  69 08                adc     #$08
+00.001564r 2  30 E8                bmi     SHIFT_RIGHT2
+00.001566r 2  F0 E6                beq     SHIFT_RIGHT2
+00.001568r 2  E9 08                sbc     #$08
+00.00156Ar 2  A8                   tay
+00.00156Br 2  A5 BD                lda     FACEXTENSION
+00.00156Dr 2  B0 3C                bcs     SHIFT_RIGHT5
+00.00156Fr 2               .ifndef CONFIG_ROR_WORKAROUND
+00.00156Fr 2               LB588:
+00.00156Fr 2                       asl     1,x
+00.00156Fr 2                       bcc     LB58E
+00.00156Fr 2                       inc     1,x
+00.00156Fr 2               LB58E:
+00.00156Fr 2                       ror     1,x
+00.00156Fr 2                       ror     1,x
+00.00156Fr 2               
+00.00156Fr 2               ; ----------------------------------------------------------------------------
+00.00156Fr 2               ; ENTER HERE FOR SHORT SHIFTS WITH NO SIGN EXTENSION
+00.00156Fr 2               ; ----------------------------------------------------------------------------
+00.00156Fr 2               SHIFT_RIGHT4:
+00.00156Fr 2                       ror     2,x
+00.00156Fr 2                       ror     3,x
+00.00156Fr 2                 .ifndef CONFIG_SMALL
+00.00156Fr 2                       ror     4,x
+00.00156Fr 2                 .endif
+00.00156Fr 2                       ror     a
+00.00156Fr 2                       iny
+00.00156Fr 2                       bne     LB588
+00.00156Fr 2               .else
+00.00156Fr 2               L37C4:
+00.00156Fr 2  48                   pha
+00.001570r 2  B5 01                lda     1,x
+00.001572r 2  29 80                and     #$80
+00.001574r 2  56 01                lsr     1,x
+00.001576r 2  15 01                ora     1,x
+00.001578r 2  95 01                sta     1,x
+00.00157Ar 2  24                   .byte   $24
+00.00157Br 2               SHIFT_RIGHT4:
+00.00157Br 2  48                   pha
+00.00157Cr 2  A9 00                lda     #$00
+00.00157Er 2  90 02                bcc     L37D7
+00.001580r 2  A9 80                lda     #$80
+00.001582r 2               L37D7:
+00.001582r 2  56 02                lsr     2,x
+00.001584r 2  15 02                ora     2,x
+00.001586r 2  95 02                sta     2,x
+00.001588r 2  A9 00                lda     #$00
+00.00158Ar 2  90 02                bcc     L37E3
+00.00158Cr 2  A9 80                lda     #$80
+00.00158Er 2               L37E3:
+00.00158Er 2  56 03                lsr     3,x
+00.001590r 2  15 03                ora     3,x
+00.001592r 2  95 03                sta     3,x
+00.001594r 2  A9 00                lda     #$00
+00.001596r 2  90 02                bcc     L37EF
+00.001598r 2  A9 80                lda     #$80
+00.00159Ar 2               L37EF:
+00.00159Ar 2  56 04                lsr     4,x
+00.00159Cr 2  15 04                ora     4,x
+00.00159Er 2  95 04                sta     4,x
+00.0015A0r 2  68                   pla
+00.0015A1r 2  08                   php
+00.0015A2r 2  4A                   lsr     a
+00.0015A3r 2  28                   plp
+00.0015A4r 2  90 02                bcc     L37FD
+00.0015A6r 2  09 80                ora     #$80
+00.0015A8r 2               L37FD:
+00.0015A8r 2  C8                   iny
+00.0015A9r 2  D0 C4                bne     L37C4
+00.0015ABr 2               .endif
+00.0015ABr 2               SHIFT_RIGHT5:
+00.0015ABr 2  18                   clc
+00.0015ACr 2  60                   rts
+00.0015ADr 2               
+00.0015ADr 2               ; ----------------------------------------------------------------------------
+00.0015ADr 2               .ifdef CONFIG_SMALL
+00.0015ADr 2               CON_ONE:
+00.0015ADr 2                       .byte   $81,$00,$00,$00
+00.0015ADr 2               POLY_LOG:
+00.0015ADr 2               		.byte	$02
+00.0015ADr 2               		.byte   $80,$19,$56,$62
+00.0015ADr 2               		.byte   $80,$76,$22,$F3
+00.0015ADr 2               		.byte   $82,$38,$AA,$40
+00.0015ADr 2               CON_SQR_HALF:
+00.0015ADr 2               		.byte   $80,$35,$04,$F3
+00.0015ADr 2               CON_SQR_TWO:
+00.0015ADr 2               		.byte   $81,$35,$04,$F3
+00.0015ADr 2               CON_NEG_HALF:
+00.0015ADr 2               		.byte   $80,$80,$00,$00
+00.0015ADr 2               CON_LOG_TWO:
+00.0015ADr 2               		.byte   $80,$31,$72,$18
+00.0015ADr 2               .else
+00.0015ADr 2               CON_ONE:
+00.0015ADr 2  81 00 00 00          .byte   $81,$00,$00,$00,$00
+00.0015B1r 2  00           
+00.0015B2r 2               POLY_LOG:
+00.0015B2r 2  03                   .byte   $03
+00.0015B3r 2  7F 5E 56 CB  		.byte   $7F,$5E,$56,$CB,$79
+00.0015B7r 2  79           
+00.0015B8r 2  80 13 9B 0B  		.byte   $80,$13,$9B,$0B,$64
+00.0015BCr 2  64           
+00.0015BDr 2  80 76 38 93  		.byte   $80,$76,$38,$93,$16
+00.0015C1r 2  16           
+00.0015C2r 2  82 38 AA 3B          .byte   $82,$38,$AA,$3B,$20
+00.0015C6r 2  20           
+00.0015C7r 2               CON_SQR_HALF:
+00.0015C7r 2  80 35 04 F3          .byte   $80,$35,$04,$F3,$34
+00.0015CBr 2  34           
+00.0015CCr 2               CON_SQR_TWO:
+00.0015CCr 2  81 35 04 F3          .byte   $81,$35,$04,$F3,$34
+00.0015D0r 2  34           
+00.0015D1r 2               CON_NEG_HALF:
+00.0015D1r 2  80 80 00 00          .byte   $80,$80,$00,$00,$00
+00.0015D5r 2  00           
+00.0015D6r 2               CON_LOG_TWO:
+00.0015D6r 2  80 31 72 17          .byte   $80,$31,$72,$17,$F8
+00.0015DAr 2  F8           
+00.0015DBr 2               .endif
+00.0015DBr 2               
+00.0015DBr 2               ; ----------------------------------------------------------------------------
+00.0015DBr 2               ; "LOG" FUNCTION
+00.0015DBr 2               ; ----------------------------------------------------------------------------
+00.0015DBr 2               LOG:
+00.0015DBr 2  20 rr rr             jsr     SIGN
+00.0015DEr 2  F0 02                beq     GIQ
+00.0015E0r 2  10 03                bpl     LOG2
+00.0015E2r 2               GIQ:
+00.0015E2r 2  4C rr rr             jmp     IQERR
+00.0015E5r 2               LOG2:
+00.0015E5r 2  A5 AE                lda     FAC
+00.0015E7r 2  E9 7F                sbc     #$7F
+00.0015E9r 2  48                   pha
+00.0015EAr 2  A9 80                lda     #$80
+00.0015ECr 2  85 AE                sta     FAC
+00.0015EEr 2  A9 rr                lda     #<CON_SQR_HALF
+00.0015F0r 2  A0 rr                ldy     #>CON_SQR_HALF
+00.0015F2r 2  20 rr rr             jsr     FADD
+00.0015F5r 2  A9 rr                lda     #<CON_SQR_TWO
+00.0015F7r 2  A0 rr                ldy     #>CON_SQR_TWO
+00.0015F9r 2  20 rr rr             jsr     FDIV
+00.0015FCr 2  A9 rr                lda     #<CON_ONE
+00.0015FEr 2  A0 rr                ldy     #>CON_ONE
+00.001600r 2  20 rr rr             jsr     FSUB
+00.001603r 2  A9 rr                lda     #<POLY_LOG
+00.001605r 2  A0 rr                ldy     #>POLY_LOG
+00.001607r 2  20 rr rr             jsr     POLYNOMIAL_ODD
+00.00160Ar 2  A9 rr                lda     #<CON_NEG_HALF
+00.00160Cr 2  A0 rr                ldy     #>CON_NEG_HALF
+00.00160Er 2  20 rr rr             jsr     FADD
+00.001611r 2  68                   pla
+00.001612r 2  20 rr rr             jsr     ADDACC
+00.001615r 2  A9 rr                lda     #<CON_LOG_TWO
+00.001617r 2  A0 rr                ldy     #>CON_LOG_TWO
+00.001619r 2               
+00.001619r 2               ; ----------------------------------------------------------------------------
+00.001619r 2               ; FAC = (Y,A) * FAC
+00.001619r 2               ; ----------------------------------------------------------------------------
+00.001619r 2               FMULT:
+00.001619r 2  20 rr rr             jsr     LOAD_ARG_FROM_YA
+00.00161Cr 2               
+00.00161Cr 2               ; ----------------------------------------------------------------------------
+00.00161Cr 2               ; FAC = ARG * FAC
+00.00161Cr 2               ; ----------------------------------------------------------------------------
+00.00161Cr 2               FMULTT:
+00.00161Cr 2               .ifndef CONFIG_11
+00.00161Cr 2                       beq     L3903
+00.00161Cr 2               .else
+00.00161Cr 2  D0 03 4C rr          jeq     L3903
+00.001620r 2  rr           
+00.001621r 2               .endif
+00.001621r 2  20 rr rr             jsr     ADD_EXPONENTS
+00.001624r 2  A9 00                lda     #$00
+00.001626r 2  85 73                sta     RESULT
+00.001628r 2  85 74                sta     RESULT+1
+00.00162Ar 2  85 75                sta     RESULT+2
+00.00162Cr 2               .ifndef CONFIG_SMALL
+00.00162Cr 2  85 76                sta     RESULT+3
+00.00162Er 2               .endif
+00.00162Er 2  A5 BD                lda     FACEXTENSION
+00.001630r 2  20 rr rr             jsr     MULTIPLY1
+00.001633r 2               .ifndef CONFIG_SMALL
+00.001633r 2  A5 B2                lda     FAC+4
+00.001635r 2  20 rr rr             jsr     MULTIPLY1
+00.001638r 2               .endif
+00.001638r 2  A5 B1                lda     FAC+3
+00.00163Ar 2  20 rr rr             jsr     MULTIPLY1
+00.00163Dr 2  A5 B0                lda     FAC+2
+00.00163Fr 2  20 rr rr             jsr     MULTIPLY1
+00.001642r 2  A5 AF                lda     FAC+1
+00.001644r 2  20 rr rr             jsr     MULTIPLY2
+00.001647r 2  4C rr rr             jmp     COPY_RESULT_INTO_FAC
+00.00164Ar 2               
+00.00164Ar 2               ; ----------------------------------------------------------------------------
+00.00164Ar 2               ; MULTIPLY ARG BY (A) INTO RESULT
+00.00164Ar 2               ; ----------------------------------------------------------------------------
+00.00164Ar 2               MULTIPLY1:
+00.00164Ar 2  D0 03                bne     MULTIPLY2
+00.00164Cr 2  4C rr rr             jmp     SHIFT_RIGHT1
+00.00164Fr 2               MULTIPLY2:
+00.00164Fr 2  4A                   lsr     a
+00.001650r 2  09 80                ora     #$80
+00.001652r 2               L38A7:
+00.001652r 2  A8                   tay
+00.001653r 2  90 19                bcc     L38C3
+00.001655r 2  18                   clc
+00.001656r 2               .ifndef CONFIG_SMALL
+00.001656r 2  A5 76                lda     RESULT+3
+00.001658r 2  65 BA                adc     ARG+4
+00.00165Ar 2  85 76                sta     RESULT+3
+00.00165Cr 2               .endif
+00.00165Cr 2  A5 75                lda     RESULT+2
+00.00165Er 2  65 B9                adc     ARG+3
+00.001660r 2  85 75                sta     RESULT+2
+00.001662r 2  A5 74                lda     RESULT+1
+00.001664r 2  65 B8                adc     ARG+2
+00.001666r 2  85 74                sta     RESULT+1
+00.001668r 2  A5 73                lda     RESULT
+00.00166Ar 2  65 B7                adc     ARG+1
+00.00166Cr 2  85 73                sta     RESULT
+00.00166Er 2               L38C3:
+00.00166Er 2               .ifndef CONFIG_ROR_WORKAROUND
+00.00166Er 2                       ror     RESULT
+00.00166Er 2                       ror     RESULT+1
+00.00166Er 2               .ifdef APPLE_BAD_BYTE
+00.00166Er 2               ; this seems to be a bad byte in the dump
+00.00166Er 2               		.byte	RESULT+2,RESULT+2 ; XXX BUG!
+00.00166Er 2               .else
+00.00166Er 2                       ror     RESULT+2
+00.00166Er 2               .endif
+00.00166Er 2               .ifndef CONFIG_SMALL
+00.00166Er 2                       ror     RESULT+3
+00.00166Er 2               .endif
+00.00166Er 2                       ror     FACEXTENSION
+00.00166Er 2               .else
+00.00166Er 2  A9 00                lda     #$00
+00.001670r 2  90 02                bcc     L38C9
+00.001672r 2  A9 80                lda     #$80
+00.001674r 2               L38C9:
+00.001674r 2  46 73                lsr     RESULT
+00.001676r 2  05 73                ora     RESULT
+00.001678r 2  85 73                sta     RESULT
+00.00167Ar 2  A9 00                lda     #$00
+00.00167Cr 2  90 02                bcc     L38D5
+00.00167Er 2  A9 80                lda     #$80
+00.001680r 2               L38D5:
+00.001680r 2  46 74                lsr     RESULT+1
+00.001682r 2  05 74                ora     RESULT+1
+00.001684r 2  85 74                sta     RESULT+1
+00.001686r 2  A9 00                lda     #$00
+00.001688r 2  90 02                bcc     L38E1
+00.00168Ar 2  A9 80                lda     #$80
+00.00168Cr 2               L38E1:
+00.00168Cr 2  46 75                lsr     RESULT+2
+00.00168Er 2  05 75                ora     RESULT+2
+00.001690r 2  85 75                sta     RESULT+2
+00.001692r 2  A9 00                lda     #$00
+00.001694r 2  90 02                bcc     L38ED
+00.001696r 2  A9 80                lda     #$80
+00.001698r 2               L38ED:
+00.001698r 2  46 76                lsr     RESULT+3
+00.00169Ar 2  05 76                ora     RESULT+3
+00.00169Cr 2  85 76                sta     RESULT+3
+00.00169Er 2  A9 00                lda     #$00
+00.0016A0r 2  90 02                bcc     L38F9
+00.0016A2r 2  A9 80                lda     #$80
+00.0016A4r 2               L38F9:
+00.0016A4r 2  46 BD                lsr     FACEXTENSION
+00.0016A6r 2  05 BD                ora     FACEXTENSION
+00.0016A8r 2  85 BD                sta     FACEXTENSION
+00.0016AAr 2               .endif
+00.0016AAr 2  98                   tya
+00.0016ABr 2  4A                   lsr     a
+00.0016ACr 2  D0 A4                bne     L38A7
+00.0016AEr 2               L3903:
+00.0016AEr 2  60                   rts
+00.0016AFr 2               
+00.0016AFr 2               ; ----------------------------------------------------------------------------
+00.0016AFr 2               ; UNPACK NUMBER AT (Y,A) INTO ARG
+00.0016AFr 2               ; ----------------------------------------------------------------------------
+00.0016AFr 2               LOAD_ARG_FROM_YA:
+00.0016AFr 2  85 6F                sta     INDEX
+00.0016B1r 2  84 70                sty     INDEX+1
+00.0016B3r 2  A0 04                ldy     #BYTES_FP-1
+00.0016B5r 2               .ifndef CONFIG_SMALL
+00.0016B5r 2  B1 6F                lda     (INDEX),y
+00.0016B7r 2  85 BA                sta     ARG+4
+00.0016B9r 2  88                   dey
+00.0016BAr 2               .endif
+00.0016BAr 2  B1 6F                lda     (INDEX),y
+00.0016BCr 2  85 B9                sta     ARG+3
+00.0016BEr 2  88                   dey
+00.0016BFr 2  B1 6F                lda     (INDEX),y
+00.0016C1r 2  85 B8                sta     ARG+2
+00.0016C3r 2  88                   dey
+00.0016C4r 2  B1 6F                lda     (INDEX),y
+00.0016C6r 2  85 BB                sta     ARGSIGN
+00.0016C8r 2  45 B3                eor     FACSIGN
+00.0016CAr 2  85 BC                sta     SGNCPR
+00.0016CCr 2  A5 BB                lda     ARGSIGN
+00.0016CEr 2  09 80                ora     #$80
+00.0016D0r 2  85 B7                sta     ARG+1
+00.0016D2r 2  88                   dey
+00.0016D3r 2  B1 6F                lda     (INDEX),y
+00.0016D5r 2  85 B6                sta     ARG
+00.0016D7r 2  A5 AE                lda     FAC
+00.0016D9r 2  60                   rts
+00.0016DAr 2               
+00.0016DAr 2               ; ----------------------------------------------------------------------------
+00.0016DAr 2               ; ADD EXPONENTS OF ARG AND FAC
+00.0016DAr 2               ; (CALLED BY FMULT AND FDIV)
+00.0016DAr 2               ;
+00.0016DAr 2               ; ALSO CHECK FOR OVERFLOW, AND SET RESULT SIGN
+00.0016DAr 2               ; ----------------------------------------------------------------------------
+00.0016DAr 2               ADD_EXPONENTS:
+00.0016DAr 2  A5 B6                lda     ARG
+00.0016DCr 2               ADD_EXPONENTS1:
+00.0016DCr 2  F0 1F                beq     ZERO
+00.0016DEr 2  18                   clc
+00.0016DFr 2  65 AE                adc     FAC
+00.0016E1r 2  90 04                bcc     L393C
+00.0016E3r 2  30 1D                bmi     JOV
+00.0016E5r 2  18                   clc
+00.0016E6r 2  2C                   .byte   $2C
+00.0016E7r 2               L393C:
+00.0016E7r 2  10 14                bpl     ZERO
+00.0016E9r 2  69 80                adc     #$80
+00.0016EBr 2  85 AE                sta     FAC
+00.0016EDr 2  D0 03                bne     L3947
+00.0016EFr 2  4C rr rr             jmp     STA_IN_FAC_SIGN
+00.0016F2r 2               L3947:
+00.0016F2r 2  A5 BC                lda     SGNCPR
+00.0016F4r 2  85 B3                sta     FACSIGN
+00.0016F6r 2  60                   rts
+00.0016F7r 2               
+00.0016F7r 2               ; ----------------------------------------------------------------------------
+00.0016F7r 2               ; IF (FAC) IS POSITIVE, GIVE "OVERFLOW" ERROR
+00.0016F7r 2               ; IF (FAC) IS NEGATIVE, SET FAC=0, POP ONE RETURN, AND RTS
+00.0016F7r 2               ; CALLED FROM "EXP" FUNCTION
+00.0016F7r 2               ; ----------------------------------------------------------------------------
+00.0016F7r 2               OUTOFRNG:
+00.0016F7r 2  A5 B3                lda     FACSIGN
+00.0016F9r 2  49 FF                eor     #$FF
+00.0016FBr 2  30 05                bmi     JOV
+00.0016FDr 2               
+00.0016FDr 2               ; ----------------------------------------------------------------------------
+00.0016FDr 2               ; POP RETURN ADDRESS AND SET FAC=0
+00.0016FDr 2               ; ----------------------------------------------------------------------------
+00.0016FDr 2               ZERO:
+00.0016FDr 2  68                   pla
+00.0016FEr 2  68                   pla
+00.0016FFr 2  4C rr rr             jmp     ZERO_FAC
+00.001702r 2               JOV:
+00.001702r 2  4C rr rr             jmp     OVERFLOW
+00.001705r 2               
+00.001705r 2               ; ----------------------------------------------------------------------------
+00.001705r 2               ; MULTIPLY FAC BY 10
+00.001705r 2               ; ----------------------------------------------------------------------------
+00.001705r 2               MUL10:
+00.001705r 2  20 rr rr             jsr     COPY_FAC_TO_ARG_ROUNDED
+00.001708r 2  AA                   tax
+00.001709r 2  F0 10                beq     L3970
+00.00170Br 2  18                   clc
+00.00170Cr 2  69 02                adc     #$02
+00.00170Er 2  B0 F2                bcs     JOV
+00.001710r 2               LD9BF:
+00.001710r 2  A2 00                ldx     #$00
+00.001712r 2  86 BC                stx     SGNCPR
+00.001714r 2  20 rr rr             jsr     FADD2
+00.001717r 2  E6 AE                inc     FAC
+00.001719r 2  F0 E7                beq     JOV
+00.00171Br 2               L3970:
+00.00171Br 2  60                   rts
+00.00171Cr 2               
+00.00171Cr 2               ; ----------------------------------------------------------------------------
+00.00171Cr 2               CONTEN:
+00.00171Cr 2               .ifdef CONFIG_SMALL
+00.00171Cr 2                       .byte   $84,$20,$00,$00
+00.00171Cr 2               .else
+00.00171Cr 2  84 20 00 00          .byte   $84,$20,$00,$00,$00
+00.001720r 2  00           
+00.001721r 2               .endif
+00.001721r 2               
+00.001721r 2               ; ----------------------------------------------------------------------------
+00.001721r 2               ; DIVIDE FAC BY 10
+00.001721r 2               ; ----------------------------------------------------------------------------
+00.001721r 2               DIV10:
+00.001721r 2  20 rr rr             jsr     COPY_FAC_TO_ARG_ROUNDED
+00.001724r 2  A9 rr                lda     #<CONTEN
+00.001726r 2  A0 rr                ldy     #>CONTEN
+00.001728r 2  A2 00                ldx     #$00
+00.00172Ar 2               
+00.00172Ar 2               ; ----------------------------------------------------------------------------
+00.00172Ar 2               ; FAC = ARG / (Y,A)
+00.00172Ar 2               ; ----------------------------------------------------------------------------
+00.00172Ar 2               DIV:
+00.00172Ar 2  86 BC                stx     SGNCPR
+00.00172Cr 2  20 rr rr             jsr     LOAD_FAC_FROM_YA
+00.00172Fr 2  4C rr rr             jmp     FDIVT
+00.001732r 2               
+00.001732r 2               ; ----------------------------------------------------------------------------
+00.001732r 2               ; FAC = (Y,A) / FAC
+00.001732r 2               ; ----------------------------------------------------------------------------
+00.001732r 2               FDIV:
+00.001732r 2  20 rr rr             jsr     LOAD_ARG_FROM_YA
+00.001735r 2               
+00.001735r 2               ; ----------------------------------------------------------------------------
+00.001735r 2               ; FAC = ARG / FAC
+00.001735r 2               ; ----------------------------------------------------------------------------
+00.001735r 2               FDIVT:
+00.001735r 2  F0 76                beq     L3A02
+00.001737r 2  20 rr rr             jsr     ROUND_FAC
+00.00173Ar 2  A9 00                lda     #$00
+00.00173Cr 2  38                   sec
+00.00173Dr 2  E5 AE                sbc     FAC
+00.00173Fr 2  85 AE                sta     FAC
+00.001741r 2  20 rr rr             jsr     ADD_EXPONENTS
+00.001744r 2  E6 AE                inc     FAC
+00.001746r 2  F0 BA                beq     JOV
+00.001748r 2  A2 FC                ldx     #<-MANTISSA_BYTES
+00.00174Ar 2  A9 01                lda     #$01
+00.00174Cr 2               L39A1:
+00.00174Cr 2  A4 B7                ldy     ARG+1
+00.00174Er 2  C4 AF                cpy     FAC+1
+00.001750r 2  D0 10                bne     L39B7
+00.001752r 2  A4 B8                ldy     ARG+2
+00.001754r 2  C4 B0                cpy     FAC+2
+00.001756r 2  D0 0A                bne     L39B7
+00.001758r 2  A4 B9                ldy     ARG+3
+00.00175Ar 2  C4 B1                cpy     FAC+3
+00.00175Cr 2               .ifndef CONFIG_SMALL
+00.00175Cr 2  D0 04                bne     L39B7
+00.00175Er 2  A4 BA                ldy     ARG+4
+00.001760r 2  C4 B2                cpy     FAC+4
+00.001762r 2               .endif
+00.001762r 2               L39B7:
+00.001762r 2  08                   php
+00.001763r 2  2A                   rol     a
+00.001764r 2  90 09                bcc     L39C4
+00.001766r 2  E8                   inx
+00.001767r 2  95 76                sta     RESULT_LAST-1,x
+00.001769r 2  F0 32                beq     L39F2
+00.00176Br 2  10 34                bpl     L39F6
+00.00176Dr 2  A9 01                lda     #$01
+00.00176Fr 2               L39C4:
+00.00176Fr 2  28                   plp
+00.001770r 2  B0 0E                bcs     L39D5
+00.001772r 2               L39C7:
+00.001772r 2  06 BA                asl     ARG_LAST
+00.001774r 2               .ifndef CONFIG_SMALL
+00.001774r 2  26 B9                rol     ARG+3
+00.001776r 2               .endif
+00.001776r 2  26 B8                rol     ARG+2
+00.001778r 2  26 B7                rol     ARG+1
+00.00177Ar 2  B0 E6                bcs     L39B7
+00.00177Cr 2  30 CE                bmi     L39A1
+00.00177Er 2  10 E2                bpl     L39B7
+00.001780r 2               L39D5:
+00.001780r 2  A8                   tay
+00.001781r 2               .ifndef CONFIG_SMALL
+00.001781r 2  A5 BA                lda     ARG+4
+00.001783r 2  E5 B2                sbc     FAC+4
+00.001785r 2  85 BA                sta     ARG+4
+00.001787r 2               .endif
+00.001787r 2  A5 B9                lda     ARG+3
+00.001789r 2  E5 B1                sbc     FAC+3
+00.00178Br 2  85 B9                sta     ARG+3
+00.00178Dr 2  A5 B8                lda     ARG+2
+00.00178Fr 2  E5 B0                sbc     FAC+2
+00.001791r 2  85 B8                sta     ARG+2
+00.001793r 2  A5 B7                lda     ARG+1
+00.001795r 2  E5 AF                sbc     FAC+1
+00.001797r 2  85 B7                sta     ARG+1
+00.001799r 2  98                   tya
+00.00179Ar 2  4C rr rr             jmp     L39C7
+00.00179Dr 2               L39F2:
+00.00179Dr 2  A9 40                lda     #$40
+00.00179Fr 2  D0 CE                bne     L39C4
+00.0017A1r 2               L39F6:
+00.0017A1r 2  0A                   asl     a
+00.0017A2r 2  0A                   asl     a
+00.0017A3r 2  0A                   asl     a
+00.0017A4r 2  0A                   asl     a
+00.0017A5r 2  0A                   asl     a
+00.0017A6r 2  0A                   asl     a
+00.0017A7r 2  85 BD                sta     FACEXTENSION
+00.0017A9r 2  28                   plp
+00.0017AAr 2  4C rr rr             jmp     COPY_RESULT_INTO_FAC
+00.0017ADr 2               L3A02:
+00.0017ADr 2  A2 85                ldx     #ERR_ZERODIV
+00.0017AFr 2  4C rr rr             jmp     ERROR
+00.0017B2r 2               
+00.0017B2r 2               ; ----------------------------------------------------------------------------
+00.0017B2r 2               ; COPY RESULT INTO FAC MANTISSA, AND NORMALIZE
+00.0017B2r 2               ; ----------------------------------------------------------------------------
+00.0017B2r 2               COPY_RESULT_INTO_FAC:
+00.0017B2r 2  A5 73                lda     RESULT
+00.0017B4r 2  85 AF                sta     FAC+1
+00.0017B6r 2  A5 74                lda     RESULT+1
+00.0017B8r 2  85 B0                sta     FAC+2
+00.0017BAr 2  A5 75                lda     RESULT+2
+00.0017BCr 2  85 B1                sta     FAC+3
+00.0017BEr 2               .ifndef CONFIG_SMALL
+00.0017BEr 2  A5 76                lda     RESULT+3
+00.0017C0r 2  85 B2                sta     FAC+4
+00.0017C2r 2               .endif
+00.0017C2r 2  4C rr rr             jmp     NORMALIZE_FAC2
+00.0017C5r 2               
+00.0017C5r 2               ; ----------------------------------------------------------------------------
+00.0017C5r 2               ; UNPACK (Y,A) INTO FAC
+00.0017C5r 2               ; ----------------------------------------------------------------------------
+00.0017C5r 2               LOAD_FAC_FROM_YA:
+00.0017C5r 2  85 6F                sta     INDEX
+00.0017C7r 2  84 70                sty     INDEX+1
+00.0017C9r 2  A0 04                ldy     #MANTISSA_BYTES
+00.0017CBr 2               .ifndef CONFIG_SMALL
+00.0017CBr 2  B1 6F                lda     (INDEX),y
+00.0017CDr 2  85 B2                sta     FAC+4
+00.0017CFr 2  88                   dey
+00.0017D0r 2               .endif
+00.0017D0r 2  B1 6F                lda     (INDEX),y
+00.0017D2r 2  85 B1                sta     FAC+3
+00.0017D4r 2  88                   dey
+00.0017D5r 2  B1 6F                lda     (INDEX),y
+00.0017D7r 2  85 B0                sta     FAC+2
+00.0017D9r 2  88                   dey
+00.0017DAr 2  B1 6F                lda     (INDEX),y
+00.0017DCr 2  85 B3                sta     FACSIGN
+00.0017DEr 2  09 80                ora     #$80
+00.0017E0r 2  85 AF                sta     FAC+1
+00.0017E2r 2  88                   dey
+00.0017E3r 2  B1 6F                lda     (INDEX),y
+00.0017E5r 2  85 AE                sta     FAC
+00.0017E7r 2  84 BD                sty     FACEXTENSION
+00.0017E9r 2  60                   rts
+00.0017EAr 2               
+00.0017EAr 2               ; ----------------------------------------------------------------------------
+00.0017EAr 2               ; ROUND FAC, STORE IN TEMP2
+00.0017EAr 2               ; ----------------------------------------------------------------------------
+00.0017EAr 2               STORE_FAC_IN_TEMP2_ROUNDED:
+00.0017EAr 2  A2 A9                ldx     #TEMP2
+00.0017ECr 2  2C                   .byte   $2C
+00.0017EDr 2               
+00.0017EDr 2               ; ----------------------------------------------------------------------------
+00.0017EDr 2               ; ROUND FAC, STORE IN TEMP1
+00.0017EDr 2               ; ----------------------------------------------------------------------------
+00.0017EDr 2               STORE_FAC_IN_TEMP1_ROUNDED:
+00.0017EDr 2  A2 A4                ldx     #TEMP1X
+00.0017EFr 2  A0 00                ldy     #$00
+00.0017F1r 2  F0 04                beq     STORE_FAC_AT_YX_ROUNDED
+00.0017F3r 2               
+00.0017F3r 2               ; ----------------------------------------------------------------------------
+00.0017F3r 2               ; ROUND FAC, AND STORE WHERE FORPNT POINTS
+00.0017F3r 2               ; ----------------------------------------------------------------------------
+00.0017F3r 2               SETFOR:
+00.0017F3r 2  A6 96                ldx     FORPNT
+00.0017F5r 2  A4 97                ldy     FORPNT+1
+00.0017F7r 2               
+00.0017F7r 2               ; ----------------------------------------------------------------------------
+00.0017F7r 2               ; ROUND FAC, AND STORE AT (Y,X)
+00.0017F7r 2               ; ----------------------------------------------------------------------------
+00.0017F7r 2               STORE_FAC_AT_YX_ROUNDED:
+00.0017F7r 2  20 rr rr             jsr     ROUND_FAC
+00.0017FAr 2  86 6F                stx     INDEX
+00.0017FCr 2  84 70                sty     INDEX+1
+00.0017FEr 2  A0 04                ldy     #MANTISSA_BYTES
+00.001800r 2               .ifndef CONFIG_SMALL
+00.001800r 2  A5 B2                lda     FAC+4
+00.001802r 2  91 6F                sta     (INDEX),y
+00.001804r 2  88                   dey
+00.001805r 2               .endif
+00.001805r 2  A5 B1                lda     FAC+3
+00.001807r 2  91 6F                sta     (INDEX),y
+00.001809r 2  88                   dey
+00.00180Ar 2  A5 B0                lda     FAC+2
+00.00180Cr 2  91 6F                sta     (INDEX),y
+00.00180Er 2  88                   dey
+00.00180Fr 2  A5 B3                lda     FACSIGN
+00.001811r 2  09 7F                ora     #$7F
+00.001813r 2  25 AF                and     FAC+1
+00.001815r 2  91 6F                sta     (INDEX),y
+00.001817r 2  88                   dey
+00.001818r 2  A5 AE                lda     FAC
+00.00181Ar 2  91 6F                sta     (INDEX),y
+00.00181Cr 2  84 BD                sty     FACEXTENSION
+00.00181Er 2  60                   rts
+00.00181Fr 2               
+00.00181Fr 2               ; ----------------------------------------------------------------------------
+00.00181Fr 2               ; COPY ARG INTO FAC
+00.00181Fr 2               ; ----------------------------------------------------------------------------
+00.00181Fr 2               COPY_ARG_TO_FAC:
+00.00181Fr 2  A5 BB                lda     ARGSIGN
+00.001821r 2               MFA:
+00.001821r 2  85 B3                sta     FACSIGN
+00.001823r 2  A2 05                ldx     #BYTES_FP
+00.001825r 2               L3A7A:
+00.001825r 2  B5 B5                lda     SHIFTSIGNEXT,x
+00.001827r 2  95 AD                sta     EXPSGN,x
+00.001829r 2  CA                   dex
+00.00182Ar 2  D0 F9                bne     L3A7A
+00.00182Cr 2  86 BD                stx     FACEXTENSION
+00.00182Er 2  60                   rts
+00.00182Fr 2               
+00.00182Fr 2               ; ----------------------------------------------------------------------------
+00.00182Fr 2               ; ROUND FAC AND COPY TO ARG
+00.00182Fr 2               ; ----------------------------------------------------------------------------
+00.00182Fr 2               COPY_FAC_TO_ARG_ROUNDED:
+00.00182Fr 2  20 rr rr             jsr     ROUND_FAC
+00.001832r 2               MAF:
+00.001832r 2  A2 06                ldx     #BYTES_FP+1
+00.001834r 2               L3A89:
+00.001834r 2  B5 AD                lda     EXPSGN,x
+00.001836r 2  95 B5                sta     SHIFTSIGNEXT,x
+00.001838r 2  CA                   dex
+00.001839r 2  D0 F9                bne     L3A89
+00.00183Br 2  86 BD                stx     FACEXTENSION
+00.00183Dr 2               RTS14:
+00.00183Dr 2  60                   rts
+00.00183Er 2               
+00.00183Er 2               ; ----------------------------------------------------------------------------
+00.00183Er 2               ; ROUND FAC USING EXTENSION BYTE
+00.00183Er 2               ; ----------------------------------------------------------------------------
+00.00183Er 2               ROUND_FAC:
+00.00183Er 2  A5 AE                lda     FAC
+00.001840r 2  F0 FB                beq     RTS14
+00.001842r 2  06 BD                asl     FACEXTENSION
+00.001844r 2  90 F7                bcc     RTS14
+00.001846r 2               
+00.001846r 2               ; ----------------------------------------------------------------------------
+00.001846r 2               ; INCREMENT MANTISSA AND RE-NORMALIZE IF CARRY
+00.001846r 2               ; ----------------------------------------------------------------------------
+00.001846r 2               INCREMENT_MANTISSA:
+00.001846r 2  20 rr rr             jsr     INCREMENT_FAC_MANTISSA
+00.001849r 2  D0 F2                bne     RTS14
+00.00184Br 2  4C rr rr             jmp     NORMALIZE_FAC6
+00.00184Er 2               
+00.00184Er 2               ; ----------------------------------------------------------------------------
+00.00184Er 2               ; TEST FAC FOR ZERO AND SIGN
+00.00184Er 2               ;
+00.00184Er 2               ; FAC > 0, RETURN +1
+00.00184Er 2               ; FAC = 0, RETURN  0
+00.00184Er 2               ; FAC < 0, RETURN -1
+00.00184Er 2               ; ----------------------------------------------------------------------------
+00.00184Er 2               SIGN:
+00.00184Er 2  A5 AE                lda     FAC
+00.001850r 2  F0 09                beq     RTS15
+00.001852r 2               L3AA7:
+00.001852r 2  A5 B3                lda     FACSIGN
+00.001854r 2               SIGN2:
+00.001854r 2  2A                   rol     a
+00.001855r 2  A9 FF                lda     #$FF
+00.001857r 2  B0 02                bcs     RTS15
+00.001859r 2  A9 01                lda     #$01
+00.00185Br 2               RTS15:
+00.00185Br 2  60                   rts
+00.00185Cr 2               
+00.00185Cr 2               ; ----------------------------------------------------------------------------
+00.00185Cr 2               ; "SGN" FUNCTION
+00.00185Cr 2               ; ----------------------------------------------------------------------------
+00.00185Cr 2               SGN:
+00.00185Cr 2  20 rr rr             jsr     SIGN
+00.00185Fr 2               
+00.00185Fr 2               ; ----------------------------------------------------------------------------
+00.00185Fr 2               ; CONVERT (A) INTO FAC, AS SIGNED VALUE -128 TO +127
+00.00185Fr 2               ; ----------------------------------------------------------------------------
+00.00185Fr 2               FLOAT:
+00.00185Fr 2  85 AF                sta     FAC+1
+00.001861r 2  A9 00                lda     #$00
+00.001863r 2  85 B0                sta     FAC+2
+00.001865r 2  A2 88                ldx     #$88
+00.001867r 2               
+00.001867r 2               ; ----------------------------------------------------------------------------
+00.001867r 2               ; FLOAT UNSIGNED VALUE IN FAC+1,2
+00.001867r 2               ; (X) = EXPONENT
+00.001867r 2               ; ----------------------------------------------------------------------------
+00.001867r 2               FLOAT1:
+00.001867r 2  A5 AF                lda     FAC+1
+00.001869r 2  49 FF                eor     #$FF
+00.00186Br 2  2A                   rol     a
+00.00186Cr 2               
+00.00186Cr 2               ; ----------------------------------------------------------------------------
+00.00186Cr 2               ; FLOAT UNSIGNED VALUE IN FAC+1,2
+00.00186Cr 2               ; (X) = EXPONENT
+00.00186Cr 2               ; C=0 TO MAKE VALUE NEGATIVE
+00.00186Cr 2               ; C=1 TO MAKE VALUE POSITIVE
+00.00186Cr 2               ; ----------------------------------------------------------------------------
+00.00186Cr 2               FLOAT2:
+00.00186Cr 2  A9 00                lda     #$00
+00.00186Er 2               .ifndef CONFIG_SMALL
+00.00186Er 2  85 B2                sta     FAC+4
+00.001870r 2               .endif
+00.001870r 2  85 B1                sta     FAC+3
+00.001872r 2               LDB21:
+00.001872r 2  86 AE                stx     FAC
+00.001874r 2  85 BD                sta     FACEXTENSION
+00.001876r 2  85 B3                sta     FACSIGN
+00.001878r 2  4C rr rr             jmp     NORMALIZE_FAC1
+00.00187Br 2               
+00.00187Br 2               ; ----------------------------------------------------------------------------
+00.00187Br 2               ; "ABS" FUNCTION
+00.00187Br 2               ; ----------------------------------------------------------------------------
+00.00187Br 2               ABS:
+00.00187Br 2  46 B3                lsr     FACSIGN
+00.00187Dr 2  60                   rts
+00.00187Er 2               
+00.00187Er 2               ; ----------------------------------------------------------------------------
+00.00187Er 2               ; COMPARE FAC WITH PACKED # AT (Y,A)
+00.00187Er 2               ; RETURN A=1,0,-1 AS (Y,A) IS <,=,> FAC
+00.00187Er 2               ; ----------------------------------------------------------------------------
+00.00187Er 2               FCOMP:
+00.00187Er 2  85 71                sta     DEST
+00.001880r 2               
+00.001880r 2               ; ----------------------------------------------------------------------------
+00.001880r 2               ; SPECIAL ENTRY FROM "NEXT" PROCESSOR
+00.001880r 2               ; "DEST" ALREADY SET UP
+00.001880r 2               ; ----------------------------------------------------------------------------
+00.001880r 2               FCOMP2:
+00.001880r 2  84 72                sty     DEST+1
+00.001882r 2  A0 00                ldy     #$00
+00.001884r 2  B1 71                lda     (DEST),y
+00.001886r 2  C8                   iny
+00.001887r 2  AA                   tax
+00.001888r 2  F0 C4                beq     SIGN
+00.00188Ar 2  B1 71                lda     (DEST),y
+00.00188Cr 2  45 B3                eor     FACSIGN
+00.00188Er 2  30 C2                bmi     L3AA7
+00.001890r 2  E4 AE                cpx     FAC
+00.001892r 2  D0 21                bne     L3B0A
+00.001894r 2  B1 71                lda     (DEST),y
+00.001896r 2  09 80                ora     #$80
+00.001898r 2  C5 AF                cmp     FAC+1
+00.00189Ar 2  D0 19                bne     L3B0A
+00.00189Cr 2  C8                   iny
+00.00189Dr 2  B1 71                lda     (DEST),y
+00.00189Fr 2  C5 B0                cmp     FAC+2
+00.0018A1r 2  D0 12                bne     L3B0A
+00.0018A3r 2  C8                   iny
+00.0018A4r 2               .ifndef CONFIG_SMALL
+00.0018A4r 2  B1 71                lda     (DEST),y
+00.0018A6r 2  C5 B1                cmp     FAC+3
+00.0018A8r 2  D0 0B                bne     L3B0A
+00.0018AAr 2  C8                   iny
+00.0018ABr 2               .endif
+00.0018ABr 2  A9 7F                lda     #$7F
+00.0018ADr 2  C5 BD                cmp     FACEXTENSION
+00.0018AFr 2  B1 71                lda     (DEST),y
+00.0018B1r 2  E5 B2                sbc     FAC_LAST
+00.0018B3r 2  F0 28                beq     L3B32
+00.0018B5r 2               L3B0A:
+00.0018B5r 2  A5 B3                lda     FACSIGN
+00.0018B7r 2  90 02                bcc     L3B10
+00.0018B9r 2  49 FF                eor     #$FF
+00.0018BBr 2               L3B10:
+00.0018BBr 2  4C rr rr             jmp     SIGN2
+00.0018BEr 2               
+00.0018BEr 2               ; ----------------------------------------------------------------------------
+00.0018BEr 2               ; QUICK INTEGER FUNCTION
+00.0018BEr 2               ;
+00.0018BEr 2               ; CONVERTS FP VALUE IN FAC TO INTEGER VALUE
+00.0018BEr 2               ; IN FAC+1...FAC+4, BY SHIFTING RIGHT WITH SIGN
+00.0018BEr 2               ; EXTENSION UNTIL FRACTIONAL BITS ARE OUT.
+00.0018BEr 2               ;
+00.0018BEr 2               ; THIS SUBROUTINE ASSUMES THE EXPONENT < 32.
+00.0018BEr 2               ; ----------------------------------------------------------------------------
+00.0018BEr 2               QINT:
+00.0018BEr 2  A5 AE                lda     FAC
+00.0018C0r 2  F0 4A                beq     QINT3
+00.0018C2r 2  38                   sec
+00.0018C3r 2  E9 A0                sbc     #120+8*BYTES_FP
+00.0018C5r 2  24 B3                bit     FACSIGN
+00.0018C7r 2  10 09                bpl     L3B27
+00.0018C9r 2  AA                   tax
+00.0018CAr 2  A9 FF                lda     #$FF
+00.0018CCr 2  85 B5                sta     SHIFTSIGNEXT
+00.0018CEr 2  20 rr rr             jsr     COMPLEMENT_FAC_MANTISSA
+00.0018D1r 2  8A                   txa
+00.0018D2r 2               L3B27:
+00.0018D2r 2  A2 AE                ldx     #FAC
+00.0018D4r 2  C9 F9                cmp     #$F9
+00.0018D6r 2  10 06                bpl     QINT2
+00.0018D8r 2  20 rr rr             jsr     SHIFT_RIGHT
+00.0018DBr 2  84 B5                sty     SHIFTSIGNEXT
+00.0018DDr 2               L3B32:
+00.0018DDr 2  60                   rts
+00.0018DEr 2               QINT2:
+00.0018DEr 2  A8                   tay
+00.0018DFr 2  A5 B3                lda     FACSIGN
+00.0018E1r 2  29 80                and     #$80
+00.0018E3r 2  46 AF                lsr     FAC+1
+00.0018E5r 2  05 AF                ora     FAC+1
+00.0018E7r 2  85 AF                sta     FAC+1
+00.0018E9r 2  20 rr rr             jsr     SHIFT_RIGHT4
+00.0018ECr 2  84 B5                sty     SHIFTSIGNEXT
+00.0018EEr 2  60                   rts
+00.0018EFr 2               
+00.0018EFr 2               ; ----------------------------------------------------------------------------
+00.0018EFr 2               ; "INT" FUNCTION
+00.0018EFr 2               ;
+00.0018EFr 2               ; USES QINT TO CONVERT (FAC) TO INTEGER FORM,
+00.0018EFr 2               ; AND THEN REFLOATS THE INTEGER.
+00.0018EFr 2               ; ----------------------------------------------------------------------------
+00.0018EFr 2               INT:
+00.0018EFr 2  A5 AE                lda     FAC
+00.0018F1r 2  C9 A0                cmp     #120+8*BYTES_FP
+00.0018F3r 2  B0 20                bcs     RTS17
+00.0018F5r 2  20 rr rr             jsr     QINT
+00.0018F8r 2  84 BD                sty     FACEXTENSION
+00.0018FAr 2  A5 B3                lda     FACSIGN
+00.0018FCr 2  84 B3                sty     FACSIGN
+00.0018FEr 2  49 80                eor     #$80
+00.001900r 2  2A                   rol     a
+00.001901r 2  A9 A0                lda     #120+8*BYTES_FP
+00.001903r 2  85 AE                sta     FAC
+00.001905r 2  A5 B2                lda     FAC_LAST
+00.001907r 2  85 0A                sta     CHARAC
+00.001909r 2  4C rr rr             jmp     NORMALIZE_FAC1
+00.00190Cr 2               QINT3:
+00.00190Cr 2  85 AF                sta     FAC+1
+00.00190Er 2  85 B0                sta     FAC+2
+00.001910r 2  85 B1                sta     FAC+3
+00.001912r 2               .ifndef CONFIG_SMALL
+00.001912r 2  85 B2                sta     FAC+4
+00.001914r 2               .endif
+00.001914r 2  A8                   tay
+00.001915r 2               RTS17:
+00.001915r 2  60                   rts
+00.001916r 2               
+00.001916r 2               ; ----------------------------------------------------------------------------
+00.001916r 2               ; CONVERT STRING TO FP VALUE IN FAC
+00.001916r 2               ;
+00.001916r 2               ; STRING POINTED TO BY TXTPTR
+00.001916r 2               ; FIRST CHAR ALREADY SCANNED BY CHRGET
+00.001916r 2               ; (A) = FIRST CHAR, C=0 IF DIGIT.
+00.001916r 2               ; ----------------------------------------------------------------------------
+00.001916r 2               FIN:
+00.001916r 2  A0 00                ldy     #$00
+00.001918r 2  A2 0A                ldx     #SERLEN-TMPEXP
+00.00191Ar 2               L3B6F:
+00.00191Ar 2  94 AA                sty     TMPEXP,x
+00.00191Cr 2  CA                   dex
+00.00191Dr 2  10 FB                bpl     L3B6F
+00.00191Fr 2  90 0F                bcc     FIN2
+00.001921r 2  C9 2D                cmp     #$2D
+00.001923r 2  D0 04                bne     L3B7E
+00.001925r 2  86 B4                stx     SERLEN
+00.001927r 2  F0 04                beq     FIN1
+00.001929r 2               L3B7E:
+00.001929r 2  C9 2B                cmp     #$2B
+00.00192Br 2  D0 05                bne     FIN3
+00.00192Dr 2               FIN1:
+00.00192Dr 2  20 C0 00             jsr     CHRGET
+00.001930r 2               FIN2:
+00.001930r 2  90 6F                bcc     FIN9
+00.001932r 2               FIN3:
+00.001932r 2  C9 2E                cmp     #$2E
+00.001934r 2  F0 38                beq     FIN10
+00.001936r 2  C9 45                cmp     #$45
+00.001938r 2  D0 44                bne     FIN7
+00.00193Ar 2  20 C0 00             jsr     CHRGET
+00.00193Dr 2  90 21                bcc     FIN5
+00.00193Fr 2  C9 A5                cmp     #TOKEN_MINUS
+00.001941r 2  F0 0E                beq     L3BA6
+00.001943r 2  C9 2D                cmp     #$2D
+00.001945r 2  F0 0A                beq     L3BA6
+00.001947r 2  C9 A4                cmp     #TOKEN_PLUS
+00.001949r 2  F0 12                beq     FIN4
+00.00194Br 2  C9 2B                cmp     #$2B
+00.00194Dr 2  F0 0E                beq     FIN4
+00.00194Fr 2  D0 11                bne     FIN6
+00.001951r 2               L3BA6:
+00.001951r 2               .ifndef CONFIG_ROR_WORKAROUND
+00.001951r 2                       ror     EXPSGN
+00.001951r 2               .else
+00.001951r 2  A9 00                lda     #$00
+00.001953r 2  90 02                bcc     L3BAC
+00.001955r 2  A9 80                lda     #$80
+00.001957r 2               L3BAC:
+00.001957r 2  46 AD                lsr     EXPSGN
+00.001959r 2  05 AD                ora     EXPSGN
+00.00195Br 2  85 AD                sta     EXPSGN
+00.00195Dr 2               .endif
+00.00195Dr 2               FIN4:
+00.00195Dr 2  20 C0 00             jsr     CHRGET
+00.001960r 2               FIN5:
+00.001960r 2  90 66                bcc     GETEXP
+00.001962r 2               FIN6:
+00.001962r 2  24 AD                bit     EXPSGN
+00.001964r 2  10 18                bpl     FIN7
+00.001966r 2  A9 00                lda     #$00
+00.001968r 2  38                   sec
+00.001969r 2  E5 AB                sbc     EXPON
+00.00196Br 2  4C rr rr             jmp     FIN8
+00.00196Er 2               
+00.00196Er 2               ; ----------------------------------------------------------------------------
+00.00196Er 2               ; FOUND A DECIMAL POINT
+00.00196Er 2               ; ----------------------------------------------------------------------------
+00.00196Er 2               FIN10:
+00.00196Er 2               .ifndef CONFIG_ROR_WORKAROUND
+00.00196Er 2                       ror     LOWTR
+00.00196Er 2               .else
+00.00196Er 2  A9 00                lda     #$00
+00.001970r 2  90 02                bcc     L3BC9
+00.001972r 2  A9 80                lda     #$80
+00.001974r 2               L3BC9:
+00.001974r 2  46 AC                lsr     LOWTR
+00.001976r 2  05 AC                ora     LOWTR
+00.001978r 2  85 AC                sta     LOWTR
+00.00197Ar 2               .endif
+00.00197Ar 2  24 AC                bit     LOWTR
+00.00197Cr 2  50 AF                bvc     FIN1
+00.00197Er 2               
+00.00197Er 2               ; ----------------------------------------------------------------------------
+00.00197Er 2               ; NUMBER TERMINATED, ADJUST EXPONENT NOW
+00.00197Er 2               ; ----------------------------------------------------------------------------
+00.00197Er 2               FIN7:
+00.00197Er 2  A5 AB                lda     EXPON
+00.001980r 2               FIN8:
+00.001980r 2  38                   sec
+00.001981r 2  E5 AA                sbc     INDX
+00.001983r 2  85 AB                sta     EXPON
+00.001985r 2  F0 12                beq     L3BEE
+00.001987r 2  10 09                bpl     L3BE7
+00.001989r 2               L3BDE:
+00.001989r 2  20 rr rr             jsr     DIV10
+00.00198Cr 2  E6 AB                inc     EXPON
+00.00198Er 2  D0 F9                bne     L3BDE
+00.001990r 2  F0 07                beq     L3BEE
+00.001992r 2               L3BE7:
+00.001992r 2  20 rr rr             jsr     MUL10
+00.001995r 2  C6 AB                dec     EXPON
+00.001997r 2  D0 F9                bne     L3BE7
+00.001999r 2               L3BEE:
+00.001999r 2  A5 B4                lda     SERLEN
+00.00199Br 2  30 01                bmi     L3BF3
+00.00199Dr 2  60                   rts
+00.00199Er 2               L3BF3:
+00.00199Er 2  4C rr rr             jmp     NEGOP
+00.0019A1r 2               
+00.0019A1r 2               ; ----------------------------------------------------------------------------
+00.0019A1r 2               ; ACCUMULATE A DIGIT INTO FAC
+00.0019A1r 2               ; ----------------------------------------------------------------------------
+00.0019A1r 2               FIN9:
+00.0019A1r 2  48                   pha
+00.0019A2r 2  24 AC                bit     LOWTR
+00.0019A4r 2  10 02                bpl     L3BFD
+00.0019A6r 2  E6 AA                inc     INDX
+00.0019A8r 2               L3BFD:
+00.0019A8r 2  20 rr rr             jsr     MUL10
+00.0019ABr 2  68                   pla
+00.0019ACr 2  38                   sec
+00.0019ADr 2  E9 30                sbc     #$30
+00.0019AFr 2  20 rr rr             jsr     ADDACC
+00.0019B2r 2  4C rr rr             jmp     FIN1
+00.0019B5r 2               
+00.0019B5r 2               ; ----------------------------------------------------------------------------
+00.0019B5r 2               ; ADD (A) TO FAC
+00.0019B5r 2               ; ----------------------------------------------------------------------------
+00.0019B5r 2               ADDACC:
+00.0019B5r 2  48                   pha
+00.0019B6r 2  20 rr rr             jsr     COPY_FAC_TO_ARG_ROUNDED
+00.0019B9r 2  68                   pla
+00.0019BAr 2  20 rr rr             jsr     FLOAT
+00.0019BDr 2  A5 BB                lda     ARGSIGN
+00.0019BFr 2  45 B3                eor     FACSIGN
+00.0019C1r 2  85 BC                sta     SGNCPR
+00.0019C3r 2  A6 AE                ldx     FAC
+00.0019C5r 2  4C rr rr             jmp     FADDT
+00.0019C8r 2               
+00.0019C8r 2               ; ----------------------------------------------------------------------------
+00.0019C8r 2               ; ACCUMULATE DIGIT OF EXPONENT
+00.0019C8r 2               ; ----------------------------------------------------------------------------
+00.0019C8r 2               GETEXP:
+00.0019C8r 2  A5 AB                lda     EXPON
+00.0019CAr 2  C9 0A                cmp     #MAX_EXPON
+00.0019CCr 2  90 09                bcc     L3C2C
+00.0019CEr 2               .ifdef CONFIG_10A
+00.0019CEr 2  A9 64                lda     #$64
+00.0019D0r 2               .endif
+00.0019D0r 2  24 AD                bit     EXPSGN
+00.0019D2r 2               .ifdef CONFIG_10A
+00.0019D2r 2  30 11                bmi     L3C3A
+00.0019D4r 2               .else
+00.0019D4r 2                       bmi     LDC70
+00.0019D4r 2               .endif
+00.0019D4r 2  4C rr rr             jmp     OVERFLOW
+00.0019D7r 2               LDC70:
+00.0019D7r 2               .ifndef CONFIG_10A
+00.0019D7r 2                       lda     #$0B
+00.0019D7r 2               .endif
+00.0019D7r 2               L3C2C:
+00.0019D7r 2  0A                   asl     a
+00.0019D8r 2  0A                   asl     a
+00.0019D9r 2  18                   clc
+00.0019DAr 2  65 AB                adc     EXPON
+00.0019DCr 2  0A                   asl     a
+00.0019DDr 2  18                   clc
+00.0019DEr 2  A0 00                ldy     #$00
+00.0019E0r 2  71 C7                adc     (TXTPTR),y
+00.0019E2r 2  38                   sec
+00.0019E3r 2  E9 30                sbc     #$30
+00.0019E5r 2               L3C3A:
+00.0019E5r 2  85 AB                sta     EXPON
+00.0019E7r 2  4C rr rr             jmp     FIN4
+00.0019EAr 2               
+00.0019EAr 2               ; ----------------------------------------------------------------------------
+00.0019EAr 2               .ifdef CONFIG_SMALL
+00.0019EAr 2               ; these values are /1000 of what the labels say
+00.0019EAr 2               CON_99999999_9:
+00.0019EAr 2                       .byte   $91,$43,$4F,$F8
+00.0019EAr 2               CON_999999999:
+00.0019EAr 2               		.byte   $94,$74,$23,$F7
+00.0019EAr 2               CON_BILLION:
+00.0019EAr 2                       .byte   $94,$74,$24,$00
+00.0019EAr 2               .else
+00.0019EAr 2               CON_99999999_9:
+00.0019EAr 2  9B 3E BC 1F          .byte   $9B,$3E,$BC,$1F,$FD
+00.0019EEr 2  FD           
+00.0019EFr 2               CON_999999999:
+00.0019EFr 2               .ifndef CONFIG_10A
+00.0019EFr 2                       .byte   $9E,$6E,$6B,$27,$FE
+00.0019EFr 2               .else
+00.0019EFr 2  9E 6E 6B 27          .byte   $9E,$6E,$6B,$27,$FD
+00.0019F3r 2  FD           
+00.0019F4r 2               .endif
+00.0019F4r 2               CON_BILLION:
+00.0019F4r 2  9E 6E 6B 28          .byte   $9E,$6E,$6B,$28,$00
+00.0019F8r 2  00           
+00.0019F9r 2               .endif
+00.0019F9r 2               
+00.0019F9r 2               ; ----------------------------------------------------------------------------
+00.0019F9r 2               ; PRINT "IN <LINE #>"
+00.0019F9r 2               ; ----------------------------------------------------------------------------
+00.0019F9r 2               INPRT:
+00.0019F9r 2               .ifdef KBD
+00.0019F9r 2                       jsr     LFE0B
+00.0019F9r 2                       .byte	" in"
+00.0019F9r 2                       .byte	0
+00.0019F9r 2               .else
+00.0019F9r 2  A9 rr                lda     #<QT_IN
+00.0019FBr 2  A0 rr                ldy     #>QT_IN
+00.0019FDr 2  20 rr rr             jsr     GOSTROUT2
+00.001A00r 2               .endif
+00.001A00r 2  A5 87                lda     CURLIN+1
+00.001A02r 2  A6 86                ldx     CURLIN
+00.001A04r 2               
+00.001A04r 2               ; ----------------------------------------------------------------------------
+00.001A04r 2               ; PRINT A,X AS DECIMAL INTEGER
+00.001A04r 2               ; ----------------------------------------------------------------------------
+00.001A04r 2               LINPRT:
+00.001A04r 2  85 AF                sta     FAC+1
+00.001A06r 2  86 B0                stx     FAC+2
+00.001A08r 2  A2 90                ldx     #$90
+00.001A0Ar 2  38                   sec
+00.001A0Br 2  20 rr rr             jsr     FLOAT2
+00.001A0Er 2  20 rr rr             jsr     FOUT
+00.001A11r 2               GOSTROUT2:
+00.001A11r 2  4C rr rr             jmp     STROUT
+00.001A14r 2               
+00.001A14r 2               ; ----------------------------------------------------------------------------
+00.001A14r 2               ; CONVERT (FAC) TO STRING STARTING AT STACK
+00.001A14r 2               ; RETURN WITH (Y,A) POINTING AT STRING
+00.001A14r 2               ; ----------------------------------------------------------------------------
+00.001A14r 2               FOUT:
+00.001A14r 2  A0 01                ldy     #$01
+00.001A16r 2               
+00.001A16r 2               ; ----------------------------------------------------------------------------
+00.001A16r 2               ; "STR$" FUNCTION ENTERS HERE, WITH (Y)=0
+00.001A16r 2               ; SO THAT RESULT STRING STARTS AT STACK-1
+00.001A16r 2               ; (THIS IS USED AS A FLAG)
+00.001A16r 2               ; ----------------------------------------------------------------------------
+00.001A16r 2               FOUT1:
+00.001A16r 2  A9 20                lda     #$20
+00.001A18r 2  24 B3                bit     FACSIGN
+00.001A1Ar 2  10 02                bpl     L3C73
+00.001A1Cr 2  A9 2D                lda     #$2D
+00.001A1Er 2               L3C73:
+00.001A1Er 2  99 FF 00             sta     $FF,y
+00.001A21r 2  85 B3                sta     FACSIGN
+00.001A23r 2  84 BE                sty     STRNG2
+00.001A25r 2  C8                   iny
+00.001A26r 2  A9 30                lda     #$30
+00.001A28r 2  A6 AE                ldx     FAC
+00.001A2Ar 2  D0 03                bne     L3C84
+00.001A2Cr 2  4C rr rr             jmp     FOUT4
+00.001A2Fr 2               L3C84:
+00.001A2Fr 2  A9 00                lda     #$00
+00.001A31r 2  E0 80                cpx     #$80
+00.001A33r 2  F0 02                beq     L3C8C
+00.001A35r 2  B0 09                bcs     L3C95
+00.001A37r 2               L3C8C:
+00.001A37r 2  A9 rr                lda     #<CON_BILLION
+00.001A39r 2  A0 rr                ldy     #>CON_BILLION
+00.001A3Br 2  20 rr rr             jsr     FMULT
+00.001A3Er 2               .ifdef CONFIG_SMALL
+00.001A3Er 2                       lda     #<-6 ; exponent adjustment
+00.001A3Er 2               .else
+00.001A3Er 2  A9 F7                lda     #<-9
+00.001A40r 2               .endif
+00.001A40r 2               L3C95:
+00.001A40r 2  85 AA                sta     INDX
+00.001A42r 2               ; ----------------------------------------------------------------------------
+00.001A42r 2               ; ADJUST UNTIL 1E8 <= (FAC) <1E9
+00.001A42r 2               ; ----------------------------------------------------------------------------
+00.001A42r 2               L3C97:
+00.001A42r 2  A9 rr                lda     #<CON_999999999
+00.001A44r 2  A0 rr                ldy     #>CON_999999999
+00.001A46r 2  20 rr rr             jsr     FCOMP
+00.001A49r 2  F0 1E                beq     L3CBE
+00.001A4Br 2  10 12                bpl     L3CB4
+00.001A4Dr 2               L3CA2:
+00.001A4Dr 2  A9 rr                lda     #<CON_99999999_9
+00.001A4Fr 2  A0 rr                ldy     #>CON_99999999_9
+00.001A51r 2  20 rr rr             jsr     FCOMP
+00.001A54r 2  F0 02                beq     L3CAD
+00.001A56r 2  10 0E                bpl     L3CBB
+00.001A58r 2               L3CAD:
+00.001A58r 2  20 rr rr             jsr     MUL10
+00.001A5Br 2  C6 AA                dec     INDX
+00.001A5Dr 2  D0 EE                bne     L3CA2
+00.001A5Fr 2               L3CB4:
+00.001A5Fr 2  20 rr rr             jsr     DIV10
+00.001A62r 2  E6 AA                inc     INDX
+00.001A64r 2  D0 DC                bne     L3C97
+00.001A66r 2               L3CBB:
+00.001A66r 2  20 rr rr             jsr     FADDH
+00.001A69r 2               L3CBE:
+00.001A69r 2  20 rr rr             jsr     QINT
+00.001A6Cr 2               ; ----------------------------------------------------------------------------
+00.001A6Cr 2               ; FAC+1...FAC+4 IS NOW IN INTEGER FORM
+00.001A6Cr 2               ; WITH POWER OF TEN ADJUSTMENT IN TMPEXP
+00.001A6Cr 2               ;
+00.001A6Cr 2               ; IF -10 < TMPEXP > 1, PRINT IN DECIMAL FORM
+00.001A6Cr 2               ; OTHERWISE, PRINT IN EXPONENTIAL FORM
+00.001A6Cr 2               ; ----------------------------------------------------------------------------
+00.001A6Cr 2  A2 01                ldx     #$01
+00.001A6Er 2  A5 AA                lda     INDX
+00.001A70r 2  18                   clc
+00.001A71r 2  69 0A                adc     #3*BYTES_FP-5
+00.001A73r 2  30 09                bmi     L3CD3
+00.001A75r 2  C9 0B                cmp     #3*BYTES_FP-4
+00.001A77r 2  B0 06                bcs     L3CD4
+00.001A79r 2  69 FF                adc     #$FF
+00.001A7Br 2  AA                   tax
+00.001A7Cr 2  A9 02                lda     #$02
+00.001A7Er 2               L3CD3:
+00.001A7Er 2  38                   sec
+00.001A7Fr 2               L3CD4:
+00.001A7Fr 2  E9 02                sbc     #$02
+00.001A81r 2  85 AB                sta     EXPON
+00.001A83r 2  86 AA                stx     INDX
+00.001A85r 2  8A                   txa
+00.001A86r 2  F0 02                beq     L3CDF
+00.001A88r 2  10 13                bpl     L3CF2
+00.001A8Ar 2               L3CDF:
+00.001A8Ar 2  A4 BE                ldy     STRNG2
+00.001A8Cr 2  A9 2E                lda     #$2E
+00.001A8Er 2  C8                   iny
+00.001A8Fr 2  99 FF 00             sta     $FF,y
+00.001A92r 2  8A                   txa
+00.001A93r 2  F0 06                beq     L3CF0
+00.001A95r 2  A9 30                lda     #$30
+00.001A97r 2  C8                   iny
+00.001A98r 2  99 FF 00             sta     $FF,y
+00.001A9Br 2               L3CF0:
+00.001A9Br 2  84 BE                sty     STRNG2
+00.001A9Dr 2               ; ----------------------------------------------------------------------------
+00.001A9Dr 2               ; NOW DIVIDE BY POWERS OF TEN TO GET SUCCESSIVE DIGITS
+00.001A9Dr 2               ; ----------------------------------------------------------------------------
+00.001A9Dr 2               L3CF2:
+00.001A9Dr 2  A0 00                ldy     #$00
+00.001A9Fr 2               LDD3A:
+00.001A9Fr 2  A2 80                ldx     #$80
+00.001AA1r 2               L3CF6:
+00.001AA1r 2  A5 B2                lda     FAC_LAST
+00.001AA3r 2  18                   clc
+00.001AA4r 2               .ifndef CONFIG_SMALL
+00.001AA4r 2  79 rr rr             adc     DECTBL+3,y
+00.001AA7r 2  85 B2                sta     FAC+4
+00.001AA9r 2  A5 B1                lda     FAC+3
+00.001AABr 2               .endif
+00.001AABr 2  79 rr rr             adc     DECTBL+2,y
+00.001AAEr 2  85 B1                sta     FAC+3
+00.001AB0r 2  A5 B0                lda     FAC+2
+00.001AB2r 2  79 rr rr             adc     DECTBL+1,y
+00.001AB5r 2  85 B0                sta     FAC+2
+00.001AB7r 2  A5 AF                lda     FAC+1
+00.001AB9r 2  79 rr rr             adc     DECTBL,y
+00.001ABCr 2  85 AF                sta     FAC+1
+00.001ABEr 2  E8                   inx
+00.001ABFr 2  B0 04                bcs     L3D1A
+00.001AC1r 2  10 DE                bpl     L3CF6
+00.001AC3r 2  30 02                bmi     L3D1C
+00.001AC5r 2               L3D1A:
+00.001AC5r 2  30 DA                bmi     L3CF6
+00.001AC7r 2               L3D1C:
+00.001AC7r 2  8A                   txa
+00.001AC8r 2  90 04                bcc     L3D23
+00.001ACAr 2  49 FF                eor     #$FF
+00.001ACCr 2  69 0A                adc     #$0A
+00.001ACEr 2               L3D23:
+00.001ACEr 2  69 2F                adc     #$2F
+00.001AD0r 2  C8                   iny
+00.001AD1r 2  C8                   iny
+00.001AD2r 2  C8                   iny
+00.001AD3r 2               .ifndef CONFIG_SMALL
+00.001AD3r 2  C8                   iny
+00.001AD4r 2               .endif
+00.001AD4r 2  84 94                sty     VARPNT
+00.001AD6r 2  A4 BE                ldy     STRNG2
+00.001AD8r 2  C8                   iny
+00.001AD9r 2  AA                   tax
+00.001ADAr 2  29 7F                and     #$7F
+00.001ADCr 2  99 FF 00             sta     $FF,y
+00.001ADFr 2  C6 AA                dec     INDX
+00.001AE1r 2  D0 06                bne     L3D3E
+00.001AE3r 2  A9 2E                lda     #$2E
+00.001AE5r 2  C8                   iny
+00.001AE6r 2  99 FF 00             sta     $FF,y
+00.001AE9r 2               L3D3E:
+00.001AE9r 2  84 BE                sty     STRNG2
+00.001AEBr 2  A4 94                ldy     VARPNT
+00.001AEDr 2  8A                   txa
+00.001AEEr 2  49 FF                eor     #$FF
+00.001AF0r 2  29 80                and     #$80
+00.001AF2r 2  AA                   tax
+00.001AF3r 2  C0 24                cpy     #DECTBL_END-DECTBL
+00.001AF5r 2               .ifdef CONFIG_CBM_ALL
+00.001AF5r 2                       beq     LDD96
+00.001AF5r 2                       cpy     #$3C ; XXX
+00.001AF5r 2               .endif
+00.001AF5r 2  D0 AA                bne     L3CF6
+00.001AF7r 2               ; ----------------------------------------------------------------------------
+00.001AF7r 2               ; NINE DIGITS HAVE BEEN STORED IN STRING.  NOW LOOK
+00.001AF7r 2               ; BACK AND LOP OFF TRAILING ZEROES AND A TRAILING
+00.001AF7r 2               ; DECIMAL POINT.
+00.001AF7r 2               ; ----------------------------------------------------------------------------
+00.001AF7r 2               LDD96:
+00.001AF7r 2  A4 BE                ldy     STRNG2
+00.001AF9r 2               L3D4E:
+00.001AF9r 2  B9 FF 00             lda     $FF,y
+00.001AFCr 2  88                   dey
+00.001AFDr 2  C9 30                cmp     #$30
+00.001AFFr 2  F0 F8                beq     L3D4E
+00.001B01r 2  C9 2E                cmp     #$2E
+00.001B03r 2  F0 01                beq     L3D5B
+00.001B05r 2  C8                   iny
+00.001B06r 2               L3D5B:
+00.001B06r 2  A9 2B                lda     #$2B
+00.001B08r 2  A6 AB                ldx     EXPON
+00.001B0Ar 2  F0 2E                beq     L3D8F
+00.001B0Cr 2  10 08                bpl     L3D6B
+00.001B0Er 2  A9 00                lda     #$00
+00.001B10r 2  38                   sec
+00.001B11r 2  E5 AB                sbc     EXPON
+00.001B13r 2  AA                   tax
+00.001B14r 2  A9 2D                lda     #$2D
+00.001B16r 2               L3D6B:
+00.001B16r 2  99 01 01             sta     STACK+1,y
+00.001B19r 2  A9 45                lda     #$45
+00.001B1Br 2  99 00 01             sta     STACK,y
+00.001B1Er 2  8A                   txa
+00.001B1Fr 2  A2 2F                ldx     #$2F
+00.001B21r 2  38                   sec
+00.001B22r 2               L3D77:
+00.001B22r 2  E8                   inx
+00.001B23r 2  E9 0A                sbc     #$0A
+00.001B25r 2  B0 FB                bcs     L3D77
+00.001B27r 2  69 3A                adc     #$3A
+00.001B29r 2  99 03 01             sta     STACK+3,y
+00.001B2Cr 2  8A                   txa
+00.001B2Dr 2  99 02 01             sta     STACK+2,y
+00.001B30r 2  A9 00                lda     #$00
+00.001B32r 2  99 04 01             sta     STACK+4,y
+00.001B35r 2  F0 08                beq     L3D94
+00.001B37r 2               FOUT4:
+00.001B37r 2  99 FF 00             sta     $FF,y
+00.001B3Ar 2               L3D8F:
+00.001B3Ar 2  A9 00                lda     #$00
+00.001B3Cr 2  99 00 01             sta     STACK,y
+00.001B3Fr 2               L3D94:
+00.001B3Fr 2  A9 00                lda     #$00
+00.001B41r 2  A0 01                ldy     #$01
+00.001B43r 2  60                   rts
+00.001B44r 2               
+00.001B44r 2               ; ----------------------------------------------------------------------------
+00.001B44r 2               CON_HALF:
+00.001B44r 2               .ifdef CONFIG_SMALL
+00.001B44r 2                       .byte   $80,$00,$00,$00
+00.001B44r 2               .else
+00.001B44r 2  80 00 00 00          .byte   $80,$00,$00,$00,$00
+00.001B48r 2  00           
+00.001B49r 2               .endif
+00.001B49r 2               
+00.001B49r 2               ; ----------------------------------------------------------------------------
+00.001B49r 2               ; POWERS OF 10 FROM 1E8 DOWN TO 1,
+00.001B49r 2               ; AS 32-BIT INTEGERS, WITH ALTERNATING SIGNS
+00.001B49r 2               ; ----------------------------------------------------------------------------
+00.001B49r 2               DECTBL:
+00.001B49r 2               .ifdef CONFIG_SMALL
+00.001B49r 2                       .byte   $FE,$79,$60 ; -100000
+00.001B49r 2               		.byte	$00,$27,$10 ; 10000
+00.001B49r 2               		.byte	$FF,$FC,$18 ; -1000
+00.001B49r 2               		.byte	$00,$00,$64 ; 100
+00.001B49r 2               		.byte	$FF,$FF,$F6 ; -10
+00.001B49r 2               		.byte	$00,$00,$01 ; 1
+00.001B49r 2               .else
+00.001B49r 2  FA 0A 1F 00  		.byte	$FA,$0A,$1F,$00	; -100000000
+00.001B4Dr 2  00 98 96 80  		.byte	$00,$98,$96,$80	; 10000000
+00.001B51r 2  FF F0 BD C0  		.byte	$FF,$F0,$BD,$C0	; -1000000
+00.001B55r 2  00 01 86 A0  		.byte	$00,$01,$86,$A0	; 100000
+00.001B59r 2  FF FF D8 F0  		.byte	$FF,$FF,$D8,$F0	; -10000
+00.001B5Dr 2  00 00 03 E8  		.byte   $00,$00,$03,$E8	; 1000
+00.001B61r 2  FF FF FF 9C  		.byte	$FF,$FF,$FF,$9C	; -100
+00.001B65r 2  00 00 00 0A  		.byte   $00,$00,$00,$0A	; 10
+00.001B69r 2  FF FF FF FF  		.byte	$FF,$FF,$FF,$FF	; -1
+00.001B6Dr 2               .endif
+00.001B6Dr 2               DECTBL_END:
+00.001B6Dr 2               .ifdef CONFIG_CBM_ALL
+00.001B6Dr 2               		.byte	$FF,$DF,$0A,$80 ; TI$
+00.001B6Dr 2               		.byte	$00,$03,$4B,$C0
+00.001B6Dr 2               		.byte	$FF,$FF,$73,$60
+00.001B6Dr 2               		.byte	$00,$00,$0E,$10
+00.001B6Dr 2               		.byte	$FF,$FF,$FD,$A8
+00.001B6Dr 2               		.byte	$00,$00,$00,$3C
+00.001B6Dr 2               .endif
+00.001B6Dr 2               .ifdef CONFIG_2
+00.001B6Dr 2               C_ZERO = CON_HALF + 2
+00.001B6Dr 2               .endif
+00.001B6Dr 2               
+00.001B6Dr 2               ; ----------------------------------------------------------------------------
+00.001B6Dr 2               ; "SQR" FUNCTION
+00.001B6Dr 2               ; ----------------------------------------------------------------------------
+00.001B6Dr 2               SQR:
+00.001B6Dr 2  20 rr rr             jsr     COPY_FAC_TO_ARG_ROUNDED
+00.001B70r 2  A9 rr                lda     #<CON_HALF
+00.001B72r 2  A0 rr                ldy     #>CON_HALF
+00.001B74r 2  20 rr rr             jsr     LOAD_FAC_FROM_YA
+00.001B77r 2               
+00.001B77r 2               ; ----------------------------------------------------------------------------
+00.001B77r 2               ; EXPONENTIATION OPERATION
+00.001B77r 2               ;
+00.001B77r 2               ; ARG ^ FAC  =  EXP( LOG(ARG) * FAC )
+00.001B77r 2               ; ----------------------------------------------------------------------------
+00.001B77r 2               FPWRT:
+00.001B77r 2  F0 70                beq     EXP
+00.001B79r 2  A5 B6                lda     ARG
+00.001B7Br 2  D0 03                bne     L3DD5
+00.001B7Dr 2  4C rr rr             jmp     STA_IN_FAC_SIGN_AND_EXP
+00.001B80r 2               L3DD5:
+00.001B80r 2  A2 9B                ldx     #TEMP3
+00.001B82r 2  A0 00                ldy     #$00
+00.001B84r 2  20 rr rr             jsr     STORE_FAC_AT_YX_ROUNDED
+00.001B87r 2  A5 BB                lda     ARGSIGN
+00.001B89r 2  10 0F                bpl     L3DEF
+00.001B8Br 2  20 rr rr             jsr     INT
+00.001B8Er 2  A9 9B                lda     #TEMP3
+00.001B90r 2  A0 00                ldy     #$00
+00.001B92r 2  20 rr rr             jsr     FCOMP
+00.001B95r 2  D0 03                bne     L3DEF
+00.001B97r 2  98                   tya
+00.001B98r 2  A4 0A                ldy     CHARAC
+00.001B9Ar 2               L3DEF:
+00.001B9Ar 2  20 rr rr             jsr     MFA
+00.001B9Dr 2  98                   tya
+00.001B9Er 2  48                   pha
+00.001B9Fr 2  20 rr rr             jsr     LOG
+00.001BA2r 2  A9 9B                lda     #TEMP3
+00.001BA4r 2  A0 00                ldy     #$00
+00.001BA6r 2  20 rr rr             jsr     FMULT
+00.001BA9r 2  20 rr rr             jsr     EXP
+00.001BACr 2  68                   pla
+00.001BADr 2  4A                   lsr     a
+00.001BAEr 2  90 0A                bcc     L3E0F
+00.001BB0r 2               
+00.001BB0r 2               ; ----------------------------------------------------------------------------
+00.001BB0r 2               ; NEGATE VALUE IN FAC
+00.001BB0r 2               ; ----------------------------------------------------------------------------
+00.001BB0r 2               NEGOP:
+00.001BB0r 2  A5 AE                lda     FAC
+00.001BB2r 2  F0 06                beq     L3E0F
+00.001BB4r 2  A5 B3                lda     FACSIGN
+00.001BB6r 2  49 FF                eor     #$FF
+00.001BB8r 2  85 B3                sta     FACSIGN
+00.001BBAr 2               L3E0F:
+00.001BBAr 2  60                   rts
+00.001BBBr 2               
+00.001BBBr 2               ; ----------------------------------------------------------------------------
+00.001BBBr 2               .ifdef CONFIG_SMALL
+00.001BBBr 2               CON_LOG_E:
+00.001BBBr 2                       .byte   $81,$38,$AA,$3B
+00.001BBBr 2               POLY_EXP:
+00.001BBBr 2               		.byte	$06
+00.001BBBr 2               		.byte	$74,$63,$90,$8C
+00.001BBBr 2               		.byte	$77,$23,$0C,$AB
+00.001BBBr 2               		.byte	$7A,$1E,$94,$00
+00.001BBBr 2               		.byte	$7C,$63,$42,$80
+00.001BBBr 2               		.byte	$7E,$75,$FE,$D0
+00.001BBBr 2               		.byte	$80,$31,$72,$15
+00.001BBBr 2               		.byte	$81,$00,$00,$00
+00.001BBBr 2               .else
+00.001BBBr 2               CON_LOG_E:
+00.001BBBr 2  81 38 AA 3B          .byte   $81,$38,$AA,$3B,$29
+00.001BBFr 2  29           
+00.001BC0r 2               POLY_EXP:
+00.001BC0r 2  07                   .byte   $07
+00.001BC1r 2  71 34 58 3E  		.byte	$71,$34,$58,$3E,$56
+00.001BC5r 2  56           
+00.001BC6r 2  74 16 7E B3  		.byte	$74,$16,$7E,$B3,$1B
+00.001BCAr 2  1B           
+00.001BCBr 2  77 2F EE E3  		.byte	$77,$2F,$EE,$E3,$85
+00.001BCFr 2  85           
+00.001BD0r 2  7A 1D 84 1C          .byte   $7A,$1D,$84,$1C,$2A
+00.001BD4r 2  2A           
+00.001BD5r 2  7C 63 59 58  		.byte	$7C,$63,$59,$58,$0A
+00.001BD9r 2  0A           
+00.001BDAr 2  7E 75 FD E7  		.byte	$7E,$75,$FD,$E7,$C6
+00.001BDEr 2  C6           
+00.001BDFr 2  80 31 72 18  		.byte	$80,$31,$72,$18,$10
+00.001BE3r 2  10           
+00.001BE4r 2  81 00 00 00  		.byte	$81,$00,$00,$00,$00
+00.001BE8r 2  00           
+00.001BE9r 2               .endif
+00.001BE9r 2               
+00.001BE9r 2               ; ----------------------------------------------------------------------------
+00.001BE9r 2               ; "EXP" FUNCTION
+00.001BE9r 2               ;
+00.001BE9r 2               ; FAC = E ^ FAC
+00.001BE9r 2               ; ----------------------------------------------------------------------------
+00.001BE9r 2               EXP:
+00.001BE9r 2  A9 rr                lda     #<CON_LOG_E
+00.001BEBr 2  A0 rr                ldy     #>CON_LOG_E
+00.001BEDr 2  20 rr rr             jsr     FMULT
+00.001BF0r 2  A5 BD                lda     FACEXTENSION
+00.001BF2r 2  69 50                adc     #$50
+00.001BF4r 2  90 03                bcc     L3E4E
+00.001BF6r 2  20 rr rr             jsr     INCREMENT_MANTISSA
+00.001BF9r 2               L3E4E:
+00.001BF9r 2  85 A3                sta     ARGEXTENSION
+00.001BFBr 2  20 rr rr             jsr     MAF
+00.001BFEr 2  A5 AE                lda     FAC
+00.001C00r 2  C9 88                cmp     #$88
+00.001C02r 2  90 03                bcc     L3E5C
+00.001C04r 2               L3E59:
+00.001C04r 2  20 rr rr             jsr     OUTOFRNG
+00.001C07r 2               L3E5C:
+00.001C07r 2  20 rr rr             jsr     INT
+00.001C0Ar 2  A5 0A                lda     CHARAC
+00.001C0Cr 2  18                   clc
+00.001C0Dr 2  69 81                adc     #$81
+00.001C0Fr 2  F0 F3                beq     L3E59
+00.001C11r 2  38                   sec
+00.001C12r 2  E9 01                sbc     #$01
+00.001C14r 2  48                   pha
+00.001C15r 2  A2 05                ldx     #BYTES_FP
+00.001C17r 2               L3E6C:
+00.001C17r 2  B5 B6                lda     ARG,x
+00.001C19r 2  B4 AE                ldy     FAC,x
+00.001C1Br 2  95 AE                sta     FAC,x
+00.001C1Dr 2  94 B6                sty     ARG,x
+00.001C1Fr 2  CA                   dex
+00.001C20r 2  10 F5                bpl     L3E6C
+00.001C22r 2  A5 A3                lda     ARGEXTENSION
+00.001C24r 2  85 BD                sta     FACEXTENSION
+00.001C26r 2  20 rr rr             jsr     FSUBT
+00.001C29r 2  20 rr rr             jsr     NEGOP
+00.001C2Cr 2  A9 rr                lda     #<POLY_EXP
+00.001C2Er 2  A0 rr                ldy     #>POLY_EXP
+00.001C30r 2  20 rr rr             jsr     POLYNOMIAL
+00.001C33r 2  A9 00                lda     #$00
+00.001C35r 2  85 BC                sta     SGNCPR
+00.001C37r 2  68                   pla
+00.001C38r 2  20 rr rr             jsr     ADD_EXPONENTS1
+00.001C3Br 2  60                   rts
+00.001C3Cr 2               
+00.001C3Cr 2               ; ----------------------------------------------------------------------------
+00.001C3Cr 2               ; ODD POLYNOMIAL SUBROUTINE
+00.001C3Cr 2               ;
+00.001C3Cr 2               ; F(X) = X * P(X^2)
+00.001C3Cr 2               ;
+00.001C3Cr 2               ; WHERE:  X IS VALUE IN FAC
+00.001C3Cr 2               ;	Y,A POINTS AT COEFFICIENT TABLE
+00.001C3Cr 2               ;	FIRST BYTE OF COEFF. TABLE IS N
+00.001C3Cr 2               ;	COEFFICIENTS FOLLOW, HIGHEST POWER FIRST
+00.001C3Cr 2               ;
+00.001C3Cr 2               ; P(X^2) COMPUTED USING NORMAL POLYNOMIAL SUBROUTINE
+00.001C3Cr 2               ; ----------------------------------------------------------------------------
+00.001C3Cr 2               POLYNOMIAL_ODD:
+00.001C3Cr 2  85 BE                sta     STRNG2
+00.001C3Er 2  84 BF                sty     STRNG2+1
+00.001C40r 2  20 rr rr             jsr     STORE_FAC_IN_TEMP1_ROUNDED
+00.001C43r 2  A9 A4                lda     #TEMP1X
+00.001C45r 2  20 rr rr             jsr     FMULT
+00.001C48r 2  20 rr rr             jsr     SERMAIN
+00.001C4Br 2  A9 A4                lda     #TEMP1X
+00.001C4Dr 2  A0 00                ldy     #$00
+00.001C4Fr 2  4C rr rr             jmp     FMULT
+00.001C52r 2               
+00.001C52r 2               ; ----------------------------------------------------------------------------
+00.001C52r 2               ; NORMAL POLYNOMIAL SUBROUTINE
+00.001C52r 2               ;
+00.001C52r 2               ; P(X) = C(0)*X^N + C(1)*X^(N-1) + ... + C(N)
+00.001C52r 2               ;
+00.001C52r 2               ; WHERE:  X IS VALUE IN FAC
+00.001C52r 2               ;	Y,A POINTS AT COEFFICIENT TABLE
+00.001C52r 2               ;	FIRST BYTE OF COEFF. TABLE IS N
+00.001C52r 2               ;	COEFFICIENTS FOLLOW, HIGHEST POWER FIRST
+00.001C52r 2               ; ----------------------------------------------------------------------------
+00.001C52r 2               POLYNOMIAL:
+00.001C52r 2  85 BE                sta     STRNG2
+00.001C54r 2  84 BF                sty     STRNG2+1
+00.001C56r 2               SERMAIN:
+00.001C56r 2  20 rr rr             jsr     STORE_FAC_IN_TEMP2_ROUNDED
+00.001C59r 2  B1 BE                lda     (STRNG2),y
+00.001C5Br 2  85 B4                sta     SERLEN
+00.001C5Dr 2  A4 BE                ldy     STRNG2
+00.001C5Fr 2  C8                   iny
+00.001C60r 2  98                   tya
+00.001C61r 2  D0 02                bne     L3EBA
+00.001C63r 2  E6 BF                inc     STRNG2+1
+00.001C65r 2               L3EBA:
+00.001C65r 2  85 BE                sta     STRNG2
+00.001C67r 2  A4 BF                ldy     STRNG2+1
+00.001C69r 2               L3EBE:
+00.001C69r 2  20 rr rr             jsr     FMULT
+00.001C6Cr 2  A5 BE                lda     STRNG2
+00.001C6Er 2  A4 BF                ldy     STRNG2+1
+00.001C70r 2  18                   clc
+00.001C71r 2  69 05                adc     #BYTES_FP
+00.001C73r 2  90 01                bcc     L3ECB
+00.001C75r 2  C8                   iny
+00.001C76r 2               L3ECB:
+00.001C76r 2  85 BE                sta     STRNG2
+00.001C78r 2  84 BF                sty     STRNG2+1
+00.001C7Ar 2  20 rr rr             jsr     FADD
+00.001C7Dr 2  A9 A9                lda     #TEMP2
+00.001C7Fr 2  A0 00                ldy     #$00
+00.001C81r 2  C6 B4                dec     SERLEN
+00.001C83r 2  D0 E4                bne     L3EBE
+00.001C85r 2               RTS19:
+00.001C85r 2  60                   rts
+00.001C86r 2               
+00.001C86r 1               .include "chrget.s"
+00.001C86r 2               .segment "CHRGET"
+0B.000000r 2               RAMSTART1:
+0B.000000r 2               GENERIC_CHRGET:
+0B.000000r 2  E6 C7                inc     TXTPTR
+0B.000002r 2  D0 02                bne     GENERIC_CHRGOT
+0B.000004r 2  E6 C8                inc     TXTPTR+1
+0B.000006r 2               GENERIC_CHRGOT:
+0B.000006r 2               GENERIC_TXTPTR = GENERIC_CHRGOT + 1
+0B.000006r 2  AD 60 EA             lda     $EA60
+0B.000009r 2               .ifdef KBD
+0B.000009r 2                       jsr     LF430
+0B.000009r 2               .endif
+0B.000009r 2  C9 3A                cmp     #$3A
+0B.00000Br 2  B0 0A                bcs     L4058
+0B.00000Dr 2               GENERIC_CHRGOT2:
+0B.00000Dr 2  C9 20                cmp     #$20
+0B.00000Fr 2  F0 EF                beq     GENERIC_CHRGET
+0B.000011r 2  38                   sec
+0B.000012r 2  E9 30                sbc     #$30
+0B.000014r 2  38                   sec
+0B.000015r 2  E9 D0                sbc     #$D0
+0B.000017r 2               L4058:
+0B.000017r 2  60                   rts
+0B.000018r 2               
+0B.000018r 1               .include "rnd.s"
+0B.000018r 2               .segment "CODE"
+00.001C86r 2               
+00.001C86r 2               ; ----------------------------------------------------------------------------
+00.001C86r 2               ; "RND" FUNCTION
+00.001C86r 2               ; ----------------------------------------------------------------------------
+00.001C86r 2               
+00.001C86r 2               .ifdef KBD
+00.001C86r 2               RND:
+00.001C86r 2                       ldx     #$10
+00.001C86r 2                       jsr     SIGN
+00.001C86r 2                       beq     LFC26
+00.001C86r 2                       bmi     LFC10
+00.001C86r 2                       lda     RNDSEED
+00.001C86r 2                       ldy     RNDSEED+1
+00.001C86r 2               LFBFA:
+00.001C86r 2                       sta     FAC+2
+00.001C86r 2                       sty     FAC+1
+00.001C86r 2               LFBFE:
+00.001C86r 2                       asl     a
+00.001C86r 2                       asl     a
+00.001C86r 2                       eor     FAC+2
+00.001C86r 2                       asl     a
+00.001C86r 2                       eor     FAC+1
+00.001C86r 2                       asl     a
+00.001C86r 2                       asl     a
+00.001C86r 2                       asl     a
+00.001C86r 2                       asl     a
+00.001C86r 2                       eor     FAC+1
+00.001C86r 2                       asl     a
+00.001C86r 2                       rol     FAC+2
+00.001C86r 2                       rol     FAC+1
+00.001C86r 2               LFC10:
+00.001C86r 2                       lda     FAC+2
+00.001C86r 2                       dex
+00.001C86r 2                       bne     LFBFE
+00.001C86r 2                       sta     RNDSEED
+00.001C86r 2                       sta     FAC+3
+00.001C86r 2                       lda     FAC+1
+00.001C86r 2                       sta     RNDSEED+1
+00.001C86r 2                       lda     #$80
+00.001C86r 2                       sta     FAC
+00.001C86r 2                       stx     FACSIGN
+00.001C86r 2                       jmp     NORMALIZE_FAC2
+00.001C86r 2               LFC26:
+00.001C86r 2                       ldy     $03CA
+00.001C86r 2                       lda     $03C7
+00.001C86r 2                       ora     #$01
+00.001C86r 2               GOMOVMF:
+00.001C86r 2                       bne     LFBFA
+00.001C86r 2                       .byte   $F0
+00.001C86r 2               .else
+00.001C86r 2               ; <<< THESE ARE MISSING ONE BYTE FOR FP VALUES >>>
+00.001C86r 2               ; (non CONFIG_SMALL)
+00.001C86r 2               CONRND1:
+00.001C86r 2  98 35 44 7A          .byte   $98,$35,$44,$7A
+00.001C8Ar 2               CONRND2:
+00.001C8Ar 2  68 28 B1 46          .byte   $68,$28,$B1,$46
+00.001C8Er 2               RND:
+00.001C8Er 2  20 rr rr             jsr     SIGN
+00.001C91r 2               .ifdef CONFIG_CBM_ALL
+00.001C91r 2                       bmi     L3F01
+00.001C91r 2                       bne     LDF63
+00.001C91r 2                       lda     ENTROPY
+00.001C91r 2                       sta     FAC+1
+00.001C91r 2                       lda     ENTROPY+4
+00.001C91r 2                       sta     FAC+2
+00.001C91r 2                       lda     ENTROPY+1
+00.001C91r 2                       sta     FAC+3
+00.001C91r 2                       lda     ENTROPY+5
+00.001C91r 2                       sta     FAC+4
+00.001C91r 2                       jmp     LDF88
+00.001C91r 2               LDF63:
+00.001C91r 2               .else
+00.001C91r 2  AA                   tax
+00.001C92r 2  30 18                bmi     L3F01
+00.001C94r 2               .endif
+00.001C94r 2  A9 D8                lda     #<RNDSEED
+00.001C96r 2  A0 00                ldy     #>RNDSEED
+00.001C98r 2  20 rr rr             jsr     LOAD_FAC_FROM_YA
+00.001C9Br 2               .ifndef CONFIG_CBM_ALL
+00.001C9Br 2  8A                   txa
+00.001C9Cr 2  F0 E7                beq     RTS19
+00.001C9Er 2               .endif
+00.001C9Er 2  A9 rr                lda     #<CONRND1
+00.001CA0r 2  A0 rr                ldy     #>CONRND1
+00.001CA2r 2  20 rr rr             jsr     FMULT
+00.001CA5r 2  A9 rr                lda     #<CONRND2
+00.001CA7r 2  A0 rr                ldy     #>CONRND2
+00.001CA9r 2  20 rr rr             jsr     FADD
+00.001CACr 2               L3F01:
+00.001CACr 2  A6 B2                ldx     FAC_LAST
+00.001CAEr 2  A5 AF                lda     FAC+1
+00.001CB0r 2  85 B2                sta     FAC_LAST
+00.001CB2r 2  86 AF                stx     FAC+1
+00.001CB4r 2               .ifdef CONFIG_CBM_ALL
+00.001CB4r 2                       ldx     FAC+2
+00.001CB4r 2                       lda     FAC+3
+00.001CB4r 2                       sta     FAC+2
+00.001CB4r 2                       stx     FAC+3
+00.001CB4r 2               LDF88:
+00.001CB4r 2               .endif
+00.001CB4r 2  A9 00                lda     #$00
+00.001CB6r 2  85 B3                sta     FACSIGN
+00.001CB8r 2  A5 AE                lda     FAC
+00.001CBAr 2  85 BD                sta     FACEXTENSION
+00.001CBCr 2  A9 80                lda     #$80
+00.001CBEr 2  85 AE                sta     FAC
+00.001CC0r 2  20 rr rr             jsr     NORMALIZE_FAC2
+00.001CC3r 2  A2 D8                ldx     #<RNDSEED
+00.001CC5r 2  A0 00                ldy     #>RNDSEED
+00.001CC7r 2               GOMOVMF:
+00.001CC7r 2  4C rr rr             jmp     STORE_FAC_AT_YX_ROUNDED
+00.001CCAr 2               .endif
+00.001CCAr 2               
+00.001CCAr 2               .segment "CHRGET"
+0B.000018r 2               ; ----------------------------------------------------------------------------
+0B.000018r 2               ; INITIAL VALUE FOR RANDOM NUMBER, ALSO COPIED
+0B.000018r 2               ; IN ALONG WITH CHRGET, BUT ERRONEOUSLY:
+0B.000018r 2               ; <<< THE LAST BYTE IS NOT COPIED >>>
+0B.000018r 2               ; (on all non-CONFIG_SMALL)
+0B.000018r 2               ; ----------------------------------------------------------------------------
+0B.000018r 2               GENERIC_RNDSEED:
+0B.000018r 2               .ifndef KBD
+0B.000018r 2               ; random number seed
+0B.000018r 2                 .ifdef CONFIG_SMALL
+0B.000018r 2                       .byte   $80,$4F,$C7,$52
+0B.000018r 2                 .else
+0B.000018r 2                   .ifdef CONFIG_11
+0B.000018r 2  80 4F C7 52          .byte   $80,$4F,$C7,$52,$58
+0B.00001Cr 2  58           
+0B.00001Dr 2                   .else
+0B.00001Dr 2                       .byte   $80,$4F,$C7,$52,$59
+0B.00001Dr 2                   .endif
+0B.00001Dr 2                 .endif
+0B.00001Dr 2               .endif
+0B.00001Dr 2               GENERIC_CHRGET_END:
+0B.00001Dr 2               
+0B.00001Dr 1               .include "trig.s"
+0B.00001Dr 2               .segment "CODE"
+00.001CCAr 2               
+00.001CCAr 2               SIN_COS_TAN_ATN:
+00.001CCAr 2               ; ----------------------------------------------------------------------------
+00.001CCAr 2               ; "COS" FUNCTION
+00.001CCAr 2               ; ----------------------------------------------------------------------------
+00.001CCAr 2               COS:
+00.001CCAr 2  A9 rr                lda     #<CON_PI_HALF
+00.001CCCr 2  A0 rr                ldy     #>CON_PI_HALF
+00.001CCEr 2  20 rr rr             jsr     FADD
+00.001CD1r 2               
+00.001CD1r 2               ; ----------------------------------------------------------------------------
+00.001CD1r 2               ; "SIN" FUNCTION
+00.001CD1r 2               ; ----------------------------------------------------------------------------
+00.001CD1r 2               SIN:
+00.001CD1r 2  20 rr rr             jsr     COPY_FAC_TO_ARG_ROUNDED
+00.001CD4r 2  A9 rr                lda     #<CON_PI_DOUB
+00.001CD6r 2  A0 rr                ldy     #>CON_PI_DOUB
+00.001CD8r 2  A6 BB                ldx     ARGSIGN
+00.001CDAr 2  20 rr rr             jsr     DIV
+00.001CDDr 2  20 rr rr             jsr     COPY_FAC_TO_ARG_ROUNDED
+00.001CE0r 2  20 rr rr             jsr     INT
+00.001CE3r 2  A9 00                lda     #$00
+00.001CE5r 2  85 BC                sta     STRNG1
+00.001CE7r 2  20 rr rr             jsr     FSUBT
+00.001CEAr 2               ; ----------------------------------------------------------------------------
+00.001CEAr 2               ; (FAC) = ANGLE AS A FRACTION OF A FULL CIRCLE
+00.001CEAr 2               ;
+00.001CEAr 2               ; NOW FOLD THE RANGE INTO A QUARTER CIRCLE
+00.001CEAr 2               ;
+00.001CEAr 2               ; <<< THERE ARE MUCH SIMPLER WAYS TO DO THIS >>>
+00.001CEAr 2               ; ----------------------------------------------------------------------------
+00.001CEAr 2  A9 rr                lda     #<QUARTER
+00.001CECr 2  A0 rr                ldy     #>QUARTER
+00.001CEEr 2  20 rr rr             jsr     FSUB
+00.001CF1r 2  A5 B3                lda     FACSIGN
+00.001CF3r 2  48                   pha
+00.001CF4r 2  10 0D                bpl     SIN1
+00.001CF6r 2  20 rr rr             jsr     FADDH
+00.001CF9r 2  A5 B3                lda     FACSIGN
+00.001CFBr 2  30 09                bmi     L3F5B
+00.001CFDr 2  A5 13                lda     CPRMASK
+00.001CFFr 2  49 FF                eor     #$FF
+00.001D01r 2  85 13                sta     CPRMASK
+00.001D03r 2               ; ----------------------------------------------------------------------------
+00.001D03r 2               ; IF FALL THRU, RANGE IS 0...1/2
+00.001D03r 2               ; IF BRANCH HERE, RANGE IS 0...1/4
+00.001D03r 2               ; ----------------------------------------------------------------------------
+00.001D03r 2               SIN1:
+00.001D03r 2  20 rr rr             jsr     NEGOP
+00.001D06r 2               ; ----------------------------------------------------------------------------
+00.001D06r 2               ; IF FALL THRU, RANGE IS -1/2...0
+00.001D06r 2               ; IF BRANCH HERE, RANGE IS -1/4...0
+00.001D06r 2               ; ----------------------------------------------------------------------------
+00.001D06r 2               L3F5B:
+00.001D06r 2  A9 rr                lda     #<QUARTER
+00.001D08r 2  A0 rr                ldy     #>QUARTER
+00.001D0Ar 2  20 rr rr             jsr     FADD
+00.001D0Dr 2  68                   pla
+00.001D0Er 2  10 03                bpl     L3F68
+00.001D10r 2  20 rr rr             jsr     NEGOP
+00.001D13r 2               L3F68:
+00.001D13r 2  A9 rr                lda     #<POLY_SIN
+00.001D15r 2  A0 rr                ldy     #>POLY_SIN
+00.001D17r 2  4C rr rr             jmp     POLYNOMIAL_ODD
+00.001D1Ar 2               
+00.001D1Ar 2               ; ----------------------------------------------------------------------------
+00.001D1Ar 2               ; "TAN" FUNCTION
+00.001D1Ar 2               ;
+00.001D1Ar 2               ; COMPUTE TAN(X) = SIN(X) / COS(X)
+00.001D1Ar 2               ; ----------------------------------------------------------------------------
+00.001D1Ar 2               TAN:
+00.001D1Ar 2  20 rr rr             jsr     STORE_FAC_IN_TEMP1_ROUNDED
+00.001D1Dr 2  A9 00                lda     #$00
+00.001D1Fr 2  85 13                sta     CPRMASK
+00.001D21r 2  20 rr rr             jsr     SIN
+00.001D24r 2  A2 9B                ldx     #TEMP3
+00.001D26r 2  A0 00                ldy     #$00
+00.001D28r 2  20 rr rr             jsr     GOMOVMF
+00.001D2Br 2  A9 A4                lda     #TEMP1+(5-BYTES_FP)
+00.001D2Dr 2  A0 00                ldy     #$00
+00.001D2Fr 2  20 rr rr             jsr     LOAD_FAC_FROM_YA
+00.001D32r 2  A9 00                lda     #$00
+00.001D34r 2  85 B3                sta     FACSIGN
+00.001D36r 2  A5 13                lda     CPRMASK
+00.001D38r 2  20 rr rr             jsr     TAN1
+00.001D3Br 2  A9 9B                lda     #TEMP3
+00.001D3Dr 2  A0 00                ldy     #$00
+00.001D3Fr 2  4C rr rr             jmp     FDIV
+00.001D42r 2               TAN1:
+00.001D42r 2  48                   pha
+00.001D43r 2  4C rr rr             jmp     SIN1
+00.001D46r 2               
+00.001D46r 2               ; ----------------------------------------------------------------------------
+00.001D46r 2               .ifdef CONFIG_SMALL
+00.001D46r 2               CON_PI_HALF:
+00.001D46r 2                       .byte   $81,$49,$0F,$DB
+00.001D46r 2               CON_PI_DOUB:
+00.001D46r 2                       .byte   $83,$49,$0F,$DB
+00.001D46r 2               QUARTER:
+00.001D46r 2                       .byte   $7F,$00,$00,$00
+00.001D46r 2               POLY_SIN:
+00.001D46r 2                       .byte   $04,$86,$1E,$D7,$FB,$87,$99,$26
+00.001D46r 2                       .byte   $65,$87,$23,$34,$58,$86,$A5,$5D
+00.001D46r 2                       .byte   $E1,$83,$49,$0F,$DB
+00.001D46r 2               .else
+00.001D46r 2               CON_PI_HALF:
+00.001D46r 2  81 49 0F DA          .byte   $81,$49,$0F,$DA,$A2
+00.001D4Ar 2  A2           
+00.001D4Br 2               CON_PI_DOUB:
+00.001D4Br 2  83 49 0F DA          .byte   $83,$49,$0F,$DA,$A2
+00.001D4Fr 2  A2           
+00.001D50r 2               QUARTER:
+00.001D50r 2  7F 00 00 00          .byte   $7F,$00,$00,$00,$00
+00.001D54r 2  00           
+00.001D55r 2               POLY_SIN:
+00.001D55r 2  05 84 E6 1A          .byte   $05,$84,$E6,$1A,$2D,$1B,$86,$28
+00.001D59r 2  2D 1B 86 28  
+00.001D5Dr 2  07 FB F8 87          .byte   $07,$FB,$F8,$87,$99,$68,$89,$01
+00.001D61r 2  99 68 89 01  
+00.001D65r 2  87 23 35 DF          .byte   $87,$23,$35,$DF,$E1,$86,$A5,$5D
+00.001D69r 2  E1 86 A5 5D  
+00.001D6Dr 2  E7 28 83 49          .byte   $E7,$28,$83,$49,$0F,$DA,$A2
+00.001D71r 2  0F DA A2     
+00.001D74r 2                 .ifndef CONFIG_11
+00.001D74r 2               ; no easter egg text before BASIC 1.1
+00.001D74r 2                 .elseif !.def(CONFIG_2A)
+00.001D74r 2               ; ASCII encoded easter egg
+00.001D74r 2               MICROSOFT:
+00.001D74r 2  A6 D3 C1 C8          .byte   $A6,$D3,$C1,$C8,$D4,$C8,$D5,$C4
+00.001D78r 2  D4 C8 D5 C4  
+00.001D7Cr 2  CE CA                .byte   $CE,$CA
+00.001D7Er 2                 .else
+00.001D7Er 2               ; PET encoded easter egg text since CBM2
+00.001D7Er 2               MICROSOFT:
+00.001D7Er 2                       .byte   $A1,$54,$46,$8F,$13,$8F,$52,$43
+00.001D7Er 2                       .byte   $89,$CD
+00.001D7Er 2                 .endif
+00.001D7Er 2               .endif
+00.001D7Er 2               
+00.001D7Er 2               ; ----------------------------------------------------------------------------
+00.001D7Er 2               ; "ATN" FUNCTION
+00.001D7Er 2               ; ----------------------------------------------------------------------------
+00.001D7Er 2               ATN:
+00.001D7Er 2  A5 B3                lda     FACSIGN
+00.001D80r 2  48                   pha
+00.001D81r 2  10 03                bpl     L3FDB
+00.001D83r 2  20 rr rr             jsr     NEGOP
+00.001D86r 2               L3FDB:
+00.001D86r 2  A5 AE                lda     FAC
+00.001D88r 2  48                   pha
+00.001D89r 2  C9 81                cmp     #$81
+00.001D8Br 2  90 07                bcc     L3FE9
+00.001D8Dr 2  A9 rr                lda     #<CON_ONE
+00.001D8Fr 2  A0 rr                ldy     #>CON_ONE
+00.001D91r 2  20 rr rr             jsr     FDIV
+00.001D94r 2               ; ----------------------------------------------------------------------------
+00.001D94r 2               ; 0 <= X <= 1
+00.001D94r 2               ; 0 <= ATN(X) <= PI/8
+00.001D94r 2               ; ----------------------------------------------------------------------------
+00.001D94r 2               L3FE9:
+00.001D94r 2  A9 rr                lda     #<POLY_ATN
+00.001D96r 2  A0 rr                ldy     #>POLY_ATN
+00.001D98r 2  20 rr rr             jsr     POLYNOMIAL_ODD
+00.001D9Br 2  68                   pla
+00.001D9Cr 2  C9 81                cmp     #$81
+00.001D9Er 2  90 07                bcc     L3FFC
+00.001DA0r 2  A9 rr                lda     #<CON_PI_HALF
+00.001DA2r 2  A0 rr                ldy     #>CON_PI_HALF
+00.001DA4r 2  20 rr rr             jsr     FSUB
+00.001DA7r 2               L3FFC:
+00.001DA7r 2  68                   pla
+00.001DA8r 2  10 03                bpl     L4002
+00.001DAAr 2  4C rr rr             jmp     NEGOP
+00.001DADr 2               L4002:
+00.001DADr 2  60                   rts
+00.001DAEr 2               
+00.001DAEr 2               ; ----------------------------------------------------------------------------
+00.001DAEr 2               POLY_ATN:
+00.001DAEr 2               .ifdef CONFIG_SMALL
+00.001DAEr 2                       .byte   $08
+00.001DAEr 2               		.byte	$78,$3A,$C5,$37
+00.001DAEr 2               		.byte	$7B,$83,$A2,$5C
+00.001DAEr 2               		.byte	$7C,$2E,$DD,$4D
+00.001DAEr 2               		.byte	$7D,$99,$B0,$1E
+00.001DAEr 2               		.byte	$7D,$59,$ED,$24
+00.001DAEr 2               		.byte	$7E,$91,$72,$00
+00.001DAEr 2               		.byte	$7E,$4C,$B9,$73
+00.001DAEr 2               		.byte	$7F,$AA,$AA,$53
+00.001DAEr 2               		.byte	$81,$00,$00,$00
+00.001DAEr 2               .else
+00.001DAEr 2  0B                   .byte   $0B
+00.001DAFr 2  76 B3 83 BD  		.byte	$76,$B3,$83,$BD,$D3
+00.001DB3r 2  D3           
+00.001DB4r 2  79 1E F4 A6  		.byte	$79,$1E,$F4,$A6,$F5
+00.001DB8r 2  F5           
+00.001DB9r 2  7B 83 FC B0  		.byte	$7B,$83,$FC,$B0,$10
+00.001DBDr 2  10           
+00.001DBEr 2  7C 0C 1F 67          .byte   $7C,$0C,$1F,$67,$CA
+00.001DC2r 2  CA           
+00.001DC3r 2  7C DE 53 CB  		.byte	$7C,$DE,$53,$CB,$C1
+00.001DC7r 2  C1           
+00.001DC8r 2  7D 14 64 70  		.byte	$7D,$14,$64,$70,$4C
+00.001DCCr 2  4C           
+00.001DCDr 2  7D B7 EA 51  		.byte	$7D,$B7,$EA,$51,$7A
+00.001DD1r 2  7A           
+00.001DD2r 2  7D 63 30 88  		.byte	$7D,$63,$30,$88,$7E
+00.001DD6r 2  7E           
+00.001DD7r 2  7E 92 44 99  		.byte	$7E,$92,$44,$99,$3A
+00.001DDBr 2  3A           
+00.001DDCr 2  7E 4C CC 91  		.byte	$7E,$4C,$CC,$91,$C7
+00.001DE0r 2  C7           
+00.001DE1r 2  7F AA AA AA  		.byte	$7F,$AA,$AA,$AA,$13
+00.001DE5r 2  13           
+00.001DE6r 2  81 00 00 00          .byte   $81,$00,$00,$00,$00
+00.001DEAr 2  00           
+00.001DEBr 2               .endif
+00.001DEBr 2               
+00.001DEBr 2               .if .def(CONFIG_11A) && (!.def(CONFIG_2))
+00.001DEBr 2  00           		.byte	$00 ; XXX
+00.001DECr 2               .endif
+00.001DECr 2               
+00.001DECr 1               .include "init.s"
+00.001DECr 2               .segment "INIT"
+0C.000000r 2               
+0C.000000r 2               .ifdef KBD
+0C.000000r 2               FNDLIN2:
+0C.000000r 2                       php
+0C.000000r 2                       jmp     FNDLIN
+0C.000000r 2               .endif
+0C.000000r 2               
+0C.000000r 2               ; ----------------------------------------------------------------------------
+0C.000000r 2               PR_WRITTEN_BY:
+0C.000000r 2               .ifndef KBD
+0C.000000r 2                 .ifndef CONFIG_CBM_ALL
+0C.000000r 2  A9 rr                lda     #<QT_WRITTEN_BY
+0C.000002r 2  A0 rr                ldy     #>QT_WRITTEN_BY
+0C.000004r 2  20 rr rr             jsr     STROUT
+0C.000007r 2                 .endif
+0C.000007r 2               .endif
+0C.000007r 2               COLD_START:
+0C.000007r 2               .ifdef KBD
+0C.000007r 2                       lda     #<LFD81
+0C.000007r 2                       sta     $03A0
+0C.000007r 2                       lda     #>LFD81
+0C.000007r 2                       sta     $03A1
+0C.000007r 2                       lda     #$20
+0C.000007r 2                       sta     $0480
+0C.000007r 2                       lda     $0352
+0C.000007r 2                       sta     $04
+0C.000007r 2                       lda     $0353
+0C.000007r 2                       sta     $05
+0C.000007r 2               .else
+0C.000007r 2                 .ifndef CBM2
+0C.000007r 2  A2 FF                ldx     #$FF
+0C.000009r 2  86 87                stx     CURLIN+1
+0C.00000Br 2                 .endif
+0C.00000Br 2                 .ifdef CONFIG_NO_INPUTBUFFER_ZP
+0C.00000Br 2                       ldx     #$FB
+0C.00000Br 2                 .endif
+0C.00000Br 2  9A                   txs
+0C.00000Cr 2                 .ifndef CONFIG_CBM_ALL
+0C.00000Cr 2  A9 rr                lda     #<COLD_START
+0C.00000Er 2  A0 rr                ldy     #>COLD_START
+0C.000010r 2  85 01                sta     GORESTART+1
+0C.000012r 2  84 02                sty     GORESTART+2
+0C.000014r 2  85 04                sta     GOSTROUT+1
+0C.000016r 2  84 05                sty     GOSTROUT+2
+0C.000018r 2  A9 rr                lda     #<AYINT
+0C.00001Ar 2  A0 rr                ldy     #>AYINT
+0C.00001Cr 2  85 06                sta     GOAYINT
+0C.00001Er 2  84 07                sty     GOAYINT+1
+0C.000020r 2  A9 rr                lda     #<GIVAYF
+0C.000022r 2  A0 rr                ldy     #>GIVAYF
+0C.000024r 2  85 08                sta     GOGIVEAYF
+0C.000026r 2  84 09                sty     GOGIVEAYF+1
+0C.000028r 2                 .endif
+0C.000028r 2  A9 4C                lda     #$4C
+0C.00002Ar 2                 .ifdef CONFIG_CBM_ALL
+0C.00002Ar 2                       sta     JMPADRS
+0C.00002Ar 2                 .endif
+0C.00002Ar 2  85 00                sta     GORESTART
+0C.00002Cr 2                 .ifndef CONFIG_CBM_ALL
+0C.00002Cr 2  85 03                sta     GOSTROUT
+0C.00002Er 2  85 A1                sta     JMPADRS
+0C.000030r 2                 .endif
+0C.000030r 2                 .if (!.def(CONFIG_RAM)) && (!.def(CONFIG_CBM_ALL))
+0C.000030r 2                       sta     USR
+0C.000030r 2                 .endif
+0C.000030r 2               
+0C.000030r 2                 .ifndef CONFIG_RAM
+0C.000030r 2                   .ifdef APPLE
+0C.000030r 2                         lda     #<USR_FUNC
+0C.000030r 2                         ldy     #>USR_FUNC
+0C.000030r 2                   .else
+0C.000030r 2                         lda     #<IQERR
+0C.000030r 2                         ldy     #>IQERR
+0C.000030r 2                   .endif
+0C.000030r 2                         sta     USR+1
+0C.000030r 2                         sty     USR+2
+0C.000030r 2                 .endif
+0C.000030r 2                 .ifndef CBM1
+0C.000030r 2  A9 48                lda     #WIDTH
+0C.000032r 2  85 17                sta     Z17
+0C.000034r 2  A9 38                lda     #WIDTH2
+0C.000036r 2  85 18                sta     Z18
+0C.000038r 2                 .endif
+0C.000038r 2               .endif ; KBD
+0C.000038r 2               
+0C.000038r 2               ; All non-CONFIG_SMALL versions of BASIC have
+0C.000038r 2               ; the same bug here: While the number of bytes
+0C.000038r 2               ; to be copied is correct for CONFIG_SMALL,
+0C.000038r 2               ; it is one byte short on non-CONFIG_SMALL:
+0C.000038r 2               ; It seems the "ldx" value below has been
+0C.000038r 2               ; hardcoded. So on these configurations,
+0C.000038r 2               ; the last byte of GENERIC_RNDSEED, which
+0C.000038r 2               ; is 5 bytes instead of 4, does not get copied -
+0C.000038r 2               ; which is nothing major, because it is just
+0C.000038r 2               ; the least significant 8 bits of the mantissa
+0C.000038r 2               ; of the random number seed.
+0C.000038r 2               ; KBD added three bytes to CHRGET and removed
+0C.000038r 2               ; the random number seed, but only adjusted
+0C.000038r 2               ; the number of bytes by adding 3 - this
+0C.000038r 2               ; copies four bytes too many, which is no
+0C.000038r 2               ; problem.
+0C.000038r 2               .ifdef CONFIG_SMALL
+0C.000038r 2                 .ifdef KBD
+0C.000038r 2                       ldx     #GENERIC_CHRGET_END-GENERIC_CHRGET+4
+0C.000038r 2                 .else
+0C.000038r 2                       ldx     #GENERIC_CHRGET_END-GENERIC_CHRGET
+0C.000038r 2                 .endif
+0C.000038r 2               .else
+0C.000038r 2  A2 1C                ldx     #GENERIC_CHRGET_END-GENERIC_CHRGET-1 ; XXX
+0C.00003Ar 2               .endif
+0C.00003Ar 2               L4098:
+0C.00003Ar 2  BD rr rr             lda     GENERIC_CHRGET-1,x
+0C.00003Dr 2  95 BF                sta     CHRGET-1,x
+0C.00003Fr 2  CA                   dex
+0C.000040r 2  D0 F8                bne     L4098
+0C.000042r 2               .ifdef CONFIG_2
+0C.000042r 2                       lda     #$03
+0C.000042r 2                       sta     DSCLEN
+0C.000042r 2               .endif
+0C.000042r 2               .ifndef KBD
+0C.000042r 2  8A                   txa
+0C.000043r 2  85 B5                sta     SHIFTSIGNEXT
+0C.000045r 2                 .ifdef CONFIG_CBM_ALL
+0C.000045r 2                       sta     CURDVC
+0C.000045r 2                 .endif
+0C.000045r 2  85 65                sta     LASTPT+1
+0C.000047r 2                 .if .defined(CONFIG_NULL) || .defined(CONFIG_PRINTNULLS)
+0C.000047r 2  85 15                sta     Z15
+0C.000049r 2                 .endif
+0C.000049r 2                 .ifndef CONFIG_11
+0C.000049r 2                       sta     POSX
+0C.000049r 2                 .endif
+0C.000049r 2  48                   pha
+0C.00004Ar 2  85 14                sta     Z14
+0C.00004Cr 2                 .ifndef CBM2
+0C.00004Cr 2                   .ifndef MICROTAN
+0C.00004Cr 2  A9 03                lda     #$03
+0C.00004Er 2  85 A0                sta     DSCLEN
+0C.000050r 2                   .endif
+0C.000050r 2                   .ifndef CONFIG_11
+0C.000050r 2                       lda     #$2C
+0C.000050r 2                       sta     LINNUM+1
+0C.000050r 2                   .endif
+0C.000050r 2  20 rr rr             jsr     CRDO
+0C.000053r 2                 .endif
+0C.000053r 2                 .ifdef CBM2
+0C.000053r 2                       inx
+0C.000053r 2                       stx     INPUTBUFFER-3
+0C.000053r 2                       stx     INPUTBUFFER-4
+0C.000053r 2                 .endif
+0C.000053r 2                 .ifdef APPLE
+0C.000053r 2                       lda     #$01
+0C.000053r 2                       sta     INPUTBUFFER-3
+0C.000053r 2                       sta     INPUTBUFFER-4
+0C.000053r 2                 .endif
+0C.000053r 2  A2 66                ldx     #TEMPST
+0C.000055r 2  86 63                stx     TEMPPT
+0C.000057r 2               .ifndef CONFIG_CBM_ALL
+0C.000057r 2  A9 rr                lda     #<QT_MEMORY_SIZE
+0C.000059r 2  A0 rr                ldy     #>QT_MEMORY_SIZE
+0C.00005Br 2  20 rr rr             jsr     STROUT
+0C.00005Er 2                 .ifdef APPLE
+0C.00005Er 2                       jsr     INLINX
+0C.00005Er 2                 .else
+0C.00005Er 2  20 rr rr             jsr     NXIN
+0C.000061r 2                 .endif
+0C.000061r 2  86 C7                stx     TXTPTR
+0C.000063r 2  84 C8                sty     TXTPTR+1
+0C.000065r 2  20 C0 00             jsr     CHRGET
+0C.000068r 2  C9 41                cmp     #$41
+0C.00006Ar 2  F0 94                beq     PR_WRITTEN_BY
+0C.00006Cr 2  A8                   tay
+0C.00006Dr 2  D0 21                bne     L40EE
+0C.00006Fr 2               .endif
+0C.00006Fr 2               .ifndef CBM2
+0C.00006Fr 2  A9 rr                lda     #<RAMSTART2
+0C.000071r 2               .endif
+0C.000071r 2  A0 rr                ldy     #>RAMSTART2
+0C.000073r 2               .ifdef CONFIG_2
+0C.000073r 2                       sta     TXTTAB
+0C.000073r 2                       sty     TXTTAB+1
+0C.000073r 2               .endif
+0C.000073r 2  85 19                sta     LINNUM
+0C.000075r 2  84 1A                sty     LINNUM+1
+0C.000077r 2               .ifdef CBM2
+0C.000077r 2               		tay
+0C.000077r 2               .else
+0C.000077r 2  A0 00                ldy     #$00
+0C.000079r 2               .endif
+0C.000079r 2               L40D7:
+0C.000079r 2  E6 19                inc     LINNUM
+0C.00007Br 2  D0 02                bne     L40DD
+0C.00007Dr 2  E6 1A                inc     LINNUM+1
+0C.00007Fr 2               .ifdef CBM1
+0C.00007Fr 2               ; CBM: hard RAM top limit is $8000
+0C.00007Fr 2                       lda     LINNUM+1
+0C.00007Fr 2                       cmp     #$80
+0C.00007Fr 2                       beq     L40FA
+0C.00007Fr 2               .endif
+0C.00007Fr 2               .ifdef CBM2
+0C.00007Fr 2               ; optimized version of the CBM1 code
+0C.00007Fr 2                       bmi     L40FA
+0C.00007Fr 2               .endif
+0C.00007Fr 2               L40DD:
+0C.00007Fr 2               .ifdef CONFIG_2
+0C.00007Fr 2                       lda     #$55 ; 01010101 / 10101010
+0C.00007Fr 2               .else
+0C.00007Fr 2  A9 92                lda     #$92 ; 10010010 / 00100100
+0C.000081r 2               .endif
+0C.000081r 2  91 19                sta     (LINNUM),y
+0C.000083r 2  D1 19                cmp     (LINNUM),y
+0C.000085r 2  D0 15                bne     L40FA
+0C.000087r 2  0A                   asl     a
+0C.000088r 2  91 19                sta     (LINNUM),y
+0C.00008Ar 2  D1 19                cmp     (LINNUM),y
+0C.00008Cr 2               .ifdef CONFIG_CBM_ALL
+0C.00008Cr 2                       beq     L40D7
+0C.00008Cr 2               .else
+0C.00008Cr 2                 .ifndef CONFIG_11
+0C.00008Cr 2                       beq     L40D7; old: faster
+0C.00008Cr 2                       bne     L40FA
+0C.00008Cr 2                 .else
+0C.00008Cr 2  D0 0E                bne     L40FA; new: slower
+0C.00008Er 2  F0 E9                beq     L40D7
+0C.000090r 2                 .endif
+0C.000090r 2               L40EE:
+0C.000090r 2  20 C6 00             jsr     CHRGOT
+0C.000093r 2  20 rr rr             jsr     LINGET
+0C.000096r 2  A8                   tay
+0C.000097r 2  F0 03                beq     L40FA
+0C.000099r 2  4C rr rr             jmp     SYNERR
+0C.00009Cr 2               .endif
+0C.00009Cr 2               L40FA:
+0C.00009Cr 2  A5 19                lda     LINNUM
+0C.00009Er 2  A4 1A                ldy     LINNUM+1
+0C.0000A0r 2  85 84                sta     MEMSIZ
+0C.0000A2r 2  84 85                sty     MEMSIZ+1
+0C.0000A4r 2               .ifndef MICROTAN
+0C.0000A4r 2  85 80                sta     FRETOP
+0C.0000A6r 2  84 81                sty     FRETOP+1
+0C.0000A8r 2               .endif
+0C.0000A8r 2               L4106:
+0C.0000A8r 2               .ifndef CONFIG_CBM_ALL
+0C.0000A8r 2                 .ifdef APPLE
+0C.0000A8r 2                       lda     #$FF
+0C.0000A8r 2                       jmp     L2829
+0C.0000A8r 2                       .word	STROUT ; PATCH!
+0C.0000A8r 2                       jsr     NXIN
+0C.0000A8r 2                 .else
+0C.0000A8r 2  A9 rr                lda     #<QT_TERMINAL_WIDTH
+0C.0000AAr 2  A0 rr                ldy     #>QT_TERMINAL_WIDTH
+0C.0000ACr 2  20 rr rr             jsr     STROUT
+0C.0000AFr 2  20 rr rr             jsr     NXIN
+0C.0000B2r 2                 .endif
+0C.0000B2r 2  86 C7                stx     TXTPTR
+0C.0000B4r 2  84 C8                sty     TXTPTR+1
+0C.0000B6r 2  20 C0 00             jsr     CHRGET
+0C.0000B9r 2  A8                   tay
+0C.0000BAr 2  F0 1C                beq     L4136
+0C.0000BCr 2  20 rr rr             jsr     LINGET
+0C.0000BFr 2  A5 1A                lda     LINNUM+1
+0C.0000C1r 2  D0 E5                bne     L4106
+0C.0000C3r 2  A5 19                lda     LINNUM
+0C.0000C5r 2  C9 10                cmp     #$10
+0C.0000C7r 2  90 DF                bcc     L4106
+0C.0000C9r 2               L2829:
+0C.0000C9r 2  85 17                sta     Z17
+0C.0000CBr 2               L4129:
+0C.0000CBr 2  E9 0E                sbc     #$0E
+0C.0000CDr 2  B0 FC                bcs     L4129
+0C.0000CFr 2  49 FF                eor     #$FF
+0C.0000D1r 2  E9 0C                sbc     #$0C
+0C.0000D3r 2  18                   clc
+0C.0000D4r 2  65 17                adc     Z17
+0C.0000D6r 2  85 18                sta     Z18
+0C.0000D8r 2               .endif
+0C.0000D8r 2               L4136:
+0C.0000D8r 2               .ifdef CONFIG_RAM
+0C.0000D8r 2  A9 rr                lda     #<QT_WANT
+0C.0000DAr 2  A0 rr                ldy     #>QT_WANT
+0C.0000DCr 2  20 rr rr             jsr     STROUT
+0C.0000DFr 2  20 rr rr             jsr     NXIN
+0C.0000E2r 2  86 C7                stx     TXTPTR
+0C.0000E4r 2  84 C8                sty     TXTPTR+1
+0C.0000E6r 2  20 C0 00             jsr     CHRGET
+0C.0000E9r 2  A2 rr                ldx     #<RAMSTART1
+0C.0000EBr 2  A0 rr                ldy     #>RAMSTART1
+0C.0000EDr 2  C9 59                cmp     #'Y'
+0C.0000EFr 2  F0 34                beq     L4183
+0C.0000F1r 2  C9 41                cmp     #'A'
+0C.0000F3r 2  F0 04                beq     L4157
+0C.0000F5r 2  C9 4E                cmp     #'N'
+0C.0000F7r 2  D0 DF                bne     L4136
+0C.0000F9r 2               L4157:
+0C.0000F9r 2  A2 rr                ldx     #<IQERR
+0C.0000FBr 2  A0 rr                ldy     #>IQERR
+0C.0000FDr 2  8E rr rr             stx     UNFNC_ATN
+0C.000100r 2  8C rr rr             sty     UNFNC_ATN+1
+0C.000103r 2  A2 rr                ldx     #<ATN	; overwrite starting
+0C.000105r 2  A0 rr                ldy     #>ATN	; with ATN
+0C.000107r 2  C9 41                cmp     #'A'
+0C.000109r 2  F0 1A                beq     L4183
+0C.00010Br 2  A2 rr                ldx     #<IQERR
+0C.00010Dr 2  A0 rr                ldy     #>IQERR
+0C.00010Fr 2  8E rr rr             stx     UNFNC_COS
+0C.000112r 2  8C rr rr             sty     UNFNC_COS+1
+0C.000115r 2  8E rr rr             stx     UNFNC_TAN
+0C.000118r 2  8C rr rr             sty     UNFNC_TAN+1
+0C.00011Br 2  8E rr rr             stx     UNFNC_SIN
+0C.00011Er 2  8C rr rr             sty     UNFNC_SIN+1
+0C.000121r 2  A2 rr                ldx     #<SIN_COS_TAN_ATN	; overwrite
+0C.000123r 2  A0 rr                ldy     #>SIN_COS_TAN_ATN	; all of trig.s
+0C.000125r 2               L4183:
+0C.000125r 2               .else
+0C.000125r 2                       ldx     #<RAMSTART2
+0C.000125r 2                       ldy     #>RAMSTART2
+0C.000125r 2               .endif
+0C.000125r 2  86 78                stx     TXTTAB
+0C.000127r 2  84 79                sty     TXTTAB+1
+0C.000129r 2  A0 00                ldy     #$00
+0C.00012Br 2  98                   tya
+0C.00012Cr 2  91 78                sta     (TXTTAB),y
+0C.00012Er 2  E6 78                inc     TXTTAB
+0C.000130r 2               .ifndef CBM2
+0C.000130r 2  D0 02                bne     L4192
+0C.000132r 2  E6 79                inc     TXTTAB+1
+0C.000134r 2               L4192:
+0C.000134r 2               .endif
+0C.000134r 2               .if CONFIG_SCRTCH_ORDER = 1
+0C.000134r 2                       jsr     SCRTCH
+0C.000134r 2               .endif
+0C.000134r 2  A5 78                lda     TXTTAB
+0C.000136r 2  A4 79                ldy     TXTTAB+1
+0C.000138r 2  20 rr rr             jsr     REASON
+0C.00013Br 2               .ifdef CBM2
+0C.00013Br 2                       lda     #<QT_BASIC
+0C.00013Br 2                       ldy     #>QT_BASIC
+0C.00013Br 2                       jsr     STROUT
+0C.00013Br 2               .else
+0C.00013Br 2  20 rr rr             jsr     CRDO
+0C.00013Er 2               .endif
+0C.00013Er 2  A5 84                lda     MEMSIZ
+0C.000140r 2  38                   sec
+0C.000141r 2  E5 78                sbc     TXTTAB
+0C.000143r 2  AA                   tax
+0C.000144r 2  A5 85                lda     MEMSIZ+1
+0C.000146r 2  E5 79                sbc     TXTTAB+1
+0C.000148r 2  20 rr rr             jsr     LINPRT
+0C.00014Br 2  A9 rr                lda     #<QT_BYTES_FREE
+0C.00014Dr 2  A0 rr                ldy     #>QT_BYTES_FREE
+0C.00014Fr 2  20 rr rr             jsr     STROUT
+0C.000152r 2               .if CONFIG_SCRTCH_ORDER = 2
+0C.000152r 2  20 rr rr             jsr     SCRTCH
+0C.000155r 2               .endif
+0C.000155r 2               .ifdef CONFIG_CBM_ALL
+0C.000155r 2                       jmp     RESTART
+0C.000155r 2               .else
+0C.000155r 2  A9 rr                lda     #<STROUT
+0C.000157r 2  A0 rr                ldy     #>STROUT
+0C.000159r 2  85 04                sta     GOSTROUT+1
+0C.00015Br 2  84 05                sty     GOSTROUT+2
+0C.00015Dr 2                 .if CONFIG_SCRTCH_ORDER = 3
+0C.00015Dr 2                        jsr     SCRTCH
+0C.00015Dr 2                 .endif
+0C.00015Dr 2  A9 rr                lda     #<RESTART
+0C.00015Fr 2  A0 rr                ldy     #>RESTART
+0C.000161r 2  85 01                sta     GORESTART+1
+0C.000163r 2  84 02                sty     GORESTART+2
+0C.000165r 2  6C 01 00             jmp     (GORESTART+1)
+0C.000168r 2               .endif
+0C.000168r 2               
+0C.000168r 2                 .if .def(CONFIG_RAM) || .def(OSI)
+0C.000168r 2               ; OSI is compiled for ROM, but includes
+0C.000168r 2               ; this unused string
+0C.000168r 2               QT_WANT:
+0C.000168r 2  57 41 4E 54          .byte   "WANT SIN-COS-TAN-ATN"
+0C.00016Cr 2  20 53 49 4E  
+0C.000170r 2  2D 43 4F 53  
+0C.00017Cr 2  00                   .byte   0
+0C.00017Dr 2                 .endif
+0C.00017Dr 2               QT_WRITTEN_BY:
+0C.00017Dr 2                 .ifndef CONFIG_CBM_ALL
+0C.00017Dr 2                   .ifdef APPLE
+0C.00017Dr 2               		asc80 "COPYRIGHT 1977 BY MICROSOFT CO"
+0C.00017Dr 2               		.byte	CR,0
+0C.00017Dr 2                   .else
+0C.00017Dr 2  0D 0A 0C             .byte   CR,LF,$0C ; FORM FEED
+0C.000180r 2                     .ifndef CONFIG_11
+0C.000180r 2                       .byte   "WRITTEN BY RICHARD W. WEILAND."
+0C.000180r 2                     .else
+0C.000180r 2  57 52 49 54          .byte   "WRITTEN BY WEILAND & GATES"
+0C.000184r 2  54 45 4E 20  
+0C.000188r 2  42 59 20 57  
+0C.00019Ar 2                     .endif
+0C.00019Ar 2  0D 0A 00             .byte   CR,LF,0
+0C.00019Dr 2                   .endif
+0C.00019Dr 2               QT_MEMORY_SIZE:
+0C.00019Dr 2  4D 45 4D 4F          .byte   "MEMORY SIZE"
+0C.0001A1r 2  52 59 20 53  
+0C.0001A5r 2  49 5A 45     
+0C.0001A8r 2  00                   .byte   0
+0C.0001A9r 2               QT_TERMINAL_WIDTH:
+0C.0001A9r 2  54 45 52 4D          .byte   "TERMINAL WIDTH"
+0C.0001ADr 2  49 4E 41 4C  
+0C.0001B1r 2  20 57 49 44  
+0C.0001B7r 2  00                   .byte   0
+0C.0001B8r 2                 .endif
+0C.0001B8r 2               QT_BYTES_FREE:
+0C.0001B8r 2  20 42 59 54          .byte   " BYTES FREE"
+0C.0001BCr 2  45 53 20 46  
+0C.0001C0r 2  52 45 45     
+0C.0001C3r 2                 .ifdef CBM1
+0C.0001C3r 2                 .elseif .def(CBM2)
+0C.0001C3r 2                       .byte   CR,0
+0C.0001C3r 2                 .elseif .def(APPLE)
+0C.0001C3r 2                       .byte   0
+0C.0001C3r 2                 .else
+0C.0001C3r 2  0D 0A 0D 0A          .byte   CR,LF,CR,LF
+0C.0001C7r 2                 .endif
+0C.0001C7r 2               QT_BASIC:
+0C.0001C7r 2                 .ifdef OSI
+0C.0001C7r 2                       .byte   "OSI 6502 BASIC VERSION 1.0 REV 3.2"
+0C.0001C7r 2                 .endif
+0C.0001C7r 2                 .ifdef KIM
+0C.0001C7r 2  4D 4F 53 20          .byte   "MOS TECH 6502 BASIC V1.1"
+0C.0001CBr 2  54 45 43 48  
+0C.0001CFr 2  20 36 35 30  
+0C.0001DFr 2                 .endif
+0C.0001DFr 2                 .ifdef MICROTAN
+0C.0001DFr 2                       .byte   "MICROTAN BASIC"
+0C.0001DFr 2                 .endif
+0C.0001DFr 2                 .ifdef CBM1
+0C.0001DFr 2                       .byte   $13 ; HOME
+0C.0001DFr 2                       .byte   "*** COMMODORE BASIC ***"
+0C.0001DFr 2                       .byte   $11,$11,$11,0 ; DOWN/DOWN/DOWN
+0C.0001DFr 2                 .endif
+0C.0001DFr 2                 .ifdef CBM2
+0C.0001DFr 2                       .byte   "### COMMODORE BASIC ###"
+0C.0001DFr 2                       .byte   CR,CR,0
+0C.0001DFr 2                 .endif
+0C.0001DFr 2                 .ifdef APPLE
+0C.0001DFr 2                       .byte   LF,CR,LF
+0C.0001DFr 2               		.byte	"APPLE BASIC V1.1"
+0C.0001DFr 2                 .endif
+0C.0001DFr 2                 .ifndef CONFIG_CBM_ALL
+0C.0001DFr 2  0D 0A                .byte   CR,LF
+0C.0001E1r 2                   .ifdef MICROTAN
+0C.0001E1r 2                       .byte   "(C) 1980 MICROSOFT"
+0C.0001E1r 2                   .else
+0C.0001E1r 2  43 4F 50 59          .byte   "COPYRIGHT 1977 BY MICROSOFT CO."
+0C.0001E5r 2  52 49 47 48  
+0C.0001E9r 2  54 20 31 39  
+0C.000200r 2                   .endif
+0C.000200r 2  0D 0A 00             .byte   CR,LF,0
+0C.000203r 2                 .endif
+0C.000203r 2               .endif ; KBD
+0C.000203r 2               
+0C.000203r 1               .include "extra.s"
+0C.000203r 2               .segment "EXTRA"
+0D.000000r 2               
+0D.000000r 2               .ifdef KIM
+0D.000000r 2               .include "kim_extra.s"
+0D.000000r 3               .segment "EXTRA"
+0D.000000r 3               
+0D.000000r 3               RAMSTART2:
+0D.000000r 3  08 29 25 20          .byte   $08,$29,$25,$20,$60,$2A,$E5,$E4
+0D.000004r 3  60 2A E5 E4  
+0D.000008r 3  20 66 24 65          .byte   $20,$66,$24,$65,$AC,$04,$A4
+0D.00000Cr 3  AC 04 A4     
+0D.00000Fr 3               
+0D.00000Fr 2               .endif
+0D.00000Fr 2               
+0D.00000Fr 2               .ifdef CONFIG_CBM1_PATCHES
+0D.00000Fr 2               .include "cbm1_patches.s"
+0D.00000Fr 2               .endif
+0D.00000Fr 2               
+0D.00000Fr 2               .ifdef KBD
+0D.00000Fr 2               .include "kbd_extra.s"
+0D.00000Fr 2               .endif
+0D.00000Fr 2               
+0D.00000Fr 2               .ifdef APPLE
+0D.00000Fr 2               .include "apple_extra.s"
+0D.00000Fr 2               .endif
+0D.00000Fr 2               
+0D.00000Fr 2               .ifdef MICROTAN
+0D.00000Fr 2               .include "microtan_extra.s"
+0D.00000Fr 2               .endif
+0D.00000Fr 2               
+0D.00000Fr 1               
+
+Segment summary
+
+Segment: 00 = CODE
+Segment: 04 = ZEROPAGE
+Segment: 07 = VECTORS
+Segment: 08 = KEYWORDS
+Segment: 09 = DUMMY
+Segment: 0A = ERROR
+Segment: 0B = CHRGET
+Segment: 0C = INIT
+Segment: 0D = EXTRA

--- a/src/ca65/global.c
+++ b/src/ca65/global.c
@@ -69,6 +69,7 @@ unsigned char RelaxChecks        = 0;   /* Relax a few assembler checks */
 unsigned char StringEscapes      = 0;   /* Allow C-style escapes in strings */
 unsigned char LongJsrJmpRts      = 0;   /* Allow JSR/JMP/RTS as alias for JSL/JML/RTL */
 unsigned char WarningsAsErrors   = 0;   /* Error if any warnings */
+unsigned char SegList = 0;
 
 /* Emulation features */
 unsigned char DollarIsPC         = 0;   /* Allow the $ symbol as current PC */

--- a/src/ca65/global.h
+++ b/src/ca65/global.h
@@ -71,6 +71,7 @@ extern unsigned char    RelaxChecks;        /* Relax a few assembler checks */
 extern unsigned char    StringEscapes;      /* Allow C-style escapes in strings */
 extern unsigned char    LongJsrJmpRts;      /* Allow JSR/JMP/RTS as alias for JSL/JML/RTL */
 extern unsigned char    WarningsAsErrors;   /* Error if any warnings */
+extern unsigned char SegList;
 
 /* Emulation features */
 extern unsigned char    DollarIsPC;         /* Allow the $ symbol as current PC */

--- a/src/ca65/listing.c
+++ b/src/ca65/listing.c
@@ -73,7 +73,6 @@ static unsigned ListBytes  = 12;        /* Number of bytes to list for one line 
 
 /* Switch the listing on/off */
 static int      ListingEnabled = 1;     /* Enabled if > 0 */
-static int      EverReloc = 0;
 
 
 /*****************************************************************************/
@@ -122,7 +121,6 @@ void NewListingLine (const StrBuf* Line, unsigned char File, unsigned char Depth
             LineLast->Next = L;
         }
         LineLast = L;
-        EverReloc = EverReloc || L->Reloc;
     }
 }
 
@@ -327,9 +325,11 @@ void CreateListing (void)
     PageNumber = 0;
     PrintPageHeader (F, LineList);
 
-    /* Terminate the header buffer. The last byte will never get overwritten */
+    /* Terminate the header buffer. The last byte will never get overwritten
+    ** the - 3 adjust is for when the segnum gets prepended to the header.
+    */
 
-    HeaderBuf [(SegList ? LINE_HEADER_LEN : LINE_HEADER_LEN -3)] = '\0';
+    HeaderBuf [(SegList ? LINE_HEADER_LEN : LINE_HEADER_LEN - 3)] = '\0';
 
     /* Walk through all listing lines */
     L = LineList;
@@ -463,7 +463,8 @@ void CreateListing (void)
         L = L->Next;
 
     }
-
+    if (SegList)
+        ListSegments (F);
     /* Close the listing file */
     (void) fclose (F);
 }

--- a/src/ca65/listing.h
+++ b/src/ca65/listing.h
@@ -61,7 +61,6 @@ struct StrBuf;
 
 /* Length of the header of a listing line */
 #define LINE_HEADER_LEN         27
-static unsigned LineHeaderLen = 24;
 
 /* One listing line as it is stored in memory */
 typedef struct ListLine ListLine;

--- a/src/ca65/listing.h
+++ b/src/ca65/listing.h
@@ -60,7 +60,8 @@ struct StrBuf;
 
 
 /* Length of the header of a listing line */
-#define LINE_HEADER_LEN         24
+#define LINE_HEADER_LEN         27
+static unsigned LineHeaderLen = 24;
 
 /* One listing line as it is stored in memory */
 typedef struct ListLine ListLine;
@@ -68,6 +69,7 @@ struct ListLine {
     ListLine*           Next;           /* Pointer to next line */
     Fragment*           FragList;       /* List of fragments for this line */
     Fragment*           FragLast;       /* Last entry in fragment list */
+    unsigned            Seg;            /* Which segment this line targets */
     unsigned long       PC;             /* Program counter for this line */
     unsigned char       Reloc;          /* Relocatable mode? */
     unsigned char       File;           /* From which file is the line? */

--- a/src/ca65/main.c
+++ b/src/ca65/main.c
@@ -107,6 +107,7 @@ static void Usage (void)
             "  -s\t\t\t\tEnable smart mode\n"
             "  -t sys\t\t\tSet the target system\n"
             "  -v\t\t\t\tIncrease verbosity\n"
+            "  -S\t\t\t\tEnable segment offset listing\n"
             "\n"
             "Long options:\n"
             "  --auto-import\t\t\tMark unresolved symbols as import\n"
@@ -129,7 +130,8 @@ static void Usage (void)
             "  --smart\t\t\tEnable smart mode\n"
             "  --target sys\t\t\tSet the target system\n"
             "  --verbose\t\t\tIncrease verbosity\n"
-            "  --version\t\t\tPrint the assembler version\n",
+            "  --version\t\t\tPrint the assembler version\n"
+            "  --segment-list\t\tEnable segment offset listing\n",
             ProgName);
 }
 
@@ -967,6 +969,7 @@ int main (int argc, char* argv [])
         { "--verbose",             0,      OptVerbose              },
         { "--version",             0,      OptVersion              },
         { "--warnings-as-errors",  0,      OptWarningsAsErrors     },
+        { "--segment-list",        0,      OptSeglist              },
     };
 
     /* Name of the global name space */
@@ -1074,6 +1077,7 @@ int main (int argc, char* argv [])
                 case 'W':
                     WarnLevel = atoi (GetArg (&I, 2));
                     break;
+
                 case 'S':
                     OptSeglist (Arg, 0);
                     break;

--- a/src/ca65/main.c
+++ b/src/ca65/main.c
@@ -661,7 +661,12 @@ static void OptVersion (const char* Opt attribute ((unused)),
     exit(EXIT_SUCCESS);
 }
 
-
+static void OptSeglist (const char* Opt attribute ((unused)),
+    const char* Arg attribute ((unused)))
+    /* Enable segment listing */
+{
+    SegList = 1;
+}
 
 static void OptWarningsAsErrors (const char* Opt attribute ((unused)),
                                  const char* Arg attribute ((unused)))
@@ -1068,6 +1073,9 @@ int main (int argc, char* argv [])
 
                 case 'W':
                     WarnLevel = atoi (GetArg (&I, 2));
+                    break;
+                case 'S':
+                    OptSeglist (Arg, 0);
                     break;
 
                 default:

--- a/src/ca65/segment.c
+++ b/src/ca65/segment.c
@@ -476,7 +476,17 @@ void SegDump (void)
     printf ("\n");
 }
 
-
+void ListSegments (FILE* destination)
+{
+    /* summary of segments when seglist requested */
+    unsigned I;
+    fprintf (destination, "\nSegment summary\n\n");
+    for (I = 0; I < CollCount (&SegmentList); ++I) {
+        Segment* S = CollAtUnchecked (&SegmentList, I);
+        if(S->FragCount)
+            fprintf (destination, "Segment: %02X = %s\n", S->Num, S->Def->Name);
+    }
+}
 
 void SegInit (void)
 /* Initialize segments */

--- a/src/ca65/segment.h
+++ b/src/ca65/segment.h
@@ -36,7 +36,7 @@
 #ifndef SEGMENT_H
 #define SEGMENT_H
 
-
+#include <stdio.h>
 
 /* common */
 #include "coll.h"
@@ -95,6 +95,9 @@ extern Segment* ActiveSeg;
 
 Fragment* GenFragment (unsigned char Type, unsigned short Len);
 /* Generate a new fragment, add it to the current segment and return it. */
+
+void ListSegments (FILE* destination);
+/* List the segments to the given file when seglist set */
 
 void UseSeg (const SegDef* D);
 /* Use the given segment */


### PR DESCRIPTION
It can be hard to keep track of which segment code is being placed in. This patch adds a segment number to the output listing. Also adds to summary of segments at the end to map numbers to names

Enabled via -S and --segment-list. 

Sample output. Original

```
0001E1r 2                   .ifdef MICROTAN
0001E1r 2                       .byte   "(C) 1980 MICROSOFT"
0001E1r 2                   .else
0001E1r 2  43 4F 50 59          .byte   "COPYRIGHT 1977 BY MICROSOFT CO."
0001E5r 2  52 49 47 48  
0001E9r 2  54 20 31 39  
000200r 2                   .endif
000200r 2  0D 0A 00             .byte   CR,LF,0
000203r 2                 .endif
000203r 2               .endif ; KBD
000203r 2               
000203r 1               .include "extra.s"
000203r 2               .segment "EXTRA"
000000r 2               
000000r 2               .ifdef KIM
000000r 2               .include "kim_extra.s"
000000r 3               .segment "EXTRA"
000000r 3               
000000r 3               RAMSTART2:
000000r 3  08 29 25 20          .byte   $08,$29,$25,$20,$60,$2A,$E5,$E4
000004r 3  60 2A E5 E4  
000008r 3  20 66 24 65          .byte   $20,$66,$24,$65,$AC,$04,$A4
00000Cr 3  AC 04 A4     
00000Fr 3         
```      

with -S

```
0C.0001E1r 2                   .ifdef MICROTAN
0C.0001E1r 2                       .byte   "(C) 1980 MICROSOFT"
0C.0001E1r 2                   .else
0C.0001E1r 2  43 4F 50 59          .byte   "COPYRIGHT 1977 BY MICROSOFT CO."
0C.0001E5r 2  52 49 47 48  
0C.0001E9r 2  54 20 31 39  
0C.000200r 2                   .endif
0C.000200r 2  0D 0A 00             .byte   CR,LF,0
0C.000203r 2                 .endif
0C.000203r 2               .endif ; KBD
0C.000203r 2               
0C.000203r 1               .include "extra.s"
0C.000203r 2               .segment "EXTRA"
0D.000000r 2               
0D.000000r 2               .ifdef KIM
0D.000000r 2               .include "kim_extra.s"
0D.000000r 3               .segment "EXTRA"
0D.000000r 3               
0D.000000r 3               RAMSTART2:
0D.000000r 3  08 29 25 20          .byte   $08,$29,$25,$20,$60,$2A,$E5,$E4
0D.000004r 3  60 2A E5 E4  
0D.000008r 3  20 66 24 65          .byte   $20,$66,$24,$65,$AC,$04,$A4
0D.00000Cr 3  AC 04 A4     
0D.00000Fr 3               
```

If code is not relocatable then no suffix is produced
```
00.000000r 1               .include "zeropage.s"
00.000000r 2               
00.000000r 2               .feature org_per_seg
00.000000r 2               .zeropage
04.000000r 2               
04.000000r 2               .org ZP_START1
   000000  2               
   000000  2               GORESTART:
   000000  2  xx xx xx     	.res 3
   000003  2               GOSTROUT:
   000003  2  xx xx xx     	.res 3
   000006  2               GOAYINT:
   000006  2  xx xx        	.res 2
   000008  2               GOGIVEAYF:
   000008  2  xx xx        	.res 2
```

A segment summary is added to the listing
```
Segment summary

Segment: 00 = CODE
Segment: 04 = ZEROPAGE
Segment: 07 = VECTORS
Segment: 08 = KEYWORDS
Segment: 09 = DUMMY
Segment: 0A = ERROR
Segment: 0B = CHRGET
Segment: 0C = INIT
Segment: 0D = EXTRA
```
