### PR TITLE
Apple2: Swap in ROM before exec()

### DIFF
--- a/doc/apple2.sgml
+++ b/doc/apple2.sgml
@@ -62,7 +62,7 @@ Special locations:
 </descrip><p>
 
 While running <tt/main()/ the Language Card bank 2 is enabled for read access.
-However while running module constructors/destructors the Language Card is disabled.
+However while running module constructors the Language Card is disabled.
 
 Enabling the Language Card allows to use it as additional memory for cc65
 generated code. However code is never automatically placed there. Rather code

--- a/doc/apple2enh.sgml
+++ b/doc/apple2enh.sgml
@@ -63,7 +63,7 @@ Special locations:
 </descrip><p>
 
 While running <tt/main()/ the Language Card bank 2 is enabled for read access.
-However while running module constructors/destructors the Language Card is disabled.
+However while running module constructors the Language Card is disabled.
 
 Enabling the Language Card allows to use it as additional memory for cc65
 generated code. However code is never automatically placed there. Rather code

--- a/libsrc/apple2/crt0.s
+++ b/libsrc/apple2/crt0.s
@@ -40,11 +40,14 @@ _exit:  ldx     #<exit
         lda     #>exit
         jsr     reset           ; Setup RESET vector
 
-        ; Switch in ROM, in case it wasn't already switched in by a RESET.
-        bit     $C082
+        ; Switch in LC bank 2 for R/O in case it was switched out by a RESET.
+        bit     $C080
 
         ; Call the module destructors.
         jsr     donelib
+
+        ; Switch in ROM.
+        bit     $C082
 
         ; Restore the original RESET vector.
 exit:   ldx     #$02


### PR DESCRIPTION
Constructors expect ROM swapped in at start. If we don't swap it in right before exec()'ing the next program, and the next program uses constructors that need the ROM swapped in, the program explodes if it was not in.

This does not always happen: _exit() swaps in ROM fairly late, [at line 44](https://github.com/cc65/cc65/blob/a173428fabfd8c362ac072ac680c61be45e880c4/libsrc/apple2/crt0.s#L44). 
However, the modules destructors are called right after that. If you had ser_install(&a2e_gs_ser), it will be ser_uninstall()'d, and there will [switch to ROM, jsr $FE1F, switch back to RAM](https://github.com/cc65/cc65/blob/a173428fabfd8c362ac072ac680c61be45e880c4/libsrc/apple2/ser/a2.gs.s#L282). 

Then exec() will start the new program with RAM switched in, and initostype() will [call $FE1F](https://github.com/cc65/cc65/blob/a173428fabfd8c362ac072ac680c61be45e880c4/libsrc/apple2/get_ostype.s#L17), and fail :)

as ser_install() and ser_uninstall() share the same code path, I'm not sure it's the best place to fix that problem.

Rather, I suggest with swap in ROM right before we jump into the new program. We could also swap in ROM in initostype(), but I feel that's safer to do it right where we want to be sure it's in.

Minimal reproducer, this TEST program:
```
#include <conio.h>
#include <serial.h>
#include <stdio.h>
#include <unistd.h>

int main(int argc, char *argv[]) {
  ser_install(&a2e_gs_ser);
  printf("OS: %d\n", get_ostype());

  cgetc();
  exec("TEST", NULL);
}
```
