### PR TITLE
Improved/fixed the time() function

### DIFF
--- a/libsrc/common/time.s
+++ b/libsrc/common/time.s
@@ -22,55 +22,50 @@
 
 ; Get the time (machine dependent)
 
+        .assert timespec::tv_sec = 0, error
         lda     #CLOCK_REALTIME
         jsr     pusha
         lda     #<time
         ldx     #>time
         jsr     _clock_gettime
-        sta     tmp2
-        lda     #<time
-        ldx     #>time
-        .assert timespec::tv_sec = 0, error
-        jsr     ldeaxi
-        sta     tmp1            ; Save low byte of result
+
+; _clock_gettime returns 0 on success and -1 on error. Check that.
+
+        inx                     ; Did _clock_gettime return -1?
+        bne     @L2             ; Jump if not
+
+; We had an error so invalidate time. A contains $FF.
+
+        ldy     #3
+@L1:    sta     time,y
+        dey
+        bpl     @L1
 
 ; Restore timep and check if it is NULL
 
-        pla
+@L2:    pla
         sta     ptr1+1
         pla
         sta     ptr1            ; Restore timep
         ora     ptr1+1          ; timep == 0?
-        beq     @L1
+        beq     @L4
 
 ; timep is not NULL, store the result there
 
         ldy     #3
-        lda     sreg+1
+@L3:    lda     time,y
         sta     (ptr1),y
         dey
-        lda     sreg
-        sta     (ptr1),y
-        dey
-        txa
-        sta     (ptr1),y
-        dey
-        lda     tmp1
-        sta     (ptr1),y
+        bpl     @L3
 
-; If the result is != 0, return -1
+; Load the final result.
 
-@L1:    lda     tmp2
-        beq     @L2
-
-        tax
-        sta     sreg
+@L4:    lda     time+3
         sta     sreg+1
-        rts
-
-; Reload the low byte of the result and return
-
-@L2:    lda     tmp1
+        lda     time+2
+        sta     sreg
+        ldx     time+1
+        lda     time
         rts
 
 .endproc

--- a/test/val/time-test2.c
+++ b/test/val/time-test2.c
@@ -1,0 +1,61 @@
+/* Another test for time() */
+
+#include <stdio.h>
+#include <time.h>
+
+static int failures = 0;
+#define INV_TIME        ((time_t)-1)
+#define TEST_TIME       ((time_t)0x78AB1234)
+
+/* We supply our own clock_gettime function so we can control the values
+** supplied to time() internally.
+*/
+static time_t timeval;
+static int timeres;
+int __fastcall__ clock_gettime (clockid_t, struct timespec *tp)
+{
+    /* Don't touch tp in case of an error */
+    if (timeres != -1) {
+        tp->tv_sec = timeval;
+        tp->tv_nsec = 0;
+    }
+    return timeres;
+}
+
+int main()
+{
+    time_t res, pres;
+
+    /* First test: Force time() to return an error. Check that both, the
+    ** returned value and the value passed via pointer are (time_t)-1.
+    */
+    timeval = 42;
+    timeres = -1;
+    res = time(&pres);
+    if (res != INV_TIME || pres != INV_TIME) {
+        printf("Error in test 1\n");
+        ++failures;
+    }
+
+    /* Second test: Return a valid value and check both results */
+    timeval = TEST_TIME;
+    timeres = 0;
+    res = time(&pres);
+    if (res != TEST_TIME || pres != TEST_TIME) {
+        printf("Error in test 2\n");
+        ++failures;
+    }
+
+    /* Third test: Return no error but an invalid value and check both
+    ** results
+    */
+    timeval = INV_TIME;
+    timeres = 0;
+    res = time(&pres);
+    if (res != INV_TIME || pres != INV_TIME) {
+        printf("Error in test 3\n");
+        ++failures;
+    }
+
+    return failures;
+}


### PR DESCRIPTION
Looking at #2511 I noticed that the `time()` function could be improved and that it doesn't always work as it should. 

When the underlying `clock_gettime()` function returns an error, the existing implementation would return `(time_t)-1` but didn't store this value into `*timep` as is required by the standard.

So this change ...
* ... fixes the error and will causes `time()` to always return identical numbers for the return value and `*timep`.
* ... reduces the code size by 7 bytes.
* ... doesn't use `ldeaxi` which may lead to additional size decreases depending on the program.
* ... adds a test.