### PR TITLE
sim65: add memory-mapped cycle/instruction/wallclock timer.

### DIFF
--- a/cfg/sim6502.cfg
+++ b/cfg/sim6502.cfg
@@ -5,7 +5,7 @@ SYMBOLS {
 MEMORY {
     ZP:     file = "",               start = $0000, size = $0100;
     HEADER: file = %O,               start = $0000, size = $000C;
-    MAIN:   file = %O, define = yes, start = $0200, size = $FDF0 - __STACKSIZE__;
+    MAIN:   file = %O, define = yes, start = $0200, size = $FDC0 - __STACKSIZE__;
 }
 SEGMENTS {
     ZEROPAGE: load = ZP,     type = zp;

--- a/cfg/sim65c02.cfg
+++ b/cfg/sim65c02.cfg
@@ -5,7 +5,7 @@ SYMBOLS {
 MEMORY {
     ZP:     file = "",               start = $0000, size = $0100;
     HEADER: file = %O,               start = $0000, size = $000C;
-    MAIN:   file = %O, define = yes, start = $0200, size = $FDF0 - __STACKSIZE__;
+    MAIN:   file = %O, define = yes, start = $0200, size = $FDC0 - __STACKSIZE__;
 }
 SEGMENTS {
     ZEROPAGE: load = ZP,     type = zp;

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -151,74 +151,6 @@ int main()
 //   sim65 example.prg
 </verb></tscreen>
 
-<sect>Counter peripheral
-
-<p>The sim65 simulator supports a memory-mapped counter peripheral that manages
-a number of 64-bit counters that are continuously updated as the simulator is
-running. For each counter, it also provides a 64 bit "latching" register.
-
-<p>The functionality of the counter peripheral is accessible through 3 registers:
-
-<itemize>
-<item><tt>PERIPHERALS_COUNTER_LATCH</tt> ($FFC0, write-only)
-<item><tt>PERIPHERALS_COUNTER_SELECT</tt> ($FFC1, read/write)
-<item><tt>PERIPHERALS_COUNTER_VALUE</tt> ($FFC2..$FFC9, read-only)
-</itemize>
-
-<p>These three registers are used as follows.
-
-<p>When a program explicitly requests a "counter latch" operation by writing any value
-to the <tt>PERIPHERALS_COUNTER_LATCH</tt> address ($FFC0), all live registers are copied to
-the latch registers. They will keep the latched value until another latch operation
-updates them.
-
-<p>The <tt>PERIPHERALS_COUNTER_SELECT</tt> address ($FFC1) register holds an 8-bit value that
-specifies which 64-bit value is currently readable through the <tt>PERIPHERALS_COUNTER_VALUE</tt>
-address range. Six values are currently defined:
-
-<itemize>
-<item>$00: latched clock cycle counter selected.
-<item>$01: latched CPU instruction counter selected.
-<item>$02: latched IRQ interrupt counter selected.
-<item>$03: latched NMI interrupt counter selected.
-<item>$80: latched wallclock time (nanoseconds) selected.
-<item>$81: latched wallclock time (split s/ns) selected.
-</itemize>
-
-<p>Values $00 to $03 provide access to the latched (frozen) value of their respective live
-counters at the time of the last write to <tt>PERIPHERALS_COUNTER_LATCH</tt> .
-
-<p>When <tt>PERIPHERALS_COUNTER_LATCH</tt> equals $80, the <tt>PERIPHERALS_COUNTER_VALUE</tt>
-will be a 64-bit value corresponding to the number of nanoseconds elapsed since Midnight, Jan 1st,
-1970 UTC.
-
-<p>When <tt>PERIPHERALS_COUNTER_LATCH</tt> equals $81, the high 32 bits of <tt>PERIPHERALS_COUNTER_VALUE</tt>
-will be a 32-bit value corresponding to the number of seconds elapsed since Midnight,
-Jan 1st, 1970 UTC. The low 32 bits of <tt>PERIPHERALS_COUNTER_VALUE</tt> will hold the
-nanoseconds since the start of that seconds.
-
-<p>The two different wallclock-time latch registers are provided for different applications.
-For some applications, the single 64-bit value will be more convenient, while for other
-applications, the split 32/32 bits representations with separate seconds and nanoseconds
-is more convenient.
-
-<p>Note that the definition above given as time since Midnight, Jan 1st, 1970 UTC is an
-approximation, as the implementation depends on the POSIX definition of time which does
-not account for leap seconds.
-
-<p>If the <tt>PERIPHERALS_COUNTER_SELECT</tt> register holds a value other than one of the six
-values described above, all <tt>PERIPHERALS_COUNTER_VALUE</tt> bytes will read as zero.
-
-<p>On reset, <tt>PERIPHERALS_COUNTER_SELECT</tt> is initialized to zero.
-
-<p>The <tt>PERIPHERALS_COUNTER_VALUE</tt> addresses ($FFC2..$FFC9) are used to read to currently
-selected latch register value. Address $FFF2 holds the least significant byte (LSB),
-while address $FFC9 holds the most significant byte (MSB).
-
-<p>On reset, all latch registers are reset to zero. this means that reading any of the
-<tt>PERIPHERALS_COUNTER_VALUE</tt> bytes before a write to <tt>PERIPHERALS_COUNTER_LATCH</tt>
-will yield zero.
-
 <sect>Creating a Test in Assembly<p>
 
 Though a C test may also link with assembly code,
@@ -296,6 +228,72 @@ but if customization is needed <tt/sim6502.cfg/ or <tt/sim65c02.cfg/ might be us
 
 </itemize>
 
+<sect>Counter peripheral
+
+<p>The sim65 simulator supports a memory-mapped counter peripheral that manages
+a number of 64-bit counters that are continuously updated as the simulator is
+running. For each counter, it also provides a 64 bit "latching" register.
+
+<p>The functionality of the counter peripheral is accessible through 3 registers:
+
+<itemize>
+<item><tt>PERIPHERALS_COUNTER_LATCH</tt> ($FFC0, write-only)
+<item><tt>PERIPHERALS_COUNTER_SELECT</tt> ($FFC1, read/write)
+<item><tt>PERIPHERALS_COUNTER_VALUE</tt> ($FFC2..$FFC9, read-only)
+</itemize>
+
+<p>These three registers are used as follows.
+
+<p>When a program explicitly requests a "counter latch" operation by writing any value
+to the <tt>PERIPHERALS_COUNTER_LATCH</tt> address ($FFC0), all live registers are simultaneously
+copied to the latch registers. They will keep the newly latched value until another latch
+operation is requested.
+
+<p>The <tt>PERIPHERALS_COUNTER_SELECT</tt> address ($FFC1) register holds an 8-bit value that
+specifies which 64-bit latch register is currently readable through the <tt>PERIPHERALS_COUNTER_VALUE</tt>
+address range. Six values are currently defined:
+
+<itemize>
+<item>$00: latched clock cycle counter selected.
+<item>$01: latched CPU instruction counter selected.
+<item>$02: latched IRQ interrupt counter selected.
+<item>$03: latched NMI interrupt counter selected.
+<item>$80: latched wallclock time (nanoseconds) selected.
+<item>$81: latched wallclock time (split s/ns) selected.
+</itemize>
+
+<p>Values $00 to $03 provide access to the latched (frozen) value of their respective live
+counters at the time of the last write to <tt>PERIPHERALS_COUNTER_LATCH</tt>.
+
+<p>When <tt>PERIPHERALS_COUNTER_LATCH</tt> equals $80, the <tt>PERIPHERALS_COUNTER_VALUE</tt>
+will be a 64-bit value corresponding to the number of nanoseconds elapsed since Midnight, Jan 1st,
+1970 UTC, at the time of the last latch operation.
+
+<p>When <tt>PERIPHERALS_COUNTER_LATCH</tt> equals $81, the high 32 bits of <tt>PERIPHERALS_COUNTER_VALUE</tt>
+will be a 32-bit value corresponding to the number of seconds elapsed since Midnight,
+Jan 1st, 1970 UTC, at the time of the last latch operation. The low 32 bits of
+<tt>PERIPHERALS_COUNTER_VALUE</tt> will hold the nanoseconds since the start of that second.
+
+<p>The two different wallclock-time latch registers will always refer to precisely the same time instant.
+For some applications, the single 64-bit value measured in nanoseconds will be more convenient, while
+for other applications, the split 32/32 bits representations with separate seconds and nanosecond
+values will be more convenient.
+
+<p>Note that the definition above, with time elapsed measured since Midnight, Jan 1st, 1970 UTC is
+an approximation, as the implementation depends on the way POSIX definition time, which does
+not account for leap seconds (POSIX falsely assumes that all days are precisely 86400 seconds
+long).
+
+<p>On reset, <tt>PERIPHERALS_COUNTER_SELECT</tt> is initialized to zero. If the <tt>PERIPHERALS_COUNTER_SELECT</tt>
+register holds a value other than one of the six values described above, all <tt>PERIPHERALS_COUNTER_VALUE</tt>
+bytes will read as zero.
+
+<p>The <tt>PERIPHERALS_COUNTER_VALUE</tt> addresses ($FFC2..$FFC9) are used to read to currently
+selected 64-bit latch register value. Address $FFC2 holds the least significant byte (LSB),
+while address $FFC9 holds the most significant byte (MSB).
+
+<p>On reset, all latch registers are reset to zero. Reading any of the <tt>PERIPHERALS_COUNTER_VALUE</tt>
+bytes before the first write to <tt>PERIPHERALS_COUNTER_LATCH</tt> will yield zero.
 
 <sect>Copyright<p>
 

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -151,70 +151,73 @@ int main()
 //   sim65 example.prg
 </verb></tscreen>
 
-<sect>Counter peripheral<p>
+<sect>Counter peripheral
 
-The sim65 simulator supports a memory-mapped counter peripheral that manages
+<p>The sim65 simulator supports a memory-mapped counter peripheral that manages
 a number of 64-bit counters that are continuously updated as the simulator is
 running. For each counter, it also provides a 64 bit "latching" register.
 
-The functionality of the counter peripheral is accessible through 3 registers:
+<p>The functionality of the counter peripheral is accessible through 3 registers:
 
-* PERIPHERALS_COUNTER_LATCH ($FFC0, write-only)
-* PERIPHERALS_COUNTER_SELECT ($FFC1, read/write)
-* PERIPHERALS_COUNTER_VALUE ($FFC2..$FFC9, read-only)
+<itemize>
+<item><tt>PERIPHERALS_COUNTER_LATCH</tt> ($FFC0, write-only)
+<item><tt>PERIPHERALS_COUNTER_SELECT</tt> ($FFC1, read/write)
+<item><tt>PERIPHERALS_COUNTER_VALUE</tt> ($FFC2..$FFC9, read-only)
+</itemize>
 
-These three registers are used as follows.
+<p>These three registers are used as follows.
 
-When a program explicitly requests a "counter latch" operation by writing any value
-to the PERIPHERALS_COUNTER_LATCH address ($FFC0), all live registers are copied to
+<p>When a program explicitly requests a "counter latch" operation by writing any value
+to the <tt>PERIPHERALS_COUNTER_LATCH</tt> address ($FFC0), all live registers are copied to
 the latch registers. They will keep the latched value until another latch operation
 updates them.
 
-The PERIPHERALS_COUNTER_SELECT address ($FFC1) register holds an 8-bit value that
-specifies which 64-bit value is currently readable through the PERIPHERALS_COUNTER_VALUE
-address range. Possible values are:
+<p>The <tt>PERIPHERALS_COUNTER_SELECT</tt> address ($FFC1) register holds an 8-bit value that
+specifies which 64-bit value is currently readable through the <tt>PERIPHERALS_COUNTER_VALUE</tt>
+address range. Six values are currently defined:
 
-$00: latched clock cycle counter selected.
-$01: latched CPU instruction counter selected.
-$02: latched IRQ interrupt counter selected.
-$03: latched NMI interrupt counter selected.
+<itemize>
+<item>$00: latched clock cycle counter selected.
+<item>$01: latched CPU instruction counter selected.
+<item>$02: latched IRQ interrupt counter selected.
+<item>$03: latched NMI interrupt counter selected.
+<item>$80: latched wallclock time (nanoseconds) selected.
+<item>$81: latched wallclock time (split s/ns) selected.
+</itemize>
 
-In addition to these counters, two other latch registers are available that are also
-updated when the PERIPHERALS_COUNTER_LATCH address is written:
+<p>Values $00 to $03 provide access to the latched (frozen) value of their respective live
+counters at the time of the last write to <tt>PERIPHERALS_COUNTER_LATCH</tt> .
 
-$80: latched wallclock time (nanoseconds) selected.
-$81: latched wallclock time (split s/ns) selected.
-
-When PERIPHERALS_COUNTER_LATCH equals $80, the PERIPHERALS_COUNTER_VALUE will be a
-64-bit value corresponding to the number of nanoseconds elapsed since Midnight, Jan 1st,
+<p>When <tt>PERIPHERALS_COUNTER_LATCH</tt> equals $80, the <tt>PERIPHERALS_COUNTER_VALUE</tt>
+will be a 64-bit value corresponding to the number of nanoseconds elapsed since Midnight, Jan 1st,
 1970 UTC.
 
-When PERIPHERALS_COUNTER_LATCH equals $81, the high 32 bits of PERIPHERALS_COUNTER_VALUE
+<p>When <tt>PERIPHERALS_COUNTER_LATCH</tt> equals $81, the high 32 bits of <tt>PERIPHERALS_COUNTER_VALUE</tt>
 will be a 32-bit value corresponding to the number of seconds elapsed since Midnight,
-Jan 1st, 1970 UTC. The low 32 bits of PERIPHERALS_COUNTER_VALUE will hold the
+Jan 1st, 1970 UTC. The low 32 bits of <tt>PERIPHERALS_COUNTER_VALUE</tt> will hold the
 nanoseconds since the start of that seconds.
 
-The two different wallclock-time latch registers are provided for different applications.
+<p>The two different wallclock-time latch registers are provided for different applications.
 For some applications, the single 64-bit value will be more convenient, while for other
 applications, the split 32/32 bits representations with separate seconds and nanoseconds
 is more convenient.
 
-Note that the definition above given as "time since Midnight, Jan 1st, 1970 UTC" is an
+<p>Note that the definition above given as time since Midnight, Jan 1st, 1970 UTC is an
 approximation, as the implementation depends on the POSIX definition of time which does
 not account for leap seconds.
 
-If the PERIPHERALS_COUNTER_SELECT register holds a value other than one of the six values
-described above, all PERIPHERALS_COUNTER_VALUE bytes will read as zero.
+<p>If the <tt>PERIPHERALS_COUNTER_SELECT</tt> register holds a value other than one of the six
+values described above, all <tt>PERIPHERALS_COUNTER_VALUE</tt> bytes will read as zero.
 
-On reset, PERIPHERALS_COUNTER_SELECT is initialized to zero.
+<p>On reset, <tt>PERIPHERALS_COUNTER_SELECT</tt> is initialized to zero.
 
-The PERIPHERALS_COUNTER_VALUE addresses ($FFC2..$FFC9) are used to read to currently
+<p>The <tt>PERIPHERALS_COUNTER_VALUE</tt> addresses ($FFC2..$FFC9) are used to read to currently
 selected latch register value. Address $FFF2 holds the least significant byte (LSB),
 while address $FFC9 holds the most significant byte (MSB).
 
-On reset, all latch registers are reset to zero. this means that reading any of the
-PERIPHERALS_COUNTER_VALUE bytes before a write to PERIPHERALS_COUNTER_LATCH will
-yield zero.
+<p>On reset, all latch registers are reset to zero. this means that reading any of the
+<tt>PERIPHERALS_COUNTER_VALUE</tt> bytes before a write to <tt>PERIPHERALS_COUNTER_LATCH</tt>
+will yield zero.
 
 <sect>Creating a Test in Assembly<p>
 

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -265,13 +265,13 @@ address range. Six values are currently defined:
 <p>Values $00 to $03 provide access to the latched (frozen) value of their respective live
 counters at the time of the last write to <tt>PERIPHERALS_COUNTER_LATCH</tt>.
 
-<p>When <tt>PERIPHERALS_COUNTER_LATCH</tt> equals $80, the <tt>PERIPHERALS_COUNTER_VALUE</tt>
-will be a 64-bit value corresponding to the number of nanoseconds elapsed since Midnight, Jan 1st,
-1970 UTC, at the time of the last latch operation.
+<p>When <tt>PERIPHERALS_COUNTER_SELECT</tt> equals $80, the <tt>PERIPHERALS_COUNTER_VALUE</tt>
+will be a 64-bit value corresponding to the number of nanoseconds elapsed since the Unix epoch
+(Midnight, Jan 1st, 1970 UTC), at the time of the last latch operation.
 
-<p>When <tt>PERIPHERALS_COUNTER_LATCH</tt> equals $81, the high 32 bits of <tt>PERIPHERALS_COUNTER_VALUE</tt>
-will be a 32-bit value corresponding to the number of seconds elapsed since Midnight,
-Jan 1st, 1970 UTC, at the time of the last latch operation. The low 32 bits of
+<p>When <tt>PERIPHERALS_COUNTER_SELECT</tt> equals $81, the high 32 bits of <tt>PERIPHERALS_COUNTER_VALUE</tt>
+will be a 32-bit value corresponding to the number of seconds elapsed since the Unix epoch (Midnight, Jan 1st,
+1970 UTC), at the time of the last latch operation. The low 32 bits of
 <tt>PERIPHERALS_COUNTER_VALUE</tt> will hold the nanoseconds since the start of that second.
 
 <p>The two different wallclock-time latch registers will always refer to precisely the same time instant.
@@ -279,10 +279,10 @@ For some applications, the single 64-bit value measured in nanoseconds will be m
 for other applications, the split 32/32 bits representation with separate second and nanosecond
 values will be more convenient.
 
-<p>Note that the definition above, with time elapsed measured since Midnight, Jan 1st, 1970 UTC, is
-an approximation, as the implementation depends on the way POSIX definition time. Unfortunately,
-POSIX does not account for leap seconds; it incorrectly assumes that all days are precisely 86400 seconds
-long.
+<p>Note that the time elapsed since the Unix epoch is an approximation, as the implementation depends on the
+way POSIX defines time-since-the-epoch. Unfortunately, POSIX incorrectly assumes that all days are precisely
+86400 seconds long, which is not true in case of leap seconds. The way this inconsistency is resolved is
+system dependent.
 
 <p>On reset, <tt>PERIPHERALS_COUNTER_SELECT</tt> is initialized to zero. If the <tt>PERIPHERALS_COUNTER_SELECT</tt>
 register holds a value other than one of the six values described above, all <tt>PERIPHERALS_COUNTER_VALUE</tt>

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -276,13 +276,12 @@ Jan 1st, 1970 UTC, at the time of the last latch operation. The low 32 bits of
 
 <p>The two different wallclock-time latch registers will always refer to precisely the same time instant.
 For some applications, the single 64-bit value measured in nanoseconds will be more convenient, while
-for other applications, the split 32/32 bits representations with separate seconds and nanosecond
+for other applications, the split 32/32 bits representations with separate second and nanosecond
 values will be more convenient.
 
-<p>Note that the definition above, with time elapsed measured since Midnight, Jan 1st, 1970 UTC is
-an approximation, as the implementation depends on the way POSIX definition time, which does
-not account for leap seconds (POSIX falsely assumes that all days are precisely 86400 seconds
-long).
+<p>Note that the definition above, with time elapsed measured since Midnight, Jan 1st, 1970 UTC, is
+an approximation, as the implementation depends on the way POSIX definition time, and POSIX does
+not account for leap seconds; it falsely assumes that all days are precisely 86400 seconds long.
 
 <p>On reset, <tt>PERIPHERALS_COUNTER_SELECT</tt> is initialized to zero. If the <tt>PERIPHERALS_COUNTER_SELECT</tt>
 register holds a value other than one of the six values described above, all <tt>PERIPHERALS_COUNTER_VALUE</tt>
@@ -294,6 +293,39 @@ while address $FFC9 holds the most significant byte (MSB).
 
 <p>On reset, all latch registers are reset to zero. Reading any of the <tt>PERIPHERALS_COUNTER_VALUE</tt>
 bytes before the first write to <tt>PERIPHERALS_COUNTER_LATCH</tt> will yield zero.
+
+Example:
+
+<tscreen><verb>
+#include <stdio.h>
+#include <stdint.h>
+
+volatile uint8_t  * CounterLatch  = (uint8_t *)0xffc0;
+volatile uint8_t  * CounterSelect = (uint8_t *)0xffc1;
+volatile uint32_t * CounterValue  = (uint32_t *)0xffc1;
+
+static void print_current_counters(void)
+{
+    *CounterLatch = 0; /* latch values */
+
+    *CounterSelect = 0x00;
+    printf("clock cycles ............... : %08lx %08lx\n", CounterValue[1], CounterValue[0]);
+    *CounterSelect = 0x01;
+    printf("instructions ............... : %08lx %08lx\n", CounterValue[1], CounterValue[0]);
+    *CounterSelect = 0x80;
+    printf("wallclock time ............. : %08lx %08lx\n", CounterValue[1], CounterValue[0]);
+    *CounterSelect = 0x81;
+    printf("wallclock time, split ...... : %08lx %08lx\n", CounterValue[1], CounterValue[0]);
+    printf("\n");
+}
+
+int main(void)
+{
+    print_current_counters();
+    print_current_counters();
+    return 0;
+}
+</verb></tscreen>
 
 <sect>Copyright<p>
 

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -246,7 +246,7 @@ running. For each counter, it also provides a 64 bit "latching" register.
 
 <p>When a program explicitly requests a "counter latch" operation by writing any value
 to the <tt>PERIPHERALS_COUNTER_LATCH</tt> address ($FFC0), all live registers are simultaneously
-copied to the latch registers. They will keep the newly latched value until another latch
+copied to the latch registers. They will keep their newly latched values until another latch
 operation is requested.
 
 <p>The <tt>PERIPHERALS_COUNTER_SELECT</tt> address ($FFC1) register holds an 8-bit value that
@@ -259,7 +259,7 @@ address range. Six values are currently defined:
 <item>$02: latched IRQ interrupt counter selected.
 <item>$03: latched NMI interrupt counter selected.
 <item>$80: latched wallclock time (nanoseconds) selected.
-<item>$81: latched wallclock time (split s/ns) selected.
+<item>$81: latched wallclock time (split: seconds, nanoseconds) selected.
 </itemize>
 
 <p>Values $00 to $03 provide access to the latched (frozen) value of their respective live
@@ -276,12 +276,13 @@ Jan 1st, 1970 UTC, at the time of the last latch operation. The low 32 bits of
 
 <p>The two different wallclock-time latch registers will always refer to precisely the same time instant.
 For some applications, the single 64-bit value measured in nanoseconds will be more convenient, while
-for other applications, the split 32/32 bits representations with separate second and nanosecond
+for other applications, the split 32/32 bits representation with separate second and nanosecond
 values will be more convenient.
 
 <p>Note that the definition above, with time elapsed measured since Midnight, Jan 1st, 1970 UTC, is
-an approximation, as the implementation depends on the way POSIX definition time, and POSIX does
-not account for leap seconds; it falsely assumes that all days are precisely 86400 seconds long.
+an approximation, as the implementation depends on the way POSIX definition time. Unfortunately,
+POSIX does not account for leap seconds; it incorrectly assumes that all days are precisely 86400 seconds
+long.
 
 <p>On reset, <tt>PERIPHERALS_COUNTER_SELECT</tt> is initialized to zero. If the <tt>PERIPHERALS_COUNTER_SELECT</tt>
 register holds a value other than one of the six values described above, all <tt>PERIPHERALS_COUNTER_VALUE</tt>
@@ -302,7 +303,7 @@ Example:
 
 volatile uint8_t  * CounterLatch  = (uint8_t *)0xffc0;
 volatile uint8_t  * CounterSelect = (uint8_t *)0xffc1;
-volatile uint32_t * CounterValue  = (uint32_t *)0xffc1;
+volatile uint32_t * CounterValue  = (uint32_t *)0xffc2;
 
 static void print_current_counters(void)
 {

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -151,6 +151,71 @@ int main()
 //   sim65 example.prg
 </verb></tscreen>
 
+<sect>Counter peripheral<p>
+
+The sim65 simulator supports a memory-mapped counter peripheral that manages
+a number of 64-bit counters that are continuously updated as the simulator is
+running. For each counter, it also provides a 64 bit "latching" register.
+
+The functionality of the counter peripheral is accessible through 3 registers:
+
+* PERIPHERALS_COUNTER_LATCH ($FFC0, write-only)
+* PERIPHERALS_COUNTER_SELECT ($FFC1, read/write)
+* PERIPHERALS_COUNTER_VALUE ($FFC2..$FFC9, read-only)
+
+These three registers are used as follows.
+
+When a program explicitly requests a "counter latch" operation by writing any value
+to the PERIPHERALS_COUNTER_LATCH address ($FFC0), all live registers are copied to
+the latch registers. They will keep the latched value until another latch operation
+updates them.
+
+The PERIPHERALS_COUNTER_SELECT address ($FFC1) register holds an 8-bit value that
+specifies which 64-bit value is currently readable through the PERIPHERALS_COUNTER_VALUE
+address range. Possible values are:
+
+$00: latched clock cycle counter selected.
+$01: latched CPU instruction counter selected.
+$02: latched IRQ interrupt counter selected.
+$03: latched NMI interrupt counter selected.
+
+In addition to these counters, two other latch registers are available that are also
+updated when the PERIPHERALS_COUNTER_LATCH address is written:
+
+$80: latched wallclock time (nanoseconds) selected.
+$81: latched wallclock time (split s/ns) selected.
+
+When PERIPHERALS_COUNTER_LATCH equals $80, the PERIPHERALS_COUNTER_VALUE will be a
+64-bit value corresponding to the number of nanoseconds elapsed since Midnight, Jan 1st,
+1970 UTC.
+
+When PERIPHERALS_COUNTER_LATCH equals $81, the high 32 bits of PERIPHERALS_COUNTER_VALUE
+will be a 32-bit value corresponding to the number of seconds elapsed since Midnight,
+Jan 1st, 1970 UTC. The low 32 bits of PERIPHERALS_COUNTER_VALUE will hold the
+nanoseconds since the start of that seconds.
+
+The two different wallclock-time latch registers are provided for different applications.
+For some applications, the single 64-bit value will be more convenient, while for other
+applications, the split 32/32 bits representations with separate seconds and nanoseconds
+is more convenient.
+
+Note that the definition above given as "time since Midnight, Jan 1st, 1970 UTC" is an
+approximation, as the implementation depends on the POSIX definition of time which does
+not account for leap seconds.
+
+If the PERIPHERALS_COUNTER_SELECT register holds a value other than one of the six values
+described above, all PERIPHERALS_COUNTER_VALUE bytes will read as zero.
+
+On reset, PERIPHERALS_COUNTER_SELECT is initialized to zero.
+
+The PERIPHERALS_COUNTER_VALUE addresses ($FFC2..$FFC9) are used to read to currently
+selected latch register value. Address $FFF2 holds the least significant byte (LSB),
+while address $FFC9 holds the most significant byte (MSB).
+
+On reset, all latch registers are reset to zero. this means that reading any of the
+PERIPHERALS_COUNTER_VALUE bytes before a write to PERIPHERALS_COUNTER_LATCH will
+yield zero.
+
 <sect>Creating a Test in Assembly<p>
 
 Though a C test may also link with assembly code,

--- a/src/sim65.vcxproj
+++ b/src/sim65.vcxproj
@@ -86,6 +86,7 @@
     <ClInclude Include="sim65\error.h" />
     <ClInclude Include="sim65\memory.h" />
     <ClInclude Include="sim65\paravirt.h" />
+    <ClInclude Include="sim65\peripherals.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="sim65\6502.c" />
@@ -93,6 +94,7 @@
     <ClCompile Include="sim65\main.c" />
     <ClCompile Include="sim65\memory.c" />
     <ClCompile Include="sim65\paravirt.c" />
+    <ClInclude Include="sim65\peripherals.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/sim65.vcxproj
+++ b/src/sim65.vcxproj
@@ -82,19 +82,19 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="sim65\peripherals.h" />
     <ClInclude Include="sim65\6502.h" />
     <ClInclude Include="sim65\error.h" />
     <ClInclude Include="sim65\memory.h" />
     <ClInclude Include="sim65\paravirt.h" />
+    <ClInclude Include="sim65\peripherals.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="sim65\peripherals.c" />
     <ClCompile Include="sim65\6502.c" />
     <ClCompile Include="sim65\error.c" />
     <ClCompile Include="sim65\main.c" />
     <ClCompile Include="sim65\memory.c" />
     <ClCompile Include="sim65\paravirt.c" />
+    <ClInclude Include="sim65\peripherals.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/sim65.vcxproj
+++ b/src/sim65.vcxproj
@@ -94,7 +94,7 @@
     <ClCompile Include="sim65\main.c" />
     <ClCompile Include="sim65\memory.c" />
     <ClCompile Include="sim65\paravirt.c" />
-    <ClInclude Include="sim65\peripherals.c" />
+    <ClCompile Include="sim65\peripherals.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/sim65.vcxproj
+++ b/src/sim65.vcxproj
@@ -82,19 +82,19 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="sim65\peripherals.h" />
     <ClInclude Include="sim65\6502.h" />
     <ClInclude Include="sim65\error.h" />
     <ClInclude Include="sim65\memory.h" />
     <ClInclude Include="sim65\paravirt.h" />
-    <ClInclude Include="sim65\peripherals.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="sim65\peripherals.c" />
     <ClCompile Include="sim65\6502.c" />
     <ClCompile Include="sim65\error.c" />
     <ClCompile Include="sim65\main.c" />
     <ClCompile Include="sim65\memory.c" />
     <ClCompile Include="sim65\paravirt.c" />
-    <ClInclude Include="sim65\peripherals.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/sim65/6502.c
+++ b/src/sim65/6502.c
@@ -4108,7 +4108,7 @@ unsigned ExecuteInsn (void)
     if (HaveNMIRequest) {
 
         HaveNMIRequest = 0;
-        Peripherals.Counter.nmi_events += 1;
+        Peripherals.Counter.NmiEvents += 1;
 
         PUSH (PCH);
         PUSH (PCL);
@@ -4124,7 +4124,7 @@ unsigned ExecuteInsn (void)
     } else if (HaveIRQRequest && GET_IF () == 0) {
 
         HaveIRQRequest = 0;
-        Peripherals.Counter.irq_events += 1;
+        Peripherals.Counter.IrqEvents += 1;
 
         PUSH (PCH);
         PUSH (PCL);
@@ -4146,11 +4146,11 @@ unsigned ExecuteInsn (void)
         Handlers[CPU][OPC] ();
 
         /* Increment the instruction counter by one.NMIs and IRQs are counted separately. */
-        Peripherals.Counter.cpu_instructions += 1;
+        Peripherals.Counter.CpuInstructions += 1;
     }
 
-    /* Increment the 64-bit clock cycle counter with the cycle count for the instruction that we just executed */
-    Peripherals.Counter.clock_cycles += Cycles;
+    /* Increment the 64-bit clock cycle counter with the cycle count for the instruction that we just executed. */
+    Peripherals.Counter.ClockCycles += Cycles;
 
     /* Return the number of clock cycles needed by this insn */
     return Cycles;

--- a/src/sim65/6502.c
+++ b/src/sim65/6502.c
@@ -4108,7 +4108,7 @@ unsigned ExecuteInsn (void)
     if (HaveNMIRequest) {
 
         HaveNMIRequest = 0;
-        PRegs.counter_nmi_events += 1;
+        Peripherals.Counter.nmi_events += 1;
 
         PUSH (PCH);
         PUSH (PCL);
@@ -4124,7 +4124,7 @@ unsigned ExecuteInsn (void)
     } else if (HaveIRQRequest && GET_IF () == 0) {
 
         HaveIRQRequest = 0;
-        PRegs.counter_irq_events += 1;
+        Peripherals.Counter.irq_events += 1;
 
         PUSH (PCH);
         PUSH (PCL);
@@ -4146,11 +4146,11 @@ unsigned ExecuteInsn (void)
         Handlers[CPU][OPC] ();
 
         /* Increment the instruction counter by one.NMIs and IRQs are counted separately. */
-        PRegs.counter_instructions += 1;
+        Peripherals.Counter.cpu_instructions += 1;
     }
 
     /* Increment the 64-bit clock cycle counter with the cycle count for the instruction that we just executed */
-    PRegs.counter_clock_cycles += Cycles;
+    Peripherals.Counter.clock_cycles += Cycles;
 
     /* Return the number of clock cycles needed by this insn */
     return Cycles;

--- a/src/sim65/error.c
+++ b/src/sim65/error.c
@@ -118,7 +118,7 @@ void SimExit (int Code)
 /* Exit the simulation with an exit code */
 {
     if (PrintCycles) {
-        fprintf (stdout, PRIu64 " cycles\n", PRegs.counter_clock_cycles);
+        fprintf (stdout, "%" PRIu64 " cycles\n", PRegs.counter_clock_cycles);
     }
     exit (Code);
 }

--- a/src/sim65/error.c
+++ b/src/sim65/error.c
@@ -118,7 +118,7 @@ void SimExit (int Code)
 /* Exit the simulation with an exit code */
 {
     if (PrintCycles) {
-        fprintf (stdout, "%" PRIu64 " cycles\n", Peripherals.Counter.clock_cycles);
+        fprintf (stdout, "%" PRIu64 " cycles\n", Peripherals.Counter.ClockCycles);
     }
     exit (Code);
 }

--- a/src/sim65/error.c
+++ b/src/sim65/error.c
@@ -36,9 +36,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <inttypes.h>
 
 #include "error.h"
-
+#include "peripherals.h"
 
 
 /*****************************************************************************/
@@ -49,9 +50,6 @@
 
 /* flag to print cycles at program termination */
 int PrintCycles = 0;
-
-/* cycles are counted by main.c */
-extern unsigned long long TotalCycles;
 
 
 
@@ -120,7 +118,7 @@ void SimExit (int Code)
 /* Exit the simulation with an exit code */
 {
     if (PrintCycles) {
-        fprintf (stdout, "%llu cycles\n", TotalCycles);
+        fprintf (stdout, PRIu64 " cycles\n", PRegs.counter_clock_cycles);
     }
     exit (Code);
 }

--- a/src/sim65/error.c
+++ b/src/sim65/error.c
@@ -118,7 +118,7 @@ void SimExit (int Code)
 /* Exit the simulation with an exit code */
 {
     if (PrintCycles) {
-        fprintf (stdout, "%" PRIu64 " cycles\n", PRegs.counter_clock_cycles);
+        fprintf (stdout, "%" PRIu64 " cycles\n", Peripherals.Counter.clock_cycles);
     }
     exit (Code);
 }

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -47,6 +47,7 @@
 #include "6502.h"
 #include "error.h"
 #include "memory.h"
+#include "peripherals.h"
 #include "paravirt.h"
 
 
@@ -59,9 +60,6 @@
 
 /* Name of program file */
 const char* ProgramFile;
-
-/* count of total cycles executed */
-unsigned long long TotalCycles = 0;
 
 /* exit simulator after MaxCycles Cccles */
 unsigned long long MaxCycles = 0;
@@ -309,6 +307,7 @@ int main (int argc, char* argv[])
     }
 
     MemInit ();
+    PeripheralsInit ();
 
     SPAddr = ReadProgramFile ();
     ParaVirtInit (I, SPAddr);
@@ -318,7 +317,6 @@ int main (int argc, char* argv[])
     RemainCycles = MaxCycles;
     while (1) {
         Cycles = ExecuteInsn ();
-        TotalCycles += Cycles;
         if (MaxCycles) {
             if (Cycles > RemainCycles) {
                 ErrorCode (SIM65_ERROR_TIMEOUT, "Maximum number of cycles reached.");

--- a/src/sim65/memory.c
+++ b/src/sim65/memory.c
@@ -36,7 +36,7 @@
 #include <string.h>
 
 #include "memory.h"
-
+#include "peripherals.h"
 
 
 /*****************************************************************************/
@@ -59,7 +59,14 @@ uint8_t Mem[0x10000];
 void MemWriteByte (uint16_t Addr, uint8_t Val)
 /* Write a byte to a memory location */
 {
-    Mem[Addr] = Val;
+    if ((PERIPHERALS_APERTURE_BASE_ADDRESS <= Addr) && (Addr <= PERIPHERALS_APERTURE_LAST_ADDRESS))
+    {
+        /* Defer the the memory-mapped peripherals handler for this write. */
+        PeripheralWriteByte (Addr - PERIPHERALS_APERTURE_BASE_ADDRESS, Val);
+    } else {
+        /* Write to the Mem array. */
+        Mem[Addr] = Val;
+    }
 }
 
 
@@ -76,7 +83,14 @@ void MemWriteWord (uint16_t Addr, uint16_t Val)
 uint8_t MemReadByte (uint16_t Addr)
 /* Read a byte from a memory location */
 {
-    return Mem[Addr];
+    if ((PERIPHERALS_APERTURE_BASE_ADDRESS <= Addr) && (Addr <= PERIPHERALS_APERTURE_LAST_ADDRESS))
+    {
+        /* Defer the the memory-mapped peripherals handler for this read. */
+        return PeripheralReadByte (Addr - PERIPHERALS_APERTURE_BASE_ADDRESS);
+    } else {
+        /* Read from the Mem array. */
+        return Mem[Addr];
+    }
 }
 
 

--- a/src/sim65/memory.c
+++ b/src/sim65/memory.c
@@ -62,7 +62,7 @@ void MemWriteByte (uint16_t Addr, uint8_t Val)
     if ((PERIPHERALS_APERTURE_BASE_ADDRESS <= Addr) && (Addr <= PERIPHERALS_APERTURE_LAST_ADDRESS))
     {
         /* Defer the the memory-mapped peripherals handler for this write. */
-        PeripheralWriteByte (Addr - PERIPHERALS_APERTURE_BASE_ADDRESS, Val);
+        PeripheralsWriteByte (Addr - PERIPHERALS_APERTURE_BASE_ADDRESS, Val);
     } else {
         /* Write to the Mem array. */
         Mem[Addr] = Val;
@@ -86,7 +86,7 @@ uint8_t MemReadByte (uint16_t Addr)
     if ((PERIPHERALS_APERTURE_BASE_ADDRESS <= Addr) && (Addr <= PERIPHERALS_APERTURE_LAST_ADDRESS))
     {
         /* Defer the the memory-mapped peripherals handler for this read. */
-        return PeripheralReadByte (Addr - PERIPHERALS_APERTURE_BASE_ADDRESS);
+        return PeripheralsReadByte (Addr - PERIPHERALS_APERTURE_BASE_ADDRESS);
     } else {
         /* Read from the Mem array. */
         return Mem[Addr];

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -164,7 +164,6 @@ uint8_t PeripheralsReadByte (uint8_t Addr)
              */
             unsigned SelectedByteIndex = Addr - PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE; /* 0 .. 7 */
             uint64_t Value;
-            uint8_t SelectedByteValue;
             switch (Peripherals.Counter.LatchedValueSelected) {
                 case PERIPHERALS_COUNTER_SELECT_CLOCKCYCLE_COUNTER: Value = Peripherals.Counter.LatchedClockCycles; break;
                 case PERIPHERALS_COUNTER_SELECT_INSTRUCTION_COUNTER: Value = Peripherals.Counter.LatchedCpuInstructions; break;
@@ -174,9 +173,8 @@ uint8_t PeripheralsReadByte (uint8_t Addr)
                 case PERIPHERALS_COUNTER_SELECT_WALLCLOCK_TIME_SPLIT: Value = Peripherals.Counter.LatchedWallclockTimeSplit; break;
                 default: Value = 0; /* Reading from a non-existent latch register will yield 0. */
             }
-            /* Return the desired byte of the latched counter. 0==LSB, 7==MSB. */
-            SelectedByteValue = Value >> (SelectedByteIndex * 8);
-            return SelectedByteValue;
+            /* Return the desired byte of the latched counter; 0==LSB, 7==MSB. */
+            return (uint8_t)(Value >> (SelectedByteIndex * 8));
         }
 
         /* Handle reads from unused peripheral and write-only addresses. */

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -68,13 +68,14 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
 #if defined(__MINGW64__)
             /* We check for MINGW64 before MINGW32, since MINGW64 also defines __MINGW32__. */
             /* Using timespec_get() in the MinGW64 compiler makes the Linux workflow build fail. */
-            bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
+            //bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
             /* does clock_gettime work? */
-            //bool time_valid = false;
+            bool time_valid = false;
 #elif defined(__MINGW32__)
             /* does timespec_get work? */
             /* does clock_gettime work? */
-            bool time_valid = false;
+            //bool time_valid = false;
+            bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
 #elif defined(_MSC_VER)
             /* clock_gettime() is not available when using the Microsoft compiler. Use timespec_get() instead. */
             bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -61,19 +61,25 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
 
             /* A write to the "latch" register performs a simultaneous latch of all registers. */
 
-            /* Latch the current wallclock time first (if possible). */
+            /* Latch the current wallclock time before doing anything else. */
 
-            struct timespec ts;
+            struct timespec ts; /* Available on all compilers we use. */
 
 #if defined(__MINGW64__)
+            /* We check for MINGW64 before MINGW32, since MINGW64 also defines __MINGW32__. */
+            /* does timespec_get work? */
+            bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
+            /* does clock_gettime work? */
             bool time_valid = false;
 #elif defined(__MINGW32__)
+            /* does timespec_get work? */
+            /* does clock_gettime work? */
             bool time_valid = false;
 #elif defined(_MSC_VER)
-            /* clock_gettime() is not available in the Visual Studio compiler. Use timespec_get() instead. */
+            /* clock_gettime() is not available when using the Microsoft compiler. Use timespec_get() instead. */
             bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
 #else
-            /* clock_gettime() is available on Linux, MacOS, MinGW32, and MinGW64. */
+            /* clock_gettime() is available on Linux and MacOS. */
             bool time_valid = clock_gettime(CLOCK_REALTIME, &ts) == 0;
 #endif
             if (time_valid) {

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -69,7 +69,7 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
             /* clock_gettime() is not available in the Visual Studio compiler. Use timespec_get() instead. */
             bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
 #else
-            /* clock_gettime() is available on Linux, MacOS, MinGW32, and MinGW64.
+            /* clock_gettime() is available on Linux, MacOS, MinGW32, and MinGW64. */
             bool time_valid = clock_gettime(CLOCK_REALTIME, &ts) == 0;
 #endif
             if (time_valid) {

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -61,7 +61,8 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
             /* A write to the "latch" register performs a simultaneous latch of all registers. */
 
             /* Latch the current wallclock time first. */
-#if 0
+#if 1
+            /* Enabling clock_gettime dependent codepath (expected to fail at least on Windows build.) */
             struct timespec ts;
             int result = clock_gettime(CLOCK_REALTIME, &ts);
             if (result != 0) {

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -70,12 +70,13 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
             /* Using timespec_get() in the MinGW64 compiler makes the Linux workflow build fail. */
             //bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
             /* does clock_gettime work? */
-            bool time_valid = false;
-#elif defined(__MINGW32__)
-            /* does timespec_get work? */
-            /* does clock_gettime work? */
+            bool time_valid = clock_gettime(CLOCK_REALTIME, &ts) == 0;
             //bool time_valid = false;
-            bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
+#elif defined(__MINGW32__)
+            /* does timespec_get work? -- yes! */
+            /* does clock_gettime work? */
+            bool time_valid = false;
+            //bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
 #elif defined(_MSC_VER)
             /* clock_gettime() is not available when using the Microsoft compiler. Use timespec_get() instead. */
             bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -72,9 +72,10 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
             bool time_valid = false;
 #elif defined(__MINGW32__)
             /* does timespec_get work? -- yes! */
-            /* does clock_gettime work? */
+            /* does clock_gettime work? -- yes! */
             //bool time_valid = false;
-            bool time_valid = clock_gettime(CLOCK_REALTIME, &ts) == 0;
+            //bool time_valid = clock_gettime(CLOCK_REALTIME, &ts) == 0;
+            #error "MinGW32 compiler was used; we're not handling it."
             //bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
 #elif defined(_MSC_VER)
             /* clock_gettime() is not available when using the Microsoft compiler. Use timespec_get() instead. */

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -82,10 +82,10 @@ void PeripheralWriteByte (uint8_t Addr, uint8_t Val)
             PRegs.latched_wallclock_time = get_uint64_wallclock_time();
 
             /* Now latch all the cycles maintained by the processor. */
-            PRegs.latched_counter_clock_cycles = PRegs.latched_counter_clock_cycles;
-            PRegs.latched_counter_instructions = PRegs.latched_counter_instructions;
-            PRegs.latched_counter_irq_events = PRegs.latched_counter_irq_events;
-            PRegs.latched_counter_nmi_events = PRegs.latched_counter_nmi_events;
+            PRegs.latched_counter_clock_cycles = PRegs.counter_clock_cycles;
+            PRegs.latched_counter_instructions = PRegs.counter_instructions;
+            PRegs.latched_counter_irq_events = PRegs.counter_irq_events;
+            PRegs.latched_counter_nmi_events = PRegs.counter_nmi_events;
             break;
         }
         case PERIPHERALS_ADDRESS_OFFSET_SELECT: {

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -61,6 +61,7 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
             /* A write to the "latch" register performs a simultaneous latch of all registers. */
 
             /* Latch the current wallclock time first. */
+#if 0
             struct timespec ts;
             int result = clock_gettime(CLOCK_REALTIME, &ts);
             if (result != 0) {
@@ -74,6 +75,11 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
                  * low word is number of nanoseconds since the start of that second. */
                 Peripherals.Counter.LatchedWallclockTimeSplit = (ts.tv_sec << 32) | ts.tv_nsec;
             }
+#else
+            /* Temporarily skip call to clock_gettime() to check that we can build for Windows */
+            Peripherals.Counter.LatchedWallclockTime = 0xffffffffffffffff;
+            Peripherals.Counter.LatchedWallclockTimeSplit = 0xffffffffffffffff;
+#endif
 
             /* Latch the counters that reflect the state of the processor. */
             Peripherals.Counter.LatchedClockCycles = Peripherals.Counter.ClockCycles;

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -40,8 +40,8 @@
 
 
 
-/* The peripheral registers. */
-PeripheralRegs PRegs;
+/* The system-wide state of the peripherals */
+Sim65Peripherals Peripherals;
 
 
 
@@ -51,46 +51,37 @@ PeripheralRegs PRegs;
 
 
 
-static uint64_t get_uint64_wallclock_time(void)
-{
-    struct timespec ts;
-    int result = clock_gettime(CLOCK_REALTIME, &ts);
-    if (result != 0)
-    {
-        // On failure, time will be set to the max value.
-        return 0xffffffffffffffff;
-    }
-
-    /* Return time since the 1-1-1970 epoch, in nanoseconds.
-     * Note that this time may be off by an integer number of seconds, as POSIX
-     * maintaines that all days are 86,400 seconds long, which is not true due to
-     * leap seconds.
-     */
-    return ts.tv_sec * 1000000000 + ts.tv_nsec;
-}
-
-
-
-void PeripheralWriteByte (uint8_t Addr, uint8_t Val)
-/* Write a byte to a memory location in the peripheral address aperture. */
+void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
+/* Write a byte to a memory location in the peripherals address aperture. */
 {
     switch (Addr) {
-        case PERIPHERALS_ADDRESS_OFFSET_LATCH: {
-            /* A write to the "latch" register performs a simultaneous latch of all registers */
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_LATCH: {
+            /* A write to the "latch" register performs a simultaneous latch of all registers. */
 
             /* Latch the current wallclock time first. */
-            PRegs.latched_wallclock_time = get_uint64_wallclock_time();
+	    struct timespec ts;
+            int result = clock_gettime(CLOCK_REALTIME, &ts);
+	    if (result != 0) {
+	        /* Unable to read time. Report max uint64 value for both fields. */
+  	        Peripherals.Counter.latched_wallclock_time = 0xffffffffffffffff;
+                Peripherals.Counter.latched_wallclock_time_split = 0xffffffffffffffff;
+	    } else {
+	        /* Number of nanoseconds since 1-1-1970. */
+                Peripherals.Counter.latched_wallclock_time = 1000000000u * ts.tv_sec + ts.tv_nsec;
+	        /* High word is number of seconds, low word is number of nanoseconds. */
+                Peripherals.Counter.latched_wallclock_time_split = (ts.tv_sec << 32) | ts.tv_nsec;
+            }
 
-            /* Now latch all the cycles maintained by the processor. */
-            PRegs.latched_counter_clock_cycles = PRegs.counter_clock_cycles;
-            PRegs.latched_counter_instructions = PRegs.counter_instructions;
-            PRegs.latched_counter_irq_events = PRegs.counter_irq_events;
-            PRegs.latched_counter_nmi_events = PRegs.counter_nmi_events;
+            /* Latch the counters that reflect the state of the processor. */
+            Peripherals.Counter.latched_clock_cycles = Peripherals.Counter.clock_cycles;
+            Peripherals.Counter.latched_cpu_instructions = Peripherals.Counter.cpu_instructions;
+            Peripherals.Counter.latched_irq_events = Peripherals.Counter.irq_events;
+            Peripherals.Counter.latched_nmi_events = Peripherals.Counter.nmi_events;
             break;
         }
-        case PERIPHERALS_ADDRESS_OFFSET_SELECT: {
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_SELECT: {
             /* Set the value of the visibility-selection register. */
-            PRegs.visible_latch_register = Val;
+            Peripherals.Counter.visible_latch_register = Val;
             break;
         }
         default: {
@@ -101,33 +92,34 @@ void PeripheralWriteByte (uint8_t Addr, uint8_t Val)
 
 
 
-uint8_t PeripheralReadByte (uint8_t Addr)
-/* Read a byte from a memory location in the peripheral address aperture. */
+uint8_t PeripheralsReadByte (uint8_t Addr)
+/* Read a byte from a memory location in the peripherals address aperture. */
 {
     switch (Addr) {
-        case PERIPHERALS_ADDRESS_OFFSET_SELECT: {
-            return PRegs.visible_latch_register;
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_SELECT: {
+            return Peripherals.Counter.visible_latch_register;
         }
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 0:
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 1:
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 2:
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 3:
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 4:
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 5:
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 6:
-        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 7: {
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 0:
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 1:
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 2:
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 3:
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 4:
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 5:
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 6:
+        case PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE + 7: {
             /* Read from any of the eight counter bytes.
              * The first byte is the 64 bit value's LSB, the seventh byte is its MSB.
              */
-            unsigned byte_select = Addr - PERIPHERALS_ADDRESS_OFFSET_REG64; /* 0 .. 7 */
+            unsigned byte_select = Addr - PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE; /* 0 .. 7 */
             uint64_t value;
-            switch (PRegs.visible_latch_register) {
-                case PERIPHERALS_REG64_SELECT_CLOCKCYCLE_COUNTER: value = PRegs.latched_counter_clock_cycles; break;
-                case PERIPHERALS_REG64_SELECT_INSTRUCTION_COUNTER: value = PRegs.latched_counter_instructions; break;
-                case PERIPHERALS_REG64_SELECT_IRQ_COUNTER: value = PRegs.latched_counter_irq_events; break;
-                case PERIPHERALS_REG64_SELECT_NMI_COUNTER: value = PRegs.latched_counter_nmi_events; break;
-                case PERIPHERALS_REG64_SELECT_WALLCLOCK_TIME: value = PRegs.latched_wallclock_time; break;
-                default: value = 0; /* Reading from a non-supported register will yield 0. */
+            switch (Peripherals.Counter.visible_latch_register) {
+                case PERIPHERALS_COUNTER_SELECT_CLOCKCYCLE_COUNTER: value = Peripherals.Counter.latched_clock_cycles; break;
+                case PERIPHERALS_COUNTER_SELECT_INSTRUCTION_COUNTER: value = Peripherals.Counter.latched_cpu_instructions; break;
+                case PERIPHERALS_COUNTER_SELECT_IRQ_COUNTER: value = Peripherals.Counter.latched_irq_events; break;
+                case PERIPHERALS_COUNTER_SELECT_NMI_COUNTER: value = Peripherals.Counter.latched_nmi_events; break;
+                case PERIPHERALS_COUNTER_SELECT_WALLCLOCK_TIME: value = Peripherals.Counter.latched_wallclock_time; break;
+                case PERIPHERALS_COUNTER_SELECT_WALLCLOCK_TIME_SPLIT: value = Peripherals.Counter.latched_wallclock_time_split; break;
+                default: value = 0; /* Reading from a non-existent register will yield 0. */
             }
             /* Return the desired byte of the latched counter. 0==LSB, 7==MSB. */
             return value >> (byte_select * 8);
@@ -144,16 +136,19 @@ uint8_t PeripheralReadByte (uint8_t Addr)
 void PeripheralsInit (void)
 /* Initialize the peripheral registers */
 {
-    PRegs.counter_clock_cycles = 0;
-    PRegs.counter_instructions = 0;
-    PRegs.counter_irq_events = 0;
-    PRegs.counter_nmi_events = 0;
+    /* Initialize the COUNTER peripheral */
 
-    PRegs.latched_counter_clock_cycles = 0;
-    PRegs.latched_counter_instructions = 0;
-    PRegs.latched_counter_irq_events = 0;
-    PRegs.latched_counter_nmi_events = 0;
-    PRegs.latched_wallclock_time = 0;
+    Peripherals.Counter.clock_cycles = 0;
+    Peripherals.Counter.cpu_instructions = 0;
+    Peripherals.Counter.irq_events = 0;
+    Peripherals.Counter.nmi_events = 0;
 
-    PRegs.visible_latch_register = 0;
+    Peripherals.Counter.latched_clock_cycles = 0;
+    Peripherals.Counter.latched_cpu_instructions = 0;
+    Peripherals.Counter.latched_irq_events = 0;
+    Peripherals.Counter.latched_nmi_events = 0;
+    Peripherals.Counter.latched_wallclock_time = 0;
+    Peripherals.Counter.latched_wallclock_time_split = 0;
+
+    Peripherals.Counter.visible_latch_register = 0;
 }

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -68,14 +68,13 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
 #if defined(__MINGW64__)
             /* We check for MINGW64 before MINGW32, since MINGW64 also defines __MINGW32__. */
             /* Using timespec_get() in the MinGW64 compiler makes the Linux workflow build fail. */
-            //bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
-            /* does clock_gettime work? */
-            bool time_valid = clock_gettime(CLOCK_REALTIME, &ts) == 0;
-            //bool time_valid = false;
+            /* Using clock_gettime() in the MinGW64 compiler makes the Linux workflow build fail. */
+            bool time_valid = false;
 #elif defined(__MINGW32__)
             /* does timespec_get work? -- yes! */
             /* does clock_gettime work? */
-            bool time_valid = false;
+            //bool time_valid = false;
+            bool time_valid = clock_gettime(CLOCK_REALTIME, &ts) == 0;
             //bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
 #elif defined(_MSC_VER)
             /* clock_gettime() is not available when using the Microsoft compiler. Use timespec_get() instead. */

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -59,16 +59,16 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
             /* A write to the "latch" register performs a simultaneous latch of all registers. */
 
             /* Latch the current wallclock time first. */
-	    struct timespec ts;
+            struct timespec ts;
             int result = clock_gettime(CLOCK_REALTIME, &ts);
-	    if (result != 0) {
-	        /* Unable to read time. Report max uint64 value for both fields. */
-  	        Peripherals.Counter.latched_wallclock_time = 0xffffffffffffffff;
+            if (result != 0) {
+                /* Unable to read time. Report max uint64 value for both fields. */
+                Peripherals.Counter.latched_wallclock_time = 0xffffffffffffffff;
                 Peripherals.Counter.latched_wallclock_time_split = 0xffffffffffffffff;
-	    } else {
-	        /* Number of nanoseconds since 1-1-1970. */
+            } else {
+                /* Number of nanoseconds since 1-1-1970. */
                 Peripherals.Counter.latched_wallclock_time = 1000000000u * ts.tv_sec + ts.tv_nsec;
-	        /* High word is number of seconds, low word is number of nanoseconds. */
+                /* High word is number of seconds, low word is number of nanoseconds. */
                 Peripherals.Counter.latched_wallclock_time_split = (ts.tv_sec << 32) | ts.tv_nsec;
             }
 
@@ -134,7 +134,7 @@ uint8_t PeripheralsReadByte (uint8_t Addr)
 
 
 void PeripheralsInit (void)
-/* Initialize the peripheral registers */
+/* Initialize the peripherals. */
 {
     /* Initialize the COUNTER peripheral */
 

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -65,7 +65,11 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
 
             struct timespec ts;
 
-#if defined(_MSC_VER)
+#if defined(__MINGW64__)
+            bool time_valid = false;
+#elif defined(__MINGW32__)
+            bool time_valid = false;
+#elif defined(_MSC_VER)
             /* clock_gettime() is not available in the Visual Studio compiler. Use timespec_get() instead. */
             bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
 #else

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -1,0 +1,159 @@
+/*****************************************************************************/
+/*                                                                           */
+/*                             peripherals.c                                 */
+/*                                                                           */
+/*        Memory-mapped peripheral subsystem for the 6502 simulator          */
+/*                                                                           */
+/*                                                                           */
+/*                                                                           */
+/* (C) 2024-2025, Sidney Cadot                                               */
+/*                                                                           */
+/*                                                                           */
+/* This software is provided 'as-is', without any expressed or implied       */
+/* warranty.  In no event will the authors be held liable for any damages    */
+/* arising from the use of this software.                                    */
+/*                                                                           */
+/* Permission is granted to anyone to use this software for any purpose,     */
+/* including commercial applications, and to alter it and redistribute it    */
+/* freely, subject to the following restrictions:                            */
+/*                                                                           */
+/* 1. The origin of this software must not be misrepresented; you must not   */
+/*    claim that you wrote the original software. If you use this software   */
+/*    in a product, an acknowledgment in the product documentation would be  */
+/*    appreciated but is not required.                                       */
+/* 2. Altered source versions must be plainly marked as such, and must not   */
+/*    be misrepresented as being the original software.                      */
+/* 3. This notice may not be removed or altered from any source              */
+/*    distribution.                                                          */
+/*                                                                           */
+/*****************************************************************************/
+
+
+
+#include <time.h>
+#include "peripherals.h"
+
+
+/*****************************************************************************/
+/*                                   Data                                    */
+/*****************************************************************************/
+
+
+
+/* The peripheral registers. */
+PeripheralRegs PRegs;
+
+
+
+/*****************************************************************************/
+/*                                   Code                                    */
+/*****************************************************************************/
+
+
+
+static uint64_t get_uint64_wallclock_time(void)
+{
+    struct timespec ts;
+    int result = clock_gettime(CLOCK_REALTIME, &ts);
+    if (result != 0)
+    {
+        // On failure, time will be set to the max value.
+        return 0xffffffffffffffff;
+    }
+
+    /* Return time since the 1-1-1970 epoch, in nanoseconds.
+     * Note that this time may be off by an integer number of seconds, as POSIX
+     * maintaines that all days are 86,400 seconds long, which is not true due to
+     * leap seconds.
+     */
+    return ts.tv_sec * 1000000000 + ts.tv_nsec;
+}
+
+
+
+void PeripheralWriteByte (uint8_t Addr, uint8_t Val)
+/* Write a byte to a memory location in the peripheral address aperture. */
+{
+    switch (Addr) {
+        case PERIPHERALS_ADDRESS_OFFSET_LATCH: {
+            /* A write to the "latch" register performs a simultaneous latch of all registers */
+
+            /* Latch the current wallclock time first. */
+            PRegs.latched_wallclock_time = get_uint64_wallclock_time();
+
+            /* Now latch all the cycles maintained by the processor. */
+            PRegs.latched_counter_clock_cycles = PRegs.latched_counter_clock_cycles;
+            PRegs.latched_counter_instructions = PRegs.latched_counter_instructions;
+            PRegs.latched_counter_irq_events = PRegs.latched_counter_irq_events;
+            PRegs.latched_counter_nmi_events = PRegs.latched_counter_nmi_events;
+            break;
+        }
+        case PERIPHERALS_ADDRESS_OFFSET_SELECT: {
+            /* Set the value of the visibility-selection register. */
+            PRegs.visible_latch_register = Val;
+            break;
+        }
+        default: {
+            /* Any other write is ignored */
+        }
+    }
+}
+
+
+
+uint8_t PeripheralReadByte (uint8_t Addr)
+/* Read a byte from a memory location in the peripheral address aperture. */
+{
+    switch (Addr) {
+        case PERIPHERALS_ADDRESS_OFFSET_SELECT: {
+            return PRegs.visible_latch_register;
+        }
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 0:
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 1:
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 2:
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 3:
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 4:
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 5:
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 6:
+        case PERIPHERALS_ADDRESS_OFFSET_REG64 + 7: {
+            /* Read from any of the eight counter bytes.
+             * The first byte is the 64 bit value's LSB, the seventh byte is its MSB.
+             */
+            unsigned byte_select = Addr - PERIPHERALS_ADDRESS_OFFSET_REG64; /* 0 .. 7 */
+            uint64_t value;
+            switch (PRegs.visible_latch_register) {
+                case PERIPHERALS_REG64_SELECT_CLOCKCYCLE_COUNTER: value = PRegs.latched_counter_clock_cycles; break;
+                case PERIPHERALS_REG64_SELECT_INSTRUCTION_COUNTER: value = PRegs.latched_counter_instructions; break;
+                case PERIPHERALS_REG64_SELECT_IRQ_COUNTER: value = PRegs.latched_counter_irq_events; break;
+                case PERIPHERALS_REG64_SELECT_NMI_COUNTER: value = PRegs.latched_counter_nmi_events; break;
+                case PERIPHERALS_REG64_SELECT_WALLCLOCK_TIME: value = PRegs.latched_wallclock_time; break;
+                default: value = 0; /* Reading from a non-supported register will yield 0. */
+            }
+            /* Return the desired byte of the latched counter. 0==LSB, 7==MSB. */
+            return value >> (byte_select * 8);
+        }
+        default: {
+            /* Any other read yields a zero value. */
+            return 0;
+        }
+    }
+}
+
+
+
+void PeripheralsInit (void)
+/* Initialize the peripheral registers */
+{
+    PRegs.counter_clock_cycles = 0;
+    PRegs.counter_instructions = 0;
+    PRegs.counter_irq_events = 0;
+    PRegs.counter_nmi_events = 0;
+
+    PRegs.latched_counter_clock_cycles = 0;
+    PRegs.latched_counter_instructions = 0;
+    PRegs.latched_counter_irq_events = 0;
+    PRegs.latched_counter_nmi_events = 0;
+    PRegs.latched_wallclock_time = 0;
+
+    PRegs.visible_latch_register = 0;
+}

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -67,10 +67,10 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
 
 #if defined(__MINGW64__)
             /* We check for MINGW64 before MINGW32, since MINGW64 also defines __MINGW32__. */
-            /* does timespec_get work? */
+            /* Using timespec_get() in the MinGW64 compiler makes the Linux workflow build fail. */
             bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
             /* does clock_gettime work? */
-            bool time_valid = false;
+            //bool time_valid = false;
 #elif defined(__MINGW32__)
             /* does timespec_get work? */
             /* does clock_gettime work? */

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -29,7 +29,6 @@
 /*****************************************************************************/
 
 
-
 #include <time.h>
 #include "peripherals.h"
 
@@ -72,7 +71,7 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
                 /* Wallclock time: number of nanoseconds since 1-1-1970. */
                 Peripherals.Counter.LatchedWallclockTime = 1000000000u * ts.tv_sec + ts.tv_nsec;
                 /* Wallclock time, split: high word is number of seconds since 1-1-1970,
-		 * low word is number of nanoseconds since the start of that second. */
+                 * low word is number of nanoseconds since the start of that second. */
                 Peripherals.Counter.LatchedWallclockTimeSplit = (ts.tv_sec << 32) | ts.tv_nsec;
             }
 
@@ -105,7 +104,7 @@ uint8_t PeripheralsReadByte (uint8_t Addr)
     switch (Addr) {
 
         /* Handle reads from the Counter peripheral. */
-      
+
         case PERIPHERALS_COUNTER_ADDRESS_OFFSET_SELECT: {
             return Peripherals.Counter.LatchedValueSelected;
         }

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -65,10 +65,11 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
 
             struct timespec ts;
 
-#if defined(_WIN32)
-            /* clock_gettime() is not available on Windows. Use timespec_get() instead. */
+#if defined(_MSC_VER)
+            /* clock_gettime() is not available in the Visual Studio compiler. Use timespec_get() instead. */
             bool time_valid = timespec_get(&ts, TIME_UTC) == TIME_UTC;
 #else
+            /* clock_gettime() is available on Linux, MacOS, MinGW32, and MinGW64.
             bool time_valid = clock_gettime(CLOCK_REALTIME, &ts) == 0;
 #endif
             if (time_valid) {

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -137,7 +137,7 @@ uint8_t PeripheralsReadByte (uint8_t Addr)
                 default: Value = 0; /* Reading from a non-existent latch register will yield 0. */
             }
             /* Return the desired byte of the latched counter. 0==LSB, 7==MSB. */
-            return Value >> (ByteIndex * 8);
+            return (uint8_t)(Value >> (ByteIndex * 8));
         }
 
         /* Handle reads from unused peripheral and write-only addresses. */

--- a/src/sim65/peripherals.h
+++ b/src/sim65/peripherals.h
@@ -59,27 +59,29 @@
 
 typedef struct {
     /* The invisible counters that keep processor state. */
-    uint64_t clock_cycles;
-    uint64_t cpu_instructions;
-    uint64_t irq_events;
-    uint64_t nmi_events;
-    /* Latched counters upon a write to the PERIPHERALS_COUNTER_LATCH address.
+    uint64_t ClockCycles;
+    uint64_t CpuInstructions;
+    uint64_t IrqEvents;
+    uint64_t NmiEvents;
+    /* The 'latched_...' fields below hold values that are sampled upon a write
+     * to the PERIPHERALS_COUNTER_LATCH address.
      * One of these will be visible (read only) through an eight-byte aperture.
      * The purpose of these latched registers is to read 64-bit values one byte
      * at a time, without having to worry that their content will change along
      * the way.
      */
-    uint64_t latched_clock_cycles;
-    uint64_t latched_cpu_instructions;
-    uint64_t latched_irq_events;
-    uint64_t latched_nmi_events;
-    uint64_t latched_wallclock_time;
-    uint64_t latched_wallclock_time_split;
+    uint64_t LatchedClockCycles;
+    uint64_t LatchedCpuInstructions;
+    uint64_t LatchedIrqEvents;
+    uint64_t LatchedNmiEvents;
+    uint64_t LatchedWallclockTime;
+    uint64_t LatchedWallclockTimeSplit;
     /* Select which of the six latched registers will be visible.
-     * This is a single byte, read/write register, accessible via address PERIPHERALS_COUNTER_SELECT.
-     * If a non-existent latch register is selected, the PERIPHERALS_REGS64 value will be zero.
+     * This is a single byte, read/write register, accessible via address
+     * PERIPHERALS_COUNTER_SELECT. If a non-existent latch register is selected,
+     * the PERIPHERALS_COUNTER_VALUE will be zero.
      */
-    uint8_t  visible_latch_register;
+    uint8_t LatchedValueSelected;
 } CounterPeripheral;
 
 
@@ -87,8 +89,8 @@ typedef struct {
 /* Declare the 'Sim65Peripherals' type and its single instance 'Peripherals'. */
 
 typedef struct {
-    /* State of the peripherals simulated by sim65.
-     * Currently, there is only one: the COUNTER peripheral. */
+    /* State of the peripherals available in sim65.
+     * Currently, there is only one peripheral: the Counter. */
     CounterPeripheral Counter;
 } Sim65Peripherals;
 

--- a/src/sim65/peripherals.h
+++ b/src/sim65/peripherals.h
@@ -1,0 +1,98 @@
+/*****************************************************************************/
+/*                                                                           */
+/*                             peripherals.h                                 */
+/*                                                                           */
+/*        Memory-mapped peripheral subsystem for the 6502 simulator          */
+/*                                                                           */
+/*                                                                           */
+/*                                                                           */
+/* (C) 2024-2025, Sidney Cadot                                               */
+/*                                                                           */
+/*                                                                           */
+/* This software is provided 'as-is', without any expressed or implied       */
+/* warranty.  In no event will the authors be held liable for any damages    */
+/* arising from the use of this software.                                    */
+/*                                                                           */
+/* Permission is granted to anyone to use this software for any purpose,     */
+/* including commercial applications, and to alter it and redistribute it    */
+/* freely, subject to the following restrictions:                            */
+/*                                                                           */
+/* 1. The origin of this software must not be misrepresented; you must not   */
+/*    claim that you wrote the original software. If you use this software   */
+/*    in a product, an acknowledgment in the product documentation would be  */
+/*    appreciated but is not required.                                       */
+/* 2. Altered source versions must be plainly marked as such, and must not   */
+/*    be misrepresented as being the original software.                      */
+/* 3. This notice may not be removed or altered from any source              */
+/*    distribution.                                                          */
+/*                                                                           */
+/*****************************************************************************/
+
+
+
+#ifndef PERIPHERALS_H
+#define PERIPHERALS_H
+
+#include <stdint.h>
+
+#define PERIPHERALS_APERTURE_BASE_ADDRESS   0xffc0
+#define PERIPHERALS_APERTURE_LAST_ADDRESS   0xffc9
+
+#define PERIPHERALS_ADDRESS_OFFSET_LATCH  0x00
+#define PERIPHERALS_ADDRESS_OFFSET_SELECT 0x01
+#define PERIPHERALS_ADDRESS_OFFSET_REG64  0x02
+
+#define PERIPHERALS_LATCH  (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_LATCH)
+#define PERIPHERALS_SELECT (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_SELECT)
+#define PERIPHERALS_REG64  (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_REG64)
+
+#define PERIPHERALS_REG64_SELECT_CLOCKCYCLE_COUNTER   0x00
+#define PERIPHERALS_REG64_SELECT_INSTRUCTION_COUNTER  0x01
+#define PERIPHERALS_REG64_SELECT_IRQ_COUNTER          0x02
+#define PERIPHERALS_REG64_SELECT_NMI_COUNTER          0x03
+#define PERIPHERALS_REG64_SELECT_WALLCLOCK_TIME       0x80
+
+typedef struct {
+    /* the invisible counters that are continuously updated */
+    uint64_t counter_clock_cycles;
+    uint64_t counter_instructions;
+    uint64_t counter_irq_events;
+    uint64_t counter_nmi_events;
+    /* latched counters upon a write to the 'latch' address.
+     * One of these will be visible (read only) through an each-byte aperture. */
+    uint64_t latched_counter_clock_cycles;
+    uint64_t latched_counter_instructions;
+    uint64_t latched_counter_irq_events;
+    uint64_t latched_counter_nmi_events;
+    uint64_t latched_wallclock_time;
+    /* Select which of the five latched registers will be visible.
+     * This is a Read/Write byte-wide register.
+     * If a non-existent register is selected, the 8-byte aperture will read as zero.
+     */
+    uint8_t  visible_latch_register;
+} PeripheralRegs;
+
+extern PeripheralRegs PRegs;
+
+/*****************************************************************************/
+/*                                   Code                                    */
+/*****************************************************************************/
+
+
+
+void PeripheralWriteByte (uint8_t Addr, uint8_t Val);
+/* Write a byte to a memory location in the peripheral address aperture. */
+
+
+uint8_t PeripheralReadByte (uint8_t Addr);
+/* Read a byte from a memory location in the peripheral address aperture. */
+
+
+void PeripheralsInit (void);
+/* Initialize the peripheral registers */
+
+
+
+/* End of peripherals.h */
+
+#endif

--- a/src/sim65/peripherals.h
+++ b/src/sim65/peripherals.h
@@ -109,7 +109,7 @@ uint8_t PeripheralsReadByte (uint8_t Addr);
 
 
 void PeripheralsInit (void);
-/* Initialize the peripheral registers */
+/* Initialize the peripherals. */
 
 
 

--- a/src/sim65/peripherals.h
+++ b/src/sim65/peripherals.h
@@ -35,44 +35,64 @@
 
 #include <stdint.h>
 
-#define PERIPHERALS_APERTURE_BASE_ADDRESS   0xffc0
-#define PERIPHERALS_APERTURE_LAST_ADDRESS   0xffc9
+/* The memory range where the memory-mapped peripherals can be accessed. */
 
-#define PERIPHERALS_ADDRESS_OFFSET_LATCH  0x00
-#define PERIPHERALS_ADDRESS_OFFSET_SELECT 0x01
-#define PERIPHERALS_ADDRESS_OFFSET_REG64  0x02
+#define PERIPHERALS_APERTURE_BASE_ADDRESS  0xffc0
+#define PERIPHERALS_APERTURE_LAST_ADDRESS  0xffc9
 
-#define PERIPHERALS_LATCH  (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_LATCH)
-#define PERIPHERALS_SELECT (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_SELECT)
-#define PERIPHERALS_REG64  (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_REG64)
+/* Declarations for the COUNTER peripheral (currently the only peripheral). */
 
-#define PERIPHERALS_REG64_SELECT_CLOCKCYCLE_COUNTER   0x00
-#define PERIPHERALS_REG64_SELECT_INSTRUCTION_COUNTER  0x01
-#define PERIPHERALS_REG64_SELECT_IRQ_COUNTER          0x02
-#define PERIPHERALS_REG64_SELECT_NMI_COUNTER          0x03
-#define PERIPHERALS_REG64_SELECT_WALLCLOCK_TIME       0x80
+#define PERIPHERALS_COUNTER_ADDRESS_OFFSET_LATCH   0x00
+#define PERIPHERALS_COUNTER_ADDRESS_OFFSET_SELECT  0x01
+#define PERIPHERALS_COUNTER_ADDRESS_OFFSET_VALUE   0x02
+
+#define PERIPHERALS_COUNTER_LATCH   (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_COUNTER_LATCH)
+#define PERIPHERALS_COUNTER_SELECT  (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_COUNTER_SELECT)
+#define PERIPHERALS_COUNTER_VALUE   (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_ADDRESS_OFFSET_COUNTER)
+
+#define PERIPHERALS_COUNTER_SELECT_CLOCKCYCLE_COUNTER    0x00
+#define PERIPHERALS_COUNTER_SELECT_INSTRUCTION_COUNTER   0x01
+#define PERIPHERALS_COUNTER_SELECT_IRQ_COUNTER           0x02
+#define PERIPHERALS_COUNTER_SELECT_NMI_COUNTER           0x03
+#define PERIPHERALS_COUNTER_SELECT_WALLCLOCK_TIME        0x80
+#define PERIPHERALS_COUNTER_SELECT_WALLCLOCK_TIME_SPLIT  0x81
 
 typedef struct {
-    /* the invisible counters that are continuously updated */
-    uint64_t counter_clock_cycles;
-    uint64_t counter_instructions;
-    uint64_t counter_irq_events;
-    uint64_t counter_nmi_events;
-    /* latched counters upon a write to the 'latch' address.
-     * One of these will be visible (read only) through an each-byte aperture. */
-    uint64_t latched_counter_clock_cycles;
-    uint64_t latched_counter_instructions;
-    uint64_t latched_counter_irq_events;
-    uint64_t latched_counter_nmi_events;
+    /* The invisible counters that keep processor state. */
+    uint64_t clock_cycles;
+    uint64_t cpu_instructions;
+    uint64_t irq_events;
+    uint64_t nmi_events;
+    /* Latched counters upon a write to the PERIPHERALS_COUNTER_LATCH address.
+     * One of these will be visible (read only) through an eight-byte aperture.
+     * The purpose of these latched registers is to read 64-bit values one byte
+     * at a time, without having to worry that their content will change along
+     * the way.
+     */
+    uint64_t latched_clock_cycles;
+    uint64_t latched_cpu_instructions;
+    uint64_t latched_irq_events;
+    uint64_t latched_nmi_events;
     uint64_t latched_wallclock_time;
-    /* Select which of the five latched registers will be visible.
-     * This is a Read/Write byte-wide register.
-     * If a non-existent register is selected, the 8-byte aperture will read as zero.
+    uint64_t latched_wallclock_time_split;
+    /* Select which of the six latched registers will be visible.
+     * This is a single byte, read/write register, accessible via address PERIPHERALS_COUNTER_SELECT.
+     * If a non-existent latch register is selected, the PERIPHERALS_REGS64 value will be zero.
      */
     uint8_t  visible_latch_register;
-} PeripheralRegs;
+} CounterPeripheral;
 
-extern PeripheralRegs PRegs;
+
+
+/* Declare the 'Sim65Peripherals' type and its single instance 'Peripherals'. */
+
+typedef struct {
+    /* State of the peripherals simulated by sim65.
+     * Currently, there is only one: the COUNTER peripheral. */
+    CounterPeripheral Counter;
+} Sim65Peripherals;
+
+extern Sim65Peripherals Peripherals;
 
 /*****************************************************************************/
 /*                                   Code                                    */
@@ -80,11 +100,11 @@ extern PeripheralRegs PRegs;
 
 
 
-void PeripheralWriteByte (uint8_t Addr, uint8_t Val);
+void PeripheralsWriteByte (uint8_t Addr, uint8_t Val);
 /* Write a byte to a memory location in the peripheral address aperture. */
 
 
-uint8_t PeripheralReadByte (uint8_t Addr);
+uint8_t PeripheralsReadByte (uint8_t Addr);
 /* Read a byte from a memory location in the peripheral address aperture. */
 
 


### PR DESCRIPTION
This PR adds timer functionality to sim65. It originates from feature request #2355.

The PR implements a functional memory-mapped timer, but not yet ready to be merged to master. Before doing that, we will need:

- [ ] tests
- [x] updated documentation
- [x] ensure that it builds on Windows.
- [ ] review

This is reviewed as a draft PR at this time to tickle the CI build for Windows and see what happens. The most obvious thing that may trip up the Windows build is the use of the 'clock_gettime' function in peripherals.c.