### PR TITLE
Sim65: removed ZR register from CPURegs type.

### DIFF
--- a/src/sim65/6502.h
+++ b/src/sim65/6502.h
@@ -60,7 +60,6 @@ struct CPURegs {
     unsigned    AC;             /* Accumulator */
     unsigned    XR;             /* X register */
     unsigned    YR;             /* Y register */
-    unsigned    ZR;             /* Z register */
     unsigned    SR;             /* Status register */
     unsigned    SP;             /* Stackpointer */
     unsigned    PC;             /* Program counter */


### PR DESCRIPTION
The sim65 simulator has a struct type "CPURegs" for holding the values of the CPU registers while executing instructions.

This type currently has a ZR field, which is not a register available in the 6502 or 65C02. This field is also not used anywhere.

This PR removes this field.