### PR TITLE
Save two bytes in pushax and popptr1

### DIFF
--- a/libsrc/runtime/popptr1.s
+++ b/libsrc/runtime/popptr1.s
@@ -8,12 +8,18 @@
         .import         incsp2
         .importzp       sp, ptr1
 
+        .macpack        cpu
+
 .proc   popptr1                 ; 14 bytes (four usages = at least 2 bytes saved)
         ldy     #1
         lda     (sp),y          ; get hi byte
         sta     ptr1+1          ; into ptr hi
-        dey                     ; no optimization for 65C02 here to have Y=0 at exit!
+        dey                     ; dey even for for 65C02 here to have Y=0 at exit!
+.if (.cpu .bitand ::CPU_ISET_65SC02)
+        lda     (sp)            ; get lo byte
+.else
         lda     (sp),y          ; get lo byte
+.endif
         sta     ptr1            ; to ptr lo
         jmp     incsp2
 .endproc

--- a/libsrc/runtime/pushax.s
+++ b/libsrc/runtime/pushax.s
@@ -7,6 +7,8 @@
         .export         push0, pusha0, pushax
         .importzp       sp
 
+        .macpack        cpu
+
 push0:  lda     #0
 pusha0: ldx     #0
 
@@ -29,7 +31,11 @@ pusha0: ldx     #0
         sta     (sp),y          ; (27)
         pla                     ; (31)
         dey                     ; (33)
+.if (.cpu .bitand ::CPU_ISET_65SC02)
+        sta     (sp)            ; (37)
+.else
         sta     (sp),y          ; (38)
-        rts                     ; (44)
+.endif
+        rts                     ; (44/43)
 
 .endproc


### PR DESCRIPTION
It's not because Y must equal zero on rts that we should'nt spare one byte and one cycle.