### PR TITLE
sim65: Fix instruction timings for 6502 and 65C02.

### DIFF
--- a/cfg/sim6502.cfg
+++ b/cfg/sim6502.cfg
@@ -5,7 +5,7 @@ SYMBOLS {
 MEMORY {
     ZP:     file = "",               start = $0000, size = $0100;
     HEADER: file = %O,               start = $0000, size = $000C;
-    MAIN:   file = %O, define = yes, start = $0200, size = $FDF0 - __STACKSIZE__;
+    MAIN:   file = %O, define = yes, start = $0200, size = $FDC0 - __STACKSIZE__;
 }
 SEGMENTS {
     ZEROPAGE: load = ZP,     type = zp;

--- a/cfg/sim65c02.cfg
+++ b/cfg/sim65c02.cfg
@@ -5,7 +5,7 @@ SYMBOLS {
 MEMORY {
     ZP:     file = "",               start = $0000, size = $0100;
     HEADER: file = %O,               start = $0000, size = $000C;
-    MAIN:   file = %O, define = yes, start = $0200, size = $FDF0 - __STACKSIZE__;
+    MAIN:   file = %O, define = yes, start = $0200, size = $FDC0 - __STACKSIZE__;
 }
 SEGMENTS {
     ZEROPAGE: load = ZP,     type = zp;

--- a/src/sim65/6502.c
+++ b/src/sim65/6502.c
@@ -4108,7 +4108,7 @@ unsigned ExecuteInsn (void)
     if (HaveNMIRequest) {
 
         HaveNMIRequest = 0;
-        Peripherals.Counter.nmi_events += 1;
+        Peripherals.Counter.NmiEvents += 1;
 
         PUSH (PCH);
         PUSH (PCL);
@@ -4124,7 +4124,7 @@ unsigned ExecuteInsn (void)
     } else if (HaveIRQRequest && GET_IF () == 0) {
 
         HaveIRQRequest = 0;
-        Peripherals.Counter.irq_events += 1;
+        Peripherals.Counter.IrqEvents += 1;
 
         PUSH (PCH);
         PUSH (PCL);
@@ -4146,11 +4146,11 @@ unsigned ExecuteInsn (void)
         Handlers[CPU][OPC] ();
 
         /* Increment the instruction counter by one.NMIs and IRQs are counted separately. */
-        Peripherals.Counter.cpu_instructions += 1;
+        Peripherals.Counter.CpuInstructions += 1;
     }
 
-    /* Increment the 64-bit clock cycle counter with the cycle count for the instruction that we just executed */
-    Peripherals.Counter.clock_cycles += Cycles;
+    /* Increment the 64-bit clock cycle counter with the cycle count for the instruction that we just executed. */
+    Peripherals.Counter.ClockCycles += Cycles;
 
     /* Return the number of clock cycles needed by this insn */
     return Cycles;

--- a/src/sim65/6502.c
+++ b/src/sim65/6502.c
@@ -4108,7 +4108,7 @@ unsigned ExecuteInsn (void)
     if (HaveNMIRequest) {
 
         HaveNMIRequest = 0;
-        PRegs.counter_nmi_events += 1;
+        Peripherals.Counter.nmi_events += 1;
 
         PUSH (PCH);
         PUSH (PCL);
@@ -4124,7 +4124,7 @@ unsigned ExecuteInsn (void)
     } else if (HaveIRQRequest && GET_IF () == 0) {
 
         HaveIRQRequest = 0;
-        PRegs.counter_irq_events += 1;
+        Peripherals.Counter.irq_events += 1;
 
         PUSH (PCH);
         PUSH (PCL);
@@ -4146,11 +4146,11 @@ unsigned ExecuteInsn (void)
         Handlers[CPU][OPC] ();
 
         /* Increment the instruction counter by one.NMIs and IRQs are counted separately. */
-        PRegs.counter_instructions += 1;
+        Peripherals.Counter.cpu_instructions += 1;
     }
 
     /* Increment the 64-bit clock cycle counter with the cycle count for the instruction that we just executed */
-    PRegs.counter_clock_cycles += Cycles;
+    Peripherals.Counter.clock_cycles += Cycles;
 
     /* Return the number of clock cycles needed by this insn */
     return Cycles;

--- a/src/sim65/error.c
+++ b/src/sim65/error.c
@@ -118,7 +118,7 @@ void SimExit (int Code)
 /* Exit the simulation with an exit code */
 {
     if (PrintCycles) {
-        fprintf (stdout, PRIu64 " cycles\n", PRegs.counter_clock_cycles);
+        fprintf (stdout, "%" PRIu64 " cycles\n", PRegs.counter_clock_cycles);
     }
     exit (Code);
 }

--- a/src/sim65/error.c
+++ b/src/sim65/error.c
@@ -118,7 +118,7 @@ void SimExit (int Code)
 /* Exit the simulation with an exit code */
 {
     if (PrintCycles) {
-        fprintf (stdout, "%" PRIu64 " cycles\n", Peripherals.Counter.clock_cycles);
+        fprintf (stdout, "%" PRIu64 " cycles\n", Peripherals.Counter.ClockCycles);
     }
     exit (Code);
 }

--- a/src/sim65/error.c
+++ b/src/sim65/error.c
@@ -36,9 +36,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <inttypes.h>
 
 #include "error.h"
-
+#include "peripherals.h"
 
 
 /*****************************************************************************/
@@ -49,9 +50,6 @@
 
 /* flag to print cycles at program termination */
 int PrintCycles = 0;
-
-/* cycles are counted by main.c */
-extern unsigned long long TotalCycles;
 
 
 
@@ -120,7 +118,7 @@ void SimExit (int Code)
 /* Exit the simulation with an exit code */
 {
     if (PrintCycles) {
-        fprintf (stdout, "%llu cycles\n", TotalCycles);
+        fprintf (stdout, PRIu64 " cycles\n", PRegs.counter_clock_cycles);
     }
     exit (Code);
 }

--- a/src/sim65/error.c
+++ b/src/sim65/error.c
@@ -118,7 +118,7 @@ void SimExit (int Code)
 /* Exit the simulation with an exit code */
 {
     if (PrintCycles) {
-        fprintf (stdout, "%" PRIu64 " cycles\n", PRegs.counter_clock_cycles);
+        fprintf (stdout, "%" PRIu64 " cycles\n", Peripherals.Counter.clock_cycles);
     }
     exit (Code);
 }

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -47,6 +47,7 @@
 #include "6502.h"
 #include "error.h"
 #include "memory.h"
+#include "peripherals.h"
 #include "paravirt.h"
 
 
@@ -59,9 +60,6 @@
 
 /* Name of program file */
 const char* ProgramFile;
-
-/* count of total cycles executed */
-unsigned long long TotalCycles = 0;
 
 /* exit simulator after MaxCycles Cccles */
 unsigned long long MaxCycles = 0;
@@ -309,6 +307,7 @@ int main (int argc, char* argv[])
     }
 
     MemInit ();
+    PeripheralsInit ();
 
     SPAddr = ReadProgramFile ();
     ParaVirtInit (I, SPAddr);
@@ -318,7 +317,6 @@ int main (int argc, char* argv[])
     RemainCycles = MaxCycles;
     while (1) {
         Cycles = ExecuteInsn ();
-        TotalCycles += Cycles;
         if (MaxCycles) {
             if (Cycles > RemainCycles) {
                 ErrorCode (SIM65_ERROR_TIMEOUT, "Maximum number of cycles reached.");

--- a/src/sim65/memory.c
+++ b/src/sim65/memory.c
@@ -36,7 +36,7 @@
 #include <string.h>
 
 #include "memory.h"
-
+#include "peripherals.h"
 
 
 /*****************************************************************************/
@@ -59,7 +59,14 @@ uint8_t Mem[0x10000];
 void MemWriteByte (uint16_t Addr, uint8_t Val)
 /* Write a byte to a memory location */
 {
-    Mem[Addr] = Val;
+    if ((PERIPHERALS_APERTURE_BASE_ADDRESS <= Addr) && (Addr <= PERIPHERALS_APERTURE_LAST_ADDRESS))
+    {
+        /* Defer the the memory-mapped peripherals handler for this write. */
+        PeripheralWriteByte (Addr - PERIPHERALS_APERTURE_BASE_ADDRESS, Val);
+    } else {
+        /* Write to the Mem array. */
+        Mem[Addr] = Val;
+    }
 }
 
 
@@ -76,7 +83,14 @@ void MemWriteWord (uint16_t Addr, uint16_t Val)
 uint8_t MemReadByte (uint16_t Addr)
 /* Read a byte from a memory location */
 {
-    return Mem[Addr];
+    if ((PERIPHERALS_APERTURE_BASE_ADDRESS <= Addr) && (Addr <= PERIPHERALS_APERTURE_LAST_ADDRESS))
+    {
+        /* Defer the the memory-mapped peripherals handler for this read. */
+        return PeripheralReadByte (Addr - PERIPHERALS_APERTURE_BASE_ADDRESS);
+    } else {
+        /* Read from the Mem array. */
+        return Mem[Addr];
+    }
 }
 
 

--- a/src/sim65/memory.c
+++ b/src/sim65/memory.c
@@ -62,7 +62,7 @@ void MemWriteByte (uint16_t Addr, uint8_t Val)
     if ((PERIPHERALS_APERTURE_BASE_ADDRESS <= Addr) && (Addr <= PERIPHERALS_APERTURE_LAST_ADDRESS))
     {
         /* Defer the the memory-mapped peripherals handler for this write. */
-        PeripheralWriteByte (Addr - PERIPHERALS_APERTURE_BASE_ADDRESS, Val);
+        PeripheralsWriteByte (Addr - PERIPHERALS_APERTURE_BASE_ADDRESS, Val);
     } else {
         /* Write to the Mem array. */
         Mem[Addr] = Val;
@@ -86,7 +86,7 @@ uint8_t MemReadByte (uint16_t Addr)
     if ((PERIPHERALS_APERTURE_BASE_ADDRESS <= Addr) && (Addr <= PERIPHERALS_APERTURE_LAST_ADDRESS))
     {
         /* Defer the the memory-mapped peripherals handler for this read. */
-        return PeripheralReadByte (Addr - PERIPHERALS_APERTURE_BASE_ADDRESS);
+        return PeripheralsReadByte (Addr - PERIPHERALS_APERTURE_BASE_ADDRESS);
     } else {
         /* Read from the Mem array. */
         return Mem[Addr];

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -82,10 +82,10 @@ void PeripheralWriteByte (uint8_t Addr, uint8_t Val)
             PRegs.latched_wallclock_time = get_uint64_wallclock_time();
 
             /* Now latch all the cycles maintained by the processor. */
-            PRegs.latched_counter_clock_cycles = PRegs.latched_counter_clock_cycles;
-            PRegs.latched_counter_instructions = PRegs.latched_counter_instructions;
-            PRegs.latched_counter_irq_events = PRegs.latched_counter_irq_events;
-            PRegs.latched_counter_nmi_events = PRegs.latched_counter_nmi_events;
+            PRegs.latched_counter_clock_cycles = PRegs.counter_clock_cycles;
+            PRegs.latched_counter_instructions = PRegs.counter_instructions;
+            PRegs.latched_counter_irq_events = PRegs.counter_irq_events;
+            PRegs.latched_counter_nmi_events = PRegs.counter_nmi_events;
             break;
         }
         case PERIPHERALS_ADDRESS_OFFSET_SELECT: {

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -40,8 +40,8 @@
 
 
 
-/* The peripheral registers. */
-PeripheralRegs PRegs;
+/* The system-wide state of the peripherals */
+Sim65Peripherals Peripherals;
 
 
 
@@ -51,46 +51,37 @@ PeripheralRegs PRegs;
 
 
 
-static uint64_t get_uint64_wallclock_time(void)
-{
-    struct timespec ts;
-    int result = clock_gettime(CLOCK_REALTIME, &ts);
-    if (result != 0)
-    {
-        // On failure, time will be set to the max value.
-        return 0xffffffffffffffff;
-    }
-
-    /* Return time since the 1-1-1970 epoch, in nanoseconds.
-     * Note that this time may be off by an integer number of seconds, as POSIX
-     * maintaines that all days are 86,400 seconds long, which is not true due to
-     * leap seconds.
-     */
-    return ts.tv_sec * 1000000000 + ts.tv_nsec;
-}
-
-
-
-void PeripheralWriteByte (uint8_t Addr, uint8_t Val)
-/* Write a byte to a memory location in the peripheral address aperture. */
+void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
+/* Write a byte to a memory location in the peripherals address aperture. */
 {
     switch (Addr) {
-        case PERIPHERALS_ADDRESS_OFFSET_LATCH: {
-            /* A write to the "latch" register performs a simultaneous latch of all registers */
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_LATCH: {
+            /* A write to the "latch" register performs a simultaneous latch of all registers. */
 
             /* Latch the current wallclock time first. */
-            PRegs.latched_wallclock_time = get_uint64_wallclock_time();
+	    struct timespec ts;
+            int result = clock_gettime(CLOCK_REALTIME, &ts);
+	    if (result != 0) {
+	        /* Unable to read time. Report max uint64 value for both fields. */
+  	        Peripherals.Counter.latched_wallclock_time = 0xffffffffffffffff;
+                Peripherals.Counter.latched_wallclock_time_split = 0xffffffffffffffff;
+	    } else {
+	        /* Number of nanoseconds since 1-1-1970. */
+                Peripherals.Counter.latched_wallclock_time = 1000000000u * ts.tv_sec + ts.tv_nsec;
+	        /* High word is number of seconds, low word is number of nanoseconds. */
+                Peripherals.Counter.latched_wallclock_time_split = (ts.tv_sec << 32) | ts.tv_nsec;
+            }
 
-            /* Now latch all the cycles maintained by the processor. */
-            PRegs.latched_counter_clock_cycles = PRegs.counter_clock_cycles;
-            PRegs.latched_counter_instructions = PRegs.counter_instructions;
-            PRegs.latched_counter_irq_events = PRegs.counter_irq_events;
-            PRegs.latched_counter_nmi_events = PRegs.counter_nmi_events;
+            /* Latch the counters that reflect the state of the processor. */
+            Peripherals.Counter.latched_clock_cycles = Peripherals.Counter.clock_cycles;
+            Peripherals.Counter.latched_cpu_instructions = Peripherals.Counter.cpu_instructions;
+            Peripherals.Counter.latched_irq_events = Peripherals.Counter.irq_events;
+            Peripherals.Counter.latched_nmi_events = Peripherals.Counter.nmi_events;
             break;
         }
-        case PERIPHERALS_ADDRESS_OFFSET_SELECT: {
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_SELECT: {
             /* Set the value of the visibility-selection register. */
-            PRegs.visible_latch_register = Val;
+            Peripherals.Counter.visible_latch_register = Val;
             break;
         }
         default: {
@@ -101,33 +92,34 @@ void PeripheralWriteByte (uint8_t Addr, uint8_t Val)
 
 
 
-uint8_t PeripheralReadByte (uint8_t Addr)
-/* Read a byte from a memory location in the peripheral address aperture. */
+uint8_t PeripheralsReadByte (uint8_t Addr)
+/* Read a byte from a memory location in the peripherals address aperture. */
 {
     switch (Addr) {
-        case PERIPHERALS_ADDRESS_OFFSET_SELECT: {
-            return PRegs.visible_latch_register;
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_SELECT: {
+            return Peripherals.Counter.visible_latch_register;
         }
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 0:
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 1:
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 2:
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 3:
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 4:
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 5:
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 6:
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 7: {
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 0:
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 1:
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 2:
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 3:
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 4:
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 5:
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 6:
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 7: {
             /* Read from any of the eight counter bytes.
              * The first byte is the 64 bit value's LSB, the seventh byte is its MSB.
              */
-            unsigned byte_select = Addr - PERIPHERALS_ADDRESS_OFFSET_REG64; /* 0 .. 7 */
+            unsigned byte_select = Addr - PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE; /* 0 .. 7 */
             uint64_t value;
-            switch (PRegs.visible_latch_register) {
-                case PERIPHERALS_REG64_SELECT_CLOCKCYCLE_COUNTER: value = PRegs.latched_counter_clock_cycles; break;
-                case PERIPHERALS_REG64_SELECT_INSTRUCTION_COUNTER: value = PRegs.latched_counter_instructions; break;
-                case PERIPHERALS_REG64_SELECT_IRQ_COUNTER: value = PRegs.latched_counter_irq_events; break;
-                case PERIPHERALS_REG64_SELECT_NMI_COUNTER: value = PRegs.latched_counter_nmi_events; break;
-                case PERIPHERALS_REG64_SELECT_WALLCLOCK_TIME: value = PRegs.latched_wallclock_time; break;
-                default: value = 0; /* Reading from a non-supported register will yield 0. */
+            switch (Peripherals.Counter.visible_latch_register) {
+                case PERIPHERALS_COUNTER_SELECT_CLOCKCYCLE_COUNTER: value = Peripherals.Counter.latched_clock_cycles; break;
+                case PERIPHERALS_COUNTER_SELECT_INSTRUCTION_COUNTER: value = Peripherals.Counter.latched_cpu_instructions; break;
+                case PERIPHERALS_COUNTER_SELECT_IRQ_COUNTER: value = Peripherals.Counter.latched_irq_events; break;
+                case PERIPHERALS_COUNTER_SELECT_NMI_COUNTER: value = Peripherals.Counter.latched_nmi_events; break;
+                case PERIPHERALS_COUNTER_SELECT_WALLCLOCK_TIME: value = Peripherals.Counter.latched_wallclock_time; break;
+                case PERIPHERALS_COUNTER_SELECT_WALLCLOCK_TIME_SPLIT: value = Peripherals.Counter.latched_wallclock_time_split; break;
+                default: value = 0; /* Reading from a non-existent register will yield 0. */
             }
             /* Return the desired byte of the latched counter. 0==LSB, 7==MSB. */
             return value >> (byte_select * 8);
@@ -144,16 +136,19 @@ uint8_t PeripheralReadByte (uint8_t Addr)
 void PeripheralsInit (void)
 /* Initialize the peripheral registers */
 {
-    PRegs.counter_clock_cycles = 0;
-    PRegs.counter_instructions = 0;
-    PRegs.counter_irq_events = 0;
-    PRegs.counter_nmi_events = 0;
+    /* Initialize the COUNTER peripheral */
 
-    PRegs.latched_counter_clock_cycles = 0;
-    PRegs.latched_counter_instructions = 0;
-    PRegs.latched_counter_irq_events = 0;
-    PRegs.latched_counter_nmi_events = 0;
-    PRegs.latched_wallclock_time = 0;
+    Peripherals.Counter.clock_cycles = 0;
+    Peripherals.Counter.cpu_instructions = 0;
+    Peripherals.Counter.irq_events = 0;
+    Peripherals.Counter.nmi_events = 0;
 
-    PRegs.visible_latch_register = 0;
+    Peripherals.Counter.latched_clock_cycles = 0;
+    Peripherals.Counter.latched_cpu_instructions = 0;
+    Peripherals.Counter.latched_irq_events = 0;
+    Peripherals.Counter.latched_nmi_events = 0;
+    Peripherals.Counter.latched_wallclock_time = 0;
+    Peripherals.Counter.latched_wallclock_time_split = 0;
+
+    Peripherals.Counter.visible_latch_register = 0;
 }

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -59,16 +59,16 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
             /* A write to the "latch" register performs a simultaneous latch of all registers. */
 
             /* Latch the current wallclock time first. */
-	    struct timespec ts;
+            struct timespec ts;
             int result = clock_gettime(CLOCK_REALTIME, &ts);
-	    if (result != 0) {
-	        /* Unable to read time. Report max uint64 value for both fields. */
-  	        Peripherals.Counter.latched_wallclock_time = 0xffffffffffffffff;
+            if (result != 0) {
+                /* Unable to read time. Report max uint64 value for both fields. */
+                Peripherals.Counter.latched_wallclock_time = 0xffffffffffffffff;
                 Peripherals.Counter.latched_wallclock_time_split = 0xffffffffffffffff;
-	    } else {
-	        /* Number of nanoseconds since 1-1-1970. */
+            } else {
+                /* Number of nanoseconds since 1-1-1970. */
                 Peripherals.Counter.latched_wallclock_time = 1000000000u * ts.tv_sec + ts.tv_nsec;
-	        /* High word is number of seconds, low word is number of nanoseconds. */
+                /* High word is number of seconds, low word is number of nanoseconds. */
                 Peripherals.Counter.latched_wallclock_time_split = (ts.tv_sec << 32) | ts.tv_nsec;
             }
 
@@ -134,7 +134,7 @@ uint8_t PeripheralsReadByte (uint8_t Addr)
 
 
 void PeripheralsInit (void)
-/* Initialize the peripheral registers */
+/* Initialize the peripherals. */
 {
     /* Initialize the COUNTER peripheral */
 

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -1,0 +1,159 @@
+/*****************************************************************************/
+/*                                                                           */
+/*                             peripherals.c                                 */
+/*                                                                           */
+/*        Memory-mapped peripheral subsystem for the 6502 simulator          */
+/*                                                                           */
+/*                                                                           */
+/*                                                                           */
+/* (C) 2024-2025, Sidney Cadot                                               */
+/*                                                                           */
+/*                                                                           */
+/* This software is provided 'as-is', without any expressed or implied       */
+/* warranty.  In no event will the authors be held liable for any damages    */
+/* arising from the use of this software.                                    */
+/*                                                                           */
+/* Permission is granted to anyone to use this software for any purpose,     */
+/* including commercial applications, and to alter it and redistribute it    */
+/* freely, subject to the following restrictions:                            */
+/*                                                                           */
+/* 1. The origin of this software must not be misrepresented; you must not   */
+/*    claim that you wrote the original software. If you use this software   */
+/*    in a product, an acknowledgment in the product documentation would be  */
+/*    appreciated but is not required.                                       */
+/* 2. Altered source versions must be plainly marked as such, and must not   */
+/*    be misrepresented as being the original software.                      */
+/* 3. This notice may not be removed or altered from any source              */
+/*    distribution.                                                          */
+/*                                                                           */
+/*****************************************************************************/
+
+
+
+#include <time.h>
+#include "peripherals.h"
+
+
+/*****************************************************************************/
+/*                                   Data                                    */
+/*****************************************************************************/
+
+
+
+/* The peripheral registers. */
+PeripheralRegs PRegs;
+
+
+
+/*****************************************************************************/
+/*                                   Code                                    */
+/*****************************************************************************/
+
+
+
+static uint64_t get_uint64_wallclock_time(void)
+{
+    struct timespec ts;
+    int result = clock_gettime(CLOCK_REALTIME, &ts);
+    if (result != 0)
+    {
+        // On failure, time will be set to the max value.
+        return 0xffffffffffffffff;
+    }
+
+    /* Return time since the 1-1-1970 epoch, in nanoseconds.
+     * Note that this time may be off by an integer number of seconds, as POSIX
+     * maintaines that all days are 86,400 seconds long, which is not true due to
+     * leap seconds.
+     */
+    return ts.tv_sec * 1000000000 + ts.tv_nsec;
+}
+
+
+
+void PeripheralWriteByte (uint8_t Addr, uint8_t Val)
+/* Write a byte to a memory location in the peripheral address aperture. */
+{
+    switch (Addr) {
+        case PERIPHERALS_ADDRESS_OFFSET_LATCH: {
+            /* A write to the "latch" register performs a simultaneous latch of all registers */
+
+            /* Latch the current wallclock time first. */
+            PRegs.latched_wallclock_time = get_uint64_wallclock_time();
+
+            /* Now latch all the cycles maintained by the processor. */
+            PRegs.latched_counter_clock_cycles = PRegs.latched_counter_clock_cycles;
+            PRegs.latched_counter_instructions = PRegs.latched_counter_instructions;
+            PRegs.latched_counter_irq_events = PRegs.latched_counter_irq_events;
+            PRegs.latched_counter_nmi_events = PRegs.latched_counter_nmi_events;
+            break;
+        }
+        case PERIPHERALS_ADDRESS_OFFSET_SELECT: {
+            /* Set the value of the visibility-selection register. */
+            PRegs.visible_latch_register = Val;
+            break;
+        }
+        default: {
+            /* Any other write is ignored */
+        }
+    }
+}
+
+
+
+uint8_t PeripheralReadByte (uint8_t Addr)
+/* Read a byte from a memory location in the peripheral address aperture. */
+{
+    switch (Addr) {
+        case PERIPHERALS_ADDRESS_OFFSET_SELECT: {
+            return PRegs.visible_latch_register;
+        }
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 0:
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 1:
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 2:
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 3:
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 4:
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 5:
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 6:
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 7: {
+            /* Read from any of the eight counter bytes.
+             * The first byte is the 64 bit value's LSB, the seventh byte is its MSB.
+             */
+            unsigned byte_select = Addr - PERIPHERALS_ADDRESS_OFFSET_REG64; /* 0 .. 7 */
+            uint64_t value;
+            switch (PRegs.visible_latch_register) {
+                case PERIPHERALS_REG64_SELECT_CLOCKCYCLE_COUNTER: value = PRegs.latched_counter_clock_cycles; break;
+                case PERIPHERALS_REG64_SELECT_INSTRUCTION_COUNTER: value = PRegs.latched_counter_instructions; break;
+                case PERIPHERALS_REG64_SELECT_IRQ_COUNTER: value = PRegs.latched_counter_irq_events; break;
+                case PERIPHERALS_REG64_SELECT_NMI_COUNTER: value = PRegs.latched_counter_nmi_events; break;
+                case PERIPHERALS_REG64_SELECT_WALLCLOCK_TIME: value = PRegs.latched_wallclock_time; break;
+                default: value = 0; /* Reading from a non-supported register will yield 0. */
+            }
+            /* Return the desired byte of the latched counter. 0==LSB, 7==MSB. */
+            return value >> (byte_select * 8);
+        }
+        default: {
+            /* Any other read yields a zero value. */
+            return 0;
+        }
+    }
+}
+
+
+
+void PeripheralsInit (void)
+/* Initialize the peripheral registers */
+{
+    PRegs.counter_clock_cycles = 0;
+    PRegs.counter_instructions = 0;
+    PRegs.counter_irq_events = 0;
+    PRegs.counter_nmi_events = 0;
+
+    PRegs.latched_counter_clock_cycles = 0;
+    PRegs.latched_counter_instructions = 0;
+    PRegs.latched_counter_irq_events = 0;
+    PRegs.latched_counter_nmi_events = 0;
+    PRegs.latched_wallclock_time = 0;
+
+    PRegs.visible_latch_register = 0;
+}

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -29,7 +29,6 @@
 /*****************************************************************************/
 
 
-
 #include <time.h>
 #include "peripherals.h"
 
@@ -72,7 +71,7 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
                 /* Wallclock time: number of nanoseconds since 1-1-1970. */
                 Peripherals.Counter.LatchedWallclockTime = 1000000000u * ts.tv_sec + ts.tv_nsec;
                 /* Wallclock time, split: high word is number of seconds since 1-1-1970,
-		 * low word is number of nanoseconds since the start of that second. */
+                 * low word is number of nanoseconds since the start of that second. */
                 Peripherals.Counter.LatchedWallclockTimeSplit = (ts.tv_sec << 32) | ts.tv_nsec;
             }
 
@@ -105,7 +104,7 @@ uint8_t PeripheralsReadByte (uint8_t Addr)
     switch (Addr) {
 
         /* Handle reads from the Counter peripheral. */
-      
+
         case PERIPHERALS_COUNTER_ADDRESS_OFFSET_SELECT: {
             return Peripherals.Counter.LatchedValueSelected;
         }

--- a/src/sim65/peripherals.h
+++ b/src/sim65/peripherals.h
@@ -59,27 +59,29 @@
 
 typedef struct {
     /* The invisible counters that keep processor state. */
-    uint64_t clock_cycles;
-    uint64_t cpu_instructions;
-    uint64_t irq_events;
-    uint64_t nmi_events;
-    /* Latched counters upon a write to the PERIPHERALS_COUNTER_LATCH address.
+    uint64_t ClockCycles;
+    uint64_t CpuInstructions;
+    uint64_t IrqEvents;
+    uint64_t NmiEvents;
+    /* The 'latched_...' fields below hold values that are sampled upon a write
+     * to the PERIPHERALS_COUNTER_LATCH address.
      * One of these will be visible (read only) through an eight-byte aperture.
      * The purpose of these latched registers is to read 64-bit values one byte
      * at a time, without having to worry that their content will change along
      * the way.
      */
-    uint64_t latched_clock_cycles;
-    uint64_t latched_cpu_instructions;
-    uint64_t latched_irq_events;
-    uint64_t latched_nmi_events;
-    uint64_t latched_wallclock_time;
-    uint64_t latched_wallclock_time_split;
+    uint64_t LatchedClockCycles;
+    uint64_t LatchedCpuInstructions;
+    uint64_t LatchedIrqEvents;
+    uint64_t LatchedNmiEvents;
+    uint64_t LatchedWallclockTime;
+    uint64_t LatchedWallclockTimeSplit;
     /* Select which of the six latched registers will be visible.
-     * This is a single byte, read/write register, accessible via address PERIPHERALS_COUNTER_SELECT.
-     * If a non-existent latch register is selected, the PERIPHERALS_REGS64 value will be zero.
+     * This is a single byte, read/write register, accessible via address
+     * PERIPHERALS_COUNTER_SELECT. If a non-existent latch register is selected,
+     * the PERIPHERALS_COUNTER_VALUE will be zero.
      */
-    uint8_t  visible_latch_register;
+    uint8_t LatchedValueSelected;
 } CounterPeripheral;
 
 
@@ -87,8 +89,8 @@ typedef struct {
 /* Declare the 'Sim65Peripherals' type and its single instance 'Peripherals'. */
 
 typedef struct {
-    /* State of the peripherals simulated by sim65.
-     * Currently, there is only one: the COUNTER peripheral. */
+    /* State of the peripherals available in sim65.
+     * Currently, there is only one peripheral: the Counter. */
     CounterPeripheral Counter;
 } Sim65Peripherals;
 

--- a/src/sim65/peripherals.h
+++ b/src/sim65/peripherals.h
@@ -1,0 +1,98 @@
+/*****************************************************************************/
+/*                                                                           */
+/*                             peripherals.h                                 */
+/*                                                                           */
+/*        Memory-mapped peripheral subsystem for the 6502 simulator          */
+/*                                                                           */
+/*                                                                           */
+/*                                                                           */
+/* (C) 2024-2025, Sidney Cadot                                               */
+/*                                                                           */
+/*                                                                           */
+/* This software is provided 'as-is', without any expressed or implied       */
+/* warranty.  In no event will the authors be held liable for any damages    */
+/* arising from the use of this software.                                    */
+/*                                                                           */
+/* Permission is granted to anyone to use this software for any purpose,     */
+/* including commercial applications, and to alter it and redistribute it    */
+/* freely, subject to the following restrictions:                            */
+/*                                                                           */
+/* 1. The origin of this software must not be misrepresented; you must not   */
+/*    claim that you wrote the original software. If you use this software   */
+/*    in a product, an acknowledgment in the product documentation would be  */
+/*    appreciated but is not required.                                       */
+/* 2. Altered source versions must be plainly marked as such, and must not   */
+/*    be misrepresented as being the original software.                      */
+/* 3. This notice may not be removed or altered from any source              */
+/*    distribution.                                                          */
+/*                                                                           */
+/*****************************************************************************/
+
+
+
+#ifndef PERIPHERALS_H
+#define PERIPHERALS_H
+
+#include <stdint.h>
+
+#define PERIPHERALS_APERTURE_BASE_ADDRESS   0xffc0
+#define PERIPHERALS_APERTURE_LAST_ADDRESS   0xffc9
+
+#define PERIPHERALS_ADDRESS_OFFSET_LATCH  0x00
+#define PERIPHERALS_ADDRESS_OFFSET_SELECT 0x01
+#define PERIPHERALS_ADDRESS_OFFSET_REG64  0x02
+
+#define PERIPHERALS_LATCH  (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_LATCH)
+#define PERIPHERALS_SELECT (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_SELECT)
+#define PERIPHERALS_REG64  (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_REG64)
+
+#define PERIPHERALS_REG64_SELECT_CLOCKCYCLE_COUNTER   0x00
+#define PERIPHERALS_REG64_SELECT_INSTRUCTION_COUNTER  0x01
+#define PERIPHERALS_REG64_SELECT_IRQ_COUNTER          0x02
+#define PERIPHERALS_REG64_SELECT_NMI_COUNTER          0x03
+#define PERIPHERALS_REG64_SELECT_WALLCLOCK_TIME       0x80
+
+typedef struct {
+    /* the invisible counters that are continuously updated */
+    uint64_t counter_clock_cycles;
+    uint64_t counter_instructions;
+    uint64_t counter_irq_events;
+    uint64_t counter_nmi_events;
+    /* latched counters upon a write to the 'latch' address.
+     * One of these will be visible (read only) through an each-byte aperture. */
+    uint64_t latched_counter_clock_cycles;
+    uint64_t latched_counter_instructions;
+    uint64_t latched_counter_irq_events;
+    uint64_t latched_counter_nmi_events;
+    uint64_t latched_wallclock_time;
+    /* Select which of the five latched registers will be visible.
+     * This is a Read/Write byte-wide register.
+     * If a non-existent register is selected, the 8-byte aperture will read as zero.
+     */
+    uint8_t  visible_latch_register;
+} PeripheralRegs;
+
+extern PeripheralRegs PRegs;
+
+/*****************************************************************************/
+/*                                   Code                                    */
+/*****************************************************************************/
+
+
+
+void PeripheralWriteByte (uint8_t Addr, uint8_t Val);
+/* Write a byte to a memory location in the peripheral address aperture. */
+
+
+uint8_t PeripheralReadByte (uint8_t Addr);
+/* Read a byte from a memory location in the peripheral address aperture. */
+
+
+void PeripheralsInit (void);
+/* Initialize the peripheral registers */
+
+
+
+/* End of peripherals.h */
+
+#endif

--- a/src/sim65/peripherals.h
+++ b/src/sim65/peripherals.h
@@ -109,7 +109,7 @@ uint8_t PeripheralsReadByte (uint8_t Addr);
 
 
 void PeripheralsInit (void);
-/* Initialize the peripheral registers */
+/* Initialize the peripherals. */
 
 
 

--- a/src/sim65/peripherals.h
+++ b/src/sim65/peripherals.h
@@ -35,44 +35,64 @@
 
 #include <stdint.h>
 
-#define PERIPHERALS_APERTURE_BASE_ADDRESS   0xffc0
-#define PERIPHERALS_APERTURE_LAST_ADDRESS   0xffc9
+/* The memory range where the memory-mapped peripherals can be accessed. */
 
-#define PERIPHERALS_ADDRESS_OFFSET_LATCH  0x00
-#define PERIPHERALS_ADDRESS_OFFSET_SELECT 0x01
-#define PERIPHERALS_ADDRESS_OFFSET_REG64  0x02
+#define PERIPHERALS_APERTURE_BASE_ADDRESS  0xffc0
+#define PERIPHERALS_APERTURE_LAST_ADDRESS  0xffc9
 
-#define PERIPHERALS_LATCH  (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_LATCH)
-#define PERIPHERALS_SELECT (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_SELECT)
-#define PERIPHERALS_REG64  (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_REG64)
+/* Declarations for the COUNTER peripheral (currently the only peripheral). */
 
-#define PERIPHERALS_REG64_SELECT_CLOCKCYCLE_COUNTER   0x00
-#define PERIPHERALS_REG64_SELECT_INSTRUCTION_COUNTER  0x01
-#define PERIPHERALS_REG64_SELECT_IRQ_COUNTER          0x02
-#define PERIPHERALS_REG64_SELECT_NMI_COUNTER          0x03
-#define PERIPHERALS_REG64_SELECT_WALLCLOCK_TIME       0x80
+#define PERIPHERALS_COUNTER_ADDRESS_OFFSET_LATCH   0x00
+#define PERIPHERALS_COUNTER_ADDRESS_OFFSET_SELECT  0x01
+#define PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE   0x02
+
+#define PERIPHERALS_COUNTER_LATCH   (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_COUNTER_LATCH)
+#define PERIPHERALS_COUNTER_SELECT  (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_COUNTER_SELECT)
+#define PERIPHERALS_COUNTER_VALUE   (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_COUNTER)
+
+#define PERIPHERALS_COUNTER_SELECT_CLOCKCYCLE_COUNTER    0x00
+#define PERIPHERALS_COUNTER_SELECT_INSTRUCTION_COUNTER   0x01
+#define PERIPHERALS_COUNTER_SELECT_IRQ_COUNTER           0x02
+#define PERIPHERALS_COUNTER_SELECT_NMI_COUNTER           0x03
+#define PERIPHERALS_COUNTER_SELECT_WALLCLOCK_TIME        0x80
+#define PERIPHERALS_COUNTER_SELECT_WALLCLOCK_TIME_SPLIT  0x81
 
 typedef struct {
-    /* the invisible counters that are continuously updated */
-    uint64_t counter_clock_cycles;
-    uint64_t counter_instructions;
-    uint64_t counter_irq_events;
-    uint64_t counter_nmi_events;
-    /* latched counters upon a write to the 'latch' address.
-     * One of these will be visible (read only) through an each-byte aperture. */
-    uint64_t latched_counter_clock_cycles;
-    uint64_t latched_counter_instructions;
-    uint64_t latched_counter_irq_events;
-    uint64_t latched_counter_nmi_events;
+    /* The invisible counters that keep processor state. */
+    uint64_t clock_cycles;
+    uint64_t cpu_instructions;
+    uint64_t irq_events;
+    uint64_t nmi_events;
+    /* Latched counters upon a write to the PERIPHERALS_COUNTER_LATCH address.
+     * One of these will be visible (read only) through an eight-byte aperture.
+     * The purpose of these latched registers is to read 64-bit values one byte
+     * at a time, without having to worry that their content will change along
+     * the way.
+     */
+    uint64_t latched_clock_cycles;
+    uint64_t latched_cpu_instructions;
+    uint64_t latched_irq_events;
+    uint64_t latched_nmi_events;
     uint64_t latched_wallclock_time;
-    /* Select which of the five latched registers will be visible.
-     * This is a Read/Write byte-wide register.
-     * If a non-existent register is selected, the 8-byte aperture will read as zero.
+    uint64_t latched_wallclock_time_split;
+    /* Select which of the six latched registers will be visible.
+     * This is a single byte, read/write register, accessible via address PERIPHERALS_COUNTER_SELECT.
+     * If a non-existent latch register is selected, the PERIPHERALS_REGS64 value will be zero.
      */
     uint8_t  visible_latch_register;
-} PeripheralRegs;
+} CounterPeripheral;
 
-extern PeripheralRegs PRegs;
+
+
+/* Declare the 'Sim65Peripherals' type and its single instance 'Peripherals'. */
+
+typedef struct {
+    /* State of the peripherals simulated by sim65.
+     * Currently, there is only one: the COUNTER peripheral. */
+    CounterPeripheral Counter;
+} Sim65Peripherals;
+
+extern Sim65Peripherals Peripherals;
 
 /*****************************************************************************/
 /*                                   Code                                    */
@@ -80,11 +100,11 @@ extern PeripheralRegs PRegs;
 
 
 
-void PeripheralWriteByte (uint8_t Addr, uint8_t Val);
+void PeripheralsWriteByte (uint8_t Addr, uint8_t Val);
 /* Write a byte to a memory location in the peripheral address aperture. */
 
 
-uint8_t PeripheralReadByte (uint8_t Addr);
+uint8_t PeripheralsReadByte (uint8_t Addr);
 /* Read a byte from a memory location in the peripheral address aperture. */
 
 


### PR DESCRIPTION
This PR fixes all remaining discrepancies of sim65 instruction timings, for both the 6502 and the 65C02 processors.
    
The timings as implemented in this PR have been verified against actual hardware (Atari 800 XL for 6502; and WDC 65C02 for 65C02).

These timings can also be verified against the 65x02 test suite. However, in this case, a single discrepancy arises; the 65x02 testsuite suggests that the 65C02 opcode 0x5c should take 4 clocks. However, tests on a hardware 65C02 have conclusively shown that this instruction takes 8 clock cycles. The 8 clock cycles duration for the 65C02 0xfc opcode is also confirmed by other sources, e.g. Section 9 of http://www.6502.org/tutorials/65c02opcodes.html. This discrepancy had been reported as a bug to the 65x02 repository (https://github.com/SingleStepTests/65x02/issues/12).

This test makes sim65 correct both in terms of functionality (all opcodes now do what they do on hardware) and in terms of timing (all instructions take as long as they would on real hardware).
    
The one discrepancy that remains, is that on a real 6502/65C02, some instructions issue R or W cycles on the bus while the instruction processing is being done. Those spurious bus cycles are not replicated in sim65. Sim65 is thus an instruction-level simulator, rather than a bus-cycle level simulator. In other words, while the clock cycle counts for each instruction are now correct, not all clock cycles are individually simulated.