### PR TITLE
Move IRQ handler into CODE

### DIFF
--- a/libsrc/apple2/irq.s
+++ b/libsrc/apple2/irq.s
@@ -60,7 +60,7 @@ doneirq:
         .addr   i_param
 :       rts
 
-        .segment        "LOWCODE"
+        .segment        "CODE"
 
 intptr:
         ; ProDOS TechRefMan, chapter 6.2:


### PR DESCRIPTION
We could have IRQs firing before LOWCODE is loaded if the user linked LOWCODE to a separate binary they load themselves.

This is a suggestion, as I saw no comment on the subject, but there may be a good reason to have it in LOWCODE?

My use case is Shufflepuck where I init the mouse first thing (because it clears HGR on IIp), then load the file containing  LOWCODE+splashscreen. 

For now I php/sei before mouse init and plp after LOWCODE load, but that breaks loading Shufflepuck over Appletalk, as far as I understand.