### PR TITLE
Apple2: Setup IRQ/RST vectors in LC if needed

### DIFF
--- a/asminc/apple2.inc
+++ b/asminc/apple2.inc
@@ -24,6 +24,8 @@ DOSWARM :=      $03D0   ; DOS warmstart vector
 BRKVec  :=      $03F0   ; Break vector
 SOFTEV  :=      $03F2   ; Vector for warm start
 PWREDUP :=      $03F4   ; This must be = EOR #$A5 of SOFTEV+1
+ROM_RST :=      $FFFC   ; 6502 reset vector
+ROM_IRQ :=      $FFFE   ; 6502 IRQ vector
 
 ;-----------------------------------------------------------------------------
 ; 80 column firmware

--- a/doc/apple2.sgml
+++ b/doc/apple2.sgml
@@ -87,7 +87,7 @@ several useful settings:
   exit then a plain vanilla ProDOS 8 doesn't make use of the Language Card bank
   2 at all.
 
-  <tag>LC address: &dollar;D000, LC size: &dollar;3000</tag>
+  <tag>LC address: &dollar;D000, LC size: &dollar;2FFC</tag>
   For plain vanilla DOS 3.3 which doesn't make use of the Language Card at all.
 
 </descrip><p>

--- a/doc/apple2enh.sgml
+++ b/doc/apple2enh.sgml
@@ -88,7 +88,7 @@ several useful settings:
   exit then a plain vanilla ProDOS 8 doesn't make use of the Language Card bank
   2 at all.
 
-  <tag>LC address: &dollar;D000, LC size: &dollar;3000</tag>
+  <tag>LC address: &dollar;D000, LC size: &dollar;2FFC</tag>
   For plain vanilla DOS 3.3 which doesn't make use of the Language Card at all.
 
 </descrip><p>


### PR DESCRIPTION
Programs running under DOS3.3 need to setup correct reset and IRQ vectors in the language card.
Fixes #2691 