### PR TITLE
sim65 : improve implementation of ROL and ROR operations

### DIFF
--- a/src/sim65/6502.c
+++ b/src/sim65/6502.c
@@ -737,23 +737,29 @@ static unsigned HaveIRQRequest;
 
 /* ROL */
 #define ROL(Val)                                                \
-    Val <<= 1;                                                  \
-    if (GET_CF ()) {                                            \
-        Val |= 0x01;                                            \
-    }                                                           \
-    TEST_ZF (Val);                                              \
-    TEST_SF (Val);                                              \
-    TEST_CF (Val)
+    do {                                                        \
+        unsigned ShiftOut = (Val & 0x80);                       \
+        Val <<= 1;                                              \
+        if (GET_CF ()) {                                        \
+            Val |= 0x01;                                        \
+        }                                                       \
+        TEST_ZF (Val);                                          \
+        TEST_SF (Val);                                          \
+        SET_CF (ShiftOut);                                      \
+    } while (0)
 
 /* ROR */
 #define ROR(Val)                                                \
-    if (GET_CF ()) {                                            \
-        Val |= 0x100;                                           \
-    }                                                           \
-    SET_CF (Val & 0x01);                                        \
-    Val >>= 1;                                                  \
-    TEST_ZF (Val);                                              \
-    TEST_SF (Val)
+    do {                                                        \
+        unsigned ShiftOut = (Val & 0x01);                       \
+        Val >>= 1;                                              \
+        if (GET_CF ()) {                                        \
+            Val |= 0x80;                                        \
+        }                                                       \
+        TEST_ZF (Val);                                          \
+        TEST_SF (Val);                                          \
+        SET_CF (ShiftOut);                                      \
+    } while(0)
 
 /* ASL */
 #define ASL(Val)                                                \


### PR DESCRIPTION
Issue #2539 brings to light a number of issues in the sim65 simulator.

Several issues can be traced back to undesirable side effects of the use of bare 'unsigned' types for the CPU registers in the 'CPURegs' type defined in src/sim65/6502.h.

The intention is to tighten the types of the registers defined there to uint8_t and uint16_t, in accordance with the actual number of bits that those registers have in the 6502. However, it turns out that a handful of opcode implementations depend on the fact that the register types currently have more bits than the actual 6502 registers themselves for correct operation. This mostly involves operations that involve the carry bit (ROL, ROR, ADC, SBC).

In preparation of fixing the CPURegs field types, we will first make sure that those opcode implementations are changed in such a way that they still work if the underlying register types are tightened to their actual bit width.

This PR concerns this specific change for the ROL and ROR operations.

The correct functioning of ROL and ROR after this patch has been verified by testing against the 65x02 test suite.