### PR TITLE
[cc65] Diagnosis improvements

### DIFF
--- a/test/ref/bug1889-missing-identifier.cref
+++ b/test/ref/bug1889-missing-identifier.cref
@@ -1,4 +1,4 @@
 bug1889-missing-identifier.c:3: Error: Identifier or ';' expected after declaration specifiers
-bug1889-missing-identifier.c:3: Warning: Implicit 'int' is an obsolete feature
+bug1889-missing-identifier.c:3: Warning: Implicit 'int' type specifier is an obsolete feature
 bug1889-missing-identifier.c:4: Error: 'inline' on empty declaration
 bug1889-missing-identifier.c:6: Error: Expression expected

--- a/test/ref/inline-error.c
+++ b/test/ref/inline-error.c
@@ -33,4 +33,6 @@ inline int main(void)               /* Error */
     f2b();                          /* Still imported */
 }
 
+inline int main(void);              /* Error */
+
 /* Warning: non-external inline functions declared but undefined in TU */

--- a/test/ref/inline-error.cref
+++ b/test/ref/inline-error.cref
@@ -13,8 +13,9 @@ inline-error.c:22: Error: 'inline' on non-function declaration
 inline-error.c:23: Error: 'inline' on non-function declaration
 inline-error.c:24: Error: 'inline' on non-function declaration
 inline-error.c:34: Warning: Variable 'fp2' is defined but never used
-inline-error.c:37: Warning: Inline function 'f1a' used but never defined
-inline-error.c:37: Warning: Inline function 'f1b' used but never defined
-inline-error.c:37: Warning: Static function 'f1c' used but never defined
-inline-error.c:37: Warning: Inline function 'f2a' used but never defined
-inline-error.c:37: Warning: Inline function 'f2b' used but never defined
+inline-error.c:36: Error: 'main' cannot be declared inline
+inline-error.c:39: Warning: Inline function 'f1a' used but never defined
+inline-error.c:39: Warning: Inline function 'f1b' used but never defined
+inline-error.c:39: Warning: Static function 'f1c' used but never defined
+inline-error.c:39: Warning: Inline function 'f2a' used but never defined
+inline-error.c:39: Warning: Inline function 'f2b' used but never defined


### PR DESCRIPTION
- Added missing checks for forward declarations of the main() function.
- More accurate diagnosis on implicit 'int' type specifiers.
