### PR TITLE
Improve description of namespace access in ca65

### DIFF
--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -1059,7 +1059,7 @@ The namespace token (<tt/::/) is used to access other scopes:
         .endscope
 
                 ...
-                lda     foo::bar        ; Access foo in scope bar
+                lda     #foo::bar        ; Access bar in scope foo
 </verb></tscreen>
 
 The only way to deny access to a scope from the outside is to declare a scope


### PR DESCRIPTION
This avoid confusion with referencing global scope with the namespace token.