### PR TITLE
Fix wrong evaluation of ternary expressions in the preprocessor

### DIFF
--- a/src/cc65/ppexpr.c
+++ b/src/cc65/ppexpr.c
@@ -726,7 +726,7 @@ static void PPhieQuest (PPExpr* Expr)
         PPhieQuest (&Expr3);
 
         /* Set the result */
-        Expr->IVal = Expr->IVal ? Expr2.IVal != 0 : Expr3.IVal != 0;
+        Expr->IVal = Expr->IVal ? Expr2.IVal : Expr3.IVal;
 
         /* Restore evaluation as before */
         PPEvaluationEnabled = PPEvaluationEnabledPrev;

--- a/test/val/bug2520.c
+++ b/test/val/bug2520.c
@@ -1,0 +1,4 @@
+#if (1 ? 2 : 0) != 2
+#error
+#endif
+int main() { return 0; }


### PR DESCRIPTION
This fixes #2520.