### PR TITLE
Added SPRCTL0 and SPRCTL1  bit definitions for ca65

### DIFF
--- a/asminc/lynx.inc
+++ b/asminc/lynx.inc
@@ -81,8 +81,42 @@ MATHJ       = $FC6F
 
 ; Suzy Misc
 
-SPRCTL0     = $FC80
-SPRCTL1     = $FC81
+SPRCTL0		     = $FC80
+; Sprite bits-per-pixel definitions
+BPP_MASK	     = %11000000 ; Mask for settings bits per pixel
+BPP_1	         = %00000000
+BPP_2	         = %01000000
+BPP_3	         = %10000000
+BPP_4	         = %11000000
+; More sprite control 0 bit definitions
+HFLIP	         = %00100000
+VFLIP	         = %00010000
+; Sprite types - redefined to reflect the reality caused by the shadow error
+TYPE_SHADOW		 = %00000111
+TYPE_XOR		 = %00000110
+TYPE_NONCOLL     = %00000101 ; Non-colliding
+TYPE_NORMAL		 = %00000100 
+TYPE_BOUNDARY    = %00000011  
+TYPE_BSHADOW     = %00000010 ; Background shadow
+TYPE_BACKNONCOLL = %00000001 ; Background non-colliding
+TYPE_BACKGROUND	 = %00000000 
+
+SPRCTL1		= $FC81
+LITERAL		= %10000000
+PACKED		= %00000000
+ALGO3		= %01000000	; Broken, do not set this bit!
+; Sprite reload mask definitions
+RELOAD_MASK	= %00110000
+RENONE	    = %00000000	; Reload nothing
+REHV	    = %00010000	; Reload hsize, vsize
+REHVS	    = %00100000	; Reload hsize, vsize, stretch
+REHVST	    = %00110000	; Reload hsize, vsize, stretch, tilt
+; More sprite control 1 bit definitions
+REUSEPAL	= %00001000
+SKIP	    = %00000100
+DRAWUP		= %00000010
+DRAWLEFT	= %00000001
+
 SPRCOLL     = $FC82
 SPRINIT     = $FC83
 SUZYHREV    = $FC88

--- a/asminc/lynx.inc
+++ b/asminc/lynx.inc
@@ -81,41 +81,41 @@ MATHJ       = $FC6F
 
 ; Suzy Misc
 
-SPRCTL0		     = $FC80
+SPRCTL0          = $FC80
 ; Sprite bits-per-pixel definitions
-BPP_MASK	     = %11000000 ; Mask for settings bits per pixel
-BPP_1	         = %00000000
-BPP_2	         = %01000000
-BPP_3	         = %10000000
-BPP_4	         = %11000000
+BPP_MASK         = %11000000 ; Mask for settings bits per pixel
+BPP_1            = %00000000
+BPP_2            = %01000000
+BPP_3            = %10000000
+BPP_4            = %11000000
 ; More sprite control 0 bit definitions
-HFLIP	         = %00100000
-VFLIP	         = %00010000
+HFLIP            = %00100000
+VFLIP            = %00010000
 ; Sprite types - redefined to reflect the reality caused by the shadow error
-TYPE_SHADOW		 = %00000111
-TYPE_XOR		 = %00000110
+TYPE_SHADOW      = %00000111
+TYPE_XOR         = %00000110
 TYPE_NONCOLL     = %00000101 ; Non-colliding
-TYPE_NORMAL		 = %00000100 
+TYPE_NORMAL      = %00000100 
 TYPE_BOUNDARY    = %00000011  
 TYPE_BSHADOW     = %00000010 ; Background shadow
 TYPE_BACKNONCOLL = %00000001 ; Background non-colliding
 TYPE_BACKGROUND	 = %00000000 
 
-SPRCTL1		= $FC81
-LITERAL		= %10000000
-PACKED		= %00000000
-ALGO3		= %01000000	; Broken, do not set this bit!
+SPRCTL1     = $FC81
+LITERAL     = %10000000
+PACKED      = %00000000
+ALGO3       = %01000000	; Broken, do not set this bit!
 ; Sprite reload mask definitions
-RELOAD_MASK	= %00110000
-RENONE	    = %00000000	; Reload nothing
-REHV	    = %00010000	; Reload hsize, vsize
-REHVS	    = %00100000	; Reload hsize, vsize, stretch
-REHVST	    = %00110000	; Reload hsize, vsize, stretch, tilt
+RELOAD_MASK = %00110000
+RENONE      = %00000000	; Reload nothing
+REHV        = %00010000	; Reload hsize, vsize
+REHVS       = %00100000	; Reload hsize, vsize, stretch
+REHVST      = %00110000	; Reload hsize, vsize, stretch, tilt
 ; More sprite control 1 bit definitions
-REUSEPAL	= %00001000
-SKIP	    = %00000100
-DRAWUP		= %00000010
-DRAWLEFT	= %00000001
+REUSEPAL    = %00001000
+SKIP        = %00000100
+DRAWUP      = %00000010
+DRAWLEFT    = %00000001
 
 SPRCOLL     = $FC82
 SPRINIT     = $FC83

--- a/asminc/lynx.inc
+++ b/asminc/lynx.inc
@@ -95,22 +95,22 @@ VFLIP            = %00010000
 TYPE_SHADOW      = %00000111
 TYPE_XOR         = %00000110
 TYPE_NONCOLL     = %00000101 ; Non-colliding
-TYPE_NORMAL      = %00000100 
-TYPE_BOUNDARY    = %00000011  
+TYPE_NORMAL      = %00000100
+TYPE_BOUNDARY    = %00000011
 TYPE_BSHADOW     = %00000010 ; Background shadow
 TYPE_BACKNONCOLL = %00000001 ; Background non-colliding
-TYPE_BACKGROUND	 = %00000000 
+TYPE_BACKGROUND  = %00000000
 
 SPRCTL1     = $FC81
 LITERAL     = %10000000
 PACKED      = %00000000
-ALGO3       = %01000000	; Broken, do not set this bit!
+ALGO3       = %01000000 ; Broken, do not set this bit!
 ; Sprite reload mask definitions
 RELOAD_MASK = %00110000
-RENONE      = %00000000	; Reload nothing
-REHV        = %00010000	; Reload hsize, vsize
-REHVS       = %00100000	; Reload hsize, vsize, stretch
-REHVST      = %00110000	; Reload hsize, vsize, stretch, tilt
+RENONE      = %00000000 ; Reload nothing
+REHV        = %00010000 ; Reload hsize, vsize
+REHVS       = %00100000 ; Reload hsize, vsize, stretch
+REHVST      = %00110000 ; Reload hsize, vsize, stretch, tilt
 ; More sprite control 1 bit definitions
 REUSEPAL    = %00001000
 SKIP        = %00000100


### PR DESCRIPTION
This adds bit definitions for the SPRCTL0 and SPRCTL1 sprite control block addresses. It allows the use of the bit definitions in .asm files for ca65. 
The definitions are mostly consistent with the /includes/_suzy.h defines for C files in cc65.