### PR TITLE
Fix #2357 - Copy est.size and flags of op when moving it

### DIFF
--- a/src/cc65/coptlong.c
+++ b/src/cc65/coptlong.c
@@ -106,9 +106,13 @@ unsigned OptLongAssign (CodeSeg* S)
               !RegXUsed (S, I+11)) {
 
               L[1]->AM = L[11]->AM;
+              L[1]->Size = L[11]->Size;
+              L[1]->Flags = L[11]->Flags;
               CE_SetArg(L[1], L[11]->Arg);
 
               L[3]->AM = L[9]->AM;
+              L[3]->Size = L[9]->Size;
+              L[3]->Flags = L[9]->Flags;
               CE_SetArg(L[3], L[9]->Arg);
 
               CS_DelEntries (S, I+8, 4);
@@ -188,9 +192,13 @@ unsigned OptLongCopy (CodeSeg* S)
               !RegXUsed (S, I+11)) {
 
               L[1]->AM = L[11]->AM;
+              L[1]->Size = L[11]->Size;
+              L[1]->Flags = L[11]->Flags;
               CE_SetArg(L[1], L[11]->Arg);
 
               L[3]->AM = L[9]->AM;
+              L[3]->Size = L[9]->Size;
+              L[3]->Flags = L[9]->Flags;
               CE_SetArg(L[3], L[9]->Arg);
 
               CS_DelEntries (S, I+8, 4);


### PR DESCRIPTION
Fixes #2357