### PR TITLE
Fixed clock-cycle timing of branch (Bxx) instructions.

### DIFF
--- a/src/sim65/6502.c
+++ b/src/sim65/6502.c
@@ -707,7 +707,7 @@ static unsigned HaveIRQRequest;
         unsigned char OldPCH;                                   \
         ++Cycles;                                               \
         Offs = (signed char) MemReadByte (Regs.PC+1);           \
-        Regs.PC +=2;                                            \
+        Regs.PC += 2;                                           \
         OldPCH = PCH;                                           \
         Regs.PC = (Regs.PC + (int) Offs) & 0xFFFF;              \
         if (PCH != OldPCH) {                                    \

--- a/src/sim65/6502.c
+++ b/src/sim65/6502.c
@@ -707,8 +707,9 @@ static unsigned HaveIRQRequest;
         unsigned char OldPCH;                                   \
         ++Cycles;                                               \
         Offs = (signed char) MemReadByte (Regs.PC+1);           \
+        Regs.PC +=2;                                            \
         OldPCH = PCH;                                           \
-        Regs.PC = (Regs.PC + 2 + (int) Offs) & 0xFFFF;          \
+        Regs.PC = (Regs.PC + (int) Offs) & 0xFFFF;              \
         if (PCH != OldPCH) {                                    \
             ++Cycles;                                           \
         }                                                       \


### PR DESCRIPTION
Branch instructions, when taken, take three or four cycles, depending on whether a page is crossed by the branch.

The proper check to determine whether the extra cycle must be added is the target address of the branch vs the address immediately following the branch.

In the former version of the BRANCH instruction handler, the target address was incorrectly checked vs the address of the branch instruction itself.

The corrected behavior was verified against a real 6502 (Atari) and the 65x02 testsuite.