### PR TITLE
Added option to disable the force-to-uppercase behavior of the apple2 target.

### DIFF
--- a/doc/apple2.sgml
+++ b/doc/apple2.sgml
@@ -330,6 +330,7 @@ usage.
 <item>_dos_type
 <item>_filetype
 <item>_datetime
+<item>allow_lowercase
 <item>beep
 <item>get_ostype
 <item>gmtime_dt

--- a/doc/funcref.sgml
+++ b/doc/funcref.sgml
@@ -95,6 +95,7 @@ function.
 
 <itemize>
 <item>_dos_type
+<item>allow_lowercase
 <item><ref id="beep" name="beep">
 <item><ref id="get_ostype" name="get_ostype">
 <item><ref id="gmtime_dt" name="gmtime_dt">

--- a/include/apple2.h
+++ b/include/apple2.h
@@ -232,6 +232,16 @@ struct tm* __fastcall__ gmtime_dt (const struct datetime* dt);
 time_t __fastcall__ mktime_dt (const struct datetime* dt);
 /* Converts a ProDOS date/time structure to a time_t UNIX timestamp */
 
+#if !defined(__APPLE2ENH__)
+unsigned char __fastcall__ allow_lowercase (unsigned char onoff);
+/* If onoff is 0, lowercase characters printed to the screen via STDIO and
+** CONIO are forced to uppercase. If onoff is 1, lowercase characters are
+** printed to the screen untouched.  By default lowercase characters are
+** forced to uppercase because a stock Apple ][+ doesn't support lowercase
+** display. The function returns the old lowercase setting.
+*/
+#endif
+
 
 
 /* End of apple2.h */

--- a/libsrc/apple2/allow_lowercase.s
+++ b/libsrc/apple2/allow_lowercase.s
@@ -1,0 +1,23 @@
+;
+; Oliver Schmidt, 2024-08-06
+;
+; unsigned char __fastcall__ allow_lowercase (unsigned char onoff);
+;
+
+        .export         _allow_lowercase
+        .import         uppercasemask, return0, return1
+
+_allow_lowercase:
+        tax
+        lda     values,x     
+        ldx     uppercasemask
+        sta     uppercasemask
+        cpx     #$FF
+        beq     :+
+        jmp     return0
+:       jmp     return1
+        
+        .rodata
+
+values: .byte   $DF         ; Force uppercase
+        .byte   $FF         ; Keep lowercase

--- a/libsrc/apple2/allow_lowercase.s
+++ b/libsrc/apple2/allow_lowercase.s
@@ -9,14 +9,14 @@
 
 _allow_lowercase:
         tax
-        lda     values,x     
+        lda     values,x
         ldx     uppercasemask
         sta     uppercasemask
         cpx     #$FF
         beq     :+
         jmp     return0
 :       jmp     return1
-        
+
         .rodata
 
 values: .byte   $DF         ; Force uppercase

--- a/libsrc/apple2/cputc.s
+++ b/libsrc/apple2/cputc.s
@@ -11,6 +11,9 @@
         .export         _cputcxy, _cputc
         .export         cputdirect, newline, putchar, putchardirect
         .import         gotoxy, VTABZ
+        .ifndef __APPLE2ENH__
+        .import         uppercasemask
+        .endif
 
         .include        "apple2.inc"
 
@@ -43,7 +46,7 @@ _cputc:
         .ifndef __APPLE2ENH__
         cmp     #$E0            ; Test for lowercase
         bcc     cputdirect
-        and     #$DF            ; Convert to uppercase
+        and     uppercasemask
         .endif
 
 cputdirect:

--- a/libsrc/apple2/uppercasemask.s
+++ b/libsrc/apple2/uppercasemask.s
@@ -1,0 +1,9 @@
+;
+; Oliver Schmidt, 2024-08-06
+;
+
+        .export         uppercasemask
+
+        .data
+        
+uppercasemask:  .byte   $DF     ; Convert to uppercase

--- a/libsrc/apple2/uppercasemask.s
+++ b/libsrc/apple2/uppercasemask.s
@@ -5,5 +5,5 @@
         .export         uppercasemask
 
         .data
-        
+
 uppercasemask:  .byte   $DF     ; Convert to uppercase

--- a/libsrc/apple2/write.s
+++ b/libsrc/apple2/write.s
@@ -7,6 +7,9 @@
         .export         _write
         .import         rwprolog, rwcommon, rwepilog
         .import         COUT
+        .ifndef __APPLE2ENH__
+        .import         uppercasemask
+        .endif
 
         .include        "zeropage.inc"
         .include        "errno.inc"
@@ -84,7 +87,7 @@ next:   lda     (ptr1),y
         .ifndef __APPLE2ENH__
         cmp     #$E0            ; Test for lowercase
         bcc     output
-        and     #$DF            ; Convert to uppercase
+        and     uppercasemask
         .endif
 output: jsr     COUT            ; Preserves X and Y
 


### PR DESCRIPTION
When a program built for the apple2 target is run on i.e. an Apple //e, it could actually display lowercase characters. Usually we don't do such runtime checks because we want a single program to behave identically on different machines. Otherwise the author would need to test a program on all possible machines in order to see how it behaves.

However, there's a really significant desire to have a single program that runs both on the ][+ and the //e - and does lowercase output on the //e. Therefore this PR adds a function allow_lowercase() that gives a program author the option to enable lowercase output. Two things are to be noted:

1. It's totally up to the program author to call allow_lowercase(1) only when he has made sure in one way or another that the current machine is actually capable of lowercase display. Otherwise the program will output garbage.

2. The function allow_lowercase() is only available for the apple2 target, not for the apple2enh target. If a source code is to be built both for apple2 and apple2enh, it's up to the program author to use the preprocessor or other means to not call allow_lowercase()  for apple2enh.