### PR TITLE
[cc65] Added primitive support for the ISO C99 inline feature as well as the __inline__ extension

### DIFF
--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -121,7 +121,7 @@ static void Parse (void)
         }
 
         /* Read the declaration specifier */
-        ParseDeclSpec (&Spec, TS_DEFAULT_TYPE_INT, SC_NONE);
+        ParseDeclSpec (&Spec, TS_DEFAULT_TYPE_INT | TS_FUNCTION_SPEC, SC_NONE);
 
         /* Don't accept illegal storage classes */
         if ((Spec.StorageClass & SC_STORAGEMASK) == SC_AUTO ||
@@ -560,6 +560,10 @@ void Compile (const char* FileName)
                 if ((Entry->Flags & SC_STORAGEMASK) == SC_STATIC && SymIsRef (Entry)) {
                     Warning ("Static function '%s' used but never defined",
                              Entry->Name);
+                } else if ((Entry->Flags & SC_INLINE) != 0) {
+                    Warning ("Inline function '%s' %s but never defined",
+                             Entry->Name,
+                             SymIsRef (Entry) ? "used" : "declared");
                 }
             }
         }

--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1407,7 +1407,7 @@ static void Primary (ExprDesc* E)
             } else {
                 /* Let's see if this is a C99-style declaration */
                 DeclSpec Spec;
-                ParseDeclSpec (&Spec, TS_DEFAULT_TYPE_NONE, SC_AUTO);
+                ParseDeclSpec (&Spec, TS_DEFAULT_TYPE_NONE | TS_FUNCTION_SPEC, SC_AUTO);
 
                 if ((Spec.Flags & DS_TYPE_MASK) != DS_NONE) {
                     Error ("Mixed declarations and code are not supported in cc65");

--- a/src/cc65/function.c
+++ b/src/cc65/function.c
@@ -518,6 +518,12 @@ void NewFunc (SymEntry* Func, FuncDesc* D)
             Error ("'main' cannot be declared as __fastcall__");
         }
 
+        /* main() cannot be an inline function */
+        if ((Func->Flags & SC_INLINE) == SC_INLINE) {
+            Error ("'main' cannot be declared inline");
+            Func->Flags &= ~SC_INLINE;
+        }
+
         /* Check return type */
         if (GetUnqualRawTypeCode (ReturnType) == T_INT) {
             /* Determine if this is a main function in a C99 environment that

--- a/src/cc65/locals.c
+++ b/src/cc65/locals.c
@@ -563,7 +563,7 @@ void DeclareLocals (void)
         }
 
         /* Read the declaration specifier */
-        ParseDeclSpec (&Spec, TS_DEFAULT_TYPE_INT, SC_AUTO);
+        ParseDeclSpec (&Spec, TS_DEFAULT_TYPE_INT | TS_FUNCTION_SPEC, SC_AUTO);
 
         /* Check variable declarations. We need distinguish between a default
         ** int type and the end of variable declarations. So we will do the

--- a/src/cc65/scanner.h
+++ b/src/cc65/scanner.h
@@ -76,6 +76,7 @@ typedef enum token_t {
 
     /* Function specifiers */
     TOK_INLINE,
+    TOK_NORETURN,
     TOK_FASTCALL,
     TOK_CDECL,
 

--- a/src/cc65/symentry.h
+++ b/src/cc65/symentry.h
@@ -151,6 +151,10 @@ struct CodeEntry;
 #define SC_THREAD       0x08000000U     /* UNSUPPORTED: Thread-local storage class */
 #define SC_STORAGEMASK  0x0F000000U     /* Storage type mask */
 
+/* Function specifiers */
+#define SC_INLINE       0x10000000U     /* Inline function */
+#define SC_NORETURN     0x20000000U     /* Noreturn function */
+
 
 
 /* Label definition or reference */

--- a/src/cc65/symtab.c
+++ b/src/cc65/symtab.c
@@ -1439,6 +1439,16 @@ SymEntry* AddGlobalSym (const char* Name, const Type* T, unsigned Flags)
             Entry->V.F.WrappedCall = WrappedCall;
             Entry->V.F.WrappedCallData = WrappedCallData;
         }
+
+        /* A files cope function declaration with the 'extern' storage
+        ** class or without the 'inline' specifier ensures that the
+        ** function definition (if any) is a non-inline definition.
+        */
+        if (SymTab == SymTab0 &&
+            ((Flags & SC_STORAGEMASK) == SC_EXTERN ||
+             (Flags & SC_INLINE) == 0)) {
+            Entry->Flags |= SC_NOINLINEDEF;
+        }
     }
 
     /* Add an alias of the global symbol to the local symbol table */
@@ -1575,7 +1585,7 @@ void EmitExternals (void)
             if (SymIsRef (Entry) && !SymIsDef (Entry)) {
                 /* An import */
                 g_defimport (Entry->Name, Flags & SC_ZEROPAGE);
-            } else if (SymIsDef (Entry)) {
+            } else if (SymIsDef (Entry) && ((Flags & SC_NOINLINEDEF) || (Flags & SC_INLINE) == 0)) {
                 /* An export */
                 g_defexport (Entry->Name, Flags & SC_ZEROPAGE);
             }

--- a/test/ref/Makefile
+++ b/test/ref/Makefile
@@ -63,6 +63,7 @@ CUSTOMSOURCES = \
 # exact error output is required
 ERRORSOURCES = \
 	custom-reference-error.c \
+	inline-error.c \
 	bug1889-missing-identifier.c \
 	bug2312-preprocessor-error.c
 

--- a/test/ref/bug1889-missing-identifier.cref
+++ b/test/ref/bug1889-missing-identifier.cref
@@ -1,4 +1,4 @@
 bug1889-missing-identifier.c:3: Error: Identifier or ';' expected after declaration specifiers
 bug1889-missing-identifier.c:3: Warning: Implicit 'int' is an obsolete feature
-bug1889-missing-identifier.c:4: Error: Declaration specifier or identifier expected
+bug1889-missing-identifier.c:4: Error: 'inline' on empty declaration
 bug1889-missing-identifier.c:6: Error: Expression expected

--- a/test/ref/inline-error.c
+++ b/test/ref/inline-error.c
@@ -1,0 +1,36 @@
+/* C99 inline in declarations */
+
+inline typedef int;                 /* Error */
+static inline int;                  /* Error */
+inline static int a1;               /* Error */
+int inline (*fp1)(void);            /* Error */
+typedef inline int f1_t(void);      /* Error */
+inline int f1a(void);               /* OK here warning later */
+inline extern int f1b(void);        /* OK here warning later */
+extern inline int f1b(void);        /* Same as above */
+inline static int f1c(void);        /* OK here warning later */
+static inline int f1c(void);        /* Same as above */
+
+void foo(inline int x);             /* Error */
+int a = sizeof (inline int);        /* TODO: better error message */
+int b = sizeof (inline int (int));  /* TODO: better error message */
+
+inline int main(void)               /* Error */
+{
+    inline typedef int;             /* Error */
+    static inline int;              /* Error */
+    extern inline int a2;           /* Error */
+    int inline (*fp2)(void);        /* Error */
+    typedef inline int f2_t(void);  /* Error */
+    inline int f2a(void);           /* OK here warning later */
+    inline extern int f2b(void);    /* OK here warning later */
+    extern inline int f2b(void);    /* Same as above */
+
+    f1a();                          /* Still imported */
+    f1b();                          /* Still imported */
+    f1c();                          /* Not imported */
+    f2a();                          /* Still imported */
+    f2b();                          /* Still imported */
+}
+
+/* Warning: non-external inline functions declared but undefined in TU */

--- a/test/ref/inline-error.cref
+++ b/test/ref/inline-error.cref
@@ -1,0 +1,20 @@
+inline-error.c:3: Error: 'inline' on empty declaration
+inline-error.c:4: Error: 'inline' on empty declaration
+inline-error.c:5: Error: 'inline' on non-function declaration
+inline-error.c:6: Error: 'inline' on non-function declaration
+inline-error.c:7: Error: 'inline' on non-function declaration
+inline-error.c:14: Error: Unexpected function specifiers
+inline-error.c:15: Error: Mixed declarations and code are not supported in cc65
+inline-error.c:16: Error: Mixed declarations and code are not supported in cc65
+inline-error.c:19: Error: 'main' cannot be declared inline
+inline-error.c:20: Error: 'inline' on empty declaration
+inline-error.c:21: Error: 'inline' on empty declaration
+inline-error.c:22: Error: 'inline' on non-function declaration
+inline-error.c:23: Error: 'inline' on non-function declaration
+inline-error.c:24: Error: 'inline' on non-function declaration
+inline-error.c:34: Warning: Variable 'fp2' is defined but never used
+inline-error.c:37: Warning: Inline function 'f1a' used but never defined
+inline-error.c:37: Warning: Inline function 'f1b' used but never defined
+inline-error.c:37: Warning: Static function 'f1c' used but never defined
+inline-error.c:37: Warning: Inline function 'f2a' used but never defined
+inline-error.c:37: Warning: Inline function 'f2b' used but never defined

--- a/test/val/inline-func.c
+++ b/test/val/inline-func.c
@@ -1,0 +1,20 @@
+/* C99 inline */
+
+#include <stdlib.h>
+
+inline static int f(int x, ...)
+{
+    return x * 2;
+}
+
+extern inline int g(int x);
+
+int main(void)
+{
+    return f(g(7)) == 42 ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+int g(int x)
+{
+    return x * 3;
+}


### PR DESCRIPTION
No inlining is actually done but that part is not required by the standard.