### PR TITLE
bug 2319 - dont allow -t after input files given

### DIFF
--- a/doc/cl65.sgml
+++ b/doc/cl65.sgml
@@ -261,6 +261,9 @@ different options for different files on the command line. As an example.
 translates main.c with full optimization and module.c with less optimization
 and debug info enabled.
 
+Note that the target system (-t , --target) must be specified before any file
+unless using the default target of c64
+
 The type of an input file is derived from its extension:
 
 <itemize>

--- a/src/cl65/main.c
+++ b/src/cl65/main.c
@@ -1305,6 +1305,9 @@ static void OptStaticLocals (const char* Opt attribute ((unused)),
 static void OptTarget (const char* Opt attribute ((unused)), const char* Arg)
 /* Set the target system */
 {
+    if (FirstInput) {
+        Error ("Target must be specified before input files");
+    }
     Target = FindTarget (Arg);
     if (Target == TGT_UNKNOWN) {
         Error ("No such target system: '%s'", Arg);


### PR DESCRIPTION
fixes #2319 cl65 now fatals if a command like this is given

```
cl65 mycode.c -t sim6502
cl65: Target must be specified before input files
```