### PR TITLE
sim65: simulated CPU registers can be accessed from outside 6502.c.

### DIFF
--- a/src/sim65/6502.c
+++ b/src/sim65/6502.c
@@ -391,7 +391,7 @@ CPUType CPU;
 typedef void (*OPFunc) (void);
 
 /* The CPU registers */
-static CPURegs Regs;
+CPURegs Regs;
 
 /* Cycles for the current insn */
 static unsigned Cycles;

--- a/src/sim65/6502.h
+++ b/src/sim65/6502.h
@@ -65,6 +65,9 @@ struct CPURegs {
     unsigned    PC;             /* Program counter */
 };
 
+/* Current CPU registers */
+extern CPURegs Regs;
+
 /* Status register bits */
 #define CF      0x01            /* Carry flag */
 #define ZF      0x02            /* Zero flag */


### PR DESCRIPTION
The linkage of the 'Regs' variable in 6502.c was changed from static to extern. This makes the Regs struct visible (and even alterable) from the outside.

This change helps tools inspect the CPU state. In particular, it was implemented to facilitate a tool that verifies opcode functionality using the '65x02' test suite. But the change is also potentially useful for, e.g., an online debugger that wants to inspect the CPU state while the 6502 is being simulated.