### PR TITLE
Allow alternative names for pragmas that contain underlines instead of dashes

### DIFF
--- a/doc/cc65.sgml
+++ b/doc/cc65.sgml
@@ -1273,6 +1273,12 @@ If the first parameter is <tt/push/, the old value is saved onto a stack
 before changing it. The value may later be restored by using the <tt/pop/
 parameter with the <tt/#pragma/.
 
+For all pragma names that contain hyphens, the same name using underlines
+instead of the hyphens is available as an alternative. While the former
+resembles the corresponding command line option and is more orthogonal, the
+latter may be more compatible with external tools that rewrite the token
+sequences of the input.
+
 
 <sect1><tt>#pragma allow-eager-inline ([push,] on|off)</tt><label id="pragma-allow-eager-inline"><p>
 

--- a/src/cc65/pragma.c
+++ b/src/cc65/pragma.c
@@ -68,28 +68,20 @@ typedef enum {
     PRAGMA_ALIGN,
     PRAGMA_ALLOW_EAGER_INLINE,
     PRAGMA_BSS_NAME,
-    PRAGMA_BSSSEG,                                      /* obsolete */
     PRAGMA_CHARMAP,
     PRAGMA_CHECK_STACK,
-    PRAGMA_CHECKSTACK,                                  /* obsolete */
     PRAGMA_CODE_NAME,
-    PRAGMA_CODESEG,                                     /* obsolete */
     PRAGMA_CODESIZE,
     PRAGMA_DATA_NAME,
-    PRAGMA_DATASEG,                                     /* obsolete */
     PRAGMA_INLINE_STDFUNCS,
     PRAGMA_LOCAL_STRINGS,
     PRAGMA_MESSAGE,
     PRAGMA_OPTIMIZE,
     PRAGMA_REGISTER_VARS,
     PRAGMA_REGVARADDR,
-    PRAGMA_REGVARS,                                     /* obsolete */
     PRAGMA_RODATA_NAME,
-    PRAGMA_RODATASEG,                                   /* obsolete */
     PRAGMA_SIGNED_CHARS,
-    PRAGMA_SIGNEDCHARS,                                 /* obsolete */
     PRAGMA_STATIC_LOCALS,
-    PRAGMA_STATICLOCALS,                                /* obsolete */
     PRAGMA_WARN,
     PRAGMA_WRAPPED_CALL,
     PRAGMA_WRITABLE_STRINGS,
@@ -105,28 +97,20 @@ static const struct Pragma {
     { "align",                  PRAGMA_ALIGN              },
     { "allow-eager-inline",     PRAGMA_ALLOW_EAGER_INLINE },
     { "bss-name",               PRAGMA_BSS_NAME           },
-    { "bssseg",                 PRAGMA_BSSSEG             },      /* obsolete */
     { "charmap",                PRAGMA_CHARMAP            },
     { "check-stack",            PRAGMA_CHECK_STACK        },
-    { "checkstack",             PRAGMA_CHECKSTACK         },      /* obsolete */
     { "code-name",              PRAGMA_CODE_NAME          },
-    { "codeseg",                PRAGMA_CODESEG            },      /* obsolete */
     { "codesize",               PRAGMA_CODESIZE           },
     { "data-name",              PRAGMA_DATA_NAME          },
-    { "dataseg",                PRAGMA_DATASEG            },      /* obsolete */
     { "inline-stdfuncs",        PRAGMA_INLINE_STDFUNCS    },
     { "local-strings",          PRAGMA_LOCAL_STRINGS      },
     { "message",                PRAGMA_MESSAGE            },
     { "optimize",               PRAGMA_OPTIMIZE           },
     { "register-vars",          PRAGMA_REGISTER_VARS      },
     { "regvaraddr",             PRAGMA_REGVARADDR         },
-    { "regvars",                PRAGMA_REGVARS            },      /* obsolete */
     { "rodata-name",            PRAGMA_RODATA_NAME        },
-    { "rodataseg",              PRAGMA_RODATASEG          },      /* obsolete */
     { "signed-chars",           PRAGMA_SIGNED_CHARS       },
-    { "signedchars",            PRAGMA_SIGNEDCHARS        },      /* obsolete */
     { "static-locals",          PRAGMA_STATIC_LOCALS      },
-    { "staticlocals",           PRAGMA_STATICLOCALS       },      /* obsolete */
     { "warn",                   PRAGMA_WARN               },
     { "wrapped-call",           PRAGMA_WRAPPED_CALL       },
     { "writable-strings",       PRAGMA_WRITABLE_STRINGS   },
@@ -402,22 +386,18 @@ static void ApplySegNamePragma (pragma_t Token, int PushPop, const char* Name, u
 
     switch (Token) {
         case PRAGMA_CODE_NAME:
-        case PRAGMA_CODESEG:
             Seg = SEG_CODE;
             break;
 
         case PRAGMA_RODATA_NAME:
-        case PRAGMA_RODATASEG:
             Seg = SEG_RODATA;
             break;
 
         case PRAGMA_DATA_NAME:
-        case PRAGMA_DATASEG:
             Seg = SEG_DATA;
             break;
 
         case PRAGMA_BSS_NAME:
-        case PRAGMA_BSSSEG:
             Seg = SEG_BSS;
             break;
 
@@ -933,9 +913,6 @@ static void ParsePragmaString (void)
             FlagPragma (PES_STMT, Pragma, &B, &EagerlyInlineFuncs);
             break;
 
-        case PRAGMA_BSSSEG:
-            Warning ("#pragma bssseg is obsolete, please use #pragma bss-name instead");
-            /* FALLTHROUGH */
         case PRAGMA_BSS_NAME:
             /* TODO: PES_STMT or even PES_EXPR (PES_DECL) maybe? */
             SegNamePragma (PES_FUNC, PRAGMA_BSS_NAME, &B);
@@ -945,17 +922,11 @@ static void ParsePragmaString (void)
             CharMapPragma (PES_IMM, &B);
             break;
 
-        case PRAGMA_CHECKSTACK:
-            Warning ("#pragma checkstack is obsolete, please use #pragma check-stack instead");
-            /* FALLTHROUGH */
         case PRAGMA_CHECK_STACK:
             /* TODO: PES_SCOPE maybe? */
             FlagPragma (PES_FUNC, Pragma, &B, &CheckStack);
             break;
 
-        case PRAGMA_CODESEG:
-            Warning ("#pragma codeseg is obsolete, please use #pragma code-name instead");
-            /* FALLTHROUGH */
         case PRAGMA_CODE_NAME:
             /* PES_FUNC is the only sensible option so far */
             SegNamePragma (PES_FUNC, PRAGMA_CODE_NAME, &B);
@@ -966,9 +937,6 @@ static void ParsePragmaString (void)
             IntPragma (PES_STMT, Pragma, &B, &CodeSizeFactor, 10, 1000);
             break;
 
-        case PRAGMA_DATASEG:
-            Warning ("#pragma dataseg is obsolete, please use #pragma data-name instead");
-            /* FALLTHROUGH */
         case PRAGMA_DATA_NAME:
             /* TODO: PES_STMT or even PES_EXPR (PES_DECL) maybe? */
             SegNamePragma (PES_FUNC, PRAGMA_DATA_NAME, &B);
@@ -999,33 +967,21 @@ static void ParsePragmaString (void)
             FlagPragma (PES_FUNC, Pragma, &B, &AllowRegVarAddr);
             break;
 
-        case PRAGMA_REGVARS:
-            Warning ("#pragma regvars is obsolete, please use #pragma register-vars instead");
-            /* FALLTHROUGH */
         case PRAGMA_REGISTER_VARS:
             /* TODO: PES_STMT or even PES_EXPR (PES_DECL) maybe? */
             FlagPragma (PES_FUNC, Pragma, &B, &EnableRegVars);
             break;
 
-        case PRAGMA_RODATASEG:
-            Warning ("#pragma rodataseg is obsolete, please use #pragma rodata-name instead");
-            /* FALLTHROUGH */
         case PRAGMA_RODATA_NAME:
             /* TODO: PES_STMT or even PES_EXPR maybe? */
             SegNamePragma (PES_FUNC, PRAGMA_RODATA_NAME, &B);
             break;
 
-        case PRAGMA_SIGNEDCHARS:
-            Warning ("#pragma signedchars is obsolete, please use #pragma signed-chars instead");
-            /* FALLTHROUGH */
         case PRAGMA_SIGNED_CHARS:
             /* TODO: PES_STMT or even PES_EXPR maybe? */
             FlagPragma (PES_FUNC, Pragma, &B, &SignedChars);
             break;
 
-        case PRAGMA_STATICLOCALS:
-            Warning ("#pragma staticlocals is obsolete, please use #pragma static-locals instead");
-            /* FALLTHROUGH */
         case PRAGMA_STATIC_LOCALS:
             /* TODO: PES_STMT or even PES_EXPR (PES_DECL) maybe? */
             FlagPragma (PES_FUNC, Pragma, &B, &StaticLocals);

--- a/src/cc65/pragma.c
+++ b/src/cc65/pragma.c
@@ -86,36 +86,49 @@ typedef enum {
     PRAGMA_WRAPPED_CALL,
     PRAGMA_WRITABLE_STRINGS,
     PRAGMA_ZPSYM,
-    PRAGMA_COUNT
 } pragma_t;
 
 /* Pragma table */
 static const struct Pragma {
     const char* Key;            /* Keyword */
     pragma_t    Tok;            /* Token */
-} Pragmas[PRAGMA_COUNT] = {
+} Pragmas[] = {
     { "align",                  PRAGMA_ALIGN              },
     { "allow-eager-inline",     PRAGMA_ALLOW_EAGER_INLINE },
+    { "allow_eager_inline",     PRAGMA_ALLOW_EAGER_INLINE },
     { "bss-name",               PRAGMA_BSS_NAME           },
+    { "bss_name",               PRAGMA_BSS_NAME           },
     { "charmap",                PRAGMA_CHARMAP            },
     { "check-stack",            PRAGMA_CHECK_STACK        },
+    { "check_stack",            PRAGMA_CHECK_STACK        },
     { "code-name",              PRAGMA_CODE_NAME          },
+    { "code_name",              PRAGMA_CODE_NAME          },
     { "codesize",               PRAGMA_CODESIZE           },
     { "data-name",              PRAGMA_DATA_NAME          },
+    { "data_name",              PRAGMA_DATA_NAME          },
     { "inline-stdfuncs",        PRAGMA_INLINE_STDFUNCS    },
+    { "inline_stdfuncs",        PRAGMA_INLINE_STDFUNCS    },
     { "local-strings",          PRAGMA_LOCAL_STRINGS      },
+    { "local_strings",          PRAGMA_LOCAL_STRINGS      },
     { "message",                PRAGMA_MESSAGE            },
     { "optimize",               PRAGMA_OPTIMIZE           },
     { "register-vars",          PRAGMA_REGISTER_VARS      },
+    { "register_vars",          PRAGMA_REGISTER_VARS      },
     { "regvaraddr",             PRAGMA_REGVARADDR         },
     { "rodata-name",            PRAGMA_RODATA_NAME        },
+    { "rodata_name",            PRAGMA_RODATA_NAME        },
     { "signed-chars",           PRAGMA_SIGNED_CHARS       },
+    { "signed_chars",           PRAGMA_SIGNED_CHARS       },
     { "static-locals",          PRAGMA_STATIC_LOCALS      },
+    { "static_locals",          PRAGMA_STATIC_LOCALS      },
     { "warn",                   PRAGMA_WARN               },
     { "wrapped-call",           PRAGMA_WRAPPED_CALL       },
+    { "wrapped_call",           PRAGMA_WRAPPED_CALL       },
     { "writable-strings",       PRAGMA_WRITABLE_STRINGS   },
+    { "writable_strings",       PRAGMA_WRITABLE_STRINGS   },
     { "zpsym",                  PRAGMA_ZPSYM              },
 };
+#define PRAGMA_COUNT    (sizeof (Pragmas) / sizeof (Pragmas[0]))
 
 /* Result of ParsePushPop */
 typedef enum {

--- a/test/val/pragmas.c
+++ b/test/val/pragmas.c
@@ -1,0 +1,44 @@
+/* Note: This tests just if the #pragmas are understood. It doesn't test if
+** they do really work. This would require much more work.
+*/
+
+void func(void);
+#pragma align(push, 1024)
+#pragma allow-eager-inline(push, on)
+#pragma allow_eager_inline(pop)
+#pragma bss-name(push, "BSS")
+#pragma bss_name(pop)
+#pragma charmap(1, 1)
+#pragma check-stack(on)
+#pragma check_stack(off)
+#pragma code-name(push, "CODE")
+#pragma code_name("CODE")
+#pragma codesize(200)
+#pragma data-name("DATA")
+#pragma data_name("DATA")
+#pragma inline-stdfuncs(off)
+#pragma inline_stdfuncs(on)
+#pragma local-strings(off)
+#pragma local_strings(off)
+#pragma message("in a bottle")
+#pragma optimize(off)
+#pragma register-vars(off)
+#pragma register_vars(on)
+#pragma regvaraddr(on)
+#pragma rodata-name("RODATA")
+#pragma rodata_name("RODATA")
+#pragma signed-chars(off)
+#pragma signed_chars(on)
+#pragma static-locals(off)
+#pragma static_locals(on)
+#pragma warn(unused-param, on)
+#pragma wrapped-call(push, func, 0)     // push is required for this #pragma
+#pragma wrapped_call(push, func, 1)
+#pragma writable-strings(on)
+#pragma writable_strings(off)
+#pragma zpsym("func")
+
+int main ()
+{
+    return 0;
+}


### PR DESCRIPTION
This fixes #2470 