### PR TITLE
Apple II: Move _exit out of STARTUP segment

### DIFF
--- a/libsrc/apple2/callmain.s
+++ b/libsrc/apple2/callmain.s
@@ -1,0 +1,75 @@
+;
+; Ullrich von Bassewitz, 2003-03-07
+;
+; Push arguments and call main()
+;
+
+
+        .export         callmain, _exit
+        .export         __argc, __argv
+
+        .import         _main, pushax, done, donelib
+        .import         zpsave, rvsave, reset
+
+        .include        "zeropage.inc"
+        .include        "apple2.inc"
+
+
+;---------------------------------------------------------------------------
+; Setup the stack for main(), then jump to it
+
+callmain:
+        lda     __argc
+        ldx     __argc+1
+        jsr     pushax          ; Push argc
+
+        lda     __argv
+        ldx     __argv+1
+        jsr     pushax          ; Push argv
+
+        ldy     #4              ; Argument size
+        jsr     _main
+
+        ; Avoid a re-entrance of donelib. This is also the exit() entry.
+_exit:  ldx     #<exit
+        lda     #>exit
+        jsr     reset           ; Setup RESET vector
+
+        ; Switch in LC bank 2 for R/O in case it was switched out by a RESET.
+        bit     $C080
+
+        ; Call the module destructors.
+        jsr     donelib
+
+        ; Switch in ROM.
+        bit     $C082
+
+        ; Restore the original RESET vector.
+exit:   ldx     #$02
+:       lda     rvsave,x
+        sta     SOFTEV,x
+        dex
+        bpl     :-
+
+        ; Copy back the zero-page stuff.
+        ldx     #zpspace-1
+:       lda     zpsave,x
+        sta     sp,x
+        dex
+        bpl     :-
+
+        ; ProDOS TechRefMan, chapter 5.2.1:
+        ; "System programs should set the stack pointer to $FF at the
+        ;  warm-start entry point."
+        ldx     #$FF
+        txs                     ; Re-init stack pointer
+
+        ; We're done
+        jmp     done
+
+;---------------------------------------------------------------------------
+; Data
+
+.data
+__argc:         .word   0
+__argv:         .addr   0

--- a/libsrc/apple2/crt0.s
+++ b/libsrc/apple2/crt0.s
@@ -4,10 +4,11 @@
 ; Startup code for cc65 (Apple2 version)
 ;
 
-        .export         _exit, done, return
+        .export         done, return
+        .export         zpsave, rvsave, reset
         .export         __STARTUP__ : absolute = 1      ; Mark as startup
 
-        .import         initlib, donelib
+        .import         initlib, _exit
         .import         zerobss, callmain
         .import         __ONCE_LOAD__, __ONCE_SIZE__    ; Linker generated
         .import         __LC_START__, __LC_LAST__       ; Linker generated
@@ -33,44 +34,7 @@
         jsr     zerobss
 
         ; Push the command-line arguments; and, call main().
-        jsr     callmain
-
-        ; Avoid a re-entrance of donelib. This is also the exit() entry.
-_exit:  ldx     #<exit
-        lda     #>exit
-        jsr     reset           ; Setup RESET vector
-
-        ; Switch in LC bank 2 for R/O in case it was switched out by a RESET.
-        bit     $C080
-
-        ; Call the module destructors.
-        jsr     donelib
-
-        ; Switch in ROM.
-        bit     $C082
-
-        ; Restore the original RESET vector.
-exit:   ldx     #$02
-:       lda     rvsave,x
-        sta     SOFTEV,x
-        dex
-        bpl     :-
-
-        ; Copy back the zero-page stuff.
-        ldx     #zpspace-1
-:       lda     zpsave,x
-        sta     sp,x
-        dex
-        bpl     :-
-
-        ; ProDOS TechRefMan, chapter 5.2.1:
-        ; "System programs should set the stack pointer to $FF at the
-        ;  warm-start entry point."
-        ldx     #$FF
-        txs                     ; Re-init stack pointer
-
-        ; We're done
-        jmp     done
+        jmp     callmain
 
 ; ------------------------------------------------------------------------
 


### PR DESCRIPTION
_exit() is in the STARTUP segment, because it's called after returning from callmain.

But I'll argue that this is counter-intuitive, and it prevents us to spare a few hundred bytes of memory in certain situations. 

For example, I want to use both HGR pages, my program's size is near the maximum, so instead of using `--start-addr 0x6000`, I want to use `--start-addr 0x5D00`, with the following segments:

```
ZEROPAGE              000080  000099  00001A  00001
EXEHDR                005CC6  005CFF  00003A  00001
STARTUP               005D00  005D0E  00000F  00001
RT_ONCE               005D0F  005F0E  000200  00001
LOWCODE               006000  007322  001323  00001
...
```

(This allows me to put my own init code into the RT_ONCE segment, inside the HGR2 page, as it's not needed anymore by the time HGR page2 is overwritten).

But if STARTUP contains _exit, this is not possible.