### PR TITLE
Fixed behavior of the 65C02 "BIT #imm" instruction in sim65.

### DIFF
--- a/src/sim65/6502.c
+++ b/src/sim65/6502.c
@@ -823,6 +823,12 @@ static unsigned HaveIRQRequest;
     SET_OF (Val & 0x40);                                        \
     SET_ZF ((Val & Regs.AC) == 0)
 
+/* BITIMM */
+/* The BIT instruction with immediate mode addressing only sets
+   the zero flag; the sign and overflow flags are not changed. */
+#define BITIMM(Val)                                             \
+    SET_ZF ((Val & Regs.AC) == 0)
+
 /* LDA */
 #define LDA(Val)                                                \
     Regs.AC = Val;                                              \
@@ -2257,7 +2263,9 @@ static void OPC_6502_88 (void)
 static void OPC_65SC02_89 (void)
 /* Opcode $89: BIT #imm */
 {
-    ALU_OP_IMM (BIT);
+    /* Note: BIT #imm behaves differently from BIT with other addressing modes,
+     * hence the different 'op' argument to the macro. */
+    ALU_OP_IMM (BITIMM);
 }
 
 


### PR DESCRIPTION
The BIT #imm instruction behaves differently from the BIT instruction with other addressing modes, in that it does /not/ set the N and V flags according to the value of its operand. It only sets the Z flag, in accordance to the value of (A & operand).

This is corroborated in two ways:

- The 65x02 test suite;
- Documentation about BIT #imm such as http://www.6502.org/tutorials/65c02opcodes.html

This patch implements the correct behavior for BIT with immediate addressing. The patched version passes the 65x02 test suite for 65C02 opcode 0x89.