### PR TITLE
[cc65] Fixed the issue that qualifiers of pointees of function parameters were ignored for type compatibility check

### DIFF
--- a/src/cc65/typecmp.c
+++ b/src/cc65/typecmp.c
@@ -69,6 +69,7 @@ static int EqualFuncParams (const FuncDesc* F1, const FuncDesc* F2)
         /* Get the symbol types */
         const Type* Type1 = Sym1->Type;
         const Type* Type2 = Sym2->Type;
+        typecmp_t   CmpResult;
 
         /* If either of both functions is old style, apply the default
         ** promotions to the parameter type.
@@ -84,9 +85,10 @@ static int EqualFuncParams (const FuncDesc* F1, const FuncDesc* F2)
             }
         }
 
-        /* Compare this field */
-        if (TypeCmp (Type1, Type2).C < TC_EQUAL) {
-            /* Field types not equal */
+        /* Compare types of this parameter */
+        CmpResult = TypeCmp (Type1, Type2);
+        if (CmpResult.C < TC_EQUAL || (CmpResult.F & TCF_MASK_PARAM_DIFF) != 0) {
+            /* The types are not compatible */
             return 0;
         }
 

--- a/src/cc65/typecmp.h
+++ b/src/cc65/typecmp.h
@@ -68,15 +68,17 @@ typedef enum {
     TCF_VOID_PTR_ON_LEFT    = 0x01, /* lhs is a void pointer */
     TCF_VOID_PTR_ON_RIGHT   = 0x02, /* rhs is a void pointer */
     TCF_MASK_VOID_PTR       = TCF_VOID_PTR_ON_LEFT | TCF_VOID_PTR_ON_RIGHT,
-    TCF_QUAL_DIFF           = 0x04, /* CVR qualifiers differ in a way that doesn't matter */
+    TCF_QUAL_DIFF           = 0x04, /* lhs doesn't have all of CVR qualifiers of rhs */
     TCF_QUAL_IMPLICIT       = 0x08, /* CVR qualifiers of lhs are stricter than those of rhs */
-    TCF_PTR_QUAL_DIFF       = 0x10, /* CVR qualifiers of pointers differ */
-    TCF_PTR_QUAL_IMPLICIT   = 0x20, /* CVR qualifiers of pointers are stricter on lhs than those on rhs */
-    TCF_MASK_C_QUAL_DIFF    = 0x3C, /* All C Standard qualifiers */
+    TCF_MASK_CVR_DIFF       = 0x0C, /* All CVR qualifiers */
+    TCF_PTR_QUAL_DIFF       = 0x10, /* lhs pointee doesn't have all of CVR qualifiers of rhs pointee */
+    TCF_PTR_QUAL_IMPLICIT   = 0x20, /* CVR qualifiers of pointees are stricter on lhs than those on rhs */
+    TCF_MASK_PTR_QUAL_DIFF  = 0x30, /* All CVR qualifiers of pointees */
     TCF_ADDRSIZE_QUAL_DIFF  = 0x40, /* Address size qualifiers differ */
     TCF_CCONV_QUAL_DIFF     = 0x80, /* Function calling conventions differ. Unused now */
     TCF_INCOMPATIBLE_QUAL   = TCF_ADDRSIZE_QUAL_DIFF | TCF_CCONV_QUAL_DIFF,
-    TCF_MASK_QUAL           = TCF_MASK_C_QUAL_DIFF | TCF_INCOMPATIBLE_QUAL,
+    TCF_MASK_PARAM_DIFF     = TCF_MASK_PTR_QUAL_DIFF | TCF_INCOMPATIBLE_QUAL,
+    TCF_MASK_QUAL           = TCF_MASK_CVR_DIFF | TCF_MASK_PTR_QUAL_DIFF | TCF_INCOMPATIBLE_QUAL,
 } typecmpflag_t;
 
 typedef struct {

--- a/test/err/bug2286-param-qualifier.c
+++ b/test/err/bug2286-param-qualifier.c
@@ -1,0 +1,4 @@
+/* Bug #2286 - Qualifiers of pointees of function parameters ignored for type compatibility check */
+
+void woo(int* p);
+void woo(const int* p); /* WRONG: Should be an error */


### PR DESCRIPTION
Fixed #2286.