### PR TITLE
sim65: properly implement 5 'illegal' 6502X opcodes.

### DIFF
--- a/src/sim65/6502.c
+++ b/src/sim65/6502.c
@@ -2534,7 +2534,20 @@ static void OPC_65SC02_92 (void)
 static void OPC_6502_93 (void)
 /* Opcode $93: SHA (zp),y */
 {
-    STO_CB (ZPINDY, SHA);
+    ++Regs.PC;
+    uint8_t zp_ptr_lo = MemReadByte(Regs.PC);
+    ++Regs.PC;
+    uint8_t zp_ptr_hi = zp_ptr_lo + 1;
+    uint8_t baselo = MemReadByte(zp_ptr_lo);
+    uint8_t basehi = MemReadByte(zp_ptr_hi);
+    uint8_t basehi_incremented = basehi + 1;
+    uint8_t write_value = Regs.AC & Regs.XR & basehi_incremented;
+    uint8_t write_address_lo = (baselo + Regs.YR);
+    bool pagecross = (baselo + Regs.YR) > 0xff;
+    uint8_t write_address_hi = pagecross ? write_value : basehi;
+    uint16_t write_address = write_address_lo + (write_address_hi << 8);
+    MemWriteByte(write_address, write_value);
+    Cycles=6;
 }
 
 
@@ -2604,7 +2617,20 @@ static void OPC_6502_9A (void)
 static void OPC_6502_9B (void)
 /* Opcode $9B: TAS abs,y */
 {
-    STO_CB (ABSY, TAS);
+    ++Regs.PC;
+    uint8_t baselo = MemReadByte(Regs.PC);
+    ++Regs.PC;
+    uint8_t basehi = MemReadByte(Regs.PC);
+    ++Regs.PC;
+    uint8_t basehi_incremented = basehi + 1;
+    uint8_t write_value = Regs.AC & Regs.XR & basehi_incremented;
+    uint8_t write_address_lo = (baselo + Regs.YR);
+    bool pagecross = (baselo + Regs.YR) > 0xff;
+    uint8_t write_address_hi = pagecross ? write_value : basehi;
+    uint16_t write_address = write_address_lo + (write_address_hi << 8);
+    MemWriteByte(write_address, write_value);
+    Regs.SP = Regs.AC & Regs.XR;
+    Cycles=5;
 }
 
 
@@ -2612,7 +2638,19 @@ static void OPC_6502_9B (void)
 static void OPC_6502_9C (void)
 /* Opcode $9D: SHY abs,x */
 {
-    STO_OP (ABSX, Regs.YR & ((address >> 8) + 1));
+    ++Regs.PC;
+    uint8_t baselo = MemReadByte(Regs.PC);
+    ++Regs.PC;
+    uint8_t basehi = MemReadByte(Regs.PC);
+    ++Regs.PC;
+    uint8_t basehi_incremented = basehi + 1;
+    uint8_t write_value = Regs.YR & basehi_incremented;
+    uint8_t write_address_lo = (baselo + Regs.XR);
+    bool pagecross = (baselo + Regs.XR) > 0xff;
+    uint8_t write_address_hi = pagecross ? write_value : basehi;
+    uint16_t write_address = write_address_lo + (write_address_hi << 8);
+    MemWriteByte(write_address, write_value);
+    Cycles=5;
 }
 
 
@@ -2636,7 +2674,19 @@ static void OPC_6502_9D (void)
 static void OPC_6502_9E (void)
 /* Opcode $9E: SHX abs,x */
 {
-    STO_OP (ABSY, Regs.XR & ((address >> 8) + 1));
+    ++Regs.PC;
+    uint8_t baselo = MemReadByte(Regs.PC);
+    ++Regs.PC;
+    uint8_t basehi = MemReadByte(Regs.PC);
+    ++Regs.PC;
+    uint8_t basehi_incremented = basehi + 1;
+    uint8_t write_value = Regs.XR & basehi_incremented;
+    uint8_t write_address_lo = (baselo + Regs.YR);
+    bool pagecross = (baselo + Regs.YR) > 0xff;
+    uint8_t write_address_hi = pagecross ? write_value : basehi;
+    uint16_t write_address = write_address_lo + (write_address_hi << 8);
+    MemWriteByte(write_address, write_value);
+    Cycles=5;
 }
 
 
@@ -2644,7 +2694,19 @@ static void OPC_6502_9E (void)
 static void OPC_6502_9F (void)
 /* Opcode $9F: SHA abs,y */
 {
-    STO_CB (ABSY, SHA);
+    ++Regs.PC;
+    uint8_t baselo = MemReadByte(Regs.PC);
+    ++Regs.PC;
+    uint8_t basehi = MemReadByte(Regs.PC);
+    ++Regs.PC;
+    uint8_t basehi_incremented = basehi + 1;
+    uint8_t write_value = Regs.AC & Regs.XR & basehi_incremented;
+    uint8_t write_address_lo = (baselo + Regs.YR);
+    bool pagecross = (baselo + Regs.YR) > 0xff;
+    uint8_t write_address_hi = pagecross ? write_value : basehi;
+    uint16_t write_address = write_address_lo + (write_address_hi << 8);
+    MemWriteByte(write_address, write_value);
+    Cycles=5;
 }
 
 


### PR DESCRIPTION
This PR fixes the implementation of 5 illegal opcodes in the 6502, which the 6502X supports:

* $93   SHA (zp),y
* $9B   TAS abs,y
* $9C   SHY abs,x
* $9E   SHX abs,x
* $9F   SHA abs,y

The common denominator of the previous implementation was that it didn't correctly handle the case when the Y or X indexing induced a page crossing. In those cases, the effective address calculation of the instructions becomes truly messed up (with the high byte of the address equal to the value being written).

The correctness of the implementations in this PR was verified using the 65x02 test suite, and corresponds to a (detailed) reading of the "No More Secrets" document.

Stylistically, there is room for improvement in these implementations, specifically in factoring out common behavior into macros. However, for now, the "explicit" coding style will suffice. It is clear enough, and we want to reach a situation soon where the sim65 code is able to pass the full '65x02' testsuite. Once we get to that point, we can refactor this code with a lot more confidence, since we will have the benefit of a working exhaustive test to make sure we don't break stuff.