### PR TITLE
Generate shorter code for main() in some cases

### DIFF
--- a/src/cc65/codegen.c
+++ b/src/cc65/codegen.c
@@ -507,34 +507,39 @@ void g_enter (unsigned flags, unsigned argsize)
 
 
 
-void g_leave (void)
+void g_leave (int IsMainFunc)
 /* Function epilogue */
 {
-    /* How many bytes of locals do we have to drop? */
-    unsigned ToDrop = (unsigned) -StackPtr;
+    /* In the main function nothing has to be dropped because the program
+    ** is terminated anyway.
+    */
+    if (!IsMainFunc) {
+        /* How many bytes of locals do we have to drop? */
+        unsigned ToDrop = (unsigned) -StackPtr;
 
-    /* If we didn't have a variable argument list, don't call leave */
-    if (funcargs >= 0) {
+        /* If we didn't have a variable argument list, don't call leave */
+        if (funcargs >= 0) {
 
-        /* Drop stackframe if needed */
-        g_drop (ToDrop + funcargs);
+            /* Drop stackframe if needed */
+            g_drop (ToDrop + funcargs);
 
-    } else if (StackPtr != 0) {
+        } else if (StackPtr != 0) {
 
-        /* We've a stack frame to drop */
-        if (ToDrop > 255) {
-            g_drop (ToDrop);            /* Inlines the code */
-            AddCodeLine ("jsr leave");
+            /* We've a stack frame to drop */
+            if (ToDrop > 255) {
+                g_drop (ToDrop);            /* Inlines the code */
+                AddCodeLine ("jsr leave");
+            } else {
+                AddCodeLine ("ldy #$%02X", ToDrop);
+                AddCodeLine ("jsr leavey");
+            }
+
         } else {
-            AddCodeLine ("ldy #$%02X", ToDrop);
-            AddCodeLine ("jsr leavey");
+
+            /* Nothing to drop */
+            AddCodeLine ("jsr leave");
+
         }
-
-    } else {
-
-        /* Nothing to drop */
-        AddCodeLine ("jsr leave");
-
     }
 
     /* Add the final rts */

--- a/src/cc65/codegen.h
+++ b/src/cc65/codegen.h
@@ -247,7 +247,7 @@ void g_scale (unsigned flags, long val);
 void g_enter (unsigned flags, unsigned argsize);
 /* Function prologue */
 
-void g_leave (void);
+void g_leave (int IsMainFunc);
 /* Function epilogue */
 
 

--- a/src/cc65/function.c
+++ b/src/cc65/function.c
@@ -646,11 +646,13 @@ void NewFunc (SymEntry* Func, FuncDesc* D)
     /* Output the function exit code label */
     g_defcodelabel (F_GetRetLab (CurrentFunc));
 
-    /* Restore the register variables */
-    F_RestoreRegVars (CurrentFunc);
+    /* Restore the register variables (not necessary for main function) */
+    if (!F_IsMainFunc (CurrentFunc)) {
+        F_RestoreRegVars (CurrentFunc);
+    }
 
     /* Generate the exit code */
-    g_leave ();
+    g_leave (F_IsMainFunc (CurrentFunc));
 
     /* Emit references to imports/exports */
     EmitExternals ();


### PR DESCRIPTION
With this change, the generated code for `main()` ...
* ... will no longer cleanup the stack on exit since the program terminates anyway, and
* ... will not save the old contents of register variables on entry since they do not contain anything useful.

This reduces code size for all programs where `main()` has parameters or declares variables; even more if there are register variables.