### PR TITLE
Clean-up preprocessor syntax

### DIFF
--- a/doc/cc65.sgml
+++ b/doc/cc65.sgml
@@ -1370,7 +1370,7 @@ sequences of the input.
   Example:
   <tscreen><verb>
   /* Use a space wherever an 'a' occurs in ISO-8859-1 source */
-  #pragma charmap (0x61, 0x20);
+  #pragma charmap (0x61, 0x20)
   </verb></tscreen>
 
 

--- a/libsrc/common/strftime.c
+++ b/libsrc/common/strftime.c
@@ -40,7 +40,7 @@
 
 
 /* Use static local variables for speed */
-#pragma static-locals (on);
+#pragma static-locals (on)
 
 
 

--- a/samples/cbm/fire.c
+++ b/samples/cbm/fire.c
@@ -56,7 +56,7 @@
 
 
 /* Use static local variables for speed */
-#pragma static-locals (1);
+#pragma static-locals (1)
 
 
 

--- a/samples/cbm/plasma.c
+++ b/samples/cbm/plasma.c
@@ -51,7 +51,7 @@
 
 
 /* Use static local variables for speed */
-#pragma static-locals (1);
+#pragma static-locals (1)
 
 
 static const unsigned char sinustable[0x100] = {

--- a/samples/geos/overlay-demo.c
+++ b/samples/geos/overlay-demo.c
@@ -27,7 +27,7 @@ void show(char *name)
 ** rather place the all the code of certain source files into the overlay by
 ** compiling them with --code-name OVERLAY1.
 */
-#pragma code-name(push, "OVERLAY1");
+#pragma code-name(push, "OVERLAY1")
 
 void foo(void)
 {
@@ -39,27 +39,27 @@ void foo(void)
     show("One");
 }
 
-#pragma code-name(pop);
+#pragma code-name(pop)
 
 
-#pragma code-name(push, "OVERLAY2");
+#pragma code-name(push, "OVERLAY2")
 
 void bar(void)
 {
     show("Two");
 }
 
-#pragma code-name(pop);
+#pragma code-name(pop)
 
 
-#pragma code-name(push, "OVERLAY3");
+#pragma code-name(push, "OVERLAY3")
 
 void foobar (void)
 {
     show("Three");
 }
 
-#pragma code-name(pop);
+#pragma code-name(pop)
 
 
 void main(int /*argc*/, char *argv[])

--- a/samples/lynx/mandelbrot.c
+++ b/samples/lynx/mandelbrot.c
@@ -26,7 +26,7 @@
 #define divfp(_a,_b)    ((((signed long)_a)<<fpshift)/(_b))
 
 /* Use static local variables for speed */
-#pragma static-locals (1);
+#pragma static-locals (1)
 
 
 

--- a/samples/mandelbrot.c
+++ b/samples/mandelbrot.c
@@ -41,7 +41,7 @@
 #endif
 
 /* Use static local variables for speed */
-#pragma static-locals (1);
+#pragma static-locals (1)
 
 
 

--- a/samples/multidemo.c
+++ b/samples/multidemo.c
@@ -64,34 +64,34 @@ void log (char *msg)
 ** rather place all the code of certain source files into the overlay by
 ** compiling them with --code-name OVERLAY1.
 */
-#pragma code-name (push, "OVERLAY1");
+#pragma code-name (push, "OVERLAY1")
 
 void foo (void)
 {
     log ("Calling main from overlay 1");
 }
 
-#pragma code-name (pop);
+#pragma code-name (pop)
 
 
-#pragma code-name (push, "OVERLAY2");
+#pragma code-name (push, "OVERLAY2")
 
 void bar (void)
 {
     log ("Calling main from overlay 2");
 }
 
-#pragma code-name (pop);
+#pragma code-name (pop)
 
 
-#pragma code-name (push, "OVERLAY3");
+#pragma code-name (push, "OVERLAY3")
 
 void foobar (void)
 {
     log ("Calling main from overlay 3");
 }
 
-#pragma code-name(pop);
+#pragma code-name(pop)
 
 
 unsigned char loademdriver (void)

--- a/samples/overlaydemo.c
+++ b/samples/overlaydemo.c
@@ -39,7 +39,7 @@ void log (char *msg)
 ** rather place all the code of certain source files into the overlay by
 ** compiling them with --code-name OVERLAY1.
 */
-#pragma code-name (push, "OVERLAY1");
+#pragma code-name (push, "OVERLAY1")
 
 void foo (void)
 {
@@ -51,27 +51,27 @@ void foo (void)
     log ("Calling main from overlay 1");
 }
 
-#pragma code-name (pop);
+#pragma code-name (pop)
 
 
-#pragma code-name (push, "OVERLAY2");
+#pragma code-name (push, "OVERLAY2")
 
 void bar (void)
 {
     log ("Calling main from overlay 2");
 }
 
-#pragma code-name (pop);
+#pragma code-name (pop)
 
 
-#pragma code-name (push, "OVERLAY3");
+#pragma code-name (push, "OVERLAY3")
 
 void foobar (void)
 {
     log ("Calling main from overlay 3");
 }
 
-#pragma code-name(pop);
+#pragma code-name(pop)
 
 
 unsigned char loadfile (char *name, void *addr, void *size)

--- a/samples/sieve.c
+++ b/samples/sieve.c
@@ -38,7 +38,7 @@ static unsigned char Sieve[COUNT];
 
 
 
-#pragma static-locals(1);
+#pragma static-locals(1)
 
 
 


### PR DESCRIPTION
Did you ever see `#include <foo.h>;`?
The C preprocessor has its own syntax.