### PR TITLE
Fix a typo in g_typeadjust()

### DIFF
--- a/src/cc65/codegen.c
+++ b/src/cc65/codegen.c
@@ -1489,7 +1489,7 @@ unsigned g_typeadjust (unsigned lhs, unsigned rhs)
     ** both operands are converted to unsigned long int.
     */
     if ((ltype == CF_LONG && rtype == CF_INT && (rhs & CF_UNSIGNED)) ||
-        (rtype == CF_LONG && ltype == CF_INT && (rhs & CF_UNSIGNED))) {
+        (rtype == CF_LONG && ltype == CF_INT && (lhs & CF_UNSIGNED))) {
         /* long can represent all unsigneds, so we are in the first sub-case. */
         return const_flag | CF_LONG;
     }


### PR DESCRIPTION
This fixes #2611. I tried to create a test program but that's not possible since the result of `g_typeadjust ()` is the same with and without the change. It takes another branch without the fix but has the same outcome. Nevertheless it's still an error since the code tried to behave as described in the standard, but did not.
