### PR TITLE
Remove the unused function ClearDiagnosticStrBufs()

### DIFF
--- a/src/cc65/error.c
+++ b/src/cc65/error.c
@@ -507,22 +507,11 @@ void InitDiagnosticStrBufs (void)
 void DoneDiagnosticStrBufs (void)
 /* Done with tracked string buffers used for diagnostics */
 {
-    ClearDiagnosticStrBufs ();
-    DoneCollection (&DiagnosticStrBufs);
-}
-
-
-
-void ClearDiagnosticStrBufs (void)
-/* Free all tracked string buffers */
-{
     unsigned I;
-
     for (I = 0; I < CollCount (&DiagnosticStrBufs); ++I) {
         SB_Done (CollAtUnchecked (&DiagnosticStrBufs, I));
     }
-
-    CollDeleteAll (&DiagnosticStrBufs);
+    DoneCollection (&DiagnosticStrBufs);
 }
 
 

--- a/src/cc65/error.h
+++ b/src/cc65/error.h
@@ -159,9 +159,6 @@ void InitDiagnosticStrBufs (void);
 void DoneDiagnosticStrBufs (void);
 /* Done with tracked string buffers used for diagnostics */
 
-void ClearDiagnosticStrBufs (void);
-/* Free all tracked string buffers */
-
 struct StrBuf* NewDiagnosticStrBuf (void);
 /* Get a new tracked string buffer */
 


### PR DESCRIPTION
This change removes a function that is never called.