### PR TITLE
sim65: add target-specific C header file and asm include file.

### DIFF
--- a/asminc/sim65.inc
+++ b/asminc/sim65.inc
@@ -1,0 +1,75 @@
+
+; *******************************************************************************
+; **                                                                           **
+; **  sim65.inc : assembler definitions for the sim6502 and sim65c02 targets.  **
+; **                                                                           **
+; **  Sidney Cadot, January 2025                                               **
+; **                                                                           **
+; *******************************************************************************
+
+            ; The '_peripherals' symbol is defined in the linker configuration
+            ; file to correspond to the first address in the periperal memory
+            ; aparture.
+            ;
+            ; We use it here as a base address for all peripheral addresses.
+
+            .import _peripherals
+
+; **************************************************************
+; **                                                          **
+; **  Define assembler symbols for the "counter" peripheral.  **
+; **                                                          **
+; **************************************************************
+
+peripheral_counter_base   := _peripherals + 0
+
+peripheral_counter_latch  := peripheral_counter_base + 0
+peripheral_counter_select := peripheral_counter_base + 1
+peripheral_counter_value  := peripheral_counter_base + 2
+
+; Values for the peripheral_counter_select register.
+
+COUNTER_SELECT_CLOCKCYCLE_COUNTER   = $00
+COUNTER_SELECT_INSTRUCTION_COUNTER  = $01
+COUNTER_SELECT_IRQ_COUNTER          = $02
+COUNTER_SELECT_NMI_COUNTER          = $03
+COUNTER_SELECT_WALLCLOCK_TIME       = $80
+COUNTER_SELECT_WALLCLOCK_TIME_SPLIT = $81
+
+; ********************************************************************
+; **                                                                **
+; **  Define assembler symbols for the "sim65 control" peripheral.  **
+; **                                                                **
+; ********************************************************************
+
+peripheral_sim65_base       := _peripherals + 10
+
+peripheral_sim65_cpu_mode   := peripheral_sim65_base + 0
+peripheral_sim65_trace_mode := peripheral_sim65_base + 1
+
+; Values for the peripheral_sim65_cpu_mode register.
+
+SIM65_CPU_MODE_6502  = $00
+SIM65_CPU_MODE_65C02 = $01
+SIM65_CPU_MODE_6502X = $02
+
+; Bitfield values for the peripheral_sim65_trace_mode field.
+
+SIM65_TRACE_MODE_FIELD_INSTR_COUNTER  = $40
+SIM65_TRACE_MODE_FIELD_CLOCK_COUNTER  = $20
+SIM65_TRACE_MODE_FIELD_PC             = $10
+SIM65_TRACE_MODE_FIELD_INSTR_BYTES    = $08
+SIM65_TRACE_MODE_FIELD_INSTR_ASSEMBLY = $04
+SIM65_TRACE_MODE_FIELD_CPU_REGISTERS  = $02
+SIM65_TRACE_MODE_FIELD_CC65_SP        = $01
+
+; Values for the peripheral_sim65_trace_mode field that fully disable / enable tracing.
+
+SIM65_TRACE_MODE_DISABLE              = $00
+SIM65_TRACE_MODE_ENABLE_FULL          = $7F
+
+; ************************
+; **                    **
+; **  End of sim65.inc  **
+; **                    **
+; ************************

--- a/cfg/sim6502.cfg
+++ b/cfg/sim6502.cfg
@@ -1,12 +1,15 @@
 SYMBOLS {
     __EXEHDR__:    type = import;
     __STACKSIZE__: type = weak, value = $0800; # 2k stack
+    _peripherals:  type = export, value = $FFC0;
 }
+
 MEMORY {
     ZP:     file = "",               start = $0000, size = $0100;
     HEADER: file = %O,               start = $0000, size = $000C;
-    MAIN:   file = %O, define = yes, start = $0200, size = $FDC0 - __STACKSIZE__;
+    MAIN:   file = %O, define = yes, start = $0200, size = $FFC0 - $0200 - __STACKSIZE__;
 }
+
 SEGMENTS {
     ZEROPAGE: load = ZP,     type = zp;
     EXEHDR:   load = HEADER, type = ro;
@@ -18,6 +21,7 @@ SEGMENTS {
     DATA:     load = MAIN,   type = rw;
     BSS:      load = MAIN,   type = bss, define   = yes;
 }
+
 FEATURES {
     CONDES: type    = constructor,
             label   = __CONSTRUCTOR_TABLE__,

--- a/cfg/sim65c02.cfg
+++ b/cfg/sim65c02.cfg
@@ -1,12 +1,15 @@
 SYMBOLS {
     __EXEHDR__:    type = import;
     __STACKSIZE__: type = weak, value = $0800; # 2k stack
+    _peripherals:  type = export, value = $FFC0;
 }
+
 MEMORY {
     ZP:     file = "",               start = $0000, size = $0100;
     HEADER: file = %O,               start = $0000, size = $000C;
-    MAIN:   file = %O, define = yes, start = $0200, size = $FDC0 - __STACKSIZE__;
+    MAIN:   file = %O, define = yes, start = $0200, size = $FFC0 - $0200 - __STACKSIZE__;
 }
+
 SEGMENTS {
     ZEROPAGE: load = ZP,     type = zp;
     EXEHDR:   load = HEADER, type = ro;
@@ -18,6 +21,7 @@ SEGMENTS {
     DATA:     load = MAIN,   type = rw;
     BSS:      load = MAIN,   type = bss, define   = yes;
 }
+
 FEATURES {
     CONDES: type    = constructor,
             label   = __CONSTRUCTOR_TABLE__,

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -40,6 +40,8 @@ The simulator is called as follows:
         Long options:
           --help                Help (this text)
           --cycles              Print amount of executed CPU cycles
+          --cpu <type>          Override CPU type (6502, 65C02, 6502X)
+          --trace               Enable CPU trace
           --verbose             Increase verbosity
           --version             Print the simulator version number
 </verb></tscreen>
@@ -69,6 +71,17 @@ Here is a description of all the command line options:
   The cycles for the final "<tt>jmp exit</tt>" are not included in this
   count.
 
+
+  <tag><tt>--cpu <type></tt></tag>
+
+  Specify the CPU type to use while executing the program. This CPU type
+  is normally determined from the program file header, but it can be useful
+  to override it.
+
+  <tag><tt>--trace</tt></tag>
+
+  Print a single line of information for each instruction or interrupt that
+  is executed by the CPU to stdout.
 
   <tag><tt>-v, --verbose</tt></tag>
 

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -346,7 +346,7 @@ int main(void)
 <p>The sim65 simulator supports a memory-mapped peripheral that allows control
 of the simulator behavior itself.
 
-<p>The functionality of the counter peripheral is accessible through 2 registers:
+<p>The sim65 control peripheral interface consists of 2 registers:
 
 <itemize>
 <item><tt>PERIPHERALS_SIMCONTROL_CPUMODE</tt> ($FFCA, read/write)
@@ -356,15 +356,15 @@ of the simulator behavior itself.
 <p>Address <tt>PERIPHERALS_SIMCONTROL_CPUMODE</tt> allows access to the currently active CPU mode.
 
 <p>Possible values are CPU_6502 (0), CPU_65C02 (1), and CPU_6502X (2). For specialized applications,
-it may be useful to be able to switch CPU models at runtime; this is supported by writing a value 0, 1,
-or 2 to this address. Writing any other value will be ignored.
+it may be useful to switch CPU models at runtime; this is supported by writing 0, 1, or 2 to this address.
+Writing any other value will be ignored.
 
 <p>Address <tt>PERIPHERALS_SIMCONTROL_TRACEMODE</tt> allows inspection and control of the currently active
 CPU tracing mode.
 
 <p>A value of 0 means tracing is disabled; a value of $7F fully enables tracing. The 7
-lower bits of the value actually provide control over which fields are printed; see 'sim65/trace.h'
-for details.
+lower bits of the value actually provide control over which fields are printed; see below
+for an explanation of the seven fields.
 
 <p>Having the ability to enable/disable tracing on the fly can be a useful debugging aid. For example,
 it can be used to enable tracing for short fragments of code. Consider the following example:
@@ -375,10 +375,10 @@ it can be used to enable tracing for short fragments of code. Consider the follo
 
 volatile uint8_t  * TraceMode = (uint8_t *)0xffcb;
 
+unsigned x;
+
 int main(void)
 {
-    unsigned x;
-
     *TraceMode = 0x7f; /* Enable tracing */
 
     x = 0x1234; /* We want to see what happens here. */
@@ -388,6 +388,58 @@ int main(void)
     return 0;
 }
 </verb></tscreen>
+
+<p>This small test program produces the output trace below:
+
+<tscreen><verb>
+75           250  0239  A2 12     ldx  #$12         A=7F X=00 Y=00 S=FD Flags=nvdiZC    SP=FFBC
+76           252  023B  A9 34     lda  #$34         A=7F X=12 Y=00 S=FD Flags=nvdizC    SP=FFBC
+77           254  023D  8D DD 02  sta  $02DD        A=34 X=12 Y=00 S=FD Flags=nvdizC    SP=FFBC
+78           258  0240  8E DE 02  stx  $02DE        A=34 X=12 Y=00 S=FD Flags=nvdizC    SP=FFBC
+79           262  0243  AD B3 02  lda  $02B3        A=34 X=12 Y=00 S=FD Flags=nvdizC    SP=FFBC
+80           266  0246  85 09     sta  $09          A=FF X=12 Y=00 S=FD Flags=NvdizC    SP=FFBC
+81           269  0248  AD B2 02  lda  $02B2        A=FF X=12 Y=00 S=FD Flags=NvdizC    SP=FFBC
+82           273  024B  85 08     sta  $08          A=CB X=12 Y=00 S=FD Flags=NvdizC    SP=FFBC
+83           276  024D  98        tya               A=CB X=12 Y=00 S=FD Flags=NvdizC    SP=FFBC
+84           278  024E  91 08     sta  ($08),Y      A=00 X=12 Y=00 S=FD Flags=nvdiZC    SP=FFBC
+</verb></tscreen>
+
+<p>The example output shows the full trace format, consisting of the following seven fields:
+
+<itemize>
+<item>The first field is an instruction counter. We see here that the assignment <tt>x = 0x1234;</tt>tt>
+starts at the 75th CPU instruction since the start of the simulator, and takes four 6502 instructions.
+The six instructions that follow correspond to the statement <tt>*TraceMode = 0x00;</tt> that disables
+tracing.
+<item>The second field shows the clock cycles since the start of the program. Here we see that the
+first four instructions take 12 clock cycles in total (262 - 250 = 12).
+<item>The third field shows the program counter as a four-digit, i.e., the PC register. Its 16-bit
+      value is displayed as a 4-digit hecadecimal number.
+<item>The fourth field shows one to three hexadecimal byte values that make up the instruction.
+<item>The fifth field shows the instruction in human-readable assembly language.
+<item>The sixth field shows the CPU registers before execution of the instruction. The A, X, Y, and
+      S registers are each shown as a single byte value. The six status bits of the CPU are shown in
+      the order NVDIZC (Negative, Overflow, Decimal, Interrupt, Zero, Carry). They are displayed as
+      a capital letter if the flag is set, or a small letter if the flag is unset.
+<item>The seventh and last field shows the software stack pointer SP as used by CC65 programs that
+      conform to the CC65 conventions.
+</itemize>
+
+<p>Writing a specific value to <tt>PERIPHERALS_SIMCONTROL_TRACEMODE</tt> will control which of these
+seven fields are displayed. The following values are defined to denote the seven fields:
+
+<itemize>
+<item>TRACE_FIELD_INSTR_COUNTER   = 0x40
+<item>TRACE_FIELD_CLOCK_COUNTER   = 0x20
+<item>TRACE_FIELD_PC              = 0x10
+<item>TRACE_FIELD_INSTR_BYTES     = 0x08
+<item>TRACE_FIELD_INSTR_ASSEMBLY  = 0x04
+<item>TRACE_FIELD_CPU_REGISTERS   = 0x02
+<item>TRACE_FIELD_CC65_SP         = 0x01
+</itemize>
+
+<p>For example, writing the value $16 to <tt>PERIPHERALS_SIMCONTROL_TRACEMODE</tt> will only display
+the program counter, instruction assembly, and CPU register fields.
 
 <sect>Copyright<p>
 

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -407,9 +407,9 @@ int main(void)
 <p>The example output shows the full trace format, consisting of the following seven fields:
 
 <itemize>
-<item>The first field is an instruction counter. We see here that the assignment <tt>x = 0x1234;</tt>tt>
+<item>The first field is an instruction counter. We see here that the assignment '<tt>x = 0x1234;</tt>'
 starts at the 75th CPU instruction since the start of the simulator, and takes four 6502 instructions.
-The six instructions that follow correspond to the statement <tt>*TraceMode = 0x00;</tt> that disables
+The six instructions that follow correspond to the statement '<tt>*TraceMode = 0x00;</tt>' that disables
 tracing.
 <item>The second field shows the clock cycles since the start of the program. Here we see that the
 first four instructions take 12 clock cycles in total (262 - 250 = 12).
@@ -439,7 +439,7 @@ seven fields are displayed. The following values are defined to denote the seven
 </itemize>
 
 <p>For example, writing the value $16 to <tt>PERIPHERALS_SIMCONTROL_TRACEMODE</tt> will only display
-the program counter, instruction assembly, and CPU register fields.
+the program counter, instruction assembly, and CPU registers fields.
 
 <sect>Copyright<p>
 

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -72,7 +72,7 @@ Here is a description of all the command line options:
   count.
 
 
-  <tag><tt>--cpu <type></tt></tag>
+  <tag><tt>--cpu &lt;type&gt;</tt></tag>
 
   Specify the CPU type to use while executing the program. This CPU type
   is normally determined from the program file header, but it can be useful
@@ -354,16 +354,19 @@ of the simulator behavior itself.
 </itemize>
 
 <p>Address <tt>PERIPHERALS_SIMCONTROL_CPUMODE</tt> allows access to the currently active CPU mode.
-Possible values are CPU_6502 (0), CPU_65C02 (1), and CPU_6502X (2). For specialized applications,
+
+<p>Possible values are CPU_6502 (0), CPU_65C02 (1), and CPU_6502X (2). For specialized applications,
 it may be useful to be able to switch CPU models at runtime; this is supported by writing a value 0, 1,
 or 2 to this address. Writing any other value will be ignored.
 
-<p>Address <tt> PERIPHERALS_SIMCONTROL_TRACEMODE</p>tt> allows inspection and control of the currently active
-CPU tracing facility. A value of 0 means tracing is disabled; a value of $7F fully enables tracing. The 7
+<p>Address <tt>PERIPHERALS_SIMCONTROL_TRACEMODE</tt> allows inspection and control of the currently active
+CPU tracing mode.
+
+<p>A value of 0 means tracing is disabled; a value of $7F fully enables tracing. The 7
 lower bits of the value actually provide control over which fields are printed; see 'sim65/trace.h'
 for details.
 
-Having the ability to enable/disable tracing on the fly can be a useful debugging aid. For example,
+<p>Having the ability to enable/disable tracing on the fly can be a useful debugging aid. For example,
 it can be used to enable tracing for short fragments of code. Consider the following example:
 
 <tscreen><verb>

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -311,25 +311,23 @@ bytes before the first write to <tt>PERIPHERALS_COUNTER_LATCH</tt> will yield ze
 Example:
 
 <tscreen><verb>
-#include <stdio.h>
-#include <stdint.h>
+/* This example uses the peripheral support in sim65.h */
 
-volatile uint8_t  * CounterLatch  = (uint8_t *)0xffc0;
-volatile uint8_t  * CounterSelect = (uint8_t *)0xffc1;
-volatile uint32_t * CounterValue  = (uint32_t *)0xffc2;
+#include <stdio.h>
+#include <sim65.h>
 
 static void print_current_counters(void)
 {
-    *CounterLatch = 0; /* latch values */
+    peripherals.counter.latch = 0; /* latch values */
 
-    *CounterSelect = 0x00;
-    printf("clock cycles ............... : %08lx %08lx\n", CounterValue[1], CounterValue[0]);
-    *CounterSelect = 0x01;
-    printf("instructions ............... : %08lx %08lx\n", CounterValue[1], CounterValue[0]);
-    *CounterSelect = 0x80;
-    printf("wallclock time ............. : %08lx %08lx\n", CounterValue[1], CounterValue[0]);
-    *CounterSelect = 0x81;
-    printf("wallclock time, split ...... : %08lx %08lx\n", CounterValue[1], CounterValue[0]);
+    peripherals.counter.select = COUNTER_SELECT_CLOCKCYCLE_COUNTER;
+    printf("clock cycles ............... : %08lx %08lx\n", peripherals.counter.value32[1], peripherals.counter.value32[0]);
+    peripherals.counter.select = COUNTER_SELECT_INSTRUCTION_COUNTER;
+    printf("instructions ............... : %08lx %08lx\n", peripherals.counter.value32[1], peripherals.counter.value32[0]);
+    peripherals.counter.select = COUNTER_SELECT_WALLCLOCK_TIME;
+    printf("wallclock time ............. : %08lx %08lx\n", peripherals.counter.value32[1], peripherals.counter.value32[0]);
+    peripherals.counter.select = COUNTER_SELECT_WALLCLOCK_TIME_SPLIT;
+    printf("wallclock time, split ...... : %08lx %08lx\n", peripherals.counter.value32[1], peripherals.counter.value32[0]);
     printf("\n");
 }
 
@@ -370,47 +368,43 @@ for an explanation of the seven fields.
 it can be used to enable tracing for short fragments of code. Consider the following example:
 
 <tscreen><verb>
-#include <stdio.h>
-#include <stdint.h>
+/* This example uses the TRACE_ON and TRACE_OFF macros defined in sim65.h */
 
-volatile uint8_t  * TraceMode = (uint8_t *)0xffcb;
+#include <stdio.h>
+#include <sim65.h>
 
 unsigned x;
 
 int main(void)
 {
-    *TraceMode = 0x7f; /* Enable tracing */
+    TRACE_ON();
 
     x = 0x1234; /* We want to see what happens here. */
 
-    *TraceMode = 0x00; /* Disable tracing */
+    TRACE_OFF();
 
     return 0;
 }
 </verb></tscreen>
 
-<p>This small test program produces the output trace below:
+<p>This small test program, when compiled with optimizations enabled (-O), produces the output trace below:
 
 <tscreen><verb>
-75           250  0239  A2 12     ldx  #$12         A=7F X=00 Y=00 S=FD Flags=nvdiZC    SP=FFBC
-76           252  023B  A9 34     lda  #$34         A=7F X=12 Y=00 S=FD Flags=nvdizC    SP=FFBC
-77           254  023D  8D DD 02  sta  $02DD        A=34 X=12 Y=00 S=FD Flags=nvdizC    SP=FFBC
-78           258  0240  8E DE 02  stx  $02DE        A=34 X=12 Y=00 S=FD Flags=nvdizC    SP=FFBC
-79           262  0243  AD B3 02  lda  $02B3        A=34 X=12 Y=00 S=FD Flags=nvdizC    SP=FFBC
-80           266  0246  85 09     sta  $09          A=FF X=12 Y=00 S=FD Flags=NvdizC    SP=FFBC
-81           269  0248  AD B2 02  lda  $02B2        A=FF X=12 Y=00 S=FD Flags=NvdizC    SP=FFBC
-82           273  024B  85 08     sta  $08          A=CB X=12 Y=00 S=FD Flags=NvdizC    SP=FFBC
-83           276  024D  98        tya               A=CB X=12 Y=00 S=FD Flags=NvdizC    SP=FFBC
-84           278  024E  91 08     sta  ($08),Y      A=00 X=12 Y=00 S=FD Flags=nvdiZC    SP=FFBC
+70           232  022E  A2 12     ldx  #$12         A=7F X=00 Y=04 S=FD Flags=nvdizC    SP=FFBC
+71           234  0230  A9 34     lda  #$34         A=7F X=12 Y=04 S=FD Flags=nvdizC    SP=FFBC
+72           236  0232  8D C8 02  sta  $02C8        A=34 X=12 Y=04 S=FD Flags=nvdizC    SP=FFBC
+73           240  0235  8E C9 02  stx  $02C9        A=34 X=12 Y=04 S=FD Flags=nvdizC    SP=FFBC
+74           244  0238  A9 00     lda  #$00         A=34 X=12 Y=04 S=FD Flags=nvdizC    SP=FFBC
+75           246  023A  8D CB FF  sta  $FFCB        A=00 X=12 Y=04 S=FD Flags=nvdiZC    SP=FFBC
 </verb></tscreen>
 
 <p>The example output shows the full trace format, consisting of the following seven fields:
 
 <itemize>
 <item>The first field is an instruction counter. We see here that the assignment '<tt>x = 0x1234;</tt>'
-starts at the 75th CPU instruction since the start of the simulator, and takes four 6502 instructions.
-The six instructions that follow correspond to the statement '<tt>*TraceMode = 0x00;</tt>' that disables
-tracing.
+starts at the 70th CPU instruction since the start of the simulator, and takes four 6502 instructions.
+The two instructions that follow correspond to the execution of the <tt>TRACE_OFF</tt>' macro
+that disables tracing.
 <item>The second field shows the clock cycles since the start of the program. Here we see that the
 first four instructions take 12 clock cycles in total (262 - 250 = 12).
 <item>The third field shows the program counter as a four-digit, i.e., the PC register. Its 16-bit

--- a/doc/sim65.sgml
+++ b/doc/sim65.sgml
@@ -341,6 +341,51 @@ int main(void)
 }
 </verb></tscreen>
 
+<sect>SIM65 control peripheral
+
+<p>The sim65 simulator supports a memory-mapped peripheral that allows control
+of the simulator behavior itself.
+
+<p>The functionality of the counter peripheral is accessible through 2 registers:
+
+<itemize>
+<item><tt>PERIPHERALS_SIMCONTROL_CPUMODE</tt> ($FFCA, read/write)
+<item><tt>PERIPHERALS_SIMCONTROL_TRACEMODE</tt> ($FFCB, read/write)
+</itemize>
+
+<p>Address <tt>PERIPHERALS_SIMCONTROL_CPUMODE</tt> allows access to the currently active CPU mode.
+Possible values are CPU_6502 (0), CPU_65C02 (1), and CPU_6502X (2). For specialized applications,
+it may be useful to be able to switch CPU models at runtime; this is supported by writing a value 0, 1,
+or 2 to this address. Writing any other value will be ignored.
+
+<p>Address <tt> PERIPHERALS_SIMCONTROL_TRACEMODE</p>tt> allows inspection and control of the currently active
+CPU tracing facility. A value of 0 means tracing is disabled; a value of $7F fully enables tracing. The 7
+lower bits of the value actually provide control over which fields are printed; see 'sim65/trace.h'
+for details.
+
+Having the ability to enable/disable tracing on the fly can be a useful debugging aid. For example,
+it can be used to enable tracing for short fragments of code. Consider the following example:
+
+<tscreen><verb>
+#include <stdio.h>
+#include <stdint.h>
+
+volatile uint8_t  * TraceMode = (uint8_t *)0xffcb;
+
+int main(void)
+{
+    unsigned x;
+
+    *TraceMode = 0x7f; /* Enable tracing */
+
+    x = 0x1234; /* We want to see what happens here. */
+
+    *TraceMode = 0x00; /* Disable tracing */
+
+    return 0;
+}
+</verb></tscreen>
+
 <sect>Copyright<p>
 
 sim65 (and all cc65 binutils) are (C) Copyright 1998-2000 Ullrich von

--- a/include/sim65.h
+++ b/include/sim65.h
@@ -107,9 +107,14 @@ extern volatile struct {
 #define SIM65_TRACE_MODE_DISABLE               0x00
 #define SIM65_TRACE_MODE_ENABLE_FULL           0x7F
 
-/* Convenience macros to enable / disable tracing. */
-#define TRACE_ON()      do peripherals.sim65.trace_mode = SIM65_TRACE_MODE_ENABLE_FULL; while(0)
-#define TRACE_OFF()     do peripherals.sim65.trace_mode = SIM65_TRACE_MODE_DISABLE; while(0)
+/* Convenience macros to enable / disable tracing at runtime. */
+#define TRACE_ON()  do peripherals.sim65.trace_mode = SIM65_TRACE_MODE_ENABLE_FULL; while(0)
+#define TRACE_OFF() do peripherals.sim65.trace_mode = SIM65_TRACE_MODE_DISABLE;     while(0)
+
+/* Convenience macros to set the CPU mode at runtime. */
+#define CPU_MODE_6502()  do peripherals.sim65.cpu_mode = SIM65_CPU_MODE_6502;  while(0)
+#define CPU_MODE_65C02() do peripherals.sim65.cpu_mode = SIM65_CPU_MODE_65C02; while(0)
+#define CPU_MODE_6502X() do peripherals.sim65.cpu_mode = SIM65_CPU_MODE_6502X; while(0)
 
 /* End of sim65.h */
 #endif

--- a/include/sim65.h
+++ b/include/sim65.h
@@ -1,0 +1,115 @@
+/*****************************************************************************/
+/*                                                                           */
+/*                                 sim65.h                                   */
+/*                                                                           */
+/*              Definitions for the sim6502 and sim65c02 targets             */
+/*                                                                           */
+/*                                                                           */
+/*                                                                           */
+/* (C) 2025 Sidney Cadot                                                     */
+/*                                                                           */
+/*                                                                           */
+/* This software is provided 'as-is', without any expressed or implied       */
+/* warranty.  In no event will the authors be held liable for any damages    */
+/* arising from the use of this software.                                    */
+/*                                                                           */
+/* Permission is granted to anyone to use this software for any purpose,     */
+/* including commercial applications, and to alter it and redistribute it    */
+/* freely, subject to the following restrictions:                            */
+/*                                                                           */
+/* 1. The origin of this software must not be misrepresented; you must not   */
+/*    claim that you wrote the original software. If you use this software   */
+/*    in a product, an acknowledgment in the product documentation would be  */
+/*    appreciated but is not required.                                       */
+/* 2. Altered source versions must be plainly marked as such, and must not   */
+/*    be misrepresented as being the original software.                      */
+/* 3. This notice may not be removed or altered from any source              */
+/*    distribution.                                                          */
+/*                                                                           */
+/*****************************************************************************/
+
+#ifndef _SIM65_H
+#define _SIM65_H
+
+/* Check that we include this file  while compiling to a compatible target. */
+#if !defined(__SIM6502__) && !defined(__SIM65C02__)
+#  error This module may only be used when compiling for the sim6502 or sim65c02 targets!
+#endif
+
+#include <stdint.h>
+
+/* The sim65 targets (sim6502, sim65c02) have a peripheral memory aperture located at
+ * address range 0xFFC0 .. 0xFFDF. Currently, the following peripherals are located
+ * inside that memory apeture:
+ *
+ * $FFC0 .. $FFC9      "counter" peripheral
+ * $FFCA .. $FFCB      "sim65 control" peripheral
+ * $FFCC .. $FFDF      (currently unused)
+ *
+ * The "peripherals" structure below corresponds to the register layout of the currently
+ * defined peripherals in this memory range. Combined with the fact that the sim6502 and
+ * sim65c02 linker configuration files define the "peripherals" symbol to be fixed at
+ * address $FFC0, this provides easy-to-use and efficient access to the peripheral registers.
+ *
+ * After including "sim65.h", it is possible for a C program to do things like:
+ *
+ * {
+ *     peripherals.counter.latch = 0;
+ *     peripherals.sim65.cpu_mode = SIM65_CPU_MODE_6502X;
+ *     peripherals.sim65.trace_mode = SIM65_TRACE_MODE_ENABLE_FULL;
+ * }
+ *
+ * Note that "peripherals" variable is declared volatile. This instructs a C compiler to
+ * forego optimizations on memory accesses to the variable. However, CC65 currently ignores
+ * the volatile attribute. Fortunately, it is not smart with respect to optimizing
+ * memory accesses, so accessing the "peripherals" fields works fine in practice.
+ */
+
+extern volatile struct {
+    struct {
+        uint8_t  latch;
+        uint8_t  select;
+        union {
+            uint8_t  value   [8]; /* Access value as eight separate bytes.  */
+            uint16_t value16 [4]; /* Access value as four 16-bit words.     */
+            uint32_t value32 [2]; /* Access value as two 32-bit long words. */
+        };
+    } counter;
+    struct {
+        uint8_t  cpu_mode;
+        uint8_t  trace_mode;
+    } sim65;
+} peripherals;
+
+/* Values for the peripherals.counter.select field. */
+#define COUNTER_SELECT_CLOCKCYCLE_COUNTER    0x00
+#define COUNTER_SELECT_INSTRUCTION_COUNTER   0x01
+#define COUNTER_SELECT_IRQ_COUNTER           0x02
+#define COUNTER_SELECT_NMI_COUNTER           0x03
+#define COUNTER_SELECT_WALLCLOCK_TIME        0x80
+#define COUNTER_SELECT_WALLCLOCK_TIME_SPLIT  0x81
+
+/* Values for the peripherals.sim65.cpu_mode field. */
+#define SIM65_CPU_MODE_6502                  0x00
+#define SIM65_CPU_MODE_65C02                 0x01
+#define SIM65_CPU_MODE_6502X                 0x02
+
+/* Bitfield values for the peripherals.sim65.trace_mode field. */
+#define SIM65_TRACE_MODE_FIELD_INSTR_COUNTER   0x40
+#define SIM65_TRACE_MODE_FIELD_CLOCK_COUNTER   0x20
+#define SIM65_TRACE_MODE_FIELD_PC              0x10
+#define SIM65_TRACE_MODE_FIELD_INSTR_BYTES     0x08
+#define SIM65_TRACE_MODE_FIELD_INSTR_ASSEMBLY  0x04
+#define SIM65_TRACE_MODE_FIELD_CPU_REGISTERS   0x02
+#define SIM65_TRACE_MODE_FIELD_CC65_SP         0x01
+
+/* Values for the peripherals.sim65.trace_mode field that fully disable / enable tracing. */
+#define SIM65_TRACE_MODE_DISABLE               0x00
+#define SIM65_TRACE_MODE_ENABLE_FULL           0x7F
+
+/* Convenience macros to enable / disable tracing. */
+#define TRACE_ON()      do peripherals.sim65.trace_mode = SIM65_TRACE_MODE_ENABLE_FULL; while(0)
+#define TRACE_OFF()     do peripherals.sim65.trace_mode = SIM65_TRACE_MODE_DISABLE; while(0)
+
+/* End of sim65.h */
+#endif

--- a/include/sim65.h
+++ b/include/sim65.h
@@ -111,10 +111,26 @@ extern volatile struct {
 #define TRACE_ON()  do peripherals.sim65.trace_mode = SIM65_TRACE_MODE_ENABLE_FULL; while(0)
 #define TRACE_OFF() do peripherals.sim65.trace_mode = SIM65_TRACE_MODE_DISABLE;     while(0)
 
-/* Convenience macros to set the CPU mode at runtime. */
-#define CPU_MODE_6502()  do peripherals.sim65.cpu_mode = SIM65_CPU_MODE_6502;  while(0)
-#define CPU_MODE_65C02() do peripherals.sim65.cpu_mode = SIM65_CPU_MODE_65C02; while(0)
-#define CPU_MODE_6502X() do peripherals.sim65.cpu_mode = SIM65_CPU_MODE_6502X; while(0)
+/* Convenience macro to query the CPU mode at runtime. */
+#define GET_CPU_MODE() peripherals.sim65.cpu_mode
+
+/* Convenience macro to set the CPU mode at runtime.
+ *
+ * Use SIM65_CPU_MODE_6502, SIM65_CPU_MODE_65C02, or SIM65_CPU_MODE_6502 as argument.
+ *
+ * Important Note:
+ *
+ * When running in a program compiled for the "sim6502" target, it is safe to switch to
+ * 65C02 or 6502X mode, since the runtime library will only use plain 6502 opcodes, and
+ * those work the same in 65C02 and 6502X mode.
+ *
+ * However, when running in a program compiled for the "sim65c02" target, it is NOT safe
+ * to switch to 6502 or 6502X mode, since many routines in the runtime library use
+ * 65C02-specific opcodes, and these will not work as expected when the CPU is switched
+ * to 6502 or 6502X mode. When such an instruction is encountered, the program will
+ * exhibit undefined behavior.
+ */
+#define SET_CPU_MODE(mode)  do peripherals.sim65.cpu_mode = mode; while(0)
 
 /* End of sim65.h */
 #endif

--- a/samples/sim65/cpumode_example.c
+++ b/samples/sim65/cpumode_example.c
@@ -1,0 +1,104 @@
+/* 
+ * Sim65 cpu-mode switching example.
+ *
+ * Description
+ * -----------
+ *
+ * We can inspect and manipulate the CPU model that sim65 emulates at runtime.
+ *
+ * Sim65 always runs in one of three modes:
+ *
+ * - 6502 mode: the 151 documented opcodes are supported; if the processor encounters
+ *              one of the 105 undocumented opcodes, the simulator ends with an
+ *              'illegal opcode' message.
+ * - 65C02 mode: the 105 undocumented opcodes now have well-defined behavior. Some
+ *               do useful things, while all others are now defined as NOPs.
+ * - 6502X mode: the 105 undocumented opcodes don't have documented behavior, but
+ *               they /do/ have behavior on a real 6502. This behavior has been
+ *               figured out, and is deterministic (with minor exceptions).
+ *               In this mode, sim65 mimics the behavior of a real 6502 when
+ *               it encounters an undocumented opcode, rather than terminating.
+ *
+ * In the example below, we first switch to 6502X mode and execute a small
+ * assembly code fragment, then repeat this in 65C02 mode.
+ *
+ * The code fragment is designed to distinguish between a 6502 and a 65C02
+ * processor based on the behavior of the ADC function in decimal mode.
+ *
+ * Important Note:
+ *
+ * When running in a program compiled for the "sim6502" target, it is safe to switch to
+ * 65C02 or 6502X mode, since the runtime library will only use plain 6502 opcodes, and
+ * those work the same in 65C02 and 6502X mode.
+ *
+ * However, when running in a program compiled for the "sim65c02" target, it is NOT safe
+ * to switch to 6502 or 6502X mode, since many routines in the runtime library use
+ * 65C02-specific opcodes, and these will not work as expected when the CPU is switched
+ * to 6502 or 6502X mode. When such an instruction is encountered, the program will
+ * exhibit undefined behavior.
+ *
+ * For this reason, this program will only work when compiled for the "sim6502" target.
+ *
+ * Running the example
+ * -------------------
+ *
+ * cl65 -t sim6502 -O cpumode_example.c -o cpumode_example.prg
+ * sim65 cpumode_example.prg
+ *
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <sim65.h>
+
+static bool __fastcall__ is_65c02(void)
+{
+    /* This assembly routine loads 0 into AX on a 6502 (also on a 6502 on which decimal
+     * mode is not implemented), and 1 on a 65C02.
+     *
+     * Note: this implementation triggers a "control reaches end of non-void function"
+     * warning that can be safely ignored. While no return statement is present, the
+     * return value is correctly loaded into AX by the assembly code.
+     */
+    __asm__("ldx #0");
+    __asm__("sed");
+    __asm__("txa");
+    __asm__("sbc #28");
+    __asm__("asl a");
+    __asm__("sbc #28");
+    __asm__("and #1");
+    __asm__("cld");
+}
+
+int main(void)
+{
+    printf("CPU mode at startup ....... : %u\n", GET_CPU_MODE());
+    printf("Is 65C02? ................. : %s\n", is_65c02() ? "YES" : "NO");
+
+    printf("\n");
+
+    printf("Switching to 6502 mode ....\n");
+    SET_CPU_MODE(SIM65_CPU_MODE_6502);
+    printf("Current CPU mode .......... : %u\n", GET_CPU_MODE());
+    printf("Is 65C02? ................. : %s\n", is_65c02() ? "YES" : "NO");
+
+    printf("\n");
+
+    printf("Switching to 65C02 mode ...\n");
+    SET_CPU_MODE(SIM65_CPU_MODE_65C02);
+    printf("Current CPU mode .......... : %u\n", GET_CPU_MODE());
+    printf("Is 65C02? ................. : %s\n", is_65c02() ? "YES" : "NO");
+
+    printf("\n");
+
+    printf("Switching to 6502X mode ...\n");
+    SET_CPU_MODE(SIM65_CPU_MODE_6502X);
+    printf("Current CPU mode .......... : %u\n", GET_CPU_MODE());
+    printf("Is 65C02? ................. : %s\n", is_65c02() ? "YES" : "NO");
+
+    printf("\n");
+
+    printf("Bye!\n");
+
+    return 0;
+}

--- a/samples/sim65/cpumode_example.c
+++ b/samples/sim65/cpumode_example.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * Sim65 cpu-mode switching example.
  *
  * Description

--- a/samples/sim65/timer_example.c
+++ b/samples/sim65/timer_example.c
@@ -44,7 +44,7 @@
 #include <stdlib.h>
 #include <sim65.h>
 
-uint32_t static timestamp(void)
+static uint32_t timestamp(void)
 {
     peripherals.counter.select = COUNTER_SELECT_CLOCKCYCLE_COUNTER;
     peripherals.counter.latch = 0;

--- a/samples/sim65/timer_example.c
+++ b/samples/sim65/timer_example.c
@@ -1,0 +1,117 @@
+/* 
+ * Sim65 timer example.
+ *
+ * Description
+ * -----------
+ *
+ * This example tests the clock cycle counter feature of sim65.
+ *
+ * The function 'timestamp' obtains the lower 32-bits of the clock cycle counter.
+ *
+ * The function 'calc_sum_terms' calculates the sum of a range of integers
+ * starting at zero. It simply iterates over all terms, which means that its
+ * runtime is a linear function of its input value.
+ *
+ * In the main function, we first derive an 'offset' value by getting two timestamp
+ * values, with nothing happening in between. Ideally this should yield a 0 clock
+ * cycle duration, but due to the overhead of calling the 'timestamp' function,
+ * and the 'timestamp' function itself, the difference between these timestamp
+ * will be non-zero. We store this value in the 'overhead' variable, and subtract
+ * this value in later measurements.
+ *
+ * Next, we measure the duration of calling the function 'calc_sum_terms' with two
+ * input values, 0, and 1. The duration includes storing the result in the 'result'
+ * variable.
+ *
+ * Extrapolating from these two measurements, and assuming that the runtime of
+ * calling 'calc_sum_terms' and storing its result scales linearly with its argument,
+ * we can predict the duration of a call to 'calc_sum_terms' with a much larger
+ * argument (max_terms = 10000).
+ *
+ * Finally, we actually measure the duration with max_terms = 10000. If the
+ * duration measured is equal to the predicted value, we exit successfully. If not,
+ * we exit with failure.
+ *
+ * Running the example
+ * -------------------
+ *
+ * cl65 -t sim6502 -O timer_example.c -o timer_example.prg
+ * sim65 timer_example.prg
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sim65.h>
+
+uint32_t static timestamp(void)
+{
+    peripherals.counter.select = COUNTER_SELECT_CLOCKCYCLE_COUNTER;
+    peripherals.counter.latch = 0;
+    return peripherals.counter.value32[0];
+}
+
+static unsigned long calc_sum_terms(unsigned max_term)
+/* A function with a runtime that scales linearly with its argument. */
+{
+    unsigned k;
+    unsigned long sum = 0;
+    for (k = 0; k <= max_term; ++k)
+    {
+        sum += k;
+    }
+    return sum;
+}
+
+int main(void)
+{
+    unsigned max_term;
+    unsigned long result;
+    uint32_t t1, t2, overhead, duration;
+    int32_t d0, d1;
+    int32_t  predicted_duration;
+
+    /* Calibration measurement of zero clock cycles, to determine the overhead. */
+
+    overhead = 0;
+    t1 = timestamp();
+    t2 = timestamp() - overhead;
+    overhead = (t2 - t1);
+
+    /* Calculate call duration (including assignment of result) for argument value 0. */
+
+    max_term = 0;
+    t1 = timestamp();
+    result = calc_sum_terms(max_term);
+    t2 = timestamp();
+    d0 = (t2 - t1) - overhead;
+    printf("max_term = %u -> result = %lu; duration = %ld\n", max_term, result, d0);
+
+    /* Calculate call duration (including assignment of result) for argument value 1. */
+
+    max_term = 1;
+    t1 = timestamp();
+    result = calc_sum_terms(max_term);
+    t2 = timestamp();
+    d1 = (t2 - t1) - overhead;
+    printf("max_term = %u -> result = %lu; duration = %ld\n", max_term, result, d1);
+
+    /* Predict runtime for a much bigger argument value, 10000. */
+
+    max_term = 10000;
+    predicted_duration = d0 + max_term * (d1 - d0);
+
+    printf("predicted duration for max_term = %u: %lu\n", max_term, predicted_duration);
+
+    /* Do the actual measurement for max_term = 10000. */
+
+    t1 = timestamp();
+    result = calc_sum_terms(max_term);
+    t2 = timestamp();
+    duration = (t2 - t1) - overhead;
+    printf("max_term = %u -> result = %lu; duration = %ld\n", max_term, result, duration);
+
+    /* Report success or failure. */
+
+    return (duration == predicted_duration) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/samples/sim65/timer_example.c
+++ b/samples/sim65/timer_example.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * Sim65 timer example.
  *
  * Description

--- a/samples/sim65/trace_example.c
+++ b/samples/sim65/trace_example.c
@@ -33,8 +33,8 @@ unsigned x;
 
 int main(void)
 {
-	TRACE_ON();
-	x = 0x1234;
-	TRACE_OFF();
-	return 0;
+    TRACE_ON();
+    x = 0x1234;
+    TRACE_OFF();
+    return 0;
 }

--- a/samples/sim65/trace_example.c
+++ b/samples/sim65/trace_example.c
@@ -1,0 +1,40 @@
+/* 
+ * Sim65 trace functionailty example.
+ *
+ * Description
+ * -----------
+ *
+ * The easiest way to use tracing in sim65 is to pass the '--trace' option
+ * to sim65 while starting a program.
+ *
+ * However, it is also possiblke to enable and disable the trace functionality
+ * at runtime, from within the C code itself. This can be useful to produce
+ * runtime traces of small code fragments for debugging purposes.
+ *
+ * In this example, We use the TRACE_ON and TRACE_OFF macros provided in sim65.h
+ * to trace what the CPU is doing during a single statement: the assignment of
+ * a constant to a global variable.
+ *
+ * Running the example
+ * -------------------
+ *
+ * cl65 -t sim6502 -O trace_example.c -o trace_example.prg
+ * sim65 trace_example.prg
+ *
+ * Compiling and running the program like this will produce a trace of six 6502 instructions.
+ * The first four instructions correspond to the 'x = 0x1234' assignment statement.
+ * The last two instructions (ending in a store to address $FFCB) disable the trace facility.
+ *
+ */
+
+#include <sim65.h>
+
+unsigned x;
+
+int main(void)
+{
+	TRACE_ON();
+	x = 0x1234;
+	TRACE_OFF();
+	return 0;
+}

--- a/samples/sim65/trace_example.c
+++ b/samples/sim65/trace_example.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * Sim65 trace functionailty example.
  *
  * Description

--- a/src/sim65.vcxproj
+++ b/src/sim65.vcxproj
@@ -87,6 +87,7 @@
     <ClInclude Include="sim65\memory.h" />
     <ClInclude Include="sim65\paravirt.h" />
     <ClInclude Include="sim65\peripherals.h" />
+    <ClInclude Include="sim65\trace.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="sim65\6502.c" />
@@ -95,6 +96,7 @@
     <ClCompile Include="sim65\memory.c" />
     <ClCompile Include="sim65\paravirt.c" />
     <ClCompile Include="sim65\peripherals.c" />
+    <ClCompile Include="sim65\trace.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/sim65/6502.h
+++ b/src/sim65/6502.h
@@ -48,9 +48,9 @@
 
 /* Supported CPUs */
 typedef enum CPUType {
-    CPU_6502,
-    CPU_65C02,
-    CPU_6502X
+    CPU_6502  = 0,
+    CPU_65C02 = 1,
+    CPU_6502X = 2
 } CPUType;
 
 /* Current CPU */

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -100,8 +100,8 @@ static void Usage (void)
             "Long options:\n"
             "  --help\t\tHelp (this text)\n"
             "  --cycles\t\tPrint amount of executed CPU cycles\n"
-            "  --cpu <type>\t\tSet CPU type\n"
-            "  --trace\t\tEnable trace mode\n"
+            "  --cpu <type>\t\tOverride CPU type (6502, 65C02, 6502X)\n"
+            "  --trace\t\tEnable CPU trace\n"
             "  --verbose\t\tIncrease verbosity\n"
             "  --version\t\tPrint the simulator version number\n",
             ProgName);

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -129,7 +129,7 @@ static void OptCPU (const char* Opt, const char* Arg)
     } else if (strcmp(Arg, "65C02") == 0 || strcmp(Arg, "65c02") == 0) {
         CPU = CPU_65C02;
         CPUOverrideActive = true;
-    } else if (strcmp(Arg, "6502X") == 0 || strcmp(Arg, "6502X") == 0) {
+    } else if (strcmp(Arg, "6502X") == 0 || strcmp(Arg, "6502x") == 0) {
         CPU = CPU_6502X;
         CPUOverrideActive = true;
     } else {
@@ -174,12 +174,16 @@ static void OptVersion (const char* Opt attribute ((unused)),
     exit (EXIT_SUCCESS);
 }
 
+
+
 static void OptQuitXIns (const char* Opt attribute ((unused)),
                         const char* Arg)
 /* Quit after MaxCycles cycles */
 {
     MaxCycles = strtoull(Arg, NULL, 0);
 }
+
+
 
 static unsigned char ReadProgramFile (void)
 /* Load program into memory */

--- a/src/sim65/main.c
+++ b/src/sim65/main.c
@@ -358,7 +358,7 @@ int main (int argc, char* argv[])
     PeripheralsInit ();
 
     /* Read program file into memory.
-     * This also sets the CPU type, unless a CPU override is in effect. 
+     * This also sets the CPU type, unless a CPU override is in effect.
      */
     SPAddr = ReadProgramFile ();
 

--- a/src/sim65/peripherals.c
+++ b/src/sim65/peripherals.c
@@ -37,6 +37,8 @@
 
 
 #include "peripherals.h"
+#include "trace.h"
+#include "6502.h"
 
 
 /*****************************************************************************/
@@ -146,6 +148,20 @@ void PeripheralsWriteByte (uint8_t Addr, uint8_t Val)
             break;
         }
 
+        /* Handle writes to the SimControl peripheral. */
+
+        case PERIPHERALS_SIMCONTROL_ADDRESS_OFFSET_CPUMODE: {
+            if (Val == CPU_6502 || Val == CPU_65C02 || Val == CPU_6502X) {
+                CPU = Val;
+            }
+            break;
+        }
+
+        case PERIPHERALS_SIMCONTROL_ADDRESS_OFFSET_TRACEMODE: {
+            TraceMode = Val;
+            break;
+        }
+
         /* Handle writes to unused and read-only peripheral addresses. */
 
         default: {
@@ -190,6 +206,16 @@ uint8_t PeripheralsReadByte (uint8_t Addr)
             }
             /* Return the desired byte of the latched counter; 0==LSB, 7==MSB. */
             return (uint8_t)(Value >> (SelectedByteIndex * 8));
+        }
+
+        /* Handle reads from the SimControl peripheral. */
+
+        case PERIPHERALS_SIMCONTROL_ADDRESS_OFFSET_CPUMODE: {
+            return CPU;
+        }
+
+        case PERIPHERALS_SIMCONTROL_ADDRESS_OFFSET_TRACEMODE: {
+            return TraceMode;
         }
 
         /* Handle reads from unused peripheral and write-only addresses. */

--- a/src/sim65/peripherals.h
+++ b/src/sim65/peripherals.h
@@ -92,16 +92,11 @@ typedef struct {
 #define PERIPHERALS_SIMCONTROL_CPUMODE   (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_SIMCONTROL_ADDRESS_OFFSET_CPUMODE)
 #define PERIPHERALS_SIMCONTROL_TRACEMODE (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_SIMCONTROL_ADDRESS_OFFSET_TRACEMODE)
 
-typedef struct {
-    /* The SimControl peripheral has no state. */
-} SimControlPeripheral;
-
 /* Declare the 'Sim65Peripherals' type and its single instance 'Peripherals'. */
 
 typedef struct {
     /* State of the peripherals available in sim65. */
     CounterPeripheral Counter;
-    SimControlPeripheral SimControl;
 } Sim65Peripherals;
 
 extern Sim65Peripherals Peripherals;

--- a/src/sim65/peripherals.h
+++ b/src/sim65/peripherals.h
@@ -38,7 +38,7 @@
 /* The memory range where the memory-mapped peripherals can be accessed. */
 
 #define PERIPHERALS_APERTURE_BASE_ADDRESS  0xffc0
-#define PERIPHERALS_APERTURE_LAST_ADDRESS  0xffc9
+#define PERIPHERALS_APERTURE_LAST_ADDRESS  0xffcb
 
 /* Declarations for the COUNTER peripheral */
 

--- a/src/sim65/peripherals.h
+++ b/src/sim65/peripherals.h
@@ -40,7 +40,7 @@
 #define PERIPHERALS_APERTURE_BASE_ADDRESS  0xffc0
 #define PERIPHERALS_APERTURE_LAST_ADDRESS  0xffc9
 
-/* Declarations for the COUNTER peripheral (currently the only peripheral). */
+/* Declarations for the COUNTER peripheral */
 
 #define PERIPHERALS_COUNTER_ADDRESS_OFFSET_LATCH   0x00
 #define PERIPHERALS_COUNTER_ADDRESS_OFFSET_SELECT  0x01
@@ -84,14 +84,24 @@ typedef struct {
     uint8_t LatchedValueSelected;
 } CounterPeripheral;
 
+/* Declarations for the SIMCONTROL peripheral. */
 
+#define PERIPHERALS_SIMCONTROL_ADDRESS_OFFSET_CPUMODE   0x0A
+#define PERIPHERALS_SIMCONTROL_ADDRESS_OFFSET_TRACEMODE 0x0B
+
+#define PERIPHERALS_SIMCONTROL_CPUMODE   (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_SIMCONTROL_ADDRESS_OFFSET_CPUMODE)
+#define PERIPHERALS_SIMCONTROL_TRACEMODE (PERIPHERALS_APERTURE_BASE_ADDRESS + PERIPHERALS_SIMCONTROL_ADDRESS_OFFSET_TRACEMODE)
+
+typedef struct {
+    /* The SimControl peripheral has no state. */
+} SimControlPeripheral;
 
 /* Declare the 'Sim65Peripherals' type and its single instance 'Peripherals'. */
 
 typedef struct {
-    /* State of the peripherals available in sim65.
-     * Currently, there is only one peripheral: the Counter. */
+    /* State of the peripherals available in sim65. */
     CounterPeripheral Counter;
+    SimControlPeripheral SimControl;
 } Sim65Peripherals;
 
 extern Sim65Peripherals Peripherals;

--- a/src/sim65/trace.c
+++ b/src/sim65/trace.c
@@ -1082,7 +1082,7 @@ static void PrintTraceInstructionOrInterrupt (const char * InterruptType)
         }
 
         /* Fill out the field to 16 characters */
-        num_bytes = traceline_ptr - save_ptr;
+        num_bytes = (unsigned)(traceline_ptr - save_ptr);
         if (num_bytes < 16) {
             traceline_ptr += sprintf (traceline_ptr, "%*s", 16 - num_bytes, "");
         }

--- a/src/sim65/trace.c
+++ b/src/sim65/trace.c
@@ -41,7 +41,7 @@
 /* Current Trace Mode. Tracing is off by default, and needs to be explicitly enabled. */
 uint8_t TraceMode = TRACE_DISABLED;
 
-/* CC65 stack pointer */ 
+/* CC65 stack pointer */
 uint8_t StackPointerZPageAddress;
 
 /* 6502, 65C02 addressing modes. */
@@ -1150,5 +1150,5 @@ void PrintTraceIRQ (void)
 
 void PrintTraceInstruction (void)
 {
-    PrintTraceInstructionOrInterrupt(NULL);    
+    PrintTraceInstructionOrInterrupt(NULL);
 }

--- a/src/sim65/trace.c
+++ b/src/sim65/trace.c
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 #include <stdlib.h>
 #include <inttypes.h>
+#include <assert.h>
 
 #include "6502.h"
 #include "memory.h"
@@ -923,6 +924,9 @@ static unsigned GetInstructionLength (uint8_t opcode)
         case ABS_X_IND:
             return 3;
     }
+
+    /* We should never get here. */
+    assert(false);
 }
 
 

--- a/src/sim65/trace.c
+++ b/src/sim65/trace.c
@@ -1,0 +1,1154 @@
+/*****************************************************************************/
+/*                                                                           */
+/*                                 trace.c                                   */
+/*                                                                           */
+/*             Instruction tracing functionality sim65 6502 simulator        */
+/*                                                                           */
+/*                                                                           */
+/*                                                                           */
+/* (C) 2025, Sidney Cadot                                                    */
+/*                                                                           */
+/*                                                                           */
+/* This software is provided 'as-is', without any expressed or implied       */
+/* warranty.  In no event will the authors be held liable for any damages    */
+/* arising from the use of this software.                                    */
+/*                                                                           */
+/* Permission is granted to anyone to use this software for any purpose,     */
+/* including commercial applications, and to alter it and redistribute it    */
+/* freely, subject to the following restrictions:                            */
+/*                                                                           */
+/* 1. The origin of this software must not be misrepresented; you must not   */
+/*    claim that you wrote the original software. If you use this software   */
+/*    in a product, an acknowledgment in the product documentation would be  */
+/*    appreciated but is not required.                                       */
+/* 2. Altered source versions must be plainly marked as such, and must not   */
+/*    be misrepresented as being the original software.                      */
+/* 3. This notice may not be removed or altered from any source              */
+/*    distribution.                                                          */
+/*                                                                           */
+/*****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include "6502.h"
+#include "memory.h"
+#include "trace.h"
+#include "peripherals.h"
+
+/* Current Trace Mode. Tracing is off by default, and needs to be explicitly enabled. */
+uint8_t TraceMode = TRACE_DISABLED;
+
+/* CC65 stack pointer */ 
+uint8_t StackPointerZPageAddress;
+
+/* 6502, 65C02 addressing modes. */
+typedef enum {
+    ILLEGAL,
+    IMPLIED,
+    ACCUMULATOR,
+    IMMEDIATE,
+    REL,
+    ZP,
+    ZP_X,
+    ZP_Y,
+    ZP_IND,
+    ZP_X_IND,
+    ZP_IND_Y,
+    ZP_REL,
+    ABS,
+    ABS_X,
+    ABS_Y,
+    ABS_IND,
+    ABS_X_IND
+} AddressingMode;
+
+/* Info for a specific opcode and addressing mode, for a specific CPU type. */
+typedef struct {
+    const char * mnemonic;
+    AddressingMode adrmode;
+} InstructionInfo;
+
+/* Information for standard 6502 opcodes. */
+static InstructionInfo II_6502[256] = {
+    { "brk"  , IMPLIED     }, /* 0x00 to 0x0f */
+    { "ora"  , ZP_X_IND    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "ora"  , ZP          },
+    { "asl"  , ZP          },
+    { "???"  , ILLEGAL     },
+    { "php"  , IMPLIED     },
+    { "ora"  , IMMEDIATE   },
+    { "asl"  , ACCUMULATOR },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "ora"  , ABS         },
+    { "asl"  , ABS         },
+    { "???"  , ILLEGAL     },
+
+    { "bpl"  , REL         }, /* 0x10 to 0x1f */
+    { "ora"  , ZP_IND_Y    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "ora"  , ZP_X        },
+    { "asl"  , ZP_X        },
+    { "???"  , ILLEGAL     },
+    { "clc"  , IMPLIED     },
+    { "ora"  , ABS_Y       },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "ora"  , ABS_X       },
+    { "asl"  , ABS_X       },
+    { "???"  , ILLEGAL     },
+
+    { "jsr"  , ABS         }, /* 0x20 to 0x2f */
+    { "and"  , ZP_X_IND    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "bit"  , ZP          },
+    { "and"  , ZP          },
+    { "rol"  , ZP          },
+    { "???"  , ILLEGAL     },
+    { "plp"  , IMPLIED     },
+    { "and"  , IMMEDIATE   },
+    { "rol"  , ACCUMULATOR },
+    { "???"  , ILLEGAL     },
+    { "bit"  , ABS         },
+    { "and"  , ABS         },
+    { "rol"  , ABS         },
+    { "???"  , ILLEGAL     },
+
+    { "bmi"  , REL         }, /* 0x30 to 0x3f */
+    { "and"  , ZP_IND_Y    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "and"  , ZP_X        },
+    { "rol"  , ZP_X        },
+    { "???"  , ILLEGAL     },
+    { "sec"  , IMPLIED     },
+    { "and"  , ABS_Y       },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "and"  , ABS_X       },
+    { "rol"  , ABS_X       },
+    { "???"  , ILLEGAL     },
+
+    { "rti"  , IMPLIED     }, /* 0x40 to 0x4f */
+    { "eor"  , ZP_X_IND    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "eor"  , ZP          },
+    { "lsr"  , ZP          },
+    { "???"  , ILLEGAL     },
+    { "pha"  , IMPLIED     },
+    { "eor"  , IMMEDIATE   },
+    { "lsr"  , ACCUMULATOR },
+    { "???"  , ILLEGAL     },
+    { "jmp"  , ABS         },
+    { "eor"  , ABS         },
+    { "lsr"  , ABS         },
+    { "???"  , ILLEGAL     },
+
+    { "bvc"  , REL         }, /* 0x50 to 0x5f */
+    { "eor"  , ZP_IND_Y    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "eor"  , ZP_X        },
+    { "lsr"  , ZP_X        },
+    { "???"  , ILLEGAL     },
+    { "cli"  , IMPLIED     },
+    { "eor"  , ABS_Y       },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "eor"  , ABS_X       },
+    { "lsr"  , ABS_X       },
+    { "???"  , ILLEGAL     },
+
+    { "rts"  , IMPLIED     }, /* 0x60 to 0x6f */
+    { "adc"  , ZP_X_IND    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "adc"  , ZP          },
+    { "ror"  , ZP          },
+    { "???"  , ILLEGAL     },
+    { "pla"  , IMPLIED     },
+    { "adc"  , IMMEDIATE   },
+    { "ror"  , ACCUMULATOR },
+    { "???"  , ILLEGAL     },
+    { "jmp"  , ABS_IND     },
+    { "adc"  , ABS         },
+    { "ror"  , ABS         },
+    { "???"  , ILLEGAL     },
+
+    { "bvs"  , REL         }, /* 0x70 to 0x7f */
+    { "adc"  , ZP_IND_Y    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "adc"  , ZP_X        },
+    { "ror"  , ZP_X        },
+    { "???"  , ILLEGAL     },
+    { "sei"  , IMPLIED     },
+    { "adc"  , ABS_Y       },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "adc"  , ABS_X       },
+    { "ror"  , ABS_X       },
+    { "???"  , ILLEGAL     },
+
+    { "???"  , ILLEGAL     }, /* 0x80 to 0x8f */
+    { "sta"  , ZP_X_IND    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "sty"  , ZP          },
+    { "sta"  , ZP          },
+    { "stx"  , ZP          },
+    { "???"  , ILLEGAL     },
+    { "dey"  , IMPLIED     },
+    { "???"  , ILLEGAL     },
+    { "txa"  , IMPLIED     },
+    { "???"  , ILLEGAL     },
+    { "sty"  , ABS         },
+    { "sta"  , ABS         },
+    { "stx"  , ABS         },
+    { "???"  , ILLEGAL     },
+
+    { "bcc"  , REL         }, /* 0x90 to 0x9f */
+    { "sta"  , ZP_IND_Y    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "sty"  , ZP_X        },
+    { "sta"  , ZP_X        },
+    { "stx"  , ZP_Y        },
+    { "???"  , ILLEGAL     },
+    { "tya"  , IMPLIED     },
+    { "sta"  , ABS_Y       },
+    { "txs"  , IMPLIED     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "sta"  , ABS_X       },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+
+    { "ldy"  , IMMEDIATE   }, /* 0xa0 to 0xaf */
+    { "lda"  , ZP_X_IND    },
+    { "ldx"  , IMMEDIATE   },
+    { "???"  , ILLEGAL     },
+    { "ldy"  , ZP          },
+    { "lda"  , ZP          },
+    { "ldx"  , ZP          },
+    { "???"  , ILLEGAL     },
+    { "tay"  , IMPLIED     },
+    { "lda"  , IMMEDIATE   },
+    { "tax"  , IMPLIED     },
+    { "???"  , ILLEGAL     },
+    { "ldy"  , ABS         },
+    { "lda"  , ABS         },
+    { "ldx"  , ABS         },
+    { "???"  , ILLEGAL     },
+
+    { "bcs"  , REL         }, /* 0xb0 to 0xbf */
+    { "lda"  , ZP_IND_Y    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "ldy"  , ZP_X        },
+    { "lda"  , ZP_X        },
+    { "ldx"  , ZP_Y        },
+    { "???"  , ILLEGAL     },
+    { "clv"  , IMPLIED     },
+    { "lda"  , ABS_Y       },
+    { "tsx"  , IMPLIED     },
+    { "???"  , ILLEGAL     },
+    { "ldy"  , ABS_X       },
+    { "lda"  , ABS_X       },
+    { "ldx"  , ABS_Y       },
+    { "???"  , ILLEGAL     },
+
+    { "cpy"  , IMMEDIATE   }, /* 0xc0 to 0xcf */
+    { "cmp"  , ZP_X_IND    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "cpy"  , ZP          },
+    { "cmp"  , ZP          },
+    { "dec"  , ZP          },
+    { "???"  , ILLEGAL     },
+    { "iny"  , IMPLIED     },
+    { "cmp"  , IMMEDIATE   },
+    { "dex"  , IMPLIED     },
+    { "???"  , ILLEGAL     },
+    { "cpy"  , ABS         },
+    { "cmp"  , ABS         },
+    { "dec"  , ABS         },
+    { "???"  , ILLEGAL     },
+
+    { "bne"  , REL         }, /* 0xd0 to 0xdf */
+    { "cmp"  , ZP_IND_Y    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "cmp"  , ZP_X        },
+    { "dec"  , ZP_X        },
+    { "???"  , ILLEGAL     },
+    { "cld"  , IMPLIED     },
+    { "cmp"  , ABS_Y       },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "cmp"  , ABS_X       },
+    { "dec"  , ABS_X       },
+    { "???"  , ILLEGAL     },
+
+    { "cpx"  , IMMEDIATE   }, /* 0xe0 to 0xef */
+    { "sbc"  , ZP_X_IND    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "cpx"  , ZP          },
+    { "sbc"  , ZP          },
+    { "inc"  , ZP          },
+    { "???"  , ILLEGAL     },
+    { "inx"  , IMPLIED     },
+    { "sbc"  , IMMEDIATE   },
+    { "nop"  , IMPLIED     },
+    { "???"  , ILLEGAL     },
+    { "cpx"  , ABS         },
+    { "sbc"  , ABS         },
+    { "inc"  , ABS         },
+    { "???"  , ILLEGAL     },
+
+    { "beq"  , REL         }, /* 0xf0 to 0xff */
+    { "sbc"  , ZP_IND_Y    },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "sbc"  , ZP_X        },
+    { "inc"  , ZP_X        },
+    { "???"  , ILLEGAL     },
+    { "sed"  , IMPLIED     },
+    { "sbc"  , ABS_Y       },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "???"  , ILLEGAL     },
+    { "sbc"  , ABS_X       },
+    { "inc"  , ABS_X       },
+    { "???"  , ILLEGAL     }
+};
+
+/* Information for 65C02 opcodes. */
+static InstructionInfo II_65C02[256] = {
+    { "brk"  , IMPLIED     }, /* 0x00 to 0x0f */
+    { "ora"  , ZP_X_IND    },
+    { "nop"  , IMMEDIATE   },
+    { "nop"  , IMPLIED     },
+    { "tsb"  , ZP          },
+    { "ora"  , ZP          },
+    { "asl"  , ZP          },
+    { "rmb0" , ZP          },
+    { "php"  , IMPLIED     },
+    { "ora"  , IMMEDIATE   },
+    { "asl"  , ACCUMULATOR },
+    { "nop"  , IMPLIED     },
+    { "tsb"  , ABS         },
+    { "ora"  , ABS         },
+    { "asl"  , ABS         },
+    { "bbr0" , ZP_REL      },
+
+    { "bpl"  , REL         }, /* 0x10 to 0x1f */
+    { "ora"  , ZP_IND_Y    },
+    { "ora"  , ZP_IND      },
+    { "nop"  , IMPLIED     },
+    { "trb"  , ZP          },
+    { "ora"  , ZP_X        },
+    { "asl"  , ZP_X        },
+    { "rmb1" , ZP          },
+    { "clc"  , IMPLIED     },
+    { "ora"  , ABS_Y       },
+    { "inc"  , ACCUMULATOR },
+    { "nop"  , IMPLIED     },
+    { "trb"  , ABS         },
+    { "ora"  , ABS_X       },
+    { "asl"  , ABS_X       },
+    { "bbr1" , ZP_REL      },
+
+    { "jsr"  , ABS         }, /* 0x20 to 0x2f */
+    { "and"  , ZP_X_IND    },
+    { "nop"  , IMMEDIATE   },
+    { "nop"  , IMPLIED     },
+    { "bit"  , ZP          },
+    { "and"  , ZP          },
+    { "rol"  , ZP          },
+    { "rmb2" , ZP          },
+    { "plp"  , IMPLIED     },
+    { "and"  , IMMEDIATE   },
+    { "rol"  , ACCUMULATOR },
+    { "nop"  , IMPLIED     },
+    { "bit"  , ABS         },
+    { "and"  , ABS         },
+    { "rol"  , ABS         },
+    { "bbr2" , ZP_REL      },
+
+    { "bmi"  , REL         }, /* 0x30 to 0x3f */
+    { "and"  , ZP_IND_Y    },
+    { "and"  , ZP_IND      },
+    { "nop"  , IMPLIED     },
+    { "bit"  , ZP_X        },
+    { "and"  , ZP_X        },
+    { "rol"  , ZP_X        },
+    { "rmb3" , ZP          },
+    { "sec"  , IMPLIED     },
+    { "and"  , ABS_Y       },
+    { "dec"  , ACCUMULATOR },
+    { "nop"  , IMPLIED     },
+    { "bit"  , ABS_X       },
+    { "and"  , ABS_X       },
+    { "rol"  , ABS_X       },
+    { "bbr3" , ZP_REL      },
+
+    { "rti"  , IMPLIED     }, /* 0x40 to 0x4f */
+    { "eor"  , ZP_X_IND    },
+    { "nop"  , IMMEDIATE   },
+    { "nop"  , ILLEGAL     },
+    { "nop"  , ZP          },
+    { "eor"  , ZP          },
+    { "lsr"  , ZP          },
+    { "rmb4" , ZP          },
+    { "pha"  , IMPLIED     },
+    { "eor"  , IMMEDIATE   },
+    { "lsr"  , ACCUMULATOR },
+    { "nop"  , IMPLIED     },
+    { "jmp"  , ABS         },
+    { "eor"  , ABS         },
+    { "lsr"  , ABS         },
+    { "bbr4" , ZP_REL      },
+
+    { "bvc"  , REL         }, /* 0x50 to 0x5f */
+    { "eor"  , ZP_IND_Y    },
+    { "eor"  , ZP_IND      },
+    { "nop"  , IMPLIED     },
+    { "nop"  , ZP_X        },
+    { "eor"  , ZP_X        },
+    { "lsr"  , ZP_X        },
+    { "rmb5" , ZP          },
+    { "cli"  , IMPLIED     },
+    { "eor"  , ABS_Y       },
+    { "phy"  , IMPLIED     },
+    { "nop"  , IMPLIED     },
+    { "nop"  , ABS         },
+    { "eor"  , ABS_X       },
+    { "lsr"  , ABS_X       },
+    { "bbr5" , ZP_REL      },
+
+    { "rts"  , IMPLIED     }, /* 0x60 to 0x6f */
+    { "adc"  , ZP_X_IND    },
+    { "nop"  , IMMEDIATE   },
+    { "nop"  , IMPLIED     },
+    { "stz"  , ZP          },
+    { "adc"  , ZP          },
+    { "ror"  , ZP          },
+    { "rmb6" , ZP          },
+    { "pla"  , IMPLIED     },
+    { "adc"  , IMMEDIATE   },
+    { "ror"  , ACCUMULATOR },
+    { "nop"  , IMPLIED     },
+    { "jmp"  , ABS_IND     },
+    { "adc"  , ABS         },
+    { "ror"  , ABS         },
+    { "bbr6" , ZP_REL      },
+
+    { "bvs"  , REL         }, /* 0x70 to 0x7f */
+    { "adc"  , ZP_IND_Y    },
+    { "adc"  , ZP_IND      },
+    { "nop"  , IMPLIED     },
+    { "stz"  , ZP_X        },
+    { "adc"  , ZP_X        },
+    { "ror"  , ZP_X        },
+    { "rmb7" , ZP          },
+    { "sei"  , IMPLIED     },
+    { "adc"  , ABS_Y       },
+    { "ply"  , IMPLIED     },
+    { "nop"  , IMPLIED     },
+    { "jmp"  , ABS_X_IND   },
+    { "adc"  , ABS_X       },
+    { "ror"  , ABS_X       },
+    { "bbr7" , ZP_REL      },
+
+    { "bra"  , REL         }, /* 0x80 to 0x8f */
+    { "sta"  , ZP_X_IND    },
+    { "nop"  , IMMEDIATE   },
+    { "nop"  , IMPLIED     },
+    { "sty"  , ZP          },
+    { "sta"  , ZP          },
+    { "stx"  , ZP          },
+    { "smb0" , ZP          },
+    { "dey"  , IMPLIED     },
+    { "bit"  , IMMEDIATE   },
+    { "txa"  , IMPLIED     },
+    { "nop"  , IMPLIED     },
+    { "sty"  , ABS         },
+    { "sta"  , ABS         },
+    { "stx"  , ABS         },
+    { "bbs0" , ZP_REL      },
+
+    { "bcc"  , REL         }, /* 0x90 to 0x9f */
+    { "sta"  , ZP_IND_Y    },
+    { "sta"  , ZP_IND      },
+    { "nop"  , IMPLIED     },
+    { "sty"  , ZP_X        },
+    { "sta"  , ZP_X        },
+    { "stx"  , ZP_Y        },
+    { "smb1" , ZP          },
+    { "tya"  , IMPLIED     },
+    { "sta"  , ABS_Y       },
+    { "txs"  , IMPLIED     },
+    { "nop"  , IMPLIED     },
+    { "stz"  , ABS         },
+    { "sta"  , ABS_X       },
+    { "stz"  , ABS_X       },
+    { "bbs1" , ZP_REL      },
+
+    { "ldy"  , IMMEDIATE   }, /* 0xa0 to 0xaf */
+    { "lda"  , ZP_X_IND    },
+    { "ldx"  , IMMEDIATE   },
+    { "nop"  , IMPLIED     },
+    { "ldy"  , ZP          },
+    { "lda"  , ZP          },
+    { "ldx"  , ZP          },
+    { "smb2" , ZP          },
+    { "tay"  , IMPLIED     },
+    { "lda"  , IMMEDIATE   },
+    { "tax"  , IMPLIED     },
+    { "nop"  , IMPLIED     },
+    { "ldy"  , ABS         },
+    { "lda"  , ABS         },
+    { "ldx"  , ABS         },
+    { "bbs2" , ZP_REL      },
+
+    { "bcs"  , REL         }, /* 0xb0 to 0xbf */
+    { "lda"  , ZP_IND_Y    },
+    { "lda"  , ZP_IND      },
+    { "nop"  , IMPLIED     },
+    { "ldy"  , ZP_X        },
+    { "lda"  , ZP_X        },
+    { "ldx"  , ZP_Y        },
+    { "smb3" , ZP          },
+    { "clv"  , IMPLIED     },
+    { "lda"  , ABS_Y       },
+    { "tsx"  , IMPLIED     },
+    { "nop"  , IMPLIED     },
+    { "ldy"  , ABS_X       },
+    { "lda"  , ABS_X       },
+    { "ldx"  , ABS_Y       },
+    { "bbs3" , ZP_REL      },
+
+    { "cpy"  , IMMEDIATE   }, /* 0xc0 to 0xcf */
+    { "cmp"  , ZP_X_IND    },
+    { "nop"  , IMMEDIATE   },
+    { "nop"  , IMPLIED     },
+    { "cpy"  , ZP          },
+    { "cmp"  , ZP          },
+    { "dec"  , ZP          },
+    { "smb4" , ZP          },
+    { "iny"  , IMPLIED     },
+    { "cmp"  , IMMEDIATE   },
+    { "dex"  , IMPLIED     },
+    { "wai"  , IMPLIED     },
+    { "cpy"  , ABS         },
+    { "cmp"  , ABS         },
+    { "dec"  , ABS         },
+    { "bbs4" , ZP_REL      },
+
+    { "bne"  , REL         }, /* 0xd0 to 0xdf */
+    { "cmp"  , ZP_IND_Y    },
+    { "cmp"  , ZP_IND      },
+    { "nop"  , IMPLIED     },
+    { "nop"  , ZP_X        },
+    { "cmp"  , ZP_X        },
+    { "dec"  , ZP_X        },
+    { "smb5" , ZP          },
+    { "cld"  , IMPLIED     },
+    { "cmp"  , ABS_Y       },
+    { "phx"  , IMPLIED     },
+    { "stp"  , IMPLIED     },
+    { "nop"  , ABS         },
+    { "cmp"  , ABS_X       },
+    { "dec"  , ABS_X       },
+    { "bbs5" , ZP_REL      },
+
+    { "cpx"  , IMMEDIATE   }, /* 0xe0 to 0xef */
+    { "sbc"  , ZP_X_IND    },
+    { "nop"  , IMMEDIATE   },
+    { "nop"  , IMPLIED     },
+    { "cpx"  , ZP          },
+    { "sbc"  , ZP          },
+    { "inc"  , ZP          },
+    { "smb6" , ZP          },
+    { "inx"  , IMPLIED     },
+    { "sbc"  , IMMEDIATE   },
+    { "nop"  , IMPLIED     },
+    { "nop"  , IMPLIED     },
+    { "cpx"  , ABS         },
+    { "sbc"  , ABS         },
+    { "inc"  , ABS         },
+    { "bbs6" , ZP_REL      },
+
+    { "beq"  , REL         }, /* 0xf0 to 0xff */
+    { "sbc"  , ZP_IND_Y    },
+    { "sbc"  , ZP_IND      },
+    { "nop"  , IMPLIED     },
+    { "nop"  , ZP_X        },
+    { "sbc"  , ZP_X        },
+    { "inc"  , ZP_X        },
+    { "smb7" , ZP          },
+    { "sed"  , IMPLIED     },
+    { "sbc"  , ABS_Y       },
+    { "plx"  , IMPLIED     },
+    { "nop"  , IMPLIED     },
+    { "nop"  , ABS         },
+    { "sbc"  , ABS_X       },
+    { "inc"  , ABS_X       },
+    { "bbs7" , ZP_REL      }
+};
+
+/* Information for 6502X (6502 with undocumented instructions) opcodes. */
+static InstructionInfo II_6502X[256] = {
+    { "brk"  , IMPLIED     }, /* 0x00 to 0x0f */
+    { "ora"  , ZP_X_IND    },
+    { "jam"  , IMPLIED     },
+    { "slo"  , ZP_X_IND    },
+    { "nop"  , ZP          },
+    { "ora"  , ZP          },
+    { "asl"  , ZP          },
+    { "slo"  , ZP          },
+    { "php"  , IMPLIED     },
+    { "ora"  , IMMEDIATE   },
+    { "asl"  , ACCUMULATOR },
+    { "anc"  , IMMEDIATE   },
+    { "nop"  , ABS         },
+    { "ora"  , ABS         },
+    { "asl"  , ABS         },
+    { "slo"  , ABS         },
+
+    { "bpl"  , REL         }, /* 0x10 to 0x1f */
+    { "ora"  , ZP_IND_Y    },
+    { "jam"  , IMPLIED     },
+    { "slo"  , ZP_IND_Y    },
+    { "nop"  , ZP_X        },
+    { "ora"  , ZP_X        },
+    { "asl"  , ZP_X        },
+    { "slo"  , ZP          },
+    { "clc"  , IMPLIED     },
+    { "ora"  , ABS_Y       },
+    { "nop"  , IMPLIED     },
+    { "slo"  , ABS_Y       },
+    { "*nop" , ABS_X       },
+    { "ora"  , ABS_X       },
+    { "asl"  , ABS_X       },
+    { "slo"  , ABS_X       },
+
+    { "jsr"  , ABS         }, /* 0x20 to 0x2f */
+    { "and"  , ZP_X_IND    },
+    { "jam"  , IMPLIED     },
+    { "rla"  , ZP_X_IND    },
+    { "bit"  , ZP          },
+    { "and"  , ZP          },
+    { "rol"  , ZP          },
+    { "rla"  , ZP          },
+    { "plp"  , IMPLIED     },
+    { "and"  , IMMEDIATE   },
+    { "rol"  , ACCUMULATOR },
+    { "anc"  , IMMEDIATE   },
+    { "bit"  , ABS         },
+    { "and"  , ABS         },
+    { "rol"  , ABS         },
+    { "rla"  , ABS         },
+
+    { "bmi"  , REL         }, /* 0x30 to 0x3f */
+    { "and"  , ZP_IND_Y    },
+    { "jam"  , IMPLIED     },
+    { "rla"  , ZP_IND_Y    },
+    { "nop"  , ZP_X        },
+    { "and"  , ZP_X        },
+    { "rol"  , ZP_X        },
+    { "rla"  , ZP_X        },
+    { "sec"  , IMPLIED     },
+    { "and"  , ABS_Y       },
+    { "nop"  , IMPLIED     },
+    { "rla"  , ABS_Y       },
+    { "nop"  , ABS_X       },
+    { "and"  , ABS_X       },
+    { "rol"  , ABS_X       },
+    { "rla"  , ABS_X       },
+
+    { "rti"  , IMPLIED     }, /* 0x40 to 0x4f */
+    { "eor"  , ZP_X_IND    },
+    { "jam"  , IMPLIED     },
+    { "sre"  , ZP_X_IND    },
+    { "nop"  , ZP          },
+    { "eor"  , ZP          },
+    { "lsr"  , ZP          },
+    { "sre"  , ZP          },
+    { "pha"  , IMPLIED     },
+    { "eor"  , IMMEDIATE   },
+    { "lsr"  , ACCUMULATOR },
+    { "alr"  , IMMEDIATE   },
+    { "jmp"  , ABS         },
+    { "eor"  , ABS         },
+    { "lsr"  , ABS         },
+    { "sre"  , ABS         },
+
+    { "bvc"  , REL         }, /* 0x50 to 0x5f */
+    { "eor"  , ZP_IND_Y    },
+    { "jam"  , IMPLIED     },
+    { "sre"  , ZP_IND_Y    },
+    { "nop"  , ZP_X        },
+    { "eor"  , ZP_X        },
+    { "lsr"  , ZP_X        },
+    { "sre"  , ZP_X        },
+    { "cli"  , IMPLIED     },
+    { "eor"  , ABS_Y       },
+    { "nop"  , IMPLIED     },
+    { "sre"  , ABS_Y       },
+    { "nop"  , ABS_X       },
+    { "eor"  , ABS_X       },
+    { "lsr"  , ABS_X       },
+    { "sre"  , ABS_X       },
+
+    { "rts"  , IMPLIED     }, /* 0x60 to 0x6f */
+    { "adc"  , ZP_X_IND    },
+    { "jam"  , IMPLIED     },
+    { "rra"  , ZP_X_IND    },
+    { "nop"  , ZP          },
+    { "adc"  , ZP          },
+    { "ror"  , ZP          },
+    { "rra"  , ZP          },
+    { "pla"  , IMPLIED     },
+    { "adc"  , IMMEDIATE   },
+    { "ror"  , ACCUMULATOR },
+    { "arr"  , IMMEDIATE   },
+    { "jmp"  , ABS_IND     },
+    { "adc"  , ABS         },
+    { "ror"  , ABS         },
+    { "rra"  , ABS         },
+
+    { "bvs"  , REL         }, /* 0x70 to 0x7f */
+    { "adc"  , ZP_IND_Y    },
+    { "jam"  , IMPLIED     },
+    { "sre"  , ZP_IND_Y    },
+    { "nop"  , ZP_X        },
+    { "adc"  , ZP_X        },
+    { "ror"  , ZP_X        },
+    { "rra"  , ZP_X        },
+    { "sei"  , IMPLIED     },
+    { "adc"  , ABS_Y       },
+    { "nop"  , IMPLIED     },
+    { "rra"  , ABS_Y       },
+    { "nop"  , ABS_X       },
+    { "adc"  , ABS_X       },
+    { "ror"  , ABS_X       },
+    { "rra"  , ABS_X       },
+
+    { "nop"  , IMMEDIATE   }, /* 0x80 to 0x8f */
+    { "sta"  , ZP_X_IND    },
+    { "nop"  , IMMEDIATE   },
+    { "sax"  , ZP_X_IND    },
+    { "sty"  , ZP          },
+    { "sta"  , ZP          },
+    { "stx"  , ZP          },
+    { "sax"  , ZP          },
+    { "dey"  , IMPLIED     },
+    { "nop"  , IMMEDIATE   },
+    { "txa"  , IMPLIED     },
+    { "ane"  , IMMEDIATE   },
+    { "sty"  , ABS         },
+    { "sta"  , ABS         },
+    { "stx"  , ABS         },
+    { "sax"  , ABS         },
+
+    { "bcc"  , REL         }, /* 0x90 to 0x9f */
+    { "sta"  , ZP_IND_Y    },
+    { "jam"  , IMPLIED     },
+    { "sha"  , ZP_IND_Y    },
+    { "sty"  , ZP_X        },
+    { "sta"  , ZP_X        },
+    { "stx"  , ZP_Y        },
+    { "sax"  , ZP_Y        },
+    { "tya"  , IMPLIED     },
+    { "sta"  , ABS_Y       },
+    { "txs"  , IMPLIED     },
+    { "tas"  , ABS_Y       },
+    { "shy"  , ABS_X       },
+    { "sta"  , ABS_X       },
+    { "shx"  , ABS_Y       },
+    { "sha"  , ABS_Y       },
+
+    { "ldy"  , IMMEDIATE   }, /* 0xa0 to 0xaf */
+    { "lda"  , ZP_X_IND    },
+    { "ldx"  , IMMEDIATE   },
+    { "lax"  , ZP_X_IND    },
+    { "ldy"  , ZP          },
+    { "lda"  , ZP          },
+    { "ldx"  , ZP          },
+    { "lax"  , ZP          },
+    { "tay"  , IMPLIED     },
+    { "lda"  , IMMEDIATE   },
+    { "tax"  , IMPLIED     },
+    { "lax"  , IMMEDIATE   },
+    { "ldy"  , ABS         },
+    { "lda"  , ABS         },
+    { "ldx"  , ABS         },
+    { "lax"  , ABS         },
+
+    { "bcs"  , REL         }, /* 0xb0 to 0xbf */
+    { "lda"  , ZP_IND_Y    },
+    { "jam"  , IMPLIED     },
+    { "lax"  , ZP_IND_Y    },
+    { "ldy"  , ZP_X        },
+    { "lda"  , ZP_X        },
+    { "ldx"  , ZP_Y        },
+    { "lax"  , ZP_Y        },
+    { "clv"  , IMPLIED     },
+    { "lda"  , ABS_Y       },
+    { "tsx"  , IMPLIED     },
+    { "las"  , ABS_Y       },
+    { "ldy"  , ABS_X       },
+    { "lda"  , ABS_X       },
+    { "ldx"  , ABS_Y       },
+    { "lax"  , ABS_Y       },
+
+    { "cpy"  , IMMEDIATE   }, /* 0xc0 to 0xcf */
+    { "cmp"  , ZP_X_IND    },
+    { "nop"  , IMMEDIATE   },
+    { "dcp"  , ZP_X_IND    },
+    { "cpy"  , ZP          },
+    { "cmp"  , ZP          },
+    { "dec"  , ZP          },
+    { "dcp"  , ZP          },
+    { "iny"  , IMPLIED     },
+    { "cmp"  , IMMEDIATE   },
+    { "dex"  , IMPLIED     },
+    { "sbx"  , IMMEDIATE   },
+    { "cpy"  , ABS         },
+    { "cmp"  , ABS         },
+    { "dec"  , ABS         },
+    { "dcp"  , ABS         },
+
+    { "bne"  , REL         }, /* 0xd0 to 0xdf */
+    { "cmp"  , ZP_IND_Y    },
+    { "jam"  , IMPLIED     },
+    { "dcp"  , ZP_IND_Y    },
+    { "nop"  , ZP_X        },
+    { "cmp"  , ZP_X        },
+    { "dec"  , ZP_X        },
+    { "dcp"  , ZP_X        },
+    { "cld"  , IMPLIED     },
+    { "cmp"  , ABS_Y       },
+    { "nop"  , IMPLIED     },
+    { "dcp"  , ABS_Y       },
+    { "nop"  , ABS_X       },
+    { "cmp"  , ABS_X       },
+    { "dec"  , ABS_X       },
+    { "dcp"  , ABS_X       },
+
+    { "cpx"  , IMMEDIATE   }, /* 0xe0 to 0xef */
+    { "sbc"  , ZP_X_IND    },
+    { "nop"  , IMMEDIATE   },
+    { "isc"  , ZP_X_IND    },
+    { "cpx"  , ZP          },
+    { "sbc"  , ZP          },
+    { "inc"  , ZP          },
+    { "isc"  , ZP          },
+    { "inx"  , IMPLIED     },
+    { "sbc"  , IMMEDIATE   },
+    { "nop"  , IMPLIED     },
+    { "sbc"  , IMMEDIATE   },
+    { "cpx"  , ABS         },
+    { "sbc"  , ABS         },
+    { "inc"  , ABS         },
+    { "isc"  , ABS         },
+
+    { "beq"  , REL         }, /* 0xf0 to 0xff */
+    { "sbc"  , ZP_IND_Y    },
+    { "jam"  , IMPLIED     },
+    { "isc"  , ZP_IND_Y    },
+    { "nop"  , ZP_X        },
+    { "sbc"  , ZP_X        },
+    { "inc"  , ZP_X        },
+    { "isc"  , ZP_X        },
+    { "sed"  , IMPLIED     },
+    { "sbc"  , ABS_Y       },
+    { "nop"  , IMPLIED     },
+    { "isc"  , ABS_Y       },
+    { "nop"  , ABS_X       },
+    { "sbc"  , ABS_X       },
+    { "inc"  , ABS_X       },
+    { "isc"  , ABS_X       }
+};
+
+static InstructionInfo * II[3] = { II_6502, II_65C02, II_6502X };
+
+static unsigned GetInstructionLength (uint8_t opcode)
+/* Get the number of bytes in the full instruction. Depends on the addressing mode. */
+{
+    switch (II[CPU][opcode].adrmode) {
+        case ILLEGAL:
+        case IMPLIED:
+        case ACCUMULATOR:
+            return 1;
+        case IMMEDIATE:
+        case REL:
+        case ZP:
+        case ZP_X:
+        case ZP_Y:
+        case ZP_IND:
+        case ZP_X_IND:
+        case ZP_IND_Y:
+            return 2;
+        case ZP_REL:
+        case ABS:
+        case ABS_X:
+        case ABS_Y:
+        case ABS_IND:
+        case ABS_X_IND:
+            return 3;
+    }
+}
+
+
+
+static char * PrintAssemblyInstruction (char * ptr)
+/* Print assembly instruction: mnemonic and addres-mode specific operand(s). */
+{
+    uint8_t opcode;
+
+    /* Print the instruction starting at the current program counter. */
+
+    opcode = MemReadByte (Regs.PC);
+
+    ptr += sprintf (ptr, "%-4s ", II[CPU][opcode].mnemonic);
+
+    switch (II[CPU][opcode].adrmode) {
+        case IMPLIED:
+        case ILLEGAL:
+            break;
+        case ACCUMULATOR:
+            ptr += sprintf (ptr, "A");
+            break;
+        case IMMEDIATE:
+            ptr += sprintf (ptr, "#$%02X", MemReadByte (Regs.PC + 1));
+            break;
+        case REL:
+            ptr += sprintf (ptr, "$%04X", Regs.PC + 2 + (int8_t)MemReadByte (Regs.PC + 1));
+            break;
+        case ZP:
+            ptr += sprintf (ptr, "$%02X", MemReadByte (Regs.PC + 1));
+            break;
+        case ZP_X:
+            ptr += sprintf (ptr, "$%02X,X", MemReadByte (Regs.PC + 1));
+            break;
+        case ZP_Y:
+            ptr += sprintf (ptr, "$%02X,Y", MemReadByte (Regs.PC + 1));
+            break;
+        case ZP_IND:
+            ptr += sprintf (ptr, "($%02X)", MemReadByte (Regs.PC + 1));
+            break;
+        case ZP_X_IND:
+            ptr += sprintf (ptr, "($%02X,X)", MemReadByte (Regs.PC + 1));
+            break;
+        case ZP_IND_Y:
+            ptr += sprintf (ptr, "($%02X),Y", MemReadByte (Regs.PC + 1));
+            break;
+        case ZP_REL:
+            ptr += sprintf (ptr, "$%02X,$%04X", MemReadByte (Regs.PC + 1), Regs.PC + 3 + (int8_t)MemReadByte (Regs.PC + 2));
+            break;
+        case ABS:
+            ptr += sprintf (ptr, "$%04X", MemReadWord (Regs.PC + 1));
+            break;
+        case ABS_IND:
+            ptr += sprintf (ptr, "($%04X)", MemReadWord (Regs.PC + 1));
+            break;
+        case ABS_X:
+            ptr += sprintf (ptr, "$%04X,X", MemReadWord (Regs.PC + 1));
+            break;
+        case ABS_X_IND:
+            ptr += sprintf (ptr, "($%04X,X)", MemReadWord (Regs.PC + 1));
+            break;
+        case ABS_Y:
+            ptr += sprintf (ptr, "$%04X,Y", MemReadWord (Regs.PC + 1));
+            break;
+    }
+
+    return ptr;
+}
+
+
+
+static void PrintTraceInstructionOrInterrupt (const char * InterruptType)
+{
+    char traceline[200];
+    char * traceline_ptr = traceline;
+    uint8_t opcode;
+    unsigned k, num_bytes;
+
+    if (TraceMode & TRACE_FIELD_INSTR_COUNTER) {
+
+        if (traceline_ptr != traceline) {
+            /* Print field separator. */
+            traceline_ptr += sprintf (traceline_ptr, "  ");
+        }
+
+        traceline_ptr += sprintf (traceline_ptr, "%12" PRIu64, Peripherals.Counter.CpuInstructions);
+    }
+
+    if (TraceMode & TRACE_FIELD_CLOCK_COUNTER) {
+
+        if (traceline_ptr != traceline) {
+            /* Print field separator. */
+            traceline_ptr += sprintf (traceline_ptr, "  ");
+        }
+
+        traceline_ptr += sprintf (traceline_ptr, "%12" PRIu64, Peripherals.Counter.ClockCycles);
+    }
+
+    if (TraceMode & TRACE_FIELD_PC) {
+
+        if (traceline_ptr != traceline) {
+            /* Print field separator. */
+            traceline_ptr += sprintf (traceline_ptr, "  ");
+        }
+
+        traceline_ptr += sprintf (traceline_ptr, "%04X", Regs.PC);
+    }
+
+    if (TraceMode & TRACE_FIELD_INSTR_BYTES) {
+
+        if (traceline_ptr != traceline) {
+            /* Print field separator. */
+            traceline_ptr += sprintf (traceline_ptr, "  ");
+        }
+
+        if (InterruptType == NULL)
+        {
+            /* Get the opcode */
+            opcode = MemReadByte (Regs.PC);
+
+            /* How many bytes are in the full instruction? 1, 2 or 3. */
+            num_bytes = GetInstructionLength (opcode);
+        } else {
+            num_bytes = 0; /* Consider interrupts as instructions that are inserted into the instruction stream. */
+        }
+
+        /* Print 0 to 3 bytes for the interrupt/instruction. */
+        for (k = 0; k < 3; ++k) {
+            if (k != 0) {
+                *traceline_ptr++ = ' ';
+            }
+            if (k < num_bytes) {
+                traceline_ptr += sprintf (traceline_ptr, "%02X", MemReadByte (Regs.PC + k));
+            } else {
+                traceline_ptr += sprintf (traceline_ptr, "  ");
+            }
+        }
+    }
+
+    if (TraceMode & TRACE_FIELD_INSTR_ASSEMBLY) {
+
+        if (traceline_ptr != traceline) {
+            /* Print field separator. */
+            traceline_ptr += sprintf (traceline_ptr, "  ");
+        }
+
+        char * save_ptr = traceline_ptr;
+
+        if (InterruptType == NULL) {
+            traceline_ptr = PrintAssemblyInstruction (traceline_ptr);
+        } else {
+            /* Print interrupt message. */
+            traceline_ptr += sprintf (traceline_ptr, "*** %s ***", InterruptType);
+        }
+
+        /* Fill out the field to 16 characters */
+        num_bytes = traceline_ptr - save_ptr;
+        if (num_bytes < 16) {
+            traceline_ptr += sprintf (traceline_ptr, "%*s", 16 - num_bytes, "");
+        }
+    }
+
+    if (TraceMode & TRACE_FIELD_CPU_REGISTERS) {
+
+        if (traceline_ptr != traceline) {
+            /* Print field separator. */
+            traceline_ptr += sprintf (traceline_ptr, "  ");
+        }
+
+        traceline_ptr += sprintf (traceline_ptr,
+            "A=%02X X=%02X Y=%02X S=%02X Flags=%c%c%c%c%c%c",
+            Regs.AC,
+            Regs.XR,
+            Regs.YR,
+            Regs.SP,
+            (Regs.SR & SF) ? 'N' : 'n',
+            (Regs.SR & OF) ? 'V' : 'v',
+            (Regs.SR & DF) ? 'D' : 'd',
+            (Regs.SR & IF) ? 'I' : 'i',
+            (Regs.SR & ZF) ? 'Z' : 'z',
+            (Regs.SR & CF) ? 'C' : 'c'
+        );
+    }
+
+    if (TraceMode & TRACE_FIELD_CC65_SP) {
+
+        if (traceline_ptr != traceline) {
+            /* Print field separator. */
+            traceline_ptr += sprintf (traceline_ptr, "  ");
+        }
+
+        traceline_ptr += sprintf (traceline_ptr,
+            "  SP=%04X",
+            MemReadZPWord (StackPointerZPageAddress)
+        );
+    }
+
+    if (traceline_ptr != traceline) {
+        puts (traceline);
+    }
+}
+
+
+
+void TraceInit (uint8_t SPAddr)
+{
+    StackPointerZPageAddress = SPAddr;
+}
+
+
+
+void PrintTraceNMI (void)
+{
+    PrintTraceInstructionOrInterrupt("NMI");
+}
+
+
+
+void PrintTraceIRQ (void)
+{
+    PrintTraceInstructionOrInterrupt("IRQ");
+}
+
+
+
+void PrintTraceInstruction (void)
+{
+    PrintTraceInstructionOrInterrupt(NULL);    
+}

--- a/src/sim65/trace.c
+++ b/src/sim65/trace.c
@@ -32,7 +32,6 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <inttypes.h>
-#include <assert.h>
 
 #include "6502.h"
 #include "memory.h"
@@ -926,7 +925,7 @@ static unsigned GetInstructionLength (uint8_t opcode)
     }
 
     /* We should never get here. */
-    assert(false);
+    return -1;
 }
 
 

--- a/src/sim65/trace.c
+++ b/src/sim65/trace.c
@@ -30,7 +30,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdlib.h>
+#include <stdbool.h>
 #include <inttypes.h>
 #include <assert.h>
 

--- a/src/sim65/trace.h
+++ b/src/sim65/trace.h
@@ -1,15 +1,12 @@
 /*****************************************************************************/
 /*                                                                           */
-/*                                paravirt.h                                 */
+/*                                 trace.h                                   */
 /*                                                                           */
-/*                Paravirtualization for the sim65 6502 simulator            */
+/*             Instruction tracing functionality sim65 6502 simulator        */
 /*                                                                           */
 /*                                                                           */
 /*                                                                           */
-/* (C) 2013-2013 Ullrich von Bassewitz                                       */
-/*               Roemerstrasse 52                                            */
-/*               D-70794 Filderstadt                                         */
-/* EMail:        uz@cc65.org                                                 */
+/* (C) 2025, Sidney Cadot                                                    */
 /*                                                                           */
 /*                                                                           */
 /* This software is provided 'as-is', without any expressed or implied       */
@@ -32,41 +29,61 @@
 /*****************************************************************************/
 
 
-#ifndef PARAVIRT_H
-#define PARAVIRT_H
+#ifndef TRACE_H
+#define TRACE_H
+
+
+#include <stdint.h>
 
 
 #include "6502.h"
 
+/* The trace mode is a bitfield that determines how trace lines are displayed.
+ *
+ * The value zero indicates that tracing is disabled (the default).
+ *
+ * In case TraceMode is not equal to zero, the value is interpreted as a bitfield:
+ *
+ * Bit    Bit value     Enables
+ * ---    -----------   -------------------------------
+ *  6      0x40 ( 64)   Print the instruction counter.
+ *  5      0x20 ( 32)   Print the clock cycle counter.
+ *  4      0x10 ( 16)   Print the PC (program counter).
+ *  3      0x08 (  8)   Print the instruction bytes.
+ *  2      0x04 (  4)   Print the instruction assembly.
+ *  1      0x02 (  2)   Print the CPU registers.
+ *  0      0x01 (  1)   Print the CC65 stack pointer.
+ *
+ */
 
-/*****************************************************************************/
-/*                                   Data                                    */
-/*****************************************************************************/
+#define TRACE_FIELD_INSTR_COUNTER   0x40
+#define TRACE_FIELD_CLOCK_COUNTER   0x20
+#define TRACE_FIELD_PC              0x10
+#define TRACE_FIELD_INSTR_BYTES     0x08
+#define TRACE_FIELD_INSTR_ASSEMBLY  0x04
+#define TRACE_FIELD_CPU_REGISTERS   0x02
+#define TRACE_FIELD_CC65_SP         0x01
+
+#define TRACE_DISABLED              0x00
+#define TRACE_ENABLE_FULL           0x7f
+
+/* Currently active tracing mode. */
+extern uint8_t TraceMode;
+
+void TraceInit (uint8_t SPAddr);
+/* Initialize the trace subsystem. */
+
+void PrintTraceNMI(void);
+/* Print trace line for an NMI interrupt. */
+
+void PrintTraceIRQ(void);
+/* Print trace line for an IRQ interrupt. */
+
+void PrintTraceInstruction (void);
+/* Print trace line for the instruction at the currrent program counter. */
 
 
 
-#define PARAVIRT_BASE        0xFFF2
-/* Lowest address used by a paravirtualization hook */
-
-#define PV_PATH_SIZE         1024
-/* Maximum path size supported by PVOpen/PVSysRemove */
-
-
-
-/*****************************************************************************/
-/*                                   Code                                    */
-/*****************************************************************************/
-
-
-
-void ParaVirtInit (unsigned aArgStart, unsigned char aSPAddr);
-/* Initialize the paravirtualization subsystem */
-
-void ParaVirtHooks (CPURegs* Regs);
-/* Potentially execute paravirtualization hooks */
-
-
-
-/* End of paravirt.h */
+/* End of trace.h */
 
 #endif


### PR DESCRIPTION
This PR adds three related features to sim65:

* Execution tracing (--trace option for sim65 executable).
* CPU model override (--cpu option for sim65 executable).
* Inspectability/controlability of SIM65 behavior from within a running sim65 program, through memory mapped addresses.

To assess the PR, you are cordially invited to read the updated documentation, temporary hosted at: http://data.jigsaw.nl/sim65.html (Specifically: see updated sim65 options, and the new Section 7).

This PR also adds a C header file (sim65.h) and an assembly include file (sim65.inc) that define convenient access to the new sim65 peripherals from C and assembly.

To implement these, a new export symbol "_peripherals" was added to the linker configuration files sim6502.cfg and sim65c02.cfg, corresponding to the base address of the peripheral memory aperture.

The C header file defines a structure rooted at _peripherals, meaning it is possible to write things like

```
    peripherals.counter.latch = 0;
```

... and have it translated to the most efficient code possible.

The assembly include file defines a number of symbols to access registers. In assembly, the above statement would correspond to

```
    lda #0
    sta peripheral_counter_latch
```

Apart from the addresses of the peripheral registers, both the C header file and assembly include file also provide a bunch of constants that are useful for readability.

Lastly, the C header file provides TRACE_ON() and TRACE_OFF() macros that make it very easy to enable processor instruction tracing from C.