### PR TITLE
Apple2: implement sleep using MONWAIT

### DIFF
--- a/doc/apple2.sgml
+++ b/doc/apple2.sgml
@@ -331,9 +331,25 @@ usage.
 <item>_filetype
 <item>_datetime
 <item>get_ostype
+<item>gmtime_dt
+<item>mktime_dt
 <item>rebootafterexit
 <item>ser_apple2_slot
 <item>tgi_apple2_mix
+</itemize>
+
+
+<sect1>Apple IIgs specific functions in accelerator.h<p>
+
+In addition to those, the <tt/accelerator.h/ header file contains three functions
+to help determine whether the program is running on a IIgs, and change the IIgs
+CPU speed. See the <url url="funcref.html" name="function reference"> for declaration and
+usage.
+
+<itemize>
+<item>detect_iigs
+<item>get_iigs_speed
+<item>set_iigs_speed
 </itemize>
 
 

--- a/doc/apple2enh.sgml
+++ b/doc/apple2enh.sgml
@@ -332,11 +332,27 @@ usage.
 <item>_filetype
 <item>_datetime
 <item>get_ostype
+<item>gmtime_dt
+<item>mktime_dt
 <item>rebootafterexit
 <item>ser_apple2_slot
 <item>tgi_apple2_mix
 <item>videomode
 <item>waitvsync
+</itemize>
+
+
+<sect1>Apple IIgs specific functions in accelerator.h<p>
+
+In addition to those, the <tt/accelerator.h/ header file contains three functions
+to help determine whether the program is running on a IIgs, and change the IIgs
+CPU speed. See the <url url="funcref.html" name="function reference"> for declaration and
+usage.
+
+<itemize>
+<item>detect_iigs
+<item>get_iigs_speed
+<item>set_iigs_speed
 </itemize>
 
 

--- a/doc/funcref.sgml
+++ b/doc/funcref.sgml
@@ -71,18 +71,21 @@ function.
 <item><ref id="detect_c64dtv" name="detect_c64dtv">
 <item><ref id="detect_c65" name="detect_c65">
 <item><ref id="detect_chameleon" name="detect_chameleon">
+<item><ref id="detect_iigs" name="detect_iigs">
 <item><ref id="detect_scpu" name="detect_scpu">
 <item><ref id="detect_turbomaster" name="detect_turbomaster">
 <item><ref id="get_c128_speed" name="get_c128_speed">
 <item><ref id="get_c64dtv_speed" name="get_c64dtv_speed">
 <item><ref id="get_c65_speed" name="get_c65_speed">
 <item><ref id="get_chameleon_speed" name="get_chameleon_speed">
+<item><ref id="get_iigs_speed" name="get_iigs_speed">
 <item><ref id="get_scpu_speed" name="get_scpu_speed">
 <item><ref id="get_turbomaster_speed" name="get_turbomaster_speed">
 <item><ref id="set_c128_speed" name="set_c128_speed">
 <item><ref id="set_c64dtv_speed" name="set_c64dtv_speed">
 <item><ref id="set_c65_speed" name="set_c65_speed">
 <item><ref id="set_chameleon_speed" name="set_chameleon_speed">
+<item><ref id="set_iigs_speed" name="set_iigs_speed">
 <item><ref id="set_scpu_speed" name="set_scpu_speed">
 <item><ref id="set_turbomaster_speed" name="set_turbomaster_speed">
 </itemize>
@@ -104,6 +107,8 @@ function.
 <itemize>
 <item>_dos_type
 <item><ref id="get_ostype" name="get_ostype">
+<item><ref id="gmtime_dt" name="gmtime_dt">
+<item><ref id="mktime_dt" name="mktime_dt">
 <item>rebootafterexit
 <item><ref id="videomode" name="videomode">
 </itemize>
@@ -3453,6 +3458,26 @@ used in presence of a prototype.
 </quote>
 
 
+<sect1>detect_iigs<label id="detect_iigs"><p>
+
+<quote>
+<descrip>
+<tag/Function/Check whether we are running on an Apple IIgs..
+<tag/Header/<tt/<ref id="accelerator.h" name="accelerator.h">/
+<tag/Declaration/<tt/unsigned char detect_iigs (void);/
+<tag/Description/The function returns a 1 if running on an Apple IIgs.
+<tag/Notes/<itemize>
+<item>The function is specific to the Apple2 and Apple2enh platforms.
+</itemize>
+<tag/Availability/cc65 (not all platforms)
+<tag/See also/
+<ref id="get_iigs_speed" name="get_iigs_speed">,
+<ref id="set_iigs_speed" name="set_iigs_speed">,
+<tag/Example/None.
+</descrip>
+</quote>
+
+
 <sect1>detect_scpu<label id="detect_scpu"><p>
 
 <quote>
@@ -4162,6 +4187,27 @@ header files define constants that can be used to check the return code.
 <tag/See also/
 <ref id="detect_chameleon" name="detect_chameleon">,
 <ref id="set_chameleon_speed" name="set_chameleon_speed">,
+<tag/Example/None.
+</descrip>
+</quote>
+
+
+<sect1>get_iigs_speed<label id="get_iigs_speed"><p>
+
+<quote>
+<descrip>
+<tag/Function/Get the current speed of the Apple IIgs.
+<tag/Header/<tt/<ref id="accelerator.h" name="accelerator.h">/
+<tag/Declaration/<tt/unsigned char get_iigs_speed (void);/
+<tag/Description/The function returns the current speed of the Apple IIgs.
+<tag/Notes/<itemize>
+<item>The function is specific to the Apple2 and Apple2enh platforms.
+<item>See the accelerator.h header for the speed definitions.
+</itemize>
+<tag/Availability/cc65 (not all platforms)
+<tag/See also/
+<ref id="detect_iigs" name="detect_iigs">,
+<ref id="set_iigs_speed" name="set_iigs_speed">,
 <tag/Example/None.
 </descrip>
 </quote>
@@ -6980,6 +7026,30 @@ clean-up when exiting the program.
 <tag/See also/
 <ref id="detect_chameleon" name="detect_chameleon">,
 <ref id="get_chameleon_speed" name="get_chameleon_speed">,
+<tag/Example/None.
+</descrip>
+</quote>
+
+
+<sect1>set_iigs_speed<label id="set_iigs_speed"><p>
+
+<quote>
+<descrip>
+<tag/Function/Set the current speed of the Apple IIgs.
+<tag/Header/<tt/<ref id="accelerator.h" name="accelerator.h">/
+<tag/Declaration/<tt/unsigned char __fastcall__ set_iigs_speed (unsigned char speed);/
+<tag/Description/The function sets the speed of the Apple IIgs CPU (and returns
+the new speed).
+<tag/Notes/<itemize>
+<item>The function is specific to the Apple2 and Apple2enh platforms.
+<item>See the accelerator.h header for the speed definitions.
+<item>Accepted parameters are SPEED_SLOW and SPEED_FAST (all other values are
+considered SPEED_FAST).
+</itemize>
+<tag/Availability/cc65 (not all platforms)
+<tag/See also/
+<ref id="detect_iigs" name="detect_iigs">,
+<ref id="get_iigs_speed" name="get_iigs_speed">,
 <tag/Example/None.
 </descrip>
 </quote>

--- a/include/accelerator.h
+++ b/include/accelerator.h
@@ -304,6 +304,36 @@ unsigned char detect_turbomaster (void);
  * 0x01  : C64 Turbo Master cartridge present
  */
 
+unsigned char __fastcall__ set_iigs_speed (unsigned char speed);
+
+/* Set the speed of the Apple IIgs CPU.
+ *
+ * Possible values:
+ * SPEED_SLOW  : 1 Mhz mode
+ * SPEED_FAST  : Fast mode (2.8MHz or more, depending on the presence of
+ *               an accelerator)
+ *
+ * Any other value will be interpreted as SPEED_FAST.
+ */
+
+unsigned char get_iigs_speed (void);
+
+/* Get the speed of the Apple IIgs CPU.
+ *
+ * Possible return values:
+ * SPEED_SLOW  : 1 Mhz mode
+ * SPEED_FAST  : Fast mode (2.8MHz or more, depending on the presence of
+ *               an accelerator)
+ */
+
+unsigned char detect_iigs (void);
+
+/* Check whether we are running on an Apple IIgs.
+ *
+ * Possible return values:
+ * 0x00  : No
+ * 0x01  : Yes
+ */
+
 /* End of accelerator.h */
 #endif
-

--- a/libsrc/apple2/detect_iigs.s
+++ b/libsrc/apple2/detect_iigs.s
@@ -1,0 +1,17 @@
+;
+; Colin Leroy-Mira <colin@colino.net>, 2024
+;
+; void __fastcall__ detect_iigs(void)
+;
+
+        .export         _detect_iigs
+        .import         ostype, return0, return1
+
+        .include        "apple2.inc"
+
+        ; Returns 1 if running on IIgs, 0 otherwise
+_detect_iigs:
+        lda     ostype
+        bpl     :+
+        jmp     return1
+:       jmp     return0

--- a/libsrc/apple2/get_iigs_speed.s
+++ b/libsrc/apple2/get_iigs_speed.s
@@ -1,0 +1,22 @@
+;
+; Colin Leroy-Mira <colin@colino.net>, 2024
+;
+; unsigned char __fastcall__ get_iigs_speed(void)
+;
+
+        .export         _get_iigs_speed
+        .import         ostype, return0
+
+        .include        "apple2.inc"
+        .include        "accelerator.inc"
+
+_get_iigs_speed:
+        lda     ostype          ; Return SLOW if not IIgs
+        bpl     :+
+        lda     CYAREG          ; Check current setting
+        bpl     :+
+        lda     #SPEED_FAST
+        ldx     #$00
+        rts
+        .assert SPEED_SLOW = 0, error
+:       jmp     return0         ; SPEED_SLOW

--- a/libsrc/apple2/get_ostype.s
+++ b/libsrc/apple2/get_ostype.s
@@ -5,7 +5,7 @@
 ;
 
         .constructor    initostype, 9
-        .export         _get_ostype
+        .export         _get_ostype, ostype
 
 ; Identify machine according to:
 ; Apple II Miscellaneous TechNote #7, Apple II Family Identification

--- a/libsrc/apple2/set_iigs_speed.s
+++ b/libsrc/apple2/set_iigs_speed.s
@@ -1,0 +1,29 @@
+;
+; Colin Leroy-Mira <colin@colino.net>, 2024
+;
+; unsigned char __fastcall__ detect_iigs(unsigned char speed)
+;
+
+        .export         _set_iigs_speed
+        .import         ostype, return0
+
+        .include        "apple2.inc"
+        .include        "accelerator.inc"
+
+_set_iigs_speed:
+        tax                     ; Keep parameter
+        lda     ostype          ; Return if not IIgs
+        bmi     :+
+        jmp     return0
+
+:       lda     CYAREG
+        cpx     #SPEED_SLOW
+        beq     :+
+        ora     #%10000000
+        bne     set_speed
+:       and     #%01111111
+set_speed:
+        sta     CYAREG
+        txa
+        ldx     #$00
+        rts

--- a/libsrc/apple2/sleep.s
+++ b/libsrc/apple2/sleep.s
@@ -1,0 +1,54 @@
+;
+; Colin Leroy-Mira <colin@colino.net>, 2024
+;
+; void __fastcall__ sleep(unsigned s)
+;
+;
+
+        .export         _sleep
+        .import         _get_iigs_speed
+        .import         _set_iigs_speed
+        .import         WAIT
+        .importzp       tmp1
+
+        .include        "accelerator.inc"
+
+        ; This functions uses the Apple2 WAIT ROM routine to waste a certain
+        ; amount of cycles and returns approximately after the numbers of
+        ; seconds passed in AX.
+        ;
+        ; It takes 1023730 cycles when called with AX=1 (1,0007s),
+        ; 10236364 cycles when called with AX=10 (10,006 seconds),
+        ; 306064298 cycles with AX=300 (299.2 seconds).
+        ;
+        ; Caveat: IRQs firing during calls to sleep will make the sleep longer
+        ; by the amount of cycles it takes to handle the IRQ.
+        ;
+_sleep:
+        stx     tmp1            ; High byte of s in X
+        tay                     ; Low byte in A
+        ora     tmp1
+        bne     :+
+        rts
+:       jsr     _get_iigs_speed ; Save current CPU speed
+        pha
+        lda     #SPEED_SLOW     ; Down to 1MHz for consistency around WAIT
+        jsr     _set_iigs_speed
+sleep_1s:
+        ldx     #$0A            ; Loop 10 times
+sleep_100ms:
+        lda     #$C7            ; Sleep about 99ms
+        jsr     WAIT
+        lda     #$0D             ; About 1ms
+        jsr     WAIT
+        dex
+        bne     sleep_100ms
+        dey
+        bne     sleep_1s
+        dec     tmp1
+        bmi     done
+        dey                     ; Down to #$FF
+        bne     sleep_1s
+done:
+        pla                     ; Restore CPU speed
+        jmp     _set_iigs_speed

--- a/libsrc/apple2/wait.s
+++ b/libsrc/apple2/wait.s
@@ -1,0 +1,20 @@
+;
+; Colin Leroy-Mira, 2024
+;
+; WAIT routine
+;
+
+        .export         WAIT
+
+        .include        "apple2.inc"
+
+        .segment        "LOWCODE"
+
+WAIT:
+        ; Switch in ROM and call WAIT
+        bit     $C082
+        jsr     $FCA8           ; Vector to WAIT routine
+
+        ; Switch in LC bank 2 for R/O and return
+        bit     $C080
+        rts

--- a/libsrc/apple2/waitvsync.s
+++ b/libsrc/apple2/waitvsync.s
@@ -5,20 +5,10 @@
 ;
         .ifdef  __APPLE2ENH__
 
-        .constructor    initvsync
         .export         _waitvsync
-        .import         _get_ostype
+        .import         ostype
 
         .include        "apple2.inc"
-
-        .segment        "ONCE"
-
-initvsync:
-        jsr     _get_ostype
-        sta     ostype
-        rts
-
-        .code
 
 _waitvsync:
         bit     ostype
@@ -52,9 +42,5 @@ iic:    sei
 :       sta     IOUDISON        ; IIc Tech Ref Man: The firmware normally leaves IOUDIS on.
         cli
         rts
-
-        .segment        "INIT"
-
-ostype: .res    1
 
         .endif                  ; __APPLE2ENH__


### PR DESCRIPTION
Also publish apple2_slowdown() and apple2_speedup() that could be useful to users (I do use those in some projects), and refactor to only store one apple2_ostype variable.
The sleep time is not precise to the millisecond of course, but close enough that it matches the chronometer on sleep(300) and sleep(600), and on
```
  while(1) {
    sleep(1);
    __asm__("bit $C030");
  }
```