### PR TITLE
[cc65] Cleanup for symbol types and flags

### DIFF
--- a/src/cc65/asmstmt.c
+++ b/src/cc65/asmstmt.c
@@ -80,9 +80,9 @@ static void AsmErrorSkip (void)
 
 
 
-static SymEntry* AsmGetSym (unsigned Arg, unsigned Type)
-/* Find the symbol with the name currently in NextTok. The symbol must be of
-** the given type. On errors, NULL is returned.
+static SymEntry* AsmGetSym (unsigned Arg, int OnStack)
+/* Find the symbol with the name currently in NextTok. The symbol must be on
+** the stack if OnStack is true. On errors, NULL is returned.
 */
 {
     SymEntry* Sym;
@@ -110,8 +110,8 @@ static SymEntry* AsmGetSym (unsigned Arg, unsigned Type)
     /* We found the symbol - skip the name token */
     NextToken ();
 
-    /* Check if we have a global symbol */
-    if ((Sym->Flags & Type) != Type) {
+    /* Check if the symbol is on the stack */
+    if ((Sym->Flags & SC_STORAGEMASK) != SC_AUTO ? OnStack : !OnStack) {
         Error ("Type of argument %u differs from format specifier", Arg);
         AsmErrorSkip ();
         return 0;
@@ -218,23 +218,24 @@ static void ParseGVarArg (StrBuf* T, unsigned Arg)
 */
 {
     /* Parse the symbol name parameter and check the type */
-    SymEntry* Sym = AsmGetSym (Arg, SC_STATIC);
+    SymEntry* Sym = AsmGetSym (Arg, 0);
     if (Sym == 0) {
         /* Some sort of error */
         return;
     }
 
-    /* Check for external linkage */
-    if (Sym->Flags & (SC_EXTERN | SC_STORAGE | SC_FUNC)) {
-        /* External linkage or a function */
+    /* Get the correct asm name */
+    if ((Sym->Flags & SC_TYPEMASK) == SC_FUNC || SymIsGlobal (Sym)) {
+        /* External or internal linkage or a function */
         SB_AppendChar (T, '_');
         SB_AppendStr (T, Sym->Name);
-    } else if (Sym->Flags & SC_REGISTER) {
+    } else if ((Sym->Flags & SC_STORAGEMASK) == SC_REGISTER) {
+        /* Register variable */
         char Buf[32];
         xsprintf (Buf, sizeof (Buf), "regbank+%d", Sym->V.R.RegOffs);
         SB_AppendStr (T, Buf);
     } else {
-        /* Static variable */
+        /* Local static variable */
         SB_AppendStr (T, LocalDataLabelName (Sym->V.L.Label));
     }
 }
@@ -248,7 +249,7 @@ static void ParseLVarArg (StrBuf* T, unsigned Arg)
     char Buf [16];
 
     /* Parse the symbol name parameter and check the type */
-    SymEntry* Sym = AsmGetSym (Arg, SC_AUTO);
+    SymEntry* Sym = AsmGetSym (Arg, 1);
     if (Sym == 0) {
         /* Some sort of error */
         return;

--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -121,15 +121,13 @@ static void Parse (void)
         }
 
         /* Read the declaration specifier */
-        ParseDeclSpec (&Spec, TS_DEFAULT_TYPE_INT, SC_EXTERN | SC_STATIC);
+        ParseDeclSpec (&Spec, TS_DEFAULT_TYPE_INT, SC_NONE);
 
         /* Don't accept illegal storage classes */
-        if ((Spec.StorageClass & SC_TYPEMASK) == 0) {
-            if ((Spec.StorageClass & SC_AUTO) != 0 ||
-                (Spec.StorageClass & SC_REGISTER) != 0) {
-                Error ("Illegal storage class");
-                Spec.StorageClass = SC_EXTERN | SC_STATIC;
-            }
+        if ((Spec.StorageClass & SC_STORAGEMASK) == SC_AUTO ||
+            (Spec.StorageClass & SC_STORAGEMASK) == SC_REGISTER) {
+            Error ("Illegal storage class");
+            Spec.StorageClass &= ~SC_STORAGEMASK;
         }
 
         /* Check if this is only a type declaration */
@@ -172,26 +170,26 @@ static void Parse (void)
             **   - if the storage class is explicitly specified as static,
             **   - or if there is an initialization.
             **
-            ** This means that "extern int i;" will not get storage allocated.
+            ** This means that "extern int i;" will not get storage allocated
+            ** in this translation unit.
             */
-            if ((Decl.StorageClass & SC_FUNC) != SC_FUNC &&
+            if ((Decl.StorageClass & SC_TYPEMASK) != SC_FUNC &&
                 (Decl.StorageClass & SC_TYPEMASK) != SC_TYPEDEF) {
-                if ((Spec.Flags & DS_DEF_STORAGE) != 0                       ||
-                    (Decl.StorageClass & (SC_EXTERN|SC_STATIC)) == SC_STATIC ||
-                    ((Decl.StorageClass & SC_EXTERN) != 0 &&
+                /* The variable is visible in the file scope */
+                if ((Decl.StorageClass & SC_STORAGEMASK) == SC_NONE     ||
+                    (Decl.StorageClass & SC_STORAGEMASK) == SC_STATIC   ||
+                    ((Decl.StorageClass & SC_STORAGEMASK) == SC_EXTERN &&
                      CurTok.Tok == TOK_ASSIGN)) {
-                    /* We will allocate storage */
-                    Decl.StorageClass |= SC_STORAGE;
-                } else {
-                    /* It's a declaration */
-                    Decl.StorageClass |= SC_DECL;
+                    /* We will allocate storage in this translation unit */
+                    Decl.StorageClass |= SC_TU_STORAGE;
                 }
             }
 
             /* If this is a function declarator that is not followed by a comma
             ** or semicolon, it must be followed by a function body.
             */
-            if ((Decl.StorageClass & SC_FUNC) != 0) {
+            if ((Decl.StorageClass & SC_TYPEMASK) == SC_FUNC) {
+                /* The function is now visible in the file scope */
                 if (CurTok.Tok == TOK_LCURLY) {
                     /* A definition */
                     Decl.StorageClass |= SC_DEF;
@@ -205,8 +203,6 @@ static void Parse (void)
                     }
                 } else {
                     /* Just a declaration */
-                    Decl.StorageClass |= SC_DECL;
-
                     FuncDef = GetFuncDesc (Decl.Type);
                     if ((FuncDef->Flags & (FD_EMPTY | FD_OLDSTYLE)) == FD_OLDSTYLE) {
                         /* A parameter list without types is only allowed in a
@@ -224,7 +220,7 @@ static void Parse (void)
             SymUseAttr (Sym, &Decl);
 
             /* Reserve storage for the variable if we need to */
-            if (Decl.StorageClass & SC_STORAGE) {
+            if (Decl.StorageClass & SC_TU_STORAGE) {
 
                 /* Get the size of the variable */
                 unsigned Size = SizeOf (Decl.Type);
@@ -327,9 +323,13 @@ static void Parse (void)
                 }
 
                 /* Make the symbol zeropage according to the segment address size */
-                if ((Sym->Flags & SC_STATIC) != 0) {
-                    if (GetSegAddrSize (GetSegName (CS->CurDSeg)) == ADDR_SIZE_ZP) {
-                        Sym->Flags |= SC_ZEROPAGE;
+                if ((Sym->Flags & SC_TYPEMASK) == SC_NONE) {
+                    if (SymIsGlobal (Sym) ||
+                        (Sym->Flags & SC_STORAGEMASK) == SC_STATIC ||
+                        (Sym->Flags & SC_STORAGEMASK) == SC_REGISTER) {
+                        if (GetSegAddrSize (GetSegName (CS->CurDSeg)) == ADDR_SIZE_ZP) {
+                            Sym->Flags |= SC_ZEROPAGE;
+                        }
                     }
                 }
 
@@ -517,7 +517,10 @@ void Compile (const char* FileName)
         ** global variables.
         */
         for (Entry = GetGlobalSymTab ()->SymHead; Entry; Entry = Entry->NextSym) {
-            if ((Entry->Flags & (SC_STORAGE | SC_DEF | SC_STATIC)) == (SC_STORAGE | SC_STATIC)) {
+            /* Is it a global (with or without static) tentative declaration of
+            ** an uninitialized variable?
+            */
+            if ((Entry->Flags & (SC_TU_STORAGE | SC_DEF)) == SC_TU_STORAGE) {
                 /* Assembly definition of uninitialized global variable */
                 SymEntry* TagSym = GetESUTagSym (Entry->Type);
                 unsigned Size = SizeOf (Entry->Type);
@@ -552,9 +555,9 @@ void Compile (const char* FileName)
                            Entry->Name,
                            GetFullTypeName (Entry->Type));
                 }
-            } else if (!SymIsDef (Entry) && (Entry->Flags & SC_FUNC) == SC_FUNC) {
+            } else if (!SymIsDef (Entry) && (Entry->Flags & SC_TYPEMASK) == SC_FUNC) {
                 /* Check for undefined functions */
-                if ((Entry->Flags & (SC_EXTERN | SC_STATIC)) == SC_STATIC && SymIsRef (Entry)) {
+                if ((Entry->Flags & SC_STORAGEMASK) == SC_STATIC && SymIsRef (Entry)) {
                     Warning ("Static function '%s' used but never defined",
                              Entry->Name);
                 }

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1223,8 +1223,8 @@ static void Primary (ExprDesc* E)
                 NextToken ();
 
                 /* Check for illegal symbol types */
-                CHECK ((Sym->Flags & SC_LABEL) != SC_LABEL);
-                if (Sym->Flags & SC_ESUTYPEMASK) {
+                CHECK ((Sym->Flags & SC_TYPEMASK) != SC_LABEL);
+                if ((Sym->Flags & SC_TYPEMASK) == SC_TYPEDEF) {
                     /* Cannot use type symbols */
                     Error ("Variable identifier expected");
                     /* Assume an int type to make E valid */
@@ -1244,7 +1244,7 @@ static void Primary (ExprDesc* E)
                     /* Enum or some other numeric constant */
                     E->Flags = E_LOC_NONE | E_RTYPE_RVAL;
                     E->IVal  = Sym->V.ConstVal;
-                } else if ((Sym->Flags & SC_AUTO) == SC_AUTO) {
+                } else if ((Sym->Flags & SC_STORAGEMASK) == SC_AUTO) {
                     /* Local variable. If this is a parameter for a variadic
                     ** function, we have to add some address calculations, and the
                     ** address is not const.
@@ -1258,25 +1258,24 @@ static void Primary (ExprDesc* E)
                         E->Flags = E_LOC_STACK | E_RTYPE_LVAL;
                         E->IVal  = Sym->V.Offs;
                     }
-                } else if ((Sym->Flags & SC_FUNC) == SC_FUNC) {
+                } else if ((Sym->Flags & SC_TYPEMASK) == SC_FUNC) {
                     /* Function */
                     E->Flags = E_LOC_GLOBAL | E_RTYPE_LVAL;
                     E->Name  = (uintptr_t) Sym->Name;
-                } else if ((Sym->Flags & SC_REGISTER) == SC_REGISTER) {
+                } else if ((Sym->Flags & SC_STORAGEMASK) == SC_REGISTER) {
                     /* Register variable, zero page based */
                     E->Flags = E_LOC_REGISTER | E_RTYPE_LVAL;
                     E->Name  = Sym->V.R.RegOffs;
-                } else if ((Sym->Flags & SC_STATIC) == SC_STATIC) {
-                    /* Static variable */
-                    if (Sym->Flags & (SC_EXTERN | SC_STORAGE | SC_DECL)) {
-                        E->Flags = E_LOC_GLOBAL | E_RTYPE_LVAL;
-                        E->Name  = (uintptr_t) Sym->Name;
-                    } else {
-                        E->Flags = E_LOC_STATIC | E_RTYPE_LVAL;
-                        E->Name  = Sym->V.L.Label;
-                    }
-                } else {
+                } else if (SymIsGlobal (Sym)) {
+                    /* Global variable */
+                    E->Flags = E_LOC_GLOBAL | E_RTYPE_LVAL;
+                    E->Name  = (uintptr_t) Sym->Name;
+                } else if ((Sym->Flags & SC_STORAGEMASK) == SC_STATIC) {
                     /* Local static variable */
+                    E->Flags = E_LOC_STATIC | E_RTYPE_LVAL;
+                    E->Name  = Sym->V.L.Label;
+                } else {
+                    /* Other */
                     E->Flags = E_LOC_STATIC | E_RTYPE_LVAL;
                     E->Name  = Sym->V.Offs;
                 }
@@ -1311,7 +1310,7 @@ static void Primary (ExprDesc* E)
                     } else {
                         Warning ("Call to undeclared function '%s'", Ident);
                     }
-                    Sym = AddGlobalSym (Ident, GetImplicitFuncType(), SC_EXTERN | SC_REF | SC_FUNC);
+                    Sym = AddGlobalSym (Ident, GetImplicitFuncType(), SC_REF | SC_FUNC);
                     E->Type  = Sym->Type;
                     E->Flags = E_LOC_GLOBAL | E_RTYPE_RVAL;
                     E->Name  = (uintptr_t) Sym->Name;

--- a/src/cc65/exprdesc.h
+++ b/src/cc65/exprdesc.h
@@ -98,7 +98,7 @@ enum {
     E_LOC_NONE          = 0x0000,       /* Pure rvalue with no storage */
     E_LOC_ABS           = 0x0001,       /* Absolute numeric addressed variable */
     E_LOC_GLOBAL        = 0x0002,       /* Global variable */
-    E_LOC_STATIC        = 0x0004,       /* Static variable */
+    E_LOC_STATIC        = 0x0004,       /* Local static variable */
     E_LOC_REGISTER      = 0x0008,       /* Register variable */
     E_LOC_STACK         = 0x0010,       /* Value on the stack */
     E_LOC_PRIMARY       = 0x0020,       /* Temporary in primary register */

--- a/src/cc65/goto.c
+++ b/src/cc65/goto.c
@@ -92,7 +92,7 @@ void GotoStatement (void)
 
             /* Find array size */
             if (!IsTypeArray (arr->Type) || SizeOf (arr->Type) == 0 ||
-                !(arr->Flags & SC_STATIC) ||
+                (arr->Flags & SC_STORAGEMASK) != SC_STATIC ||
                 SizeOf (GetElementType(arr->Type)) != 2) {
                 Error ("Expected a static array");
             } else if (GetElementCount (arr->Type) > 127) {

--- a/src/cc65/pragma.c
+++ b/src/cc65/pragma.c
@@ -630,7 +630,7 @@ static void WrappedCallPragma (pragma_scope_t Scope, StrBuf* B)
     Entry = FindSym(Name);
 
     /* Check if the name is valid */
-    if (Entry && (Entry->Flags & SC_FUNC) == SC_FUNC) {
+    if (Entry && (Entry->Flags & SC_TYPEMASK) == SC_FUNC) {
 
         PushWrappedCall(Entry, (unsigned int) Val);
         Entry->Flags |= SC_REF;

--- a/src/cc65/symentry.h
+++ b/src/cc65/symentry.h
@@ -68,47 +68,88 @@ struct CodeEntry;
 
 
 
-/* Storage classes and flags */
+/* Symbol types and flags */
 #define SC_NONE         0x0000U         /* Nothing */
-#define SC_STRUCT       0x0001U         /* Struct */
-#define SC_UNION        0x0002U         /* Union */
-#define SC_ENUM         0x0003U         /* Enum */
-#define SC_TYPEDEF      0x0004U         /* Typedef */
-#define SC_ESUTYPEMASK  0x0007U         /* Mask for above types */
-#define SC_ENUMERATOR   0x0008U         /* An enumerator */
-#define SC_BITFIELD     0x0010U         /* A bit-field inside a struct or union */
-#define SC_TYPEMASK     0x001FU         /* Mask for above types */
 
-#define SC_FUNC         0x0020U         /* A function */
-#define SC_LABEL        0x0040U         /* A goto code label */
-#define SC_CONST        0x0080U         /* A numeric constant with a type */
-#define SC_PARAM        0x0100U         /* A function parameter */
-#define SC_DEFTYPE      0x0200U         /* Parameter has default type (=int, old style) */
-#define SC_STRUCTFIELD  0x0400U         /* Struct or union field */
+/* Types of symbols */
+#define SC_STRUCT       0x0001U         /* Struct tag */
+#define SC_UNION        0x0002U         /* Union tag */
+#define SC_ENUM         0x0003U         /* Enum tag */
+#define SC_LABEL        0x0004U         /* A goto code label */
+#define SC_BITFIELD     0x0005U         /* A bit-field inside a struct or union */
+#define SC_TYPEDEF      0x0006U         /* A typedef */
+#define SC_ENUMERATOR   0x0007U         /* An enumerator */
 
-#define SC_ZEROPAGE     0x0800U         /* Symbol marked as zeropage */
+/* Note: These symbol types might be checked as bit-flags occasionally.
+**       So don't share their unique bits with other symbol types.
+*/
+#define SC_FUNC         0x0008U         /* A function */
+#define SC_ARRAY        0x0010U         /* UNUSED: An array */
+#define SC_TYPEMASK     0x001FU         /* Mask for symbol types all above */
 
-#define SC_DEF          0x1000U         /* Symbol is defined */
-#define SC_REF          0x2000U         /* Symbol is referenced */
-#define SC_DECL         0x4000U         /* Symbol is declared in global scope */
-#define SC_STORAGE      0x8000U         /* Symbol with associated storage */
+/* Additional property of the symbols */
+#define SC_CONST        0x0020U         /* A numeric constant with a type */
+#define SC_STRUCTFIELD  0x0040U         /* A struct or union field */
+#define SC_PARAM        0x0080U         /* A function parameter */
+#define SC_DEFTYPE      0x0100U         /* An old-style parameter with default type (=int) */
 
-#define SC_AUTO         0x010000U       /* Auto variable */
-#define SC_REGISTER     0x020000U       /* Register variable */
-#define SC_STATIC       0x040000U       /* Static - not to be confused with other *_STATIC */
-#define SC_EXTERN       0x080000U       /* Extern linkage */
-#define SC_STORAGEMASK  0x0F0000U       /* Storage type mask */
+/* Address property of the symbol */
+#define SC_ZEROPAGE     0x0200U         /* Symbol marked as on zeropage */
 
-#define SC_HAVEATTR     0x100000U       /* Symbol has attributes */
+/* Additional attributes of the symbol */
+#define SC_HAVEALIGN    0x0400U         /* UNUSED: Symbol has special alignment */
+#define SC_HAVEATTR     0x0800U         /* Symbol has attributes */
 
-#define SC_GOTO         0x200000U
-#define SC_SPADJUSTMENT 0x400000U
-#define SC_GOTO_IND     0x800000U       /* Indirect goto */
+/* Special property of declaration */
+#define SC_TU_STORAGE   0x1000U         /* Symbol has allocated storage in the TU */
+#define SC_ASSIGN_INIT  0x2000U         /* Symbol is to be initialized with assignment code */
 
-#define SC_ALIAS        0x01000000U     /* Alias of global or anonymous field */
-#define SC_FICTITIOUS   0x02000000U     /* Symbol is fictitious (for error recovery) */
-#define SC_HAVEFAM      0x04000000U     /* Type has a Flexible Array Member */
-#define SC_HAVECONST    0x08000000U     /* Type has a const member */
+#define SC_ALIAS        0x4000U         /* Symbol is an alias */
+#define SC_FICTITIOUS   0x8000U         /* Symbol is fictitious (for error recovery) */
+#define SC_HAVEFAM      0x010000U       /* Struct/union has a Flexible Array Member */
+#define SC_HAVECONST    0x020000U       /* Struct/union has a const member */
+
+/* Status of the symbol */
+#define SC_DEF          0x040000U       /* Symbol is defined */
+#define SC_REF          0x080000U       /* Symbol is referenced */
+#define SC_GOTO         0x100000U       /* Symbol is destination of a goto */
+#define SC_GOTO_IND     0x200000U       /* Symbol is destination of an indirect goto */
+#define SC_LOCALSCOPE   0x400000U       /* Symbol is invisible in file scope */
+#define SC_NOINLINEDEF  0x800000U       /* Symbol may never have an inline definition */
+
+/* To figure out the linkage of an object or function symbol Sym:
+** - external linkage:
+**    SymIsGlobal (Sym) && (Sym->Flags & SC_STORAGEMASK) != SC_STATIC
+** - internal linkage:
+**    SymIsGlobal (Sym) && (Sym->Flags & SC_STORAGEMASK) == SC_STATIC
+** - no linkage:
+**    !SymIsGlobal (Sym)
+**
+** To figure out the storage class of a symbol by its SC_ flags:
+**
+** - no explicit storage class specifiers (in file scope):
+**    (flags & SC_STORAGEMASK) == SC_NONE
+** - no explicit storage class specifiers (in block scope):
+**    (flags & SC_STORAGEMASK) == SC_AUTO
+** - extern:
+**    (flags & SC_STORAGEMASK) == SC_EXTERN
+** - static:
+**    (flags & SC_STORAGEMASK) == SC_STATIC
+** - auto:
+**    (flags & SC_STORAGEMASK) == SC_AUTO
+** - register:
+**    (flags & SC_STORAGEMASK) == SC_REGISTER
+** - typedef (per ISO C):
+**    (flags & SC_TYPEMASK) == SC_TYPEDEF
+**
+** Note: SC_TYPEDEF can be also used as a flag.
+*/
+#define SC_AUTO         0x01000000U     /* Auto storage class */
+#define SC_REGISTER     0x02000000U     /* Register storage class */
+#define SC_STATIC       0x03000000U     /* Static storage class */
+#define SC_EXTERN       0x04000000U     /* Extern storage class */
+#define SC_THREAD       0x08000000U     /* UNSUPPORTED: Thread-local storage class */
+#define SC_STORAGEMASK  0x0F000000U     /* Storage type mask */
 
 
 
@@ -214,14 +255,37 @@ void FreeSymEntry (SymEntry* E);
 void DumpSymEntry (FILE* F, const SymEntry* E);
 /* Dump the given symbol table entry to the file in readable form */
 
+int SymIsOutputFunc (const SymEntry* Sym);
+/* Return true if this is a function that must be output */
+
+#if defined(HAVE_INLINE)
+INLINE int SymIsArray (const SymEntry* Sym)
+/* Return true if the given entry is an array entry */
+{
+    return ((Sym->Flags & SC_TYPEMASK) == SC_ARRAY);
+}
+#else
+#  define SymIsArray(Sym)       (((Sym)->Flags & SC_TYPEMASK) == SC_ARRAY)
+#endif
+
 #if defined(HAVE_INLINE)
 INLINE int SymIsBitField (const SymEntry* Sym)
 /* Return true if the given entry is a bit-field entry */
 {
-    return ((Sym->Flags & SC_BITFIELD) == SC_BITFIELD);
+    return ((Sym->Flags & SC_TYPEMASK) == SC_BITFIELD);
 }
 #else
-#  define SymIsBitField(Sym)    (((Sym)->Flags & SC_BITFIELD) == SC_BITFIELD)
+#  define SymIsBitField(Sym)    (((Sym)->Flags & SC_TYPEMASK) == SC_BITFIELD)
+#endif
+
+#if defined(HAVE_INLINE)
+INLINE int SymIsLabel (const SymEntry* Sym)
+/* Return true if the given entry is a label entry */
+{
+    return ((Sym)->Flags & SC_TYPEMASK) == SC_LABEL;
+}
+#else
+#  define SymIsLabel(Sym)       (((Sym)->Flags & SC_TYPEMASK) == SC_LABEL)
 #endif
 
 #if defined(HAVE_INLINE)
@@ -257,16 +321,12 @@ INLINE int SymIsRef (const SymEntry* Sym)
 #if defined(HAVE_INLINE)
 INLINE int SymIsRegVar (const SymEntry* Sym)
 /* Return true if the given entry is a register variable */
-/* ### HACK! Fix the ugly type flags! */
 {
-    return ((Sym->Flags & (SC_REGISTER | SC_TYPEMASK)) == SC_REGISTER);
+    return ((Sym->Flags & (SC_STORAGEMASK | SC_TYPEMASK)) == (SC_REGISTER | SC_NONE));
 }
 #else
-#  define SymIsRegVar(Sym)  (((Sym)->Flags & (SC_REGISTER | SC_TYPEMASK)) == SC_REGISTER)
+#  define SymIsRegVar(Sym)  (((Sym)->Flags & (SC_STORAGEMASK | SC_TYPEMASK)) == (SC_REGISTER | SC_NONE))
 #endif
-
-int SymIsOutputFunc (const SymEntry* Sym);
-/* Return true if this is a function that must be output */
 
 #if defined(HAVE_INLINE)
 INLINE int SymHasFlexibleArrayMember (const SymEntry* Sym)

--- a/src/cc65/symtab.h
+++ b/src/cc65/symtab.h
@@ -211,8 +211,11 @@ SymTable* GetFieldSymTab (void);
 SymTable* GetLabelSymTab (void);
 /* Return the label symbol table */
 
-int SymIsLocal (SymEntry* Sym);
-/* Return true if the symbol is defined in the highest lexical level */
+int SymIsLocal (const SymEntry* Sym);
+/* Return true if the symbol is declared in the highest lexical level */
+
+int SymIsGlobal (const SymEntry* Sym);
+/* Return true if the symbol is declared in the file scope level */
 
 void MakeZPSym (const char* Name);
 /* Mark the given symbol as zero page symbol */


### PR DESCRIPTION
This cleans up the definition and application of `SC_*` flags. Now the symbol types and storage classes are exclusive values instead of bits flags. To check for them you need bitmask the bits first and then compare the result to them rather than bitwise-and the bits with them directly.

These changes make the storage duration, linkage and visibility of symbols clearer as well as remove some hurdles for some bug fixes and future enhancements.

Note: `SC_` might mean "**S**torage **C**lass" in the beginning, but nowadays you may take it as "**S**ymbol **C**ategory".