### PR TITLE
Fix #2388

### DIFF
--- a/test/ref/test_gets.c
+++ b/test/ref/test_gets.c
@@ -30,9 +30,7 @@ char *argv[];
 #endif
 {
     /* Fake stdin with the reference file */
-    fclose(stdin);
-    stdin = fopen(INFILE, "r");
-    if (stdin == NULL) {
+    if (freopen(INFILE, "rb", stdin) == NULL) {
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
@mrdudz, can you test if this works?

(If it does, it contradicts https://learn.microsoft.com/en-us/cpp/c-runtime-library/gets-getws?view=msvc-170 that mention nothing of \r).
Also, cf.in has Unix file format with \n line endings...