### PR TITLE
Improvements and fixes in serial support for Atari Lynx

### DIFF
--- a/asminc/lynx.inc
+++ b/asminc/lynx.inc
@@ -267,22 +267,26 @@ MIKEYHREV   = $FD88
 MIKEYSREV   = $FD89
 IODIR       = $FD8A
 IODAT       = $FD8B
-TxIntEnable = %10000000
-RxIntEnable = %01000000
-TxParEnable = %00010000
-ResetErr    = %00001000
-TxOpenColl  = %00000100
-TxBreak     = %00000010
-ParEven     = %00000001
-TxReady     = %10000000
-RxReady     = %01000000
-TxEmpty     = %00100000
-RxParityErr = %00010000
-RxOverrun   = %00001000
-RxFrameErr  = %00000100
-RxBreak     = %00000010
-ParityBit   = %00000001
+
 SERCTL      = $FD8C
+; SERCTL bit definitions for write operations
+TXINTEN  = $80
+RXINTEN  = $40
+PAREN    = $10
+RESETERR = $08
+TXOPEN   = $04
+TXBRK    = $02
+PAREVEN  = $01
+; SERCTL bit definitions for read operations
+TXRDY   = $80
+RXRDY   = $40
+TXEMPTY = $20
+PARERR  = $10
+OVERRUN = $08
+FRAMERR = $04
+RXBRK   = $02
+PARBIT  = $01
+
 SERDAT      = $FD8D
 SDONEACK    = $FD90
 CPUSLEEP    = $FD91

--- a/asminc/lynx.inc
+++ b/asminc/lynx.inc
@@ -259,16 +259,26 @@ SND_INTERRUPT = TIMER7_INTERRUPT
 
 INTRST      = $FD80
 INTSET      = $FD81
+
 MAGRDY0     = $FD84
 MAGRDY1     = $FD85
 AUDIN       = $FD86
 SYSCTL1     = $FD87
 MIKEYHREV   = $FD88
 MIKEYSREV   = $FD89
-IODIR       = $FD8A
-IODAT       = $FD8B
 
-SERCTL      = $FD8C
+IODIR          = $FD8A
+IODAT          = $FD8B
+; IODIR and IODAT bit definitions
+AUDIN_BIT      = $10  ; Note that there is also the address AUDIN
+READ_ENABLE    = $10  ; Same bit for AUDIN_BIT
+RESTLESS       = $08
+NOEXP          = $04  ; If set, redeye is not connected
+CART_ADDR_DATA = $02
+CART_POWER_OFF = $02  ; Same bit for CART_ADDR_DATA
+EXTERNAL_POWER = $01
+
+SERCTL   = $FD8C
 ; SERCTL bit definitions for write operations
 TXINTEN  = $80
 RXINTEN  = $40

--- a/libsrc/lynx/crt0.s
+++ b/libsrc/lynx/crt0.s
@@ -68,7 +68,7 @@ MikeyInitData:  .byte $9e,$18,$68,$1f,$00,$00,$00,$00,$00,$ff,$1a,$1b,$04,$0d,$2
 
 ; Disable the TX/RX IRQ; set to 8E1.
 
-        lda     #%00011101
+        lda     #PAREN|RESETERR|TXOPEN|PAREVEN  ; #%00011101
         sta     SERCTL
 
 ; Clear all pending interrupts.

--- a/libsrc/lynx/ser/lynx-comlynx.s
+++ b/libsrc/lynx/ser/lynx-comlynx.s
@@ -200,7 +200,18 @@ checkhs:
         ldy     #SER_PARAMS::HANDSHAKE  ; Handshake
         lda     (ptr1),y
         cmp     #SER_HS_NONE
+        beq     redeye_ok
+        cmp     #SER_HS_SW              ; Software handshake will check for connected redeye
         bne     invparameter
+
+        lda     IODAT
+        and     #NOEXP                  ; Check if redeye bit flag is unset
+        beq     redeye_ok
+        lda     #SER_ERR_NO_DEVICE      ; ComLynx cable is not inserted
+        ldx     #0
+        rts
+
+redeye_ok:
         lda     SERDAT
         lda     contrl
         ora     #RXINTEN|RESETERR       ; Turn on interrupts for receive
@@ -209,6 +220,7 @@ checkhs:
         .assert SER_ERR_OK = 0, error
         tax
         rts
+
 invparameter:
         lda     #SER_ERR_INIT_FAILED
         ldx     #0 ; return value is char

--- a/libsrc/lynx/ser/lynx-comlynx.s
+++ b/libsrc/lynx/ser/lynx-comlynx.s
@@ -76,8 +76,7 @@ SER_CLOSE:
         ; Disable interrupts and stop timer 4 (serial)
         lda     #TXOPEN|RESETERR
         sta     SERCTL
-        lda     #$00  ; Disable count and no reload
-        sta     TIM4CTLA
+        stz     TIM4CTLA  ; Disable count and no reload
 
         ; Done, return an error code
         lda     #SER_ERR_OK

--- a/libsrc/lynx/ser/lynx-comlynx.s
+++ b/libsrc/lynx/ser/lynx-comlynx.s
@@ -76,7 +76,8 @@ SER_CLOSE:
         ; Disable interrupts and stop timer 4 (serial)
         lda     #TXOPEN|RESETERR
         sta     SERCTL
-        stz     TIM4CTLA  ; Disable count and no reload
+        stz     TIM4CTLA    ; Disable count and no reload
+        stz     SerialStat  ; Reset status
 
         ; Done, return an error code
         lda     #SER_ERR_OK
@@ -241,8 +242,8 @@ GetByte:
         ldy     RxPtrOut
         lda     RxBuffer,y
         inc     RxPtrOut
+        sta     (ptr1)
         ldx     #$00
-        sta     (ptr1,x)
         txa                     ; Return code = 0
         rts
 
@@ -288,8 +289,8 @@ PutByte:
 
 SER_STATUS:
         lda     SerialStat
+        sta     (ptr1)
         ldx     #$00
-        sta     (ptr1,x)
         txa                     ; Return code = 0
         rts
 
@@ -327,7 +328,7 @@ SER_IRQ:
         and     #PAREN      ; Parity enabled implies SER_PAR_EVEN or SER_PAR_ODD
         tay
         ora     #OVERRUN|FRAMERR|RXBRK
-        bit     SERCTL      ; Check presence of relevant error flags in SERCTL
+        and     SERCTL      ; Check presence of relevant error flags in SERCTL
 
         beq     @rx_irq     ; No errors so far
 

--- a/libsrc/lynx/ser/lynx-comlynx.s
+++ b/libsrc/lynx/ser/lynx-comlynx.s
@@ -158,33 +158,6 @@ SER_OPEN:
         cmp     #SER_BAUD_300
         beq     setbaudrate
 
-        ldx     #103
-        cmp     #SER_BAUD_150
-        beq     setbaudrate
-
-        ldx     #115
-        cmp     #SER_BAUD_134_5
-        beq     setbaudrate
-
-        ldx     #141
-        cmp     #SER_BAUD_110
-        beq     setbaudrate
-
-        ; Source period is 32 us
-        ldy     #%00011101 ; ENABLE_RELOAD|ENABLE_COUNT|AUD_32
-
-        ldx     #51
-        cmp     #SER_BAUD_75
-        beq     setbaudrate
-
-        ldx     #68
-        cmp     #SER_BAUD_56_875
-        beq     setbaudrate
-
-        ldx     #77
-        cmp     #SER_BAUD_50
-        beq     setbaudrate
-
         lda     #SER_ERR_BAUD_UNAVAIL
         ldx     #0 ; return value is char
         rts
@@ -342,8 +315,8 @@ SER_IRQ:
         lda     contrl
         and     #PAREN      ; Parity enabled implies SER_PAR_EVEN or SER_PAR_ODD
         tay
-        ora 	#OVERRUN|FRAMERR|RXBRK
-        bit     SERCTL      ; Check error flags in SERCTL
+        ora     #OVERRUN|FRAMERR|RXBRK
+        bit     SERCTL      ; Check presence of relevant error flags in SERCTL
 
         beq     @rx_irq     ; No errors so far
 

--- a/libsrc/lynx/ser/lynx-comlynx.s
+++ b/libsrc/lynx/ser/lynx-comlynx.s
@@ -74,7 +74,7 @@ SER_UNINSTALL:
 
 SER_CLOSE:
         ; Disable interrupts and stop timer 4 (serial)
-        lda     #$0C  ; TXOPEN|RESETERR
+        lda     #TXOPEN|RESETERR
         sta     SERCTL
         lda     #$00  ; Disable count and no reload
         sta     TIM4CTLA

--- a/libsrc/lynx/uploader.s
+++ b/libsrc/lynx/uploader.s
@@ -40,14 +40,14 @@ cont1:
         bra     loop1
 
 read_byte:
-        bit     SERCTL
+        bit     SERCTL         ; Check for RXRDY ($40)
         bvc     read_byte
         lda     SERDAT
         rts
 
 _UpLoaderIRQ:
         lda     INTSET
-        and     #$10
+        and     #SERIAL_INTERRUPT
         bne     @L0
         clc
         rts
@@ -69,7 +69,7 @@ again:
 ; last action : clear interrupt
 ;
 exit:
-        lda     #$10
+        lda     #SERIAL_INTERRUPT
         sta     INTRST
         clc
         rts


### PR DESCRIPTION
This improves the codebase for the serial library and its support for the Atari Lynx.

Functionality changes:
- On close the serial timer is stopped and serial errors are cleared
- Parity bit is now checked correctly for each of the even/odd/mark/space settings
- Baud rates are now calculated and set correctly
- Baud rates of 150 bit/s and below are regarded as invalid
- Using SER_HS_SW software handshake will check for connected redeye (comlynx cable) on ser_open

Improvements and other changes:
- Added bit definition values for IODAT
- Renamed bit definitions for SERCTL read and write to be same as Epyx harddefs.i defined names
- Changed hardcoded bit values for SERCTL to use new names
- Removed duplication for resetting interrupt flag and return value