### PR TITLE
[cc65] Added warning on static functions that are used but not defined

### DIFF
--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -273,11 +273,12 @@ static void Parse (void)
                     if (IsTypeVoid (Decl.Type)) {
                         /* We cannot declare variables of type void */
                         Error ("Illegal type for variable '%s'", Decl.Ident);
-                        Sym->Flags &= ~(SC_STORAGE | SC_DEF);
+                        Sym->Flags |= SC_DEF;
                     } else if (Size == 0 && SymIsDef (Sym) && !IsEmptiableObjectType (Decl.Type)) {
                         /* Size is unknown. Is it an array? */
                         if (!IsTypeArray (Decl.Type)) {
                             Error ("Variable '%s' has unknown size", Decl.Ident);
+                            Sym->Flags |= SC_DEF;
                         }
                     } else {
                         /* Check for enum forward declaration.
@@ -539,9 +540,15 @@ void Compile (const char* FileName)
                     Entry->Flags |= SC_DEF;
                 } else if (!IsTypeArray (Entry->Type)) {
                     /* Tentative declared variable is still of incomplete type */
-                    Error ("Definition of '%s' has type '%s' that is never completed",
+                    Error ("Definition of '%s' never has its type '%s' completed",
                            Entry->Name,
                            GetFullTypeName (Entry->Type));
+                }
+            } else if (!SymIsDef (Entry) && (Entry->Flags & SC_FUNC) == SC_FUNC) {
+                /* Check for undefined functions */
+                if ((Entry->Flags & (SC_EXTERN | SC_STATIC)) == SC_STATIC && SymIsRef (Entry)) {
+                    Warning ("Static function '%s' used but never defined",
+                             Entry->Name);
                 }
             }
         }


### PR DESCRIPTION
Also shortened the error message text on tentative declarations of incomplete types.
```c
struct S s;
static void f(void); /* No warning if 'f' were never used */

int main(void)
{
    f();
}
```
Before:
```
test.c:8: Error: Definition of 's' has type 'struct S' that is never completed
1 errors and 0 warnings generated.
```
After:
```
test.c:8: Error: Definition of 's' never has its type 'struct S' completed
test.c:8: Warning: Static function 'f' used but never defined
1 errors and 1 warnings generated.
```