### PR TITLE
conform to 6.4.4.4 for hex and octal escapes

### DIFF
--- a/src/cc65/litpool.c
+++ b/src/cc65/litpool.c
@@ -92,7 +92,7 @@ static Collection       LPStack  = STATIC_COLLECTION_INITIALIZER;
 
 
 
-static Literal* NewLiteral (const void* Buf, unsigned Len)
+static Literal* NewLiteral (const StrBuf* S)
 /* Create a new literal and return it */
 {
     /* Allocate memory */
@@ -103,7 +103,7 @@ static Literal* NewLiteral (const void* Buf, unsigned Len)
     L->RefCount = 0;
     L->Output   = 0;
     SB_Init (&L->Data);
-    SB_AppendBuf (&L->Data, Buf, Len);
+    SB_Append (&L->Data, S);
 
     /* Return the new literal */
     return L;
@@ -162,7 +162,7 @@ void ReleaseLiteral (Literal* L)
 void TranslateLiteral (Literal* L)
 /* Translate a literal into the target charset */
 {
-    TgtTranslateBuf (SB_GetBuf (&L->Data), SB_GetLen (&L->Data));
+    TgtTranslateStrBuf (&L->Data);
 }
 
 
@@ -468,18 +468,18 @@ void OutputGlobalLiteralPool (void)
 Literal* AddLiteral (const char* S)
 /* Add a literal string to the literal pool. Return the literal. */
 {
-    return AddLiteralBuf (S, strlen (S) + 1);
+    StrBuf SB;
+    SB_InitFromString(&SB, S);
+    return AddLiteralStr(&SB);
 }
 
 
 
-Literal* AddLiteralBuf (const void* Buf, unsigned Len)
-/* Add a buffer containing a literal string to the literal pool. Return the
-** literal.
-*/
+Literal* AddLiteralStr (const StrBuf* S)
+/* Add a literal string to the literal pool. Return the literal. */
 {
     /* Create a new literal */
-    Literal* L = NewLiteral (Buf, Len);
+    Literal* L = NewLiteral (S);
 
     /* Add the literal to the correct pool */
     if (IS_Get (&WritableStrings)) {
@@ -490,12 +490,4 @@ Literal* AddLiteralBuf (const void* Buf, unsigned Len)
 
     /* Return the new literal */
     return L;
-}
-
-
-
-Literal* AddLiteralStr (const StrBuf* S)
-/* Add a literal string to the literal pool. Return the literal. */
-{
-    return AddLiteralBuf (SB_GetConstBuf (S), SB_GetLen (S));
 }

--- a/src/cc65/litpool.h
+++ b/src/cc65/litpool.h
@@ -125,11 +125,6 @@ void OutputGlobalLiteralPool (void);
 Literal* AddLiteral (const char* S);
 /* Add a literal string to the literal pool. Return the literal. */
 
-Literal* AddLiteralBuf (const void* Buf, unsigned Len);
-/* Add a buffer containing a literal string to the literal pool. Return the
-** literal.
-*/
-
 Literal* AddLiteralStr (const StrBuf* S);
 /* Add a literal string to the literal pool. Return the literal. */
 

--- a/src/cc65/scanner.h
+++ b/src/cc65/scanner.h
@@ -213,6 +213,7 @@ typedef struct Token Token;
 struct Token {
     token_t         Tok;        /* The token itself */
     long            IVal;       /* The integer attribute */
+    int             Cooked;     /* The "cooked" flag for char constants */
     Double          FVal;       /* The float attribute */
     struct Literal* SVal;       /* String literal is any */
     ident           Ident;      /* Identifier if IDENT */

--- a/src/common/tgttrans.c
+++ b/src/common/tgttrans.c
@@ -121,7 +121,19 @@ void TgtTranslateStrBuf (StrBuf* Buf)
 ** system character set.
 */
 {
-    TgtTranslateBuf (SB_GetBuf (Buf), SB_GetLen (Buf));
+    unsigned char* B = (unsigned char*)SB_GetBuf(Buf);
+    unsigned char* Cooked = (unsigned char*)SB_GetCooked(Buf);
+    unsigned Len = SB_GetLen(Buf);
+
+    /* Translate */
+    while (Len--) {
+        if (*Cooked) {
+            *B = Tab[*B];
+        }
+        /* else { *B = *B; } */
+        ++B;
+        ++Cooked;
+    }
 }
 
 
@@ -129,7 +141,7 @@ void TgtTranslateStrBuf (StrBuf* Buf)
 void TgtTranslateSet (unsigned Index, unsigned char C)
 /* Set the translation code for the given character */
 {
-    CHECK (Index < sizeof (Tab));
+    CHECK (Index < (sizeof (Tab) / sizeof(Tab[0])));
     Tab[Index] = C;
 }
 

--- a/test/val/bug2609.c
+++ b/test/val/bug2609.c
@@ -1,0 +1,72 @@
+/* Bug #2609 - charmap translation violates C specification 6.4.4.4 Character constant */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#pragma charmap (0x07, 0x62) /* map \a to b */
+static_assert('\a' == 0x62);
+static_assert('\07' == 0x07);
+static_assert('\x07' == 0x07);
+
+#pragma charmap (0x07, 0x63) /* map \a to c */
+static_assert('\a' == 0x63);
+static_assert('\07' == 0x07);
+static_assert('\x07' == 0x07);
+
+#pragma charmap (0x07, 0x07) /* map \a back to x07 */
+static_assert('\a' == 0x07);
+static_assert('\07' == 0x07);
+static_assert('\x07' == 0x07);
+
+#pragma charmap (0x07, 0x61) /* map \a to a */
+
+char *s = "\07\a\x07";
+char t[] = { 7, 0x61, 7, 0 };
+
+static_assert('\a' == 0x61);
+static_assert('\07' == 0x07);
+static_assert('\x07' == 0x07);
+
+char c_back_a = '\a';
+char c_hex_07 = '\x07';
+char c_oct_07 = '\07';
+int  i_back_a = '\a';
+int  i_hex_07 = '\x07';
+int  i_oct_07 = '\07';
+
+#define TEST(a,b) \
+    if (a != b) { printf("\n\n !FAIL! %s = %04x not %04x\n\n", #a, a, b); return EXIT_FAILURE; }
+
+int main (void) {
+    int i;
+
+    TEST(c_back_a, 0x61)
+    TEST(c_hex_07, 0x07)
+    TEST(c_oct_07, 07)
+
+    TEST(i_back_a, 0x61)
+    TEST(i_hex_07, 0x07)
+    TEST(i_oct_07, 07)
+
+    assert('\a' == 0x61);
+    assert('\07' == 0x07);
+    assert('\x07' == 0x07);
+
+    if (strcmp(s,t) || s[0] == s[1]) {
+        printf("\n\n !FAIL! strcmp\n");
+	for (i = 0; i < 4; i++) {
+            printf("%02x ", s[i]);
+	}
+	printf("\n");
+	for (i = 0; i < 4; i++) {
+            printf("%02x ", t[i]);
+	}
+	printf("\n");
+	printf("\n");
+	return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/test/val/bug2610.c
+++ b/test/val/bug2610.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#if '\x0A' != 0x0A
+#error "Suspicious character set translation"
+#endif
+int main()
+{
+    char c = '\x0A';
+    if (c == 0x0A) {
+        printf("Ok\n");
+        return 0;
+    } else {
+        printf("Failed\n");
+        return 1;
+    }
+}


### PR DESCRIPTION
fixes issue #2609 

// compile with "cc65 -t c64 test.c"

char backslash_n = '\n';   // should be PETSCII newline character 0x0D
char hex_0A      = '\x0a'; // should be literal byte 0x0A
char octal_012   = '\012'; // should also be 0x0A
int  int_hex_0A      = '\x0a'; // should be literal int 0x000A
int  int_octal_012   = '\012'; // should also be 0x000A
char char_ten        = 10; // should be 0x0A
int  int_ten         = 10; // should be 0x000A

const char doubled[] = "\n\x0a"; // should be 0x0D 0x0A

;
; File generated by cc65 v 2.19 - N/A
;
        .fopt           compiler,"cc65 v 2.19 - N/A"
        .setcpu         "6502"
        .smart          on
        .autoimport     on
        .case           on
        .debuginfo      off
        .importzp       sp, sreg, regsave, regbank
        .importzp       tmp1, tmp2, tmp3, tmp4, ptr1, ptr2, ptr3, ptr4
        .macpack        longbranch
        .export         _backslash_n
        .export         _hex_0A
        .export         _octal_012
        .export         _int_hex_0A
        .export         _int_octal_012
        .export         _char_ten
        .export         _int_ten
        .export         _doubled

.segment        "DATA"

_backslash_n:
        .byte   $0D
_hex_0A:
        .byte   $0A
_octal_012:
        .byte   $0A
_int_hex_0A:
        .word   $000A
_int_octal_012:
        .word   $000A
_char_ten:
        .byte   $0A
_int_ten:
        .word   $000A

.segment        "RODATA"

_doubled:
        .byte   $0D,$0A,$00


