### PR TITLE
Fix missing warning for non void functions without a return statement

### DIFF
--- a/src/cc65/function.c
+++ b/src/cc65/function.c
@@ -636,7 +636,9 @@ void NewFunc (SymEntry* Func, FuncDesc* D)
         /* If this is the main function in a C99 environment returning an int,
         ** let it always return zero. Otherwise output a warning.
         */
-        if (IS_Get (&Standard) >= STD_C99 && GetUnqualRawTypeCode (ReturnType) == T_INT) {
+        if (F_IsMainFunc (CurrentFunc) &&
+            IS_Get (&Standard) >= STD_C99 &&
+            GetUnqualRawTypeCode (ReturnType) == T_INT) {
             g_getimmed (CF_INT | CF_CONST, 0, 0);
         } else if (IS_Get (&WarnReturnType)) {
             Warning ("Control reaches end of non-void function [-Wreturn-type]");


### PR DESCRIPTION
The compiler handled all functions returning an int but without a "return" statement by silently adding "return 0" instead of emitting a warning. This is the desired behavior for the "main" function in C99 and above, but the compiler applied it to all functions.

I tried to add a test but the current test infrastructure doesn't easily allow checking for warnings. Anyway, the fix should be obvious since the comment above the erroneous code describes the correct behavior but the code didn't implement it.

Fixes #2599.