### PR TITLE
Lynx upload fixes for IRQ and configuration

### DIFF
--- a/cfg/lynx-uploader.cfg
+++ b/cfg/lynx-uploader.cfg
@@ -5,16 +5,17 @@ SYMBOLS {
     __BANK1BLOCKSIZE__:   type = weak, value = $0000; # bank 1 block size
     __EXEHDR__:           type = import;
     __BOOTLDR__:          type = import;
-    __DEFDIR__:           type = import;
     __UPLOADER__:         type = import;
+    __UPLOADERSIZE__:     type = export, value = $61;
+    __HEADERSIZE__:       type = export, value = 64;
 }
 MEMORY {
     ZP:     file = "", define = yes, start = $0000, size = $0100;
-    HEADER: file = %O,               start = $0000, size = $0040;
+    HEADER: file = %O,               start = $0000, size = __HEADERSIZE__;
     BOOT:   file = %O,               start = $0200, size = __STARTOFDIRECTORY__;
-    DIR:    file = %O,               start = $0000, size = 8;
-    MAIN:   file = %O, define = yes, start = $0200, size = $BD38 - __STACKSIZE__;
-    UPLDR:  file = %O, define = yes, start = $BFDC, size = $005C;
+    DIR:    file = %O,               start = $0000, size = 16;
+    MAIN:   file = %O, define = yes, start = $0200, size = $C038 - __UPLOADERSIZE__ - $200 - __STACKSIZE__;
+	UPLOAD: file = %O, define = yes, start = $C038 - __UPLOADERSIZE__, size = $0061;
 }
 SEGMENTS {
     ZEROPAGE: load = ZP,     type = zp;
@@ -30,8 +31,8 @@ SEGMENTS {
     RODATA:   load = MAIN,   type = ro,  define = yes;
     DATA:     load = MAIN,   type = rw,  define = yes;
     BSS:      load = MAIN,   type = bss, define = yes;
-    UPCODE:   load = UPLDR,  type = ro,  define = yes;
-    UPDATA:   load = UPLDR,  type = rw,  define = yes;
+    UPCODE:   load = UPLOAD, type = ro,  define = yes;
+    UPDATA:   load = UPLOAD, type = rw,  define = yes;
 }
 FEATURES {
     CONDES: type    = constructor,

--- a/cfg/lynx-uploader.cfg
+++ b/cfg/lynx-uploader.cfg
@@ -15,7 +15,7 @@ MEMORY {
     BOOT:   file = %O,               start = $0200, size = __STARTOFDIRECTORY__;
     DIR:    file = %O,               start = $0000, size = 16;
     MAIN:   file = %O, define = yes, start = $0200, size = $C038 - __UPLOADERSIZE__ - $200 - __STACKSIZE__;
-	UPLOAD: file = %O, define = yes, start = $C038 - __UPLOADERSIZE__, size = $0061;
+    UPLOAD: file = %O, define = yes, start = $C038 - __UPLOADERSIZE__, size = $0061;
 }
 SEGMENTS {
     ZEROPAGE: load = ZP,     type = zp;

--- a/libsrc/lynx/lseek.s
+++ b/libsrc/lynx/lseek.s
@@ -18,7 +18,7 @@
         .import         ldeaxysp, decsp2, pushax, incsp8
         .import         tosandeax,decax1,tosdiveax,axlong,ldaxysp
         .import         lynxskip0, lynxblock,tosasreax
-        .import         __BLOCKSIZE__
+        .import         __BANK0BLOCKSIZE__
         .importzp       _FileCurrBlock
 
 .segment        "CODE"
@@ -32,15 +32,15 @@
         jsr     ldeaxysp
         jsr     pusheax
         ldx     #$00
-        lda     #<(__BLOCKSIZE__/1024 + 9)
+        lda     #<(__BANK0BLOCKSIZE__/1024 + 9)
         jsr     tosasreax
         sta     _FileCurrBlock
         jsr     lynxblock
         ldy     #$05
         jsr     ldeaxysp
         jsr     pusheax
-        lda     #<(__BLOCKSIZE__-1)
-        ldx     #>(__BLOCKSIZE__-1)
+        lda     #<(__BANK0BLOCKSIZE__-1)
+        ldx     #>(__BANK0BLOCKSIZE__-1)
         jsr     axlong
         jsr     tosandeax
         eor     #$FF

--- a/libsrc/lynx/lynx-cart.s
+++ b/libsrc/lynx/lynx-cart.s
@@ -88,7 +88,7 @@ lynxblock:
         lda __iodat
         sta IODAT
         stz _FileBlockByte
-        lda #<($100-(>__BLOCKSIZE__))
+        lda #<($100-(>__BANK0BLOCKSIZE__))
         sta _FileBlockByte+1
         ply
         plx

--- a/libsrc/lynx/lynx-cart.s
+++ b/libsrc/lynx/lynx-cart.s
@@ -17,7 +17,7 @@
         .include "extzp.inc"
         .export  lynxskip0, lynxread0
         .export  lynxblock
-        .import  __BLOCKSIZE__
+        .import  __BANK0BLOCKSIZE__
 
         .code
 

--- a/libsrc/lynx/uploader.s
+++ b/libsrc/lynx/uploader.s
@@ -33,7 +33,7 @@ loop1:
 cont1:
         jsr     read_byte
         sta     (load_ptr2),y
-        sta     PALETTE         ; feedback ;-)
+        sta     PALETTE + 1         ; feedback ;-)
         iny
         bne     loop1
         inc     load_ptr2+1
@@ -69,6 +69,8 @@ again:
 ; last action : clear interrupt
 ;
 exit:
+        lda     #$10
+        sta     INTRST
         clc
         rts
 


### PR DESCRIPTION
Fix #2369
Changes for the uploader implementation for the Atari Lynx library.

- The interrupt handler logic is adjusted to clear timer 4 bit for serial IRQs. This IRQ bit is level-sensitive instead of edge-sensitive due to a hardware bug and must reset to avoid firing the interrupt continuously as long as the bit is set. 
- The feedback is now given from palette color green on pen 1 instead of 0. This works better for the default cc65 Lynx color palette
- Uploader configuration `lynx-uploader.cfg` is adjusted. Encourages a second directory entry for a separate file to be loaded with the uploader logic in `UPCODE` and `UPDATA`. Size of the `UPCODE` code is taken into account for RAM area.
- Removed redundant `__BLOCKSIZE__` and changed it to __BANK0BLOCKSIZE__ where it was still being referenced in the `libsrc\lynx` files (`lseek.s` and `lynx-cart.s`)