### PR TITLE
[cc65] fixes and enhancements for source file info in diagnosis and debug output

### DIFF
--- a/src/cc65/codeseg.c
+++ b/src/cc65/codeseg.c
@@ -1471,7 +1471,7 @@ void CS_Output (CodeSeg* S)
             /* Add line debug info */
             if (DebugInfo) {
                 WriteOutput ("\t.dbg\tline, \"%s\", %u\n",
-                             GetInputName (LI), GetInputLine (LI));
+                             GetActualFileName (LI), GetActualLineNum (LI));
             }
         }
         /* Output the code */

--- a/src/cc65/error.h
+++ b/src/cc65/error.h
@@ -100,6 +100,9 @@ struct StrBuf;
 
 
 
+void PrintFileInclusionInfo (const LineInfo* LI);
+/* Print hierarchy of file inclusion */
+
 void Fatal (const char* Format, ...) attribute ((noreturn, format (printf, 1, 2)));
 /* Print a message about a fatal error and die */
 
@@ -109,7 +112,7 @@ void Internal (const char* Format, ...) attribute ((noreturn, format (printf, 1,
 void Error (const char* Format, ...) attribute ((format (printf, 1, 2)));
 /* Print an error message */
 
-void LIError (errcat_t EC, const LineInfo* LI, const char* Format, ...) attribute ((format (printf, 3, 4)));
+void LIError (errcat_t EC, LineInfo* LI, const char* Format, ...) attribute ((format (printf, 3, 4)));
 /* Print an error message with the line info given explicitly */
 
 void PPError (const char* Format, ...) attribute ((format (printf, 1, 2)));
@@ -118,7 +121,7 @@ void PPError (const char* Format, ...) attribute ((format (printf, 1, 2)));
 void Warning (const char* Format, ...) attribute ((format (printf, 1, 2)));
 /* Print a warning message */
 
-void LIWarning (errcat_t EC, const LineInfo* LI, const char* Format, ...) attribute ((format (printf, 3, 4)));
+void LIWarning (errcat_t EC, LineInfo* LI, const char* Format, ...) attribute ((format (printf, 3, 4)));
 /* Print a warning message with the line info given explicitly */
 
 void PPWarning (const char* Format, ...) attribute ((format (printf, 1, 2)));

--- a/src/cc65/input.h
+++ b/src/cc65/input.h
@@ -52,6 +52,10 @@
 
 
 
+/* Forwards */
+struct IFile;
+struct LineInfo;
+
 /* An enum that describes different types of input files. The members are
 ** choosen so that it is possible to combine them to bitsets
 */
@@ -60,9 +64,6 @@ typedef enum {
     IT_SYSINC = 0x02,           /* System include file (using <>) */
     IT_USRINC = 0x04,           /* User include file (using "") */
 } InputType;
-
-/* Forward for an IFile structure */
-struct IFile;
 
 /* The current input line */
 extern StrBuf* Line;
@@ -125,10 +126,19 @@ int PreprocessNextLine (void);
 ** main file.
 */
 
-const char* GetInputFile (const struct IFile* IF);
-/* Return a filename from an IFile struct */
+void GetFileInclusionInfo (struct LineInfo* LI);
+/* Get info about source file inclusion for LineInfo struct */
 
-const char* GetCurrentFilename (void);
+void FreeFileInclusionInfo (struct LineInfo* LI);
+/* Free info about source file inclusion for LineInfo struct */
+
+int HasFileInclusionChanged (const struct LineInfo* LI);
+/* Return true if file inclusion has changed from last time */
+
+const char* GetInputFileName (const struct IFile* IF);
+/* Return the name of the file from an IFile struct */
+
+const char* GetCurrentFileName (void);
 /* Return the name of the current input file */
 
 unsigned GetCurrentLineNum (void);
@@ -137,7 +147,7 @@ unsigned GetCurrentLineNum (void);
 void SetCurrentLineNum (unsigned LineNum);
 /* Set the line number in the current input file */
 
-void SetCurrentFilename (const char* Name);
+void SetCurrentFileName (const char* Name);
 /* Set the presumed name of the current input file */
 
 unsigned GetCurrentCounter (void);

--- a/src/cc65/lineinfo.h
+++ b/src/cc65/lineinfo.h
@@ -60,15 +60,24 @@ struct IFile;
 
 
 
+/* Struct that describes an input file for line info */
+typedef struct LineInfoFile LineInfoFile;
+struct LineInfoFile {
+    struct IFile*       InputFile;      /* Points to corresponding IFile */
+    unsigned            LineNum;        /* Presumed line number for this file */
+    char                Name[1];        /* Presumed name of the file */
+};
+
 /* The text for the actual line is allocated at the end of the structure, so
 ** the size of the structure varies.
 */
 typedef struct LineInfo LineInfo;
 struct LineInfo {
-    unsigned        RefCount;             /* Reference counter */
-    struct IFile*   InputFile;            /* Input file for this line */
-    unsigned        LineNum;              /* Line number */
-    char            Line[1];              /* Source code line */
+    unsigned            RefCount;       /* Reference counter */
+    LineInfoFile*       File;           /* Presumed input files for this line */
+    unsigned            ActualLineNum;  /* Actual line number for this file */
+    struct Collection*  IncFiles;       /* Presumed inclusion input files */
+    char                Line[1];        /* Text of source code line */
 };
 
 
@@ -92,14 +101,26 @@ LineInfo* GetCurLineInfo (void);
 ** increased, use UseLineInfo for that purpose.
 */
 
-void UpdateLineInfo (struct IFile* F, unsigned LineNum, const StrBuf* Line);
-/* Update the line info - called if a new line is read */
+void UpdateCurrentLineInfo (const StrBuf* Line);
+/* Update the current line info - called if a new line is read */
 
-const char* GetInputName (const LineInfo* LI);
-/* Return the file name from a line info */
+void RememberCheckedLI (struct LineInfo* LI);
+/* Remember the latest checked line info struct */
 
-unsigned GetInputLine (const LineInfo* LI);
-/* Return the line number from a line info */
+LineInfo* GetPrevCheckedLI (void);
+/* Get the latest checked line info struct */
+
+const char* GetPresumedFileName (const LineInfo* LI);
+/* Return the presumed file name from a line info */
+
+unsigned GetPresumedLineNum (const LineInfo* LI);
+/* Return the presumed line number from a line info */
+
+const char* GetActualFileName (const struct LineInfo* LI);
+/* Return the actual name of the source file from a line info struct */
+
+unsigned GetActualLineNum (const struct LineInfo* LI);
+/* Return the actual line number of the source file from a line info struct */
 
 
 

--- a/src/cc65/preproc.c
+++ b/src/cc65/preproc.c
@@ -842,7 +842,7 @@ static void AddPreLine (StrBuf* Str)
             SB_AppendChar (Str, '\n');
         }
         SB_Printf (&Comment, "#line %u \"%s\"\n",
-                   GetCurrentLineNum () - ContinuedLines, GetCurrentFilename ());
+                   GetCurrentLineNum () - ContinuedLines, GetCurrentFileName ());
         SB_Append (Str, &Comment);
     } else {
         /* Output new lines */
@@ -2943,7 +2943,7 @@ static void DoLine (void)
             StrBuf Filename = AUTO_STRBUF_INITIALIZER;
             if (SB_GetString (Line, &Filename)) {
                 SB_Terminate (&Filename);
-                SetCurrentFilename (SB_GetConstBuf (&Filename));
+                SetCurrentFileName (SB_GetConstBuf (&Filename));
             } else {
                 PPError ("Invalid filename for #line directive");
                 LineNum = 0;
@@ -3220,7 +3220,7 @@ void HandleSpecialMacro (Macro* M, const char* Name)
     } else if (strcmp (Name, "__FILE__") == 0) {
         /* Replace __FILE__ with the current filename */
         StrBuf B = AUTO_STRBUF_INITIALIZER;
-        SB_InitFromString (&B, GetCurrentFilename ());
+        SB_InitFromString (&B, GetCurrentFileName ());
         SB_Clear (&M->Replacement);
         Stringize (&B, &M->Replacement);
         SB_Done (&B);
@@ -3332,7 +3332,7 @@ void Preprocess (void)
     PLine = InitLine (PLine);
 
     if (Verbosity > 1 && SB_NotEmpty (Line)) {
-        printf ("%s:%u: %.*s\n", GetCurrentFilename (), GetCurrentLineNum (),
+        printf ("%s:%u: %.*s\n", GetCurrentFileName (), GetCurrentLineNum (),
                 (int) SB_GetLen (Line), SB_GetConstBuf (Line));
     }
 


### PR DESCRIPTION
- Fixed some issues in #2168.
  - Fixed the bug [(in comment)](https://github.com/cc65/cc65/issues/2168#issuecomment-1693987360) that non-pp diagnostic messages ignored presumed names of source files set with `#line`.
  - Fixed the bug [(in comment)](https://github.com/cc65/cc65/issues/2168#issuecomment-1883821136) that presumed line numbers of source files set with `#line` were used in debug info.
  - The [feature requested](https://github.com/cc65/cc65/issues/2168#issuecomment-1694573390) by the OP is not implemented. See also [comment](https://github.com/cc65/cc65/issues/2168#issuecomment-1883625761).
- Resolved #1474.
  - Added hierarchy info about source file inclusion in diagnostic output.

The style of the hierarchy info looks like GCC's but is organized like Clang's.
Example:

2168.c:
```c
#include "2168_1.h"
#line 1 "main.c"
// main.c
#warning "main.c:2"

int;
```

2168_1.h:
```c
#line 1 "foo.c"
// foo.c
void foo() {}
#warning "foo.c:3"

#line 2 "bar.c"
// bar.c
void bar() {}
#warning "bar.c:4"

#include "2168_2.h"
#include "2168_2.h"
```

2168_2.h:
```c
#ifndef INCLUDED_ONCE
#define INCLUDED_ONCE

#line 1 "zoo.c"
// zoo.c
void zoo() {}
#warning "zoo.c:3"
#line 1 "zoo.c"
// zoo.c
#warning "zoo.c:2"
#line 1 "yoo.c"
// yoo.c
#warning "yoo.c:2"

#else

#line 1 "zoo.c"
// zoo.c
void zoo();
#warning "zoo.c:3"

#endif
```

Output:
```
In file included from 2168.c:1:
foo.c:3: Warning: #warning: "foo.c:3"
bar.c:4: Warning: #warning: "bar.c:4"
In file included from 2168.c:1,
                 from bar.c:6:
zoo.c:3: Warning: #warning: "zoo.c:3"
zoo.c:2: Warning: #warning: "zoo.c:2"
yoo.c:2: Warning: #warning: "yoo.c:2"
In file included from 2168.c:1,
                 from bar.c:7:
zoo.c:3: Warning: #warning: "zoo.c:3"
main.c:2: Warning: #warning: "main.c:2"
main.c:4: Warning: Declaration does not declare anything
```
