### PR TITLE
Atari: fix fallout of change of INIT segment to 'bss' type

### DIFF
--- a/cfg/atari-cassette.cfg
+++ b/cfg/atari-cassette.cfg
@@ -22,8 +22,8 @@ SEGMENTS {
     CODE:     load = MAIN, type = ro,  define = yes;
     RODATA:   load = MAIN, type = ro,                optional = yes;
     DATA:     load = MAIN, type = rw,                optional = yes;
+    INIT:     load = MAIN, type = bss, define = yes, optional = yes;
     BSS:      load = MAIN, type = bss, define = yes, optional = yes;
-    INIT:     load = MAIN, type = bss,               optional = yes;
 }
 FEATURES {
     CONDES: type    = constructor,

--- a/cfg/atari-overlay.cfg
+++ b/cfg/atari-overlay.cfg
@@ -52,7 +52,7 @@ SEGMENTS {
     CODE:      load = MAIN,       type = ro,  define = yes;
     RODATA:    load = MAIN,       type = ro;
     DATA:      load = MAIN,       type = rw;
-    INIT:      load = MAIN,       type = bss,               optional = yes;
+    INIT:      load = MAIN,       type = bss, define = yes, optional = yes;
     BSS:       load = MAIN,       type = bss, define = yes;
     AUTOSTRT:  load = TRAILER,    type = ro;
     OVERLAY1:  load = OVL1,       type = ro,  define = yes, optional = yes;

--- a/cfg/atari-xex.cfg
+++ b/cfg/atari-xex.cfg
@@ -36,7 +36,7 @@ SEGMENTS {
     CODE:      load = MAIN,       type = ro,  define = yes;
     RODATA:    load = MAIN,       type = ro;
     DATA:      load = MAIN,       type = rw;
-    INIT:      load = MAIN,       type = bss,               optional = yes;
+    INIT:      load = MAIN,       type = bss, define = yes, optional = yes;
     BSS:       load = MAIN,       type = bss, define = yes;
 }
 FEATURES {

--- a/cfg/atari.cfg
+++ b/cfg/atari.cfg
@@ -40,7 +40,7 @@ SEGMENTS {
     CODE:      load = MAIN,       type = ro,  define = yes;
     RODATA:    load = MAIN,       type = ro;
     DATA:      load = MAIN,       type = rw;
-    INIT:      load = MAIN,       type = bss,               optional = yes;
+    INIT:      load = MAIN,       type = bss, define = yes, optional = yes;
     BSS:       load = MAIN,       type = bss, define = yes;
     AUTOSTRT:  load = TRAILER,    type = ro;
 }

--- a/cfg/atarixl-largehimem.cfg
+++ b/cfg/atarixl-largehimem.cfg
@@ -67,7 +67,7 @@ SEGMENTS {
     CODE:        load = MAIN,                         type = ro,  define = yes;
     RODATA:      load = MAIN,                         type = ro;
     DATA:        load = MAIN,                         type = rw;
-    INIT:        load = MAIN,                         type = bss,               optional = yes;
+    INIT:        load = MAIN,                         type = bss, define = yes, optional = yes;
     BSS:         load = MAIN,                         type = bss, define = yes;
     AUTOSTRT:    load = TRAILER,                      type = ro;
 }

--- a/cfg/atarixl-overlay.cfg
+++ b/cfg/atarixl-overlay.cfg
@@ -78,7 +78,7 @@ SEGMENTS {
     CODE:        load = MAIN,                          type = ro,  define = yes;
     RODATA:      load = MAIN,                          type = ro;
     DATA:        load = MAIN,                          type = rw;
-    INIT:        load = MAIN,                          type = bss,               optional = yes;
+    INIT:        load = MAIN,                          type = bss, define = yes, optional = yes;
     BSS:         load = MAIN,                          type = bss, define = yes;
     AUTOSTRT:    load = TRAILER,                       type = ro;
 

--- a/cfg/atarixl-xex.cfg
+++ b/cfg/atarixl-xex.cfg
@@ -58,7 +58,7 @@ SEGMENTS {
     CODE:        load = MAIN,                          type = ro,  define = yes;
     RODATA:      load = MAIN,                          type = ro;
     DATA:        load = MAIN,                          type = rw;
-    INIT:        load = MAIN,                          type = bss,               optional = yes;
+    INIT:        load = MAIN,                          type = bss, define = yes, optional = yes;
     BSS:         load = MAIN,                          type = bss, define = yes;
     SRPREPHDR:   load = UNUSED,                        type = ro;
     SRPREPTRL:   load = UNUSED,                        type = ro;

--- a/cfg/atarixl.cfg
+++ b/cfg/atarixl.cfg
@@ -65,7 +65,7 @@ SEGMENTS {
     CODE:        load = MAIN,                          type = ro,  define = yes;
     RODATA:      load = MAIN,                          type = ro;
     DATA:        load = MAIN,                          type = rw;
-    INIT:        load = MAIN,                          type = bss,               optional = yes;
+    INIT:        load = MAIN,                          type = bss, define = yes, optional = yes;
     BSS:         load = MAIN,                          type = bss, define = yes;
     AUTOSTRT:    load = TRAILER,                       type = ro;
 }

--- a/libsrc/atari/cashdr.s
+++ b/libsrc/atari/cashdr.s
@@ -10,10 +10,10 @@
 
         .include "atari.inc"
 
-        .import __BSS_RUN__, __STARTADDRESS__, _cas_init
+        .import __INIT_RUN__, __STARTADDRESS__, _cas_init
         .export _cas_hdr
 
-.assert ((__BSS_RUN__ - __STARTADDRESS__ + 127) / 128) < $101, error, "File to big to load from cassette"
+.assert ((__INIT_RUN__ - __STARTADDRESS__ + 127) / 128) < $101, error, "File to big to load from cassette"
 
 
 ; for a description of the cassette header, see De Re Atari, appendix C
@@ -22,7 +22,7 @@
 
 _cas_hdr:
         .byte   0                       ; ignored
-        .byte   <((__BSS_RUN__ - __STARTADDRESS__ + 127) / 128)         ; # of 128-byte records to read
+        .byte   <((__INIT_RUN__ - __STARTADDRESS__ + 127) / 128)        ; # of 128-byte records to read
         .word   __STARTADDRESS__        ; load address
         .word   _cas_init               ; init address
 

--- a/libsrc/atari/crt0.s
+++ b/libsrc/atari/crt0.s
@@ -204,6 +204,10 @@ APPMHI_save:    .res    2
 
 ; ------------------------------------------------------------------------
 
+.segment "INIT"       ; have at least one (empty) segment of INIT, exehdr.s needs its definition
+
+; ------------------------------------------------------------------------
+
 .segment "LOWCODE"       ; have at least one (empty) segment of LOWCODE, so that the next line works even if the program doesn't make use of this segment
 .assert (__LOWCODE_RUN__ + __LOWCODE_SIZE__ <= $4000 || __LOWCODE_RUN__ > $7FFF || __LOWCODE_SIZE__ = 0), warning, "'lowcode area' reaches into $4000..$7FFF bank memory window"
 ; check for LOWBSS_SIZE = 0 not needed since the only file which uses LOWBSS (irq.s) also uses LOWCODE

--- a/libsrc/atari/exehdr.s
+++ b/libsrc/atari/exehdr.s
@@ -1,11 +1,11 @@
 ; This file defines the EXE header and main chunk load header for Atari executables
 
         .export         __EXEHDR__: absolute = 1
-        .import         __MAIN_START__, __BSS_LOAD__
+        .import         __MAIN_START__, __INIT_LOAD__
 
 .segment        "EXEHDR"
         .word   $FFFF
 
 .segment        "MAINHDR"
         .word   __MAIN_START__
-        .word   __BSS_LOAD__ - 1
+        .word   __INIT_LOAD__ - 1


### PR DESCRIPTION
The size of the load chunk was calculated incorrectly in exehdr.s since the INIT segment is no longer being part of the file anymore.

While at it, change atari-cassette.cfg so that order of BSS and INIT is the same as in the other configs. See 692f96409d4e809d8 why it was in different order.

Putting it here for review and comments. I am going to merge it in the next few days if there are no objections.