### PR TITLE
gmtime() / mktime(): work on unsigned 

### DIFF
--- a/libsrc/common/gmtime.c
+++ b/libsrc/common/gmtime.c
@@ -48,11 +48,7 @@ struct tm* __fastcall__ gmtime (const time_t* timep)
     static struct tm timebuf;
     time_t t;
 
-    /* Check the argument */
-    if (timep == 0 || (long) (t = *timep) < 0) {
-        /* Invalid arg */
-        return 0;
-    }
+    t = *timep;
 
     /* Since our ints are just 16 bits, split the given time into seconds,
     ** hours and days. Each of the values will fit in a 16 bit variable.

--- a/libsrc/common/mktime.c
+++ b/libsrc/common/mktime.c
@@ -82,8 +82,8 @@ time_t __fastcall__ mktime (register struct tm* TM)
 */
 {
     register div_t D;
-    int Max;
-    unsigned DayCount;
+    static int Max;
+    static unsigned DayCount;
 
     /* Check if TM is valid */
     if (TM == 0) {

--- a/libsrc/common/mktime.c
+++ b/libsrc/common/mktime.c
@@ -112,9 +112,6 @@ time_t __fastcall__ mktime (register struct tm* TM)
     TM->tm_hour = D.rem;
 
     /* Adjust days */
-    if (TM->tm_mday + D.quot < 0) {
-        goto Error;
-    }
     TM->tm_mday += D.quot;
 
     /* Adjust month and year. This is an iterative process, since changing
@@ -138,7 +135,7 @@ time_t __fastcall__ mktime (register struct tm* TM)
         } else {
             Max = MonthLength[TM->tm_mon];
         }
-        if (TM->tm_mday > Max) {
+        if ((unsigned int)TM->tm_mday > Max) {
             /* Must correct month and eventually, year */
             if (TM->tm_mon == DECEMBER) {
                 TM->tm_mon = JANUARY;
@@ -187,6 +184,3 @@ Error:
     /* Error exit */
     return (time_t) -1L;
 }
-
-
-

--- a/test/val/lib_common_mktime.c
+++ b/test/val/lib_common_mktime.c
@@ -1,0 +1,61 @@
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+int fails = 0;
+
+time_t timestamps[] = {
+  0,
+  0x2FFFFFFF,
+  0x6FFFFFFF,
+  0xF48656FF,
+  0xF4865700,
+  0xFC5A3EFF,
+  0x6D6739FF,
+  0x6D673A00,
+  0xFFFFFFFF,
+};
+
+/* Values checked against glibc 2.37's implementation of ctime() */
+const char *dates[] = {
+  "Thu Jan  1 00:00:00 1970\n",
+  "Sun Jul  9 16:12:47 1995\n",
+  "Wed Jul 18 05:49:51 2029\n",
+  "Thu Dec 31 23:59:59 2099\n",
+  "Fri Jan  1 00:00:00 2100\n",
+  "Fri Feb 29 23:59:59 2104\n",
+  "Tue Feb 29 23:59:59 2028\n",
+  "Wed Mar  1 00:00:00 2028\n",
+  "Sun Feb  7 06:28:15 2106\n",
+  NULL
+};
+
+int main (void)
+{
+    struct tm tm;
+    time_t t;
+    int i;
+
+    /* Verify conversion both ways */
+    for (t = 0x0FFFFFFF; ; t += 0x10000000) {
+      struct tm *tm = gmtime(&t);
+      time_t r = mktime(tm);
+      if (t != r) {
+        fails++;
+        printf("Unexpected result for t %lx: %lx\n", t, r);
+      }
+      if (t == 0xFFFFFFFF) {
+        break;
+      }
+    }
+
+    for (i = 0; dates[i] != NULL; i++) {
+      char *str = ctime(&timestamps[i]);
+      if (strcmp(str, dates[i])) {
+        fails++;
+        printf("Unexpected result for t %lx: Expected \"%s\", got \"%s\"\n",
+               t, dates[i], str);
+      }
+    }
+    return fails;
+}


### PR DESCRIPTION
Edit: wrong analysis of the problem, see https://github.com/cc65/cc65/pull/2328#issuecomment-1880017105

This is only useful in case of weird (aka wrong) values in the input struct tm, but may be considered useful enough to spend 8 more bytes on strftime: on Apple II, trying to
```
time_t t = (time_t)-1;
printf("%s", ctime(&t));
```
outputs garbage (as expected), but also somehow clears the screen.

![image](https://github.com/cc65/cc65/assets/1016317/66d0b153-d778-4b9d-9b57-fd022bbd85ad)

This patch makes it print garbage, but in a safe way:
![image](https://github.com/cc65/cc65/assets/1016317/a1e683e2-e78c-4013-922f-84ed97c5d542)
