### PR TITLE
[cc65] Diagnosis fixes

### DIFF
--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -4305,8 +4305,13 @@ ExprDesc NoCodeConstExpr (void (*Func) (ExprDesc*))
     if (!ED_IsConst (&Expr) || !ED_CodeRangeIsEmpty (&Expr)) {
         Error ("Constant expression expected");
         /* To avoid any compiler errors, make the expression a valid const */
-        Expr.Flags &= E_MASK_RTYPE | E_MASK_KEEP_RESULT;
+        Expr.Flags &= E_MASK_RTYPE | E_MASK_KEEP_MAKE;
         Expr.Flags |= E_LOC_NONE;
+
+        /* Remove any non-constant code generated */
+        if (!ED_CodeRangeIsEmpty (&Expr)) {
+            RemoveCodeRange (&Expr.Start, &Expr.End);
+        }
     }
 
     /* Return by value */
@@ -4331,6 +4336,11 @@ ExprDesc NoCodeConstAbsIntExpr (void (*Func) (ExprDesc*))
         Error ("Constant integer expression expected");
         /* To avoid any compiler errors, make the expression a valid const */
         ED_MakeConstAbsInt (&Expr, 1);
+
+        /* Remove any non-constant code generated */
+        if (!ED_CodeRangeIsEmpty (&Expr)) {
+            RemoveCodeRange (&Expr.Start, &Expr.End);
+        }
     }
 
     /* Return by value */

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1408,7 +1408,7 @@ static void Primary (ExprDesc* E)
             } else {
                 /* Let's see if this is a C99-style declaration */
                 DeclSpec Spec;
-                ParseDeclSpec (&Spec, TS_DEFAULT_TYPE_INT, SC_AUTO);
+                ParseDeclSpec (&Spec, TS_DEFAULT_TYPE_NONE, SC_AUTO);
 
                 if ((Spec.Flags & DS_TYPE_MASK) != DS_NONE) {
                     Error ("Mixed declarations and code are not supported in cc65");

--- a/test/ref/bug1889-missing-identifier.c
+++ b/test/ref/bug1889-missing-identifier.c
@@ -3,6 +3,8 @@
 int enum { a } x;
 inline enum { b };
 
+_Static_assert();
+
 int main(void)
 {
     return 0;

--- a/test/ref/bug1889-missing-identifier.cref
+++ b/test/ref/bug1889-missing-identifier.cref
@@ -1,3 +1,4 @@
 bug1889-missing-identifier.c:3: Error: Identifier or ';' expected after declaration specifiers
 bug1889-missing-identifier.c:3: Warning: Implicit 'int' is an obsolete feature
 bug1889-missing-identifier.c:4: Error: Declaration specifier or identifier expected
+bug1889-missing-identifier.c:6: Error: Expression expected

--- a/test/ref/custom-reference-error.c
+++ b/test/ref/custom-reference-error.c
@@ -14,7 +14,7 @@
 */
 
 typedef short return_t;
-#error /* produce an error */
+#error This is an/* produce an error */error
 
 return_t main(int argc, char* argv[])
 {
@@ -22,3 +22,6 @@ return_t main(int argc, char* argv[])
     n = 0;                /* produce an error */
     /* produce a warning */
 }
+
+int arr[main(0, 0)]; /* produce an error */
+int b = 0;

--- a/test/ref/custom-reference-error.cref
+++ b/test/ref/custom-reference-error.cref
@@ -1,6 +1,7 @@
-custom-reference-error.c:17: Error: #error
+custom-reference-error.c:17: Error: #error: This is an error
 custom-reference-error.c:21: Error: Call to undeclared function 'printf'
 custom-reference-error.c:22: Error: Undeclared identifier 'n'
 custom-reference-error.c:24: Warning: Control reaches end of non-void function [-Wreturn-type]
 custom-reference-error.c:24: Warning: Parameter 'argc' is never used
 custom-reference-error.c:24: Warning: Parameter 'argv' is never used
+custom-reference-error.c:26: Error: Constant integer expression expected


### PR DESCRIPTION
Note: the incorrect "Mixed declarations and code are not supported in cc65" diagnosis was once fixed in a previous PR but got "reverted" in a later PR by mistake. Now it's fixed again and checked in a testcase.
