### PR TITLE
Fixed wrong clearing of D-flag on interrupts for sim65 with 6502X CPU.

### DIFF
--- a/src/sim65/6502.c
+++ b/src/sim65/6502.c
@@ -4104,7 +4104,7 @@ unsigned ExecuteInsn (void)
         PUSH (PCL);
         PUSH (Regs.SR & ~BF);
         SET_IF (1);
-        if (CPU != CPU_6502)
+        if (CPU == CPU_65C02)
         {
             SET_DF (0);
         }
@@ -4118,7 +4118,7 @@ unsigned ExecuteInsn (void)
         PUSH (PCL);
         PUSH (Regs.SR & ~BF);
         SET_IF (1);
-        if (CPU != CPU_6502)
+        if (CPU == CPU_65C02)
         {
             SET_DF (0);
         }


### PR DESCRIPTION

The 65C02 clears the D flag on interrupts while the 6502 does not.

The old sim65 code erroneously cleared the D flag also for the 6502X CPU type, which was incorrect.