### PR TITLE
[cc65] More accurate diagnostic messages on empty declarations without any type specifiers

### DIFF
--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -2087,10 +2087,13 @@ static void DirectDecl (DeclSpec* Spec, Declarator* D, declmode_t Mode)
         NextToken ();
     } else {
         D->Ident[0] = '\0';
-        if ((Spec->Flags & DS_NO_EMPTY_DECL) != 0   &&
-            CurTok.Tok != TOK_LBRACK                &&
+        if (CurTok.Tok != TOK_LBRACK &&
             ((Spec->Flags & DS_ALLOW_BITFIELD) == 0 || CurTok.Tok != TOK_COLON)) {
-            Error ("Identifier expected");
+            if ((Spec->Flags & DS_TYPE_MASK) == DS_DEF_TYPE) {
+                Error ("Declaration specifier or identifier expected");
+            } else if ((Spec->Flags & DS_NO_EMPTY_DECL) != 0) {
+                Error ("Identifier expected");
+            }
         }
     }
 

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1412,7 +1412,7 @@ static void Primary (ExprDesc* E)
             } else {
                 /* Let's see if this is a C99-style declaration */
                 DeclSpec Spec;
-                ParseDeclSpec (&Spec, TS_DEFAULT_TYPE_NONE, SC_AUTO);
+                ParseDeclSpec (&Spec, TS_DEFAULT_TYPE_INT, SC_AUTO);
 
                 if ((Spec.Flags & DS_TYPE_MASK) != DS_NONE) {
                     Error ("Mixed declarations and code are not supported in cc65");

--- a/test/ref/bug1889-missing-identifier.cref
+++ b/test/ref/bug1889-missing-identifier.cref
@@ -1,3 +1,3 @@
 bug1889-missing-identifier.c:3: Error: Identifier or ';' expected after declaration specifiers
 bug1889-missing-identifier.c:3: Warning: Implicit 'int' is an obsolete feature
-bug1889-missing-identifier.c:4: Error: Identifier expected
+bug1889-missing-identifier.c:4: Error: Declaration specifier or identifier expected


### PR DESCRIPTION
```c
-;
```
Before:
```
test.c:1: Error: Identifier expected
```
After:
```
test.c:1: Error: Declaration specifier or identifier expected
```
