### PR TITLE
In time(), set the clock id to CLOCK_REALTIME when calling clock_gettime.

### DIFF
--- a/asminc/time.inc
+++ b/asminc/time.inc
@@ -66,3 +66,9 @@
 .global         _clock_settime
 .global         _localtime
 .global         _mktime
+
+
+;------------------------------------------------------------------------------
+; Constants
+
+CLOCK_REALTIME = 0

--- a/libsrc/common/time.s
+++ b/libsrc/common/time.s
@@ -6,7 +6,7 @@
 
         .export         _time
 
-        .import         decsp1, ldeaxi
+        .import         pusha, ldeaxi
         .importzp       ptr1, sreg, tmp1, tmp2
 
         .include        "time.inc"
@@ -22,7 +22,8 @@
 
 ; Get the time (machine dependent)
 
-        jsr     decsp1
+        lda     #CLOCK_REALTIME
+        jsr     pusha
         lda     #<time
         ldx     #>time
         jsr     _clock_gettime


### PR DESCRIPTION
While implementing time functions for my homebrew, I noticed that time() allocates stack space for the clock id argument when it calls clock_gettime(), but doesn't actually set a value. So the system-specific clock_gettime() implementation receives some arbitrary clock id value. I set it to CLOCK_REALTIME so that at least it's doing something consistent.

