### PR TITLE
Sim65 : improve implementation of ROL and ROR operations

### DIFF
--- a/src/sim65/6502.c
+++ b/src/sim65/6502.c
@@ -737,23 +737,29 @@ static unsigned HaveIRQRequest;
 
 /* ROL */
 #define ROL(Val)                                                \
-    Val <<= 1;                                                  \
-    if (GET_CF ()) {                                            \
-        Val |= 0x01;                                            \
-    }                                                           \
-    TEST_ZF (Val);                                              \
-    TEST_SF (Val);                                              \
-    TEST_CF (Val)
+    do {                                                        \
+        unsigned ShiftOut = (Val & 0x80);                       \
+        Val <<= 1;                                              \
+        if (GET_CF ()) {                                        \
+            Val |= 0x01;                                        \
+        }                                                       \
+        TEST_ZF (Val);                                          \
+        TEST_SF (Val);                                          \
+        SET_CF (ShiftOut);                                      \
+    } while (0)
 
 /* ROR */
 #define ROR(Val)                                                \
-    if (GET_CF ()) {                                            \
-        Val |= 0x100;                                           \
-    }                                                           \
-    SET_CF (Val & 0x01);                                        \
-    Val >>= 1;                                                  \
-    TEST_ZF (Val);                                              \
-    TEST_SF (Val)
+    do {                                                        \
+        unsigned ShiftOut = (Val & 0x01);                       \
+        Val >>= 1;                                              \
+        if (GET_CF ()) {                                        \
+            Val |= 0x80;                                        \
+        }                                                       \
+        TEST_ZF (Val);                                          \
+        TEST_SF (Val);                                          \
+        SET_CF (ShiftOut);                                      \
+    } while(0)
 
 /* ASL */
 #define ASL(Val)                                                \

--- a/src/sim65/memory.c
+++ b/src/sim65/memory.c
@@ -45,8 +45,8 @@
 
 
 
-/* THE memory */
-unsigned char Mem[0x10000];
+/* The memory */
+uint8_t Mem[0x10000];
 
 
 
@@ -56,7 +56,7 @@ unsigned char Mem[0x10000];
 
 
 
-void MemWriteByte (unsigned Addr, unsigned char Val)
+void MemWriteByte (uint16_t Addr, uint8_t Val)
 /* Write a byte to a memory location */
 {
     Mem[Addr] = Val;
@@ -64,7 +64,7 @@ void MemWriteByte (unsigned Addr, unsigned char Val)
 
 
 
-void MemWriteWord (unsigned Addr, unsigned Val)
+void MemWriteWord (uint16_t Addr, uint16_t Val)
 /* Write a word to a memory location */
 {
     MemWriteByte (Addr, Val & 0xFF);
@@ -73,22 +73,30 @@ void MemWriteWord (unsigned Addr, unsigned Val)
 
 
 
-unsigned MemReadWord (unsigned Addr)
+uint8_t MemReadByte (uint16_t Addr)
+/* Read a byte from a memory location */
+{
+    return Mem[Addr];
+}
+
+
+
+uint16_t MemReadWord (uint16_t Addr)
 /* Read a word from a memory location */
 {
-    unsigned W = MemReadByte (Addr++);
+    uint8_t W = MemReadByte (Addr++);
     return (W | (MemReadByte (Addr) << 8));
 }
 
 
 
-unsigned MemReadZPWord (unsigned char Addr)
+uint16_t MemReadZPWord (uint8_t Addr)
 /* Read a word from the zero page. This function differs from MemReadWord in that
 ** the read will always be in the zero page, even in case of an address
 ** overflow.
 */
 {
-    unsigned W = MemReadByte (Addr++);
+    uint8_t W = MemReadByte (Addr++);
     return (W | (MemReadByte (Addr) << 8));
 }
 

--- a/src/sim65/memory.h
+++ b/src/sim65/memory.h
@@ -36,9 +36,9 @@
 #ifndef MEMORY_H
 #define MEMORY_H
 
-#include "inline.h"
+#include <stdint.h>
 
-extern unsigned char Mem[0x10000];
+extern uint8_t Mem[0x10000];
 
 /*****************************************************************************/
 /*                                   Code                                    */
@@ -46,26 +46,19 @@ extern unsigned char Mem[0x10000];
 
 
 
-void MemWriteByte (unsigned Addr, unsigned char Val);
+void MemWriteByte (uint16_t Addr, uint8_t Val);
 /* Write a byte to a memory location */
 
-void MemWriteWord (unsigned Addr, unsigned Val);
+void MemWriteWord (uint16_t Addr, uint16_t Val);
 /* Write a word to a memory location */
 
-#if defined(HAVE_INLINE)
-INLINE unsigned char MemReadByte (unsigned Addr)
+uint8_t MemReadByte (uint16_t Addr);
 /* Read a byte from a memory location */
-{
-    return Mem[Addr];
-}
-#else
-#define MemReadByte(Addr) Mem[Addr]
-#endif
 
-unsigned MemReadWord (unsigned Addr);
+uint16_t MemReadWord (uint16_t Addr);
 /* Read a word from a memory location */
 
-unsigned MemReadZPWord (unsigned char Addr);
+uint16_t MemReadZPWord (uint8_t Addr);
 /* Read a word from the zero page. This function differs from MemReadWord in that
 ** the read will always be in the zero page, even in case of an address
 ** overflow.


### PR DESCRIPTION
Issue #2539 demonstrates a number of issues in the sim65 simulator.

Several issues can be traced back to undesirable side effects of the
use of bare 'unregistered' types for the CPU registers in the CPURegs
type defined in '6502.h'.

The intention is to tighten the types of the registers defined there
to uint8_t and uint16_t, in accordance with the actual number of bits
that those registers have in the 6502. However, it turns out that about
10 opcode implementations make use of the fact that the register types
have more bits than the actual 6502 registers themselves.

In preparation of fixing the CPURegs types, we will first make sure
that those opcode implementations are changed in such a way that they
still work if the underlying register types are tightened to their
actual bit width.

Today's opcodes that get this upgrade are ROL and ROR.
