### PR TITLE
add dbginfo to src/Makefile, add building dbginfo example to CI.

### DIFF
--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Build the tools.
         shell: bash
         run: make -j2 bin USER_CFLAGS=-Werror
+      - name: Build the dbginfo example
+        shell: bash
+        run: make -j2 src dbginfo
       - name: Build the utilities.
         shell: bash
         run: make -j2 util

--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
         run: make -j2 bin USER_CFLAGS=-Werror
       - name: Build the dbginfo example
         shell: bash
-        run: make -j2 -C src dbginfo
+        run: make -j2 -C src test
       - name: Build the utilities.
         shell: bash
         run: make -j2 util

--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
         run: make -j2 bin USER_CFLAGS=-Werror
       - name: Build the dbginfo example
         shell: bash
-        run: make -j2 src dbginfo
+        run: make -j2 -C src dbginfo
       - name: Build the utilities.
         shell: bash
         run: make -j2 util

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test:
 # GNU "check" target, which runs all tests
 check:
 	@$(MAKE) -C .github/checks checkstyle --no-print-directory
-	@$(MAKE) -C src dbginfo               --no-print-directory
+	@$(MAKE) -C src test                  --no-print-directory
 	@$(MAKE) test
 	@$(MAKE) -C targettest platforms      --no-print-directory
 	@$(MAKE) -C samples platforms         --no-print-directory

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ test:
 # GNU "check" target, which runs all tests
 check:
 	@$(MAKE) -C .github/checks checkstyle --no-print-directory
+	@$(MAKE) -C src dbginfo               --no-print-directory
 	@$(MAKE) test
 	@$(MAKE) -C targettest platforms      --no-print-directory
 	@$(MAKE) -C samples platforms         --no-print-directory

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@ PROGS = ar65     \
         sim65    \
         sp65
 
-.PHONY: all mostlyclean clean install zip avail unavail bin $(PROGS) dbginfo
+.PHONY: all mostlyclean clean install zip avail unavail bin $(PROGS)
 
 .SUFFIXES:
 
@@ -168,7 +168,19 @@ $(eval $(call OBJS_template,common))
 
 $(foreach prog,$(PROGS),$(eval $(call PROG_template,$(prog))))
 
-dbginfo:
-$(eval $(call PROG_template,dbginfo))
+
+.PHONY: dbginfo dbgsh test
+
+test: dbginfo dbgsh
+
+$(eval $(call OBJS_template,dbginfo))
+
+dbginfo: $(dbginfo_OBJS)
+
+../wrk/dbgsh$(EXE_SUFFIX): $(dbginfo_OBJS) ../wrk/common/common.a
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+dbgsh: ../wrk/dbgsh$(EXE_SUFFIX)
+
 
 -include $(DEPS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@ PROGS = ar65     \
         sim65    \
         sp65
 
-.PHONY: all mostlyclean clean install zip avail unavail bin $(PROGS)
+.PHONY: all mostlyclean clean install zip avail unavail bin $(PROGS) dbginfo
 
 .SUFFIXES:
 
@@ -167,5 +167,8 @@ $(eval $(call OBJS_template,common))
 	$(AR) r $@ $?
 
 $(foreach prog,$(PROGS),$(eval $(call PROG_template,$(prog))))
+
+dbginfo:
+$(eval $(call PROG_template,dbginfo))
 
 -include $(DEPS)


### PR DESCRIPTION
Fixes #2681, supersedes #2682 (Doesn't add Makefile that will not work on Windows, builds dbginfo example only when explicitly requested)