### PR TITLE
Fix bug introduced in #2260

### DIFF
--- a/src/cc65/codegen.c
+++ b/src/cc65/codegen.c
@@ -3697,13 +3697,7 @@ void g_dec (unsigned flags, unsigned long val)
             } else {
                 /* Inline the code */
                 if (val < 0x300) {
-                    if ((CPUIsets[CPU] & CPU_ISET_65SC02) != 0 && val == 1) {
-                        unsigned L = GetLocalLabel();
-                        AddCodeLine ("bne %s", LocalLabelName (L));
-                        AddCodeLine ("dex");
-                        g_defcodelabel (L);
-                        AddCodeLine ("dea");
-                    } else if ((val & 0xFF) != 0) {
+                    if ((val & 0xFF) != 0) {
                         unsigned L = GetLocalLabel();
                         AddCodeLine ("sec");
                         AddCodeLine ("sbc #$%02X", (unsigned char) val);

--- a/test/val/sub3.c
+++ b/test/val/sub3.c
@@ -168,6 +168,31 @@ void post_dec_assign_test(void)
     failures++;
 }
 
+void dex_tests(void) {
+  static unsigned int a, b;
+
+  a = 257;
+  b = a - 1;
+  if (b != 256) {
+    printf("fail 257 => 256\n");
+    failures++;
+  }
+
+  a = 256;
+  b = a - 1;
+  if (b != 255) {
+    printf("fail 256 => 255\n");
+    failures++;
+  }
+
+  a = 255;
+  b = a - 1;
+  if (b != 254) {
+    printf("fail 255 => 254\n");
+    failures++;
+  }
+}
+
 int main(void)
 {
   int0 = 5;
@@ -185,6 +210,8 @@ int main(void)
   int0 = 5;
   int1 = 5;
   post_dec_assign_test();
+
+  dex_tests();
 
   printf("failures: %d\n",failures);
 


### PR DESCRIPTION
bne should have applied to A, not X, but adding a cmp #$00 before would make that change less optimized than the existing: revert this part.
The bug is visible with the added unit test. (256-1 = 511)