### PR TITLE
Apple2: Provide a way to get directory file count

### DIFF
--- a/doc/apple2.sgml
+++ b/doc/apple2.sgml
@@ -332,6 +332,7 @@ usage.
 <item>_datetime
 <item>allow_lowercase
 <item>beep
+<item>dir_file_count
 <item>get_ostype
 <item>gmtime_dt
 <item>mktime_dt

--- a/doc/apple2.sgml
+++ b/doc/apple2.sgml
@@ -332,7 +332,7 @@ usage.
 <item>_datetime
 <item>allow_lowercase
 <item>beep
-<item>dir_file_count
+<item>dir_entry_count
 <item>get_ostype
 <item>gmtime_dt
 <item>mktime_dt

--- a/doc/apple2enh.sgml
+++ b/doc/apple2enh.sgml
@@ -332,6 +332,7 @@ usage.
 <item>_filetype
 <item>_datetime
 <item>beep
+<item>dir_file_count
 <item>get_ostype
 <item>gmtime_dt
 <item>mktime_dt

--- a/doc/apple2enh.sgml
+++ b/doc/apple2enh.sgml
@@ -332,7 +332,7 @@ usage.
 <item>_filetype
 <item>_datetime
 <item>beep
-<item>dir_file_count
+<item>dir_entry_count
 <item>get_ostype
 <item>gmtime_dt
 <item>mktime_dt

--- a/doc/funcref.sgml
+++ b/doc/funcref.sgml
@@ -97,6 +97,7 @@ function.
 <item>_dos_type
 <item>allow_lowercase
 <item><ref id="beep" name="beep">
+<item><ref id="dir_file_count" name="dir_file_count">
 <item><ref id="get_ostype" name="get_ostype">
 <item><ref id="gmtime_dt" name="gmtime_dt">
 <item><ref id="mktime_dt" name="mktime_dt">
@@ -109,6 +110,7 @@ function.
 <itemize>
 <item>_dos_type
 <item><ref id="beep" name="beep">
+<item><ref id="dir_file_count" name="dir_file_count">
 <item><ref id="get_ostype" name="get_ostype">
 <item><ref id="gmtime_dt" name="gmtime_dt">
 <item><ref id="mktime_dt" name="mktime_dt">
@@ -3519,6 +3521,25 @@ used in presence of a prototype.
 <tag/See also/
 <ref id="get_turbomaster_speed" name="get_turbomaster_speed">,
 <ref id="set_turbomaster_speed" name="set_turbomaster_speed">,
+<tag/Example/None.
+</descrip>
+</quote>
+
+
+<sect1>dir_file_count<label id="dir_file_count"><p>
+
+<quote>
+<descrip>
+<tag/Function/Returns the number of files in the directory.
+<tag/Header/<tt/<ref id="apple2.h" name="apple2.h">/
+<tag/Declaration/<tt/unsigned int __fastcall__ dir_file_count(DIR *dir);/
+<tag/Description/<tt/dir_file_count/ is machine dependent and does not exist for
+all supported targets. If it exists, it returns the number of active
+(non-deleted) files in the directory.
+<tag/Notes/<itemize>
+<item>The function does not exist on all platforms.
+</itemize>
+<tag/Availability/cc65 (not all platforms)
 <tag/Example/None.
 </descrip>
 </quote>

--- a/doc/funcref.sgml
+++ b/doc/funcref.sgml
@@ -97,7 +97,7 @@ function.
 <item>_dos_type
 <item>allow_lowercase
 <item><ref id="beep" name="beep">
-<item><ref id="dir_file_count" name="dir_file_count">
+<item><ref id="dir_entry_count" name="dir_entry_count">
 <item><ref id="get_ostype" name="get_ostype">
 <item><ref id="gmtime_dt" name="gmtime_dt">
 <item><ref id="mktime_dt" name="mktime_dt">
@@ -110,7 +110,7 @@ function.
 <itemize>
 <item>_dos_type
 <item><ref id="beep" name="beep">
-<item><ref id="dir_file_count" name="dir_file_count">
+<item><ref id="dir_entry_count" name="dir_entry_count">
 <item><ref id="get_ostype" name="get_ostype">
 <item><ref id="gmtime_dt" name="gmtime_dt">
 <item><ref id="mktime_dt" name="mktime_dt">
@@ -3526,16 +3526,16 @@ used in presence of a prototype.
 </quote>
 
 
-<sect1>dir_file_count<label id="dir_file_count"><p>
+<sect1>dir_entry_count<label id="dir_entry_count"><p>
 
 <quote>
 <descrip>
-<tag/Function/Returns the number of files in the directory.
+<tag/Function/Returns the number of entries in the directory.
 <tag/Header/<tt/<ref id="apple2.h" name="apple2.h">/
-<tag/Declaration/<tt/unsigned int __fastcall__ dir_file_count(DIR *dir);/
-<tag/Description/<tt/dir_file_count/ is machine dependent and does not exist for
+<tag/Declaration/<tt/unsigned int __fastcall__ dir_entry_count(DIR *dir);/
+<tag/Description/<tt/dir_entry_count/ is machine dependent and does not exist for
 all supported targets. If it exists, it returns the number of active
-(non-deleted) files in the directory.
+(non-deleted) files and directories in the directory.
 <tag/Notes/<itemize>
 <item>The function does not exist on all platforms.
 </itemize>

--- a/include/apple2.h
+++ b/include/apple2.h
@@ -232,6 +232,11 @@ struct tm* __fastcall__ gmtime_dt (const struct datetime* dt);
 time_t __fastcall__ mktime_dt (const struct datetime* dt);
 /* Converts a ProDOS date/time structure to a time_t UNIX timestamp */
 
+typedef struct DIR DIR;
+
+unsigned int __fastcall__ dir_file_count(DIR *dir);
+/* Returns the number of active files in a ProDOS directory */
+
 #if !defined(__APPLE2ENH__)
 unsigned char __fastcall__ allow_lowercase (unsigned char onoff);
 /* If onoff is 0, lowercase characters printed to the screen via STDIO and

--- a/include/apple2.h
+++ b/include/apple2.h
@@ -234,7 +234,7 @@ time_t __fastcall__ mktime_dt (const struct datetime* dt);
 
 typedef struct DIR DIR;
 
-unsigned int __fastcall__ dir_file_count(DIR *dir);
+unsigned int __fastcall__ dir_entry_count(DIR *dir);
 /* Returns the number of active files in a ProDOS directory */
 
 #if !defined(__APPLE2ENH__)

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -147,7 +147,5 @@ void __fastcall__ seekdir (DIR* dir, long offs);
 
 void __fastcall__ rewinddir (DIR* dir);
 
-
-
 /* End of dirent.h */
 #endif

--- a/libsrc/apple2/dir.h
+++ b/libsrc/apple2/dir.h
@@ -45,6 +45,7 @@ struct DIR {
     int           fd;
     unsigned char entry_length;
     unsigned char entries_per_block;
+    unsigned int  file_count;
     unsigned char current_entry;
     union {
         unsigned char bytes[512];

--- a/libsrc/apple2/dir.inc
+++ b/libsrc/apple2/dir.inc
@@ -2,8 +2,8 @@
         FD                .word
         ENTRY_LENGTH      .byte
         ENTRIES_PER_BLOCK .byte
+        FILE_COUNT        .word
         CURRENT_ENTRY     .byte
-
         .union
                 BYTES               .byte 512
                 .struct CONTENT

--- a/libsrc/apple2/dir_entry_count.s
+++ b/libsrc/apple2/dir_entry_count.s
@@ -1,17 +1,17 @@
 ;
 ; Colin Leroy-Mira <colin@colino.net>, 2024
 ;
-; unsigned int __fastcall__ dir_file_count(DIR *dir);
+; unsigned int __fastcall__ dir_entry_count(DIR *dir);
 ;
 
-        .export   _dir_file_count
+        .export   _dir_entry_count
 
         .importzp ptr1
 
         .include  "apple2.inc"
         .include  "dir.inc"
 
-.proc _dir_file_count
+.proc _dir_entry_count
         sta       ptr1
         stx       ptr1+1
 

--- a/libsrc/apple2/dir_file_count.s
+++ b/libsrc/apple2/dir_file_count.s
@@ -1,0 +1,24 @@
+;
+; Colin Leroy-Mira <colin@colino.net>, 2024
+;
+; unsigned int __fastcall__ dir_file_count(DIR *dir);
+;
+
+        .export   _dir_file_count
+
+        .importzp ptr1
+
+        .include  "apple2.inc"
+        .include  "dir.inc"
+
+.proc _dir_file_count
+        sta       ptr1
+        stx       ptr1+1
+
+        ldy       #DIR::FILE_COUNT + 1
+        lda       (ptr1),y
+        tax
+        dey
+        lda       (ptr1),y
+        rts
+.endproc

--- a/libsrc/apple2/opendir.s
+++ b/libsrc/apple2/opendir.s
@@ -128,24 +128,23 @@
         ; Read succeeded, populate dir struct
         jsr       popptr1     ; Restore our dir pointer
 
-        ldy       #$24 + DIR::BYTES
-        lda       (ptr1),y    ; ENTRIES_PER_BLOCK
-        pha                   ; Back it up
-
+        ; Get file_count to entry_length from block
+        ldy       #$26 + DIR::BYTES
+:       lda       (ptr1),y
+        pha
         dey
-        lda       (ptr1),y    ; ENTRY_LENGTH
+        cpy       #$23 + DIR::BYTES - 1
+        bne       :-
 
+        ; Set entry_length to file_count in struct
         ldy       #DIR::ENTRY_LENGTH
+:       pla
         sta       (ptr1),y
-
-        pla
-        .assert   DIR::ENTRIES_PER_BLOCK = DIR::ENTRY_LENGTH + 1, error
         iny
-        sta       (ptr1),y
+        cpy       #DIR::CURRENT_ENTRY
+        bne       :-
 
         ; Skip directory header entry
-        .assert   DIR::CURRENT_ENTRY = DIR::ENTRIES_PER_BLOCK + 1, error
-        iny
         lda       #$01
         sta       (ptr1),y
 


### PR DESCRIPTION
The information is available in the directory key block. Providing it to the user as soon as opendir() is done can save them costly code.