### PR TITLE
Fix Atari buffer overrun on keyboard EOF

### DIFF
--- a/libsrc/atari/read.s
+++ b/libsrc/atari/read.s
@@ -147,6 +147,7 @@ icbll_copy:
         sta     dataptr+1
         lda     ICBLL,x
         sta     copylen
+        beq     copied          ; length = 0 if EOF
         pha                     ; remember for return value
         ldy     #0
         ldx     index
@@ -159,7 +160,7 @@ copy:   lda     linebuf,x
         bne     copy
 
         pla                     ; length
-        pha                     ; save length to return at okdone
+copied: pha                     ; save length to return at okdone
 
         clc
         adc     index


### PR DESCRIPTION
I was writing a program and wanted it to allow entering multiple lines to `stdin` on the keyboard and finish by typing `<CTRL-3>`, Atari's EOF character. But I discovered this causes the screen to go haywire. I found the bug in `libsrc/atari/read.s`. On `stdin` EOF, the number of characters read (stored in `ICBLL` by `CIOV`) is zero. So the loop at line 155 incorrectly copies 256 bytes instead, overwriting the display list and messing up the screen. My fix is to just jump over the loop if the length is zero. A simple test program is:
```
#include <stdio.h>

void main(void)
{
    printf("\nPress <CTRL-3>: ");
    getchar();
    puts("If you can see this, it worked!");
    for(;;);
}
```
