### PR TITLE
[cc65] Improved diagnosis

### DIFF
--- a/src/cc65/datatype.c
+++ b/src/cc65/datatype.c
@@ -989,6 +989,24 @@ int IsIncompleteESUType (const Type* T)
 
 
 
+int IsAnonESUType (const Type* T)
+/* Return true if this is an anonymous ESU type */
+{
+    SymEntry* TagSym = GetESUTagSym (T);
+
+    return TagSym != 0 && SymHasAnonName (TagSym);
+}
+
+
+
+int IsAnonStructClass (const Type* T)
+/* Return true if this is an anonymous struct or union type */
+{
+    return IsClassStruct (T) && IsAnonESUType (T);
+}
+
+
+
 int IsPassByRefType (const Type* T)
 /* Return true if this is a large struct/union type that doesn't fit in the
 ** primary. This returns false for the void value extension type since it is

--- a/src/cc65/datatype.h
+++ b/src/cc65/datatype.h
@@ -792,6 +792,12 @@ int IsESUType (const Type* T);
 int IsIncompleteESUType (const Type* T);
 /* Return true if this is an incomplete ESU type */
 
+int IsAnonESUType (const Type* T);
+/* Return true if this is an anonymous ESU type */
+
+int IsAnonStructClass (const Type* T);
+/* Return true if this is an anonymous struct or union type */
+
 int IsPassByRefType (const Type* T);
 /* Return true if this is a large struct/union type that doesn't fit in the
 ** primary. This returns false for the void value extension type since it is

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -997,7 +997,7 @@ static SymEntry* ParseUnionSpec (const char* Name, unsigned* DSFlags)
 
     /* Parse union fields */
     UnionSize = 0;
-    while (CurTok.Tok != TOK_RCURLY) {
+    while (CurTok.Tok != TOK_RCURLY && CurTok.Tok != TOK_CEOF) {
 
         /* Get the type of the entry */
         DeclSpec    Spec;
@@ -1217,7 +1217,7 @@ static SymEntry* ParseStructSpec (const char* Name, unsigned* DSFlags)
     FlexibleMember = 0;
     StructSize     = 0;
     BitOffs        = 0;
-    while (CurTok.Tok != TOK_RCURLY) {
+    while (CurTok.Tok != TOK_RCURLY && CurTok.Tok != TOK_CEOF) {
 
         /* Get the type of the entry */
         DeclSpec    Spec;
@@ -1814,7 +1814,7 @@ static void ParseOldStyleParamDeclList (FuncDesc* F attribute ((unused)))
     }
 
     /* An optional list of type specifications follows */
-    while (CurTok.Tok != TOK_LCURLY) {
+    while (CurTok.Tok != TOK_LCURLY && CurTok.Tok != TOK_CEOF) {
 
         DeclSpec        Spec;
         int             NeedClean;

--- a/src/cc65/declare.c
+++ b/src/cc65/declare.c
@@ -2388,16 +2388,26 @@ int ParseDecl (DeclSpec* Spec, Declarator* D, declmode_t Mode)
             GetFuncDesc (D->Type)->Flags |= FD_OLDSTYLE_INTRET;
         }
 
-        /* For anything that is not a function or typedef, check for an implicit
-        ** int declaration.
+        /* For anything that is not a function, check for an implicit int
+        ** declaration.
         */
-        if (!IsTypeFunc (D->Type) &&
-            (D->StorageClass & SC_TYPEMASK) != SC_TYPEDEF) {
-            /* If the standard was not set explicitly to C89, print a warning
-            ** for variables with implicit int type.
-            */
-            if (IS_Get (&Standard) >= STD_C99) {
-                Warning ("Implicit 'int' is an obsolete feature");
+        if (!IsTypeFunc (D->Type) && IsRankInt (D->Type)) {
+            if ((D->StorageClass & SC_TYPEMASK) != SC_TYPEDEF) {
+                /* If the standard was not set explicitly to C89, print a warning
+                ** for variables with implicit int type.
+                */
+                if (IS_Get (&Standard) >= STD_C99) {
+                    Warning ("Implicit 'int' is an obsolete feature");
+                }
+            } else {
+                /* If the standard was not set explicitly to C89, print a warning
+                ** for typedefs with implicit int type.
+                */
+                if (IS_Get (&Standard) >= STD_C99) {
+                    Warning ("Type defaults to 'int' in typedef of '%s'",
+                             D->Ident);
+                    Note ("Implicit 'int' is an obsolete feature");
+                }
             }
         }
     }

--- a/src/cc65/locals.c
+++ b/src/cc65/locals.c
@@ -551,7 +551,9 @@ void DeclareLocals (void)
     /* A place to store info about potential initializations of auto variables */
     CollAppend (&CurrentFunc->LocalsBlockStack, 0);
 
-    /* Loop until we don't find any more variables */
+    /* Loop until we don't find any more variables. EOF is handled in the loop
+    ** as well.
+    */
     while (1) {
         DeclSpec Spec;
         int      NeedClean;

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -955,7 +955,13 @@ SymEntry* AddStructSym (const char* Name, unsigned Flags, unsigned Size, SymTabl
                     TagEntry = 0;
                 } else if (Size == 0) {
                     /* Empty struct is not supported now */
-                    Error ("Empty %s type '%s' is not supported", SCType == SC_STRUCT ? "struct" : "union", Name);
+                    if (!IsAnonName (Name)) {
+                        Error ("Empty %s type '%s' is not supported",
+                               SCType == SC_STRUCT ? "struct" : "union", Name);
+                    } else {
+                        Error ("Empty %s type is not supported",
+                               SCType == SC_STRUCT ? "struct" : "union");
+                    }
                     TagEntry = 0;
                 }
             }

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -170,7 +170,8 @@ static void CheckSymTable (SymTable* Tab)
                 if (SymIsDef (Entry) && !SymIsRef (Entry) &&
                     !SymHasAttr (Entry, atUnused)) {
                     if (Flags & SC_PARAM) {
-                        if (IS_Get (&WarnUnusedParam)) {
+                        if (IS_Get (&WarnUnusedParam) &&
+                            !IsAnonName (Entry->Name)) {
                             Warning ("Parameter '%s' is never used", Entry->Name);
                         }
                     } else if ((Flags & SC_TYPEMASK) == SC_FUNC) {


### PR DESCRIPTION
- Added a warning on implicit `int` type in `typedef`s in post-C89 mode. See https://github.com/cc65/cc65/issues/1428#issuecomment-1890588844
- Removed the extra "unused parameter" warning when the parameter had an duplicated identifier error.
- Removed unnecessary warning on tagless enum/struct/unions that would be invisible out of a function declaration.
- Skipped anonymous tag names in diagnosis on empty structs/unions.
- Fixed repeated diagnosis when reading EOF in certain cases:
  - In unfinished declaration list of a K&R-style function definition.
  - In unfinished member declaration in a struct/union.
- Added warning on some code patterns of faulty attempt to declare anonymous structs/unions.
  - Using a _tagged_ struct/union to form an empty declaration (that declares no instances) - the standard requires a _tagless_ struct/union for the empty declaration.
  - Declaring outside a struct/union - the standard only supports anonymous structs/unions nested inside a struct/union.
