### PR TITLE
issue #2633 print unambiguous success message

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -12,7 +12,7 @@ endif
 
 WORKDIR = ../testwrk
 
-.PHONY: test continue mostlyclean clean
+.PHONY: test continue mostlyclean clean success_message
 
 test:
 	@$(MAKE) mostlyclean
@@ -27,6 +27,12 @@ continue:
 	@$(MAKE) -C standard all
 	@$(MAKE) -C misc all
 	@$(MAKE) -C todo all
+	@$(MAKE) success_message
+
+success_message:
+	$(info ###################################)
+	$(info ### validation suite successful ###)
+	$(info ###################################)
 
 mostlyclean:
 	@$(MAKE) -C asm clean


### PR DESCRIPTION
prints at the end, does not use echo

<pre>
562: n = 0x5A5A0004
     n = 0x5A5A5A04
563: n = 0x5A5A0004
     n = 0x00000004
sprintf-test: 348 tests, 114 failures
###################################
### validation suite successful ###
###################################
make[3]: Nothing to be done for 'success_message'.
</pre>