### PR TITLE
Allow choosing 115200bps as the card allows it

### DIFF
--- a/doc/apple2.sgml
+++ b/doc/apple2.sgml
@@ -452,9 +452,14 @@ The names in the parentheses denote the symbols to be used for static linking of
   (RTS/CTS) and does interrupt driven receives. Speeds faster than 9600 baud
   aren't reachable because the ROM and ProDOS IRQ handlers are too slow.
   Software flow control (XON/XOFF) is not supported.
+
   Note that because of the peculiarities of the 6551 chip transmits are not
   interrupt driven, and the transceiver blocks if the receiver asserts
   flow control because of a full buffer.
+
+  Note that using the driver at SER_BAUD_115200 will disable IRQs. It will be up
+  to the users to use the serial port, either by re-enabling IRQs themselves,
+  or by directly poll-reading the ACIA DATA register without the help of ser_get().
 
   The driver defaults to slot 2. Call <tt/ser_apple2_slot()/ prior to
   <tt/ser_open()/ in order to select a different slot. <tt/ser_apple2_slot()/

--- a/doc/apple2enh.sgml
+++ b/doc/apple2enh.sgml
@@ -453,9 +453,14 @@ The names in the parentheses denote the symbols to be used for static linking of
   (RTS/CTS) and does interrupt driven receives. Speeds faster than 9600 baud
   aren't reachable because the ROM and ProDOS IRQ handlers are too slow.
   Software flow control (XON/XOFF) is not supported.
+
   Note that because of the peculiarities of the 6551 chip transmits are not
   interrupt driven, and the transceiver blocks if the receiver asserts
   flow control because of a full buffer.
+
+  Note that using the driver at SER_BAUD_115200 will disable IRQs. It will be up
+  to the users to use the serial port, either by re-enabling IRQs themselves,
+  or by directly poll-reading the ACIA DATA register without the help of ser_get().
 
   The driver defaults to slot 2. Call <tt/ser_apple2_slot()/ prior to
   <tt/ser_open()/ in order to select a different slot. <tt/ser_apple2_slot()/

--- a/libsrc/apple2/ser/a2.ssc.s
+++ b/libsrc/apple2/ser/a2.ssc.s
@@ -121,7 +121,7 @@ BaudTable:                      ; Table used to translate RS232 baudrate param
         .byte   $0F             ; SER_BAUD_19200
         .byte   $FF             ; SER_BAUD_38400
         .byte   $FF             ; SER_BAUD_57600
-        .byte   $FF             ; SER_BAUD_115200
+        .byte   $00             ; SER_BAUD_115200
         .byte   $FF             ; SER_BAUD_230400
 
 BitTable:                       ; Table used to translate RS232 databits param

--- a/libsrc/apple2/ser/a2.ssc.s
+++ b/libsrc/apple2/ser/a2.ssc.s
@@ -302,6 +302,7 @@ HandshakeOK:
         lda     (ptr1),y        ; Baudrate index
         tay
         lda     BaudTable,y     ; Get 6551 value
+        sta     tmp2            ; Backup for IRQ setting
         bpl     BaudOK          ; Check that baudrate is supported
 
         lda     #SER_ERR_BAUD_UNAVAIL
@@ -332,8 +333,13 @@ BaudOK: sta     tmp1
 
         ora     #%00000001      ; Set DTR active
         sta     RtsOff          ; Store value to easily handle flow control later
-        ora     #%00001000      ; Enable receive interrupts (RTS low)
-        sta     ACIA_CMD,x
+
+        ora     #%00001010      ; Disable interrupts and set RTS low
+
+        ldy     tmp2            ; Don't enable IRQs if 115200bps
+        beq     :+
+        and     #%11111101      ; Enable receive IRQs
+:       sta     ACIA_CMD,x
 
         ; Done
         stx     Index           ; Mark port as open


### PR DESCRIPTION
Of course, that won't work full speed with the standard IRQ-based RX. But that will allow users to setup the port at this speed without duplicating the setup part of the code. Up to them to add hooks to disable IRQs and read directly in a tight asm loop.