### PR TITLE
Apple2: Don't depend on apple2enh definition for keys the //e has

### DIFF
--- a/include/apple2.h
+++ b/include/apple2.h
@@ -83,6 +83,26 @@
 #define CH_CURS_LEFT    0x08
 #define CH_CURS_RIGHT   0x15
 
+/* These characters are not available on the ][+, but
+ * are on the //e. */
+#if defined(__APPLE2ENH__) || defined(APPLE2_INCLUDE_IIE_CHARS)
+#define CH_DEL          0x7F
+#define CH_CURS_UP      0x0B
+#define CH_CURS_DOWN    0x0A
+
+/* These are defined to be OpenApple + NumberKey */
+#define CH_F1   0xB1
+#define CH_F2   0xB2
+#define CH_F3   0xB3
+#define CH_F4   0xB4
+#define CH_F5   0xB5
+#define CH_F6   0xB6
+#define CH_F7   0xB7
+#define CH_F8   0xB8
+#define CH_F9   0xB9
+#define CH_F10  0xB0
+#endif
+
 #if defined(__APPLE2ENH__)
 
 /* MouseText-based functions for boxes and lines drawing */

--- a/include/apple2enh.h
+++ b/include/apple2enh.h
@@ -47,31 +47,6 @@
 
 
 /*****************************************************************************/
-/*                                   Data                                    */
-/*****************************************************************************/
-
-
-
-/* Characters codes */
-#define CH_DEL          0x7F
-#define CH_CURS_UP      0x0B
-#define CH_CURS_DOWN    0x0A
-
-/* These are defined to be OpenApple + NumberKey */
-#define CH_F1   0xB1
-#define CH_F2   0xB2
-#define CH_F3   0xB3
-#define CH_F4   0xB4
-#define CH_F5   0xB5
-#define CH_F6   0xB6
-#define CH_F7   0xB7
-#define CH_F8   0xB8
-#define CH_F9   0xB9
-#define CH_F10  0xB0
-
-
-
-/*****************************************************************************/
 /*                                 Variables                                 */
 /*****************************************************************************/
 

--- a/libsrc/apple2/cgetc.s
+++ b/libsrc/apple2/cgetc.s
@@ -51,10 +51,14 @@ put_caret:
 
         ; At this time, the high bit of the key pressed is set.
 :       bit     KBDSTRB         ; Clear keyboard strobe
-        .ifdef __APPLE2ENH__
+
+        .ifndef __APPLE2ENH__
+        bit     machinetype     ; Apple //e or more recent?
+        bpl     clear
+        .endif
         bit     BUTN0           ; Check if OpenApple is down
         bmi     done
-        .endif
-        and     #$7F            ; If not down, then clear high bit
+
+clear:  and     #$7F            ; If not down, then clear high bit
 done:   ldx     #>$0000
         rts


### PR DESCRIPTION
Up, Down and Del, as well as Open-Apple, exist on
non-enhanced Apple //e.