### PR TITLE
[cc65] Fixed missing diagnosis on function parameter lists with trailing commas

### DIFF
--- a/test/err/bug2301-trailing-coma-1.c
+++ b/test/err/bug2301-trailing-coma-1.c
@@ -1,0 +1,3 @@
+/* Bug #2301 - Function parameter list with an extra trailing comma should not compile */
+
+int foo(int a,); /* Should fail */

--- a/test/err/bug2301-trailing-coma-2.c
+++ b/test/err/bug2301-trailing-coma-2.c
@@ -1,0 +1,6 @@
+/* Bug #2301 - Function parameter list with an extra trailing comma should not compile */
+
+int bar(a,) int a;  /* Should fail */
+{
+    return a;
+}


### PR DESCRIPTION
#Fixed #2301.