### PR TITLE
Temporary fix for fgets() not using target-specific newline.

### DIFF
--- a/libsrc/common/fgets.s
+++ b/libsrc/common/fgets.s
@@ -8,6 +8,8 @@
         .import         _fgetc, popptr1, pushptr1, popax, pushax, return0, ___errno
         .importzp       ptr1, ptr4
 
+        .feature        string_escapes
+
         .include        "errno.inc"
         .include        "stdio.inc"
         .include        "_file.inc"
@@ -88,7 +90,22 @@ read_loop:
         bne     :+
         inc     ptr4+1
 
-:       cmp     #$0A            ; Stop at \n
+        ; The next code line:
+        ;
+        ;     .byte $c9, "\n"
+        ;
+        ; corresponds to a CMP #imm with the target-specific newline value as its operand.
+        ; This works because (with the 'string_escapes' feature enabled), the "\n" string
+        ; assembles to the target-specific value for the newline character.
+        ;
+        ; It would be better if we could just write:
+        ;
+        ; cmp #'\n'
+        ;
+        ; Unfortunately, ca65 doesn't currently handle escape characters in character
+        ; constants. In the longer term, fixing that would be the preferred solution.
+
+:       .byte   $c9, "\n"       ; cmp #'\n'
         beq     done
         bne     read_loop
 

--- a/libsrc/common/fgets.s
+++ b/libsrc/common/fgets.s
@@ -100,7 +100,7 @@ read_loop:
         ;
         ; It would be better if we could just write:
         ;
-        ; cmp #'\n'
+        ;     cmp #'\n'
         ;
         ; Unfortunately, ca65 doesn't currently handle escape characters in character
         ; constants. In the longer term, fixing that would be the preferred solution.


### PR DESCRIPTION
This patch provides a temporary fix for the issue where the fgets() function did not use the target-specific newline character to decide if it has reached the end of the line. It defaulted to the value $0a, which is the newline character on only some targets. The Atari, for example, has newline character $9b instead.

This issue was discovered while investigating #2562. 

This patch is ugly, because the ca65 assembler that is used for fgets doesn't currently accept C-type character escape sequences as values. Ideally we'd be able to write:

		cmp #'\n'

And this would end up being translated to a compare-immediate to the target-specific newline character.

Since that is impossible, this patch substitutes the equivalent, but ugly, code:

		.byte $c9, "\n"

This works because $c9 is the opcode for cmp #imm, and the "\n" string /is/ translated to the platform-specific newline character, at least when the 'string_escapes' feature is enabled.
