### PR TITLE
Added search path relative to the binary on POSIX systems

### DIFF
--- a/src/ca65/incpath.c
+++ b/src/ca65/incpath.c
@@ -79,6 +79,11 @@ void FinishIncludePaths (void)
     AddSearchPath (IncSearchPath, CA65_INC);
 #endif
 
+#if defined(_WIN32)
     /* Add paths relative to the parent directory of the Windows binary. */
     AddSubSearchPathFromBin (IncSearchPath, "asminc");
+#else
+    /* Add paths relative to the parent directory of the POSIX binary. */
+    AddSubSearchPathFromBin (IncSearchPath, "share/cc65/asminc");
+#endif
 }

--- a/src/ca65/incpath.c
+++ b/src/ca65/incpath.c
@@ -79,10 +79,11 @@ void FinishIncludePaths (void)
     AddSearchPath (IncSearchPath, CA65_INC);
 #endif
 
-#if defined(_WIN32)
     /* Add paths relative to the parent directory of the Windows binary. */
+    /* Also needed for "make test" to work. */
     AddSubSearchPathFromBin (IncSearchPath, "asminc");
-#else
+
+#if !defined(_WIN32)
     /* Add paths relative to the parent directory of the POSIX binary. */
     AddSubSearchPathFromBin (IncSearchPath, "share/cc65/asminc");
 #endif


### PR DESCRIPTION
On POSIX systems, including FreeBSD, a ".macpack longbranch" will fail to find the include file in $(DESTDIR)/share/cc65/asminc, as that is not in the include paths. This small patch corrects that oversight.