### PR TITLE
C style character translation in ca65

### DIFF
--- a/libsrc/common/fgets.s
+++ b/libsrc/common/fgets.s
@@ -90,22 +90,7 @@ read_loop:
         bne     :+
         inc     ptr4+1
 
-        ; The next code line:
-        ;
-        ;     .byte $c9, "\n"
-        ;
-        ; corresponds to a CMP #imm with the target-specific newline value as its operand.
-        ; This works because (with the 'string_escapes' feature enabled), the "\n" string
-        ; assembles to the target-specific value for the newline character.
-        ;
-        ; It would be better if we could just write:
-        ;
-        ;     cmp #'\n'
-        ;
-        ; Unfortunately, ca65 doesn't currently handle escape characters in character
-        ; constants. In the longer term, fixing that would be the preferred solution.
-
-:       .byte   $c9, "\n"       ; cmp #'\n'
+:       cmp     #'\n'    ; #'\n' should get translated properly
         beq     done
         bne     read_loop
 


### PR DESCRIPTION
this brings C style character translations to ca65.  this mostly builds on my previous check ins.

this is related to all of these issues, possibly more:
#2562 #2565 #2571 #2581


NB: ca65 has some parser goofiness,  here are the notes i kept while doing this:


the features loose_string_term and missing_char_term both affect character
and string parsing.

all combinations should be tested with old style character constants,
particularly:

<pre>
#'\'   ; the backslash character
#'\\'  ; same, but escaped
#'''   ; the single quote character
#'\''  ; same, but escaped
#'"'   ; the double quote character
#'\"'  ; same but escaped
</pre>

and of course all of the same WITHOUT the ending single quote when
missing_char_term is set.

they should all also be tested as strings when loose_string_term
is set.  i'm not sure which ones could/should produces errors and
when.

in particular,
''
may be problematic.  it is both a "loose_string_term" empty string
and a "missing_char_term" single quote character.

however, the documentation says that "missing_char_term does not work
in conjunction with loose_string_term."

as a "smoke test" to convince myself it worked, i ran this script:
<pre>
for each in `find . | grep fgets.o`
do
   echo ===============$each
   od -t x1 -A x -w65536 $each | grep "c9" | sed "s/^.*c9/c9/g" | cut -c1-40
done
</pre>

and got this output:
<pre>
===============./libwrk/apple2/fgets.o
c9 0a 01 14 00 01 f0 01 4f 00 01 0f 01 4
===============./libwrk/sim6502/fgets.o
c9 0a 01 14 00 01 f0 01 4e 00 01 0f 01 4
===============./libwrk/osic1p/fgets.o
c9 0a 01 14 00 01 f0 01 4e 00 01 0f 01 4
===============./libwrk/c64/fgets.o
c9 0d 01 14 00 01 f0 01 4f 00 01 0f 01 4
===============./libwrk/supervision/fgets.o
c9 0a 01 12 00 01 f0 01 4c 00 01 0f 01 4
===============./libwrk/atari5200/fgets.o
c9 9b 01 14 00 01 f0 01 4e 00 01 0f 01 4
===============./libwrk/none/fgets.o
c9 0a 01 14 00 01 f0 01 4d 00 01 0f 01 4
===============./libwrk/telestrat/fgets.o
c9 0a 01 14 00 01 f0 01 4e 00 01 0f 01 4
===============./libwrk/nes/fgets.o
c9 0a 01 14 00 01 f0 01 4e 00 01 0f 01 4
===============./libwrk/atmos/fgets.o
c9 0a 01 14 00 01 f0 01 4e 00 01 0f 01 4
===============./libwrk/gamate/fgets.o
c9 0a 01 14 00 01 f0 01 4e 00 01 0f 01 4
===============./libwrk/atarixl/fgets.o
c9 9b 01 14 00 01 f0 01 4f 00 01 0f 01 4
===============./libwrk/kim1/fgets.o
c9 0a 01 14 00 01 f0 01 4e 00 01 0f 01 4
===============./libwrk/cbm610/fgets.o
c9 0d 01 14 00 01 f0 01 4f 00 01 0f 01 4
===============./libwrk/apple2enh/fgets.o
c9 0a 01 12 00 01 f0 01 4d 00 01 0f 01 4
===============./libwrk/geos-apple/fgets.o
c9 0a 01 12 00 01 f0 01 4c 00 01 0f 01 4
===============./libwrk/atari/fgets.o
c9 9b 01 14 00 01 f0 01 4f 00 01 0f 01 4
===============./libwrk/vic20/fgets.o
c9 0d 01 14 00 01 f0 01 4f 00 01 0f 01 4
===============./libwrk/sim65c02/fgets.o
c9 0a 01 12 00 01 f0 01 4c 00 01 0f 01 4
===============./libwrk/rp6502/fgets.o
c9 0a 01 12 00 01 f0 01 4c 00 01 0f 01 4
===============./libwrk/pce/fgets.o
c9 0a 01 12 00 01 f0 01 4c 00 01 0f 01 4
===============./libwrk/lynx/fgets.o
c9 0a 01 12 00 01 f0 01 4c 00 01 0f 01 4
===============./libwrk/cbm510/fgets.o
c9 0d 01 14 00 01 f0 01 4f 00 01 0f 01 4
===============./libwrk/geos-cbm/fgets.o
c9 0a 01 14 00 01 f0 01 4e 00 01 0f 01 4
===============./libwrk/atari7800/fgets.o
c9 0a 01 14 00 01 f0 01 4e 00 01 0f 01 4
===============./libwrk/plus4/fgets.o
c9 0d 01 14 00 01 f0 01 4f 00 01 0f 01 4
===============./libwrk/atari2600/fgets.o
c9 0a 01 14 00 01 f0 01 4e 00 01 0f 01 4
===============./libwrk/c128/fgets.o
c9 0d 01 14 00 01 f0 01 4f 00 01 0f 01 4
===============./libwrk/c16/fgets.o
c9 0d 01 14 00 01 f0 01 4f 00 01 0f 01 4
===============./libwrk/creativision/fgets.o
c9 0a 01 14 00 01 f0 01 4e 00 01 0f 01 4
===============./libwrk/sym1/fgets.o
c9 0a 01 14 00 01 f0 01 4e 00 01 0f 01 4
===============./libwrk/pet/fgets.o
c9 0d 01 14 00 01 f0 01 4f 00 01 0f 01 4
===============./libwrk/cx16/fgets.o
c9 0d 01 12 00 01 f0 01 4d 00 01 0f 01 4
</pre>