### PR TITLE
[LD65] Add bank number to `seg` entries in dbgfile

### DIFF
--- a/src/dbginfo/dbginfo.c
+++ b/src/dbginfo/dbginfo.c
@@ -127,6 +127,7 @@ typedef enum {
     TOK_ABSOLUTE = TOK_FIRST_KEYWORD,   /* ABSOLUTE keyword */
     TOK_ADDRSIZE,                       /* ADDRSIZE keyword */
     TOK_AUTO,                           /* AUTO keyword */
+    TOK_BANK,                           /* BANK keyword */
     TOK_COUNT,                          /* COUNT keyword */
     TOK_CSYM,                           /* CSYM keyword */
     TOK_DEF,                            /* DEF keyword */
@@ -347,6 +348,7 @@ struct SegInfo {
     cc65_size           Size;           /* Size of segment */
     char*               OutputName;     /* Name of output file */
     unsigned long       OutputOffs;     /* Offset in output file */
+    unsigned            Bank;           /* Bank number of memory area */
     char                Name[1];        /* Name of segment */
 };
 
@@ -1618,7 +1620,8 @@ static int CompareScopeInfoByName (const void* L, const void* R)
 
 static SegInfo* NewSegInfo (const StrBuf* Name, unsigned Id,
                             cc65_addr Start, cc65_addr Size,
-                            const StrBuf* OutputName, unsigned long OutputOffs)
+                            const StrBuf* OutputName, unsigned long OutputOffs,
+                            unsigned Bank)
 /* Create a new SegInfo struct and return it */
 {
     /* Allocate memory */
@@ -1628,6 +1631,7 @@ static SegInfo* NewSegInfo (const StrBuf* Name, unsigned Id,
     S->Id         = Id;
     S->Start      = Start;
     S->Size       = Size;
+    S->Bank       = Bank;
     if (SB_GetLen (OutputName) > 0) {
         /* Output file given */
         S->OutputName = SB_StrDup (OutputName);
@@ -1676,6 +1680,7 @@ static void CopySegInfo (cc65_segmentdata* D, const SegInfo* S)
     D->segment_size  = S->Size;
     D->output_name   = S->OutputName;
     D->output_offs   = S->OutputOffs;
+    D->segment_bank  = S->Bank;
 }
 
 
@@ -2528,6 +2533,7 @@ static void NextToken (InputData* D)
         { "abs",        TOK_ABSOLUTE    },
         { "addrsize",   TOK_ADDRSIZE    },
         { "auto",       TOK_AUTO        },
+        { "bank",       TOK_BANK        },
         { "count",      TOK_COUNT       },
         { "csym",       TOK_CSYM        },
         { "def",        TOK_DEF         },
@@ -3838,6 +3844,7 @@ static void ParseSegment (InputData* D)
     StrBuf          Name = STRBUF_INITIALIZER;
     StrBuf          OutputName = STRBUF_INITIALIZER;
     unsigned long   OutputOffs = 0;
+    unsigned        Bank = 0;
     SegInfo*        S;
     enum {
         ibNone      = 0x000,
@@ -3850,6 +3857,7 @@ static void ParseSegment (InputData* D)
         ibSize      = 0x020,
         ibStart     = 0x040,
         ibType      = 0x080,
+        ibBank      = 0x100,
 
         ibRequired  = ibId | ibName | ibStart | ibSize | ibAddrSize | ibType,
     } InfoBits = ibNone;
@@ -3863,10 +3871,11 @@ static void ParseSegment (InputData* D)
         Token Tok;
 
         /* Something we know? */
-        if (D->Tok != TOK_ADDRSIZE      && D->Tok != TOK_ID         &&
-            D->Tok != TOK_NAME          && D->Tok != TOK_OUTPUTNAME &&
-            D->Tok != TOK_OUTPUTOFFS    && D->Tok != TOK_SIZE       &&
-            D->Tok != TOK_START         && D->Tok != TOK_TYPE) {
+        if (D->Tok != TOK_ADDRSIZE      && D->Tok != TOK_BANK       &&
+            D->Tok != TOK_ID            && D->Tok != TOK_NAME       &&
+            D->Tok != TOK_OUTPUTNAME    && D->Tok != TOK_OUTPUTOFFS &&
+            D->Tok != TOK_SIZE          && D->Tok != TOK_START      &&
+            D->Tok != TOK_TYPE) {
 
             /* Try smart error recovery */
             if (D->Tok == TOK_IDENT || TokenIsKeyword (D->Tok)) {
@@ -3890,6 +3899,15 @@ static void ParseSegment (InputData* D)
             case TOK_ADDRSIZE:
                 NextToken (D);
                 InfoBits |= ibAddrSize;
+                break;
+
+            case TOK_BANK:
+                if (!IntConstFollows (D)) {
+                    goto ErrorExit;
+                }
+                Bank = D->IVal;
+                InfoBits |= ibBank;
+                NextToken (D);
                 break;
 
             case TOK_ID:
@@ -3992,7 +4010,7 @@ static void ParseSegment (InputData* D)
     }
 
     /* Create the segment info and remember it */
-    S = NewSegInfo (&Name, Id, Start, Size, &OutputName, OutputOffs);
+    S = NewSegInfo (&Name, Id, Start, Size, &OutputName, OutputOffs, Bank);
     CollReplaceExpand (&D->Info->SegInfoById, S, Id);
     CollAppend (&D->Info->SegInfoByName, S);
 

--- a/src/dbginfo/dbginfo.h
+++ b/src/dbginfo/dbginfo.h
@@ -521,6 +521,7 @@ struct cc65_segmentdata {
     cc65_size           segment_size;   /* Size of segment */
     const char*         output_name;    /* Output file this seg was written to */
     unsigned long       output_offs;    /* Offset of this seg in output file */
+    unsigned            segment_bank;
 };
 
 typedef struct cc65_segmentinfo cc65_segmentinfo;

--- a/src/dbginfo/dbgsh.c
+++ b/src/dbginfo/dbgsh.c
@@ -721,7 +721,7 @@ static void PrintSegmentHeader (void)
 /* Output a header for a list of segments */
 {
     /* Header */
-    PrintLine ("  id    name            address  size   output file     offs");
+    PrintLine ("  id    name            address  size   output file     offs   bank");
     PrintSeparator ();
 }
 
@@ -741,6 +741,7 @@ static void PrintSegments (const cc65_segmentinfo* S)
         PrintSize (D->segment_size, 7);
         Print ("%-16s", D->output_name? D->output_name : "");
         PrintSize (D->output_offs, 6);
+        PrintId (D->segment_bank, 8);
         NewLine ();
     }
 }

--- a/src/ld65/segments.c
+++ b/src/ld65/segments.c
@@ -638,6 +638,13 @@ void PrintDbgSegments (FILE* F)
             fprintf (F, ",oname=\"%s\",ooffs=%lu",
                      S->OutputName, S->OutputOffs);
         }
+        if (S->MemArea) {
+            if (S->MemArea->BankExpr) {
+                if (IsConstExpr (S->MemArea->BankExpr)) {
+                    fprintf (F, ",bank=%lu", GetExprVal(S->MemArea->BankExpr));
+                }
+            }
+        }
         fputc ('\n', F);
     }
 }


### PR DESCRIPTION
For https://github.com/cc65/cc65/issues/2537

This PR adds the bank number to `seg` entries, appended as ",bank=%lu" if it exists.

Example:
```
seg	id=0,name="CODE",start=0x00C305,size=0x2394,addrsize=absolute,type=ro,oname="bin/game.gtr.bankFF",ooffs=773,bank=255
seg	id=1,name="RODATA",start=0x00E699,size=0x0020,addrsize=absolute,type=ro,oname="bin/game.gtr.bankFF",ooffs=9881,bank=255
seg	id=2,name="BSS",start=0x0004F9,size=0x0444,addrsize=absolute,type=rw
seg	id=3,name="DATA",start=0x000200,size=0x02F9,addrsize=absolute,type=rw,oname="bin/game.gtr.bankFF",ooffs=0
seg	id=4,name="ZEROPAGE",start=0x000000,size=0x001A,addrsize=zeropage,type=rw
seg	id=5,name="NULL",start=0x000000,size=0x0000,addrsize=absolute,type=rw
seg	id=6,name="gfx",start=0x008000,size=0x1615,addrsize=absolute,type=ro,oname="bin/game.gtr.bank83",ooffs=0,bank=131
seg	id=7,name="audio",start=0x008000,size=0x01E9,addrsize=absolute,type=ro,oname="bin/game.gtr.bank81",ooffs=0,bank=129
seg	id=8,name="font",start=0x008000,size=0x04A3,addrsize=absolute,type=ro,oname="bin/game.gtr.bank82",ooffs=0,bank=130
seg	id=9,name="VECTORS",start=0x00FFFA,size=0x0006,addrsize=absolute,type=ro,oname="bin/game.gtr.bankFF",ooffs=16378,bank=255
seg	id=10,name="STARTUP",start=0x00E6B9,size=0x00DC,addrsize=absolute,type=ro,oname="bin/game.gtr.bankFF",ooffs=9913,bank=255
seg	id=11,name="COMMON",start=0x008000,size=0x0618,addrsize=absolute,type=ro,oname="bin/game.gtr.bank80",ooffs=0,bank=128
seg	id=12,name="LOADERS",start=0x008000,size=0x001E,addrsize=absolute,type=ro,oname="bin/game.gtr.bankFD",ooffs=0,bank=253
seg	id=13,name="PROG0",start=0x008000,size=0x0064,addrsize=absolute,type=ro,oname="bin/game.gtr.bankFC",ooffs=0,bank=252
seg	id=14,name="ONCE",start=0x00C2F9,size=0x000C,addrsize=absolute,type=ro,oname="bin/game.gtr.bankFF",ooffs=761,bank=255
```