### PR TITLE
Fixed the behavior of JMP (ind) in sim65 when it runs with the 6502X CPU type.

### DIFF
--- a/src/sim65/6502.c
+++ b/src/sim65/6502.c
@@ -1964,25 +1964,17 @@ static void OPC_6502_6C (void)
     PC = Regs.PC;
     Lo = MemReadWord (PC+1);
 
-    if (CPU == CPU_6502)
-    {
-         /* Emulate the 6502 bug */
-        Cycles = 5;
-        Regs.PC = MemReadByte (Lo);
-        Hi = (Lo & 0xFF00) | ((Lo + 1) & 0xFF);
-        Regs.PC |= (MemReadByte (Hi) << 8);
+    /* Emulate the buggy 6502 behavior */
+    Cycles = 5;
+    Regs.PC = MemReadByte (Lo);
+    Hi = (Lo & 0xFF00) | ((Lo + 1) & 0xFF);
+    Regs.PC |= (MemReadByte (Hi) << 8);
 
-        /* Output a warning if the bug is triggered */
-        if (Hi != Lo + 1)
-        {
-            Warning ("6502 indirect jump bug triggered at $%04X, ind addr = $%04X",
-                     PC, Lo);
-        }
-    }
-    else
+    /* Output a warning if the bug is triggered */
+    if (Hi != Lo + 1)
     {
-        Cycles = 6;
-        Regs.PC = MemReadWord(Lo);
+        Warning ("6502 indirect jump bug triggered at $%04X, ind addr = $%04X",
+                    PC, Lo);
     }
 
     ParaVirtHooks (&Regs);


### PR DESCRIPTION
The JMP (ind) bug is present in the 6502 which is emulated by both the "6502" and "6502X" emulation targets of sim65; specifically, the OPC_6502_6C handler. In the old code, the bug-exhibiting code was not executed when the target was set to 6502X, which is incorrect. The patch removes the (CPU == CPU_6502) check, which made no sense.

The JMP (ind) bug was actually fixed in the 65c02. Indeed, the OPC_65C02_6C opcode handler has code that implements the 'right' behavior.