### PR TITLE
let clrscr() make use of _bzero() (-17 bytes + 20% speed)

### DIFF
--- a/libsrc/atari/clrscr.s
+++ b/libsrc/atari/clrscr.s
@@ -1,36 +1,29 @@
 ;
-; Christian Groessler, Apr-2000
-;
 ; void clrscr (void);
 ;
 
         .export         _clrscr
         .include        "atari.inc"
-        .importzp       ptr1
+        .import         _bzero
+        .import         pushax
         .import         setcursor
 
 SCRSIZE =       960             ; 40x24: size of default atari screen
 
-_clrscr:lda     SAVMSC          ; screen memory
-        sta     ptr1
-        lda     SAVMSC+1
-        clc
-        adc     #>(SCRSIZE-1)
-        sta     ptr1+1
-        lda     #0              ; screen code of space char
-        sta     OLDCHR
-        ldy     #<(SCRSIZE-1)
-        ldx     #>(SCRSIZE-1)
-_clr1:  sta     (ptr1),y
-        dey
-        bne     _clr1
-        sta     (ptr1),y
-        dex
-        bmi     done
-        dec     ptr1+1
-        dey
-        jmp     _clr1
+_clrscr:
+        lda     SAVMSC          ; screen memory
+        ldx     SAVMSC+1
 
-done:   sta     COLCRS
+        jsr     pushax          ; pointer to memory to clear
+
+        lda     #<SCRSIZE
+        ldx     #>SCRSIZE
+
+        jsr     _bzero
+
+        lda     #0
+        sta     OLDCHR
+        sta     COLCRS
         sta     ROWCRS
+
         jmp     setcursor


### PR DESCRIPTION
Optimization for Atari-"clrscr()"