### PR TITLE
fixes issue #2637

### DIFF
--- a/src/cc65/preproc.c
+++ b/src/cc65/preproc.c
@@ -2647,8 +2647,9 @@ static void DoDefine (void)
         ** "There shall be white-space between the identifier and the
         ** replacement list in the definition of an object-like macro."
         ** Note: C89 doesn't have this constraint.
+        ** Note: if there is no replacement list, a space is not required.
         */
-        if (Std == STD_C99 && !IsSpace (CurC)) {
+        if (Std == STD_C99 && !IsSpace (CurC) && CurC != 0) {
             PPWarning ("ISO C99 requires whitespace after the macro name");
         }
 

--- a/test/misc/Makefile
+++ b/test/misc/Makefile
@@ -110,6 +110,12 @@ $(WORKDIR)/bug2515.$1.$2.prg: bug2515.c | $(WORKDIR)
 	$(NOT) $(CC65) -t sim$2 -$1 -o $$(@:.prg=.s) $$< 2>$(WORKDIR)/bug2515.$1.$2.out
 	$(ISEQUAL) $(WORKDIR)/bug2515.$1.$2.out bug2515.ref
 
+# should not issue any warnings in C99 mode
+$(WORKDIR)/bug2637.$1.$2.prg: bug2637.c | $(WORKDIR)
+	$(if $(QUIET),echo misc/bug2637.$1.$2.prg)
+	$(CC65) --standard c99 -t sim$2 -$1 -o $$(@:.prg=.s) $$< 2>$(WORKDIR)/bug2637.$1.$2.out
+	$(ISEQUAL) $(WORKDIR)/bug2637.$1.$2.out bug2637.ref
+
 # this one requires -Werror
 $(WORKDIR)/bug1768.$1.$2.prg: bug1768.c | $(WORKDIR)
 	$(if $(QUIET),echo misc/bug1768.$1.$2.prg)

--- a/test/misc/bug2637.c
+++ b/test/misc/bug2637.c
@@ -1,0 +1,15 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+// compile with --standard c99
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
in c99, whitespace is not required if there is no replacement list

we were producing warnings for things like
<pre>
#define FOO
</pre>
when we really shouldn't.