### PR TITLE
Possible segfault in coptcmp.c

### DIFF
--- a/src/cc65/coptcmp.c
+++ b/src/cc65/coptcmp.c
@@ -637,12 +637,12 @@ unsigned OptCmp8 (CodeSeg* S)
                     ** shared branch operation. This prevents the unsafe
                     ** removal of the compare for known problem cases.
                     */
-                    if (
+                    if (L &&
                         /* Jump to branch that relies on the comparison. */
-                        (L->Owner->Info & (OF_CBRA | OF_ZBRA)) ||
+                        ((L->Owner->Info & (OF_CBRA | OF_ZBRA)) ||
                         /* Jump to boolean transformer that relies on the comparison. */
                         (L->Owner->OPC == OP65_JSR &&
-                         (FindBoolCmpCond (L->Owner->Arg)) != CMP_INV)
+                         (FindBoolCmpCond (L->Owner->Arg)) != CMP_INV))
                        )
                     {
                         ++ProtectCompare;


### PR DESCRIPTION
On debian testing cc65 2.19-2 segfaulted while optimizing a recursive function. I'm not familiar with the codebase but I believe L should be checked for NULL here also. This was the output of gdb on debian:

(gdb) run -Oirs /tmp/s64.c
Starting program: /usr/bin/cc65 -Oirs /tmp/s64.c
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Program received signal SIGSEGV, Segmentation fault. OptCmp8 (S=0x5555555f88a0) at cc65/coptcmp.c:887
887	                    if (
(gdb) bt
    Max=1) at cc65/codeopt.c:1205
    Max=<optimized out>) at cc65/codeopt.c:1188
    at cc65/codeopt.c:1343
    at cc65/main.c:1069
(gdb) p L
$1 = (CodeLabel *) 0x0

This segfault doesn't occur on the master branch.