### PR TITLE
Implement -dD, -dM and -dN command line switches to output macro definitions

### DIFF
--- a/doc/cc65.sgml
+++ b/doc/cc65.sgml
@@ -63,6 +63,9 @@ Short options:
   -V                            Print the compiler version number
   -W [-+]warning[,...]          Control warnings ('-' disables, '+' enables)
   -d                            Debug mode
+  -dD                           Output all macro definitions (needs -E)
+  -dM                           Output user defined macros (needs -E)
+  -dN                           Output user defined macro names (needs -E)
   -g                            Add debug info to object file
   -h                            Help (this text)
   -j                            Default characters are signed
@@ -197,6 +200,26 @@ Here is a description of all the command line options:
   <tag><tt>-d, --debug</tt></tag>
 
   Enables debug mode, for debugging the behavior of cc65.
+
+
+  <label id="option-dD">
+  <tag><tt>-dD</tt></tag>
+
+  Like <tt/<ref id="option-dM" name="-dM">/ but does not include the predefined
+  macros.
+
+
+  <label id="option-dM">
+  <tag><tt>-dM</tt></tag>
+
+  When used with -E, will output <tt>#define</tt> directives for all the macros
+  defined during execution of the preprocessor, including predefined macros.
+
+
+  <tag><tt>-dN</tt></tag>
+
+  Like <tt/<ref id="option-dD" name="-dD">/ but will only output the macro names,
+  not their definitions.
 
 
   <tag><tt>--debug-tables name</tt></tag>

--- a/src/cc65/compile.c
+++ b/src/cc65/compile.c
@@ -496,6 +496,17 @@ void Compile (const char* FileName)
         while (PreprocessNextLine ())
         { /* Nothing */ }
 
+        /* Output macros if requested by the user */
+        if (DumpAllMacrosFull) {
+            OutputAllMacrosFull ();
+        }
+        if (DumpUserMacros) {
+            OutputUserMacros ();
+        }
+        if (DumpUserMacrosFull) {
+            OutputUserMacrosFull ();
+        }
+
         /* Close the output file */
         CloseOutputFile ();
 

--- a/src/cc65/global.c
+++ b/src/cc65/global.c
@@ -44,12 +44,15 @@
 
 
 unsigned char AddSource         = 0;    /* Add source lines as comments */
+unsigned char AllowNewComments  = 0;    /* Allow new style comments in C89 mode */
 unsigned char AutoCDecl         = 0;    /* Make functions default to __cdecl__ */
 unsigned char DebugInfo         = 0;    /* Add debug info to the obj */
+unsigned char DumpAllMacrosFull = 0;    /* Output all macro defs */
+unsigned char DumpUserMacros    = 0;    /* Output user macro names */
+unsigned char DumpUserMacrosFull= 0;    /* Output user macro defs */
 unsigned char PreprocessOnly    = 0;    /* Just preprocess the input */
 unsigned char DebugOptOutput    = 0;    /* Output debug stuff */
 unsigned      RegisterSpace     = 6;    /* Space available for register vars */
-unsigned      AllowNewComments  = 0;    /* Allow new style comments in C89 mode */
 
 /* Stackable options */
 IntStack WritableStrings    = INTSTACK(0);  /* Literal strings are r/w */

--- a/src/cc65/global.h
+++ b/src/cc65/global.h
@@ -52,12 +52,15 @@
 
 /* Options */
 extern unsigned char    AddSource;              /* Add source lines as comments */
+extern unsigned char    AllowNewComments;       /* Allow new style comments in C89 mode */
 extern unsigned char    AutoCDecl;              /* Make functions default to __cdecl__ */
 extern unsigned char    DebugInfo;              /* Add debug info to the obj */
+extern unsigned char    DumpAllMacrosFull;      /* Output all macro defs */
+extern unsigned char    DumpUserMacros;         /* Output user macro names */
+extern unsigned char    DumpUserMacrosFull;     /* Output user macro defs */
 extern unsigned char    PreprocessOnly;         /* Just preprocess the input */
 extern unsigned char    DebugOptOutput;         /* Output debug stuff */
 extern unsigned         RegisterSpace;          /* Space available for register vars */
-extern unsigned         AllowNewComments;       /* Allow new style comments in C89 mode */
 
 /* Stackable options */
 extern IntStack         WritableStrings;        /* Literal strings are r/w */

--- a/src/cc65/macrotab.h
+++ b/src/cc65/macrotab.h
@@ -58,6 +58,7 @@ struct Macro {
     int           ParamCount;   /* Number of parameters, -1 = no parens */
     Collection    Params;       /* Parameter list (char*) */
     StrBuf        Replacement;  /* Replacement text */
+    unsigned char Predefined;   /* True if this is a predefined macro */
     unsigned char Variadic;     /* C99 variadic macro */
     char          Name[1];      /* Name, dynamically allocated */
 };
@@ -70,7 +71,7 @@ struct Macro {
 
 
 
-Macro* NewMacro (const char* Name);
+Macro* NewMacro (const char* Name, unsigned char Predefined);
 /* Allocate a macro structure with the given name. The structure is not
 ** inserted into the macro table.
 */
@@ -87,10 +88,10 @@ Macro* CloneMacro (const Macro* M);
 */
 
 void DefineNumericMacro (const char* Name, long Val);
-/* Define a macro for a numeric constant */
+/* Define a predefined macro for a numeric constant */
 
 void DefineTextMacro (const char* Name, const char* Val);
-/* Define a macro for a textual constant */
+/* Define a predefined macro for a textual constant */
 
 void InsertMacro (Macro* M);
 /* Insert the given macro into the macro table. */
@@ -131,6 +132,15 @@ int MacroCmp (const Macro* M1, const Macro* M2);
 
 void PrintMacroStats (FILE* F);
 /* Print macro statistics to the given text file. */
+
+void OutputAllMacrosFull (void);
+/* Output all macros to the output file */
+
+void OutputUserMacros (void);
+/* Output the names of all user defined macros to the output file */
+
+void OutputUserMacrosFull (void);
+/* Output all user defined macros to the output file */
 
 
 

--- a/src/cc65/main.c
+++ b/src/cc65/main.c
@@ -93,6 +93,9 @@ static void Usage (void)
             "  -V\t\t\t\tPrint the compiler version number\n"
             "  -W [-+]warning[,...]\t\tControl warnings ('-' disables, '+' enables)\n"
             "  -d\t\t\t\tDebug mode\n"
+            "  -dD\t\t\t\tOutput all macro definitions (needs -E)\n"
+            "  -dM\t\t\t\tOutput user defined macros (needs -E)\n"
+            "  -dN\t\t\t\tOutput user defined macro names (needs -E)\n"
             "  -g\t\t\t\tAdd debug info to object file\n"
             "  -h\t\t\t\tHelp (this text)\n"
             "  -j\t\t\t\tDefault characters are signed\n"
@@ -1022,7 +1025,26 @@ int main (int argc, char* argv[])
                     break;
 
                 case 'd':
-                    OptDebug (Arg, 0);
+                    switch (Arg[2]) {
+                        case '\0':
+                            OptDebug (Arg, 0);
+                            break;
+                        case 'D':
+                            DumpUserMacrosFull = 1;
+                            break;
+                        case 'M':
+                            DumpAllMacrosFull = 1;
+                            break;
+                        case 'N':
+                            DumpUserMacros = 1;
+                            break;
+                        default:
+                            UnknownOption (Arg);
+                            break;
+                    }
+                    if (Arg[2] && Arg[3]) {
+                        UnknownOption (Arg);
+                    }
                     break;
 
                 case 'h':
@@ -1132,6 +1154,13 @@ int main (int argc, char* argv[])
     /* Did we have a file spec on the command line? */
     if (InputFile == 0) {
         AbEnd ("No input files");
+    }
+
+    /* The options to output macros can only be used with -E */
+    if (DumpAllMacrosFull || DumpUserMacros || DumpUserMacrosFull) {
+        if (!PreprocessOnly) {
+            AbEnd ("Preprocessor macro output can only be used together with -E");
+        }
     }
 
     /* Add the default include search paths. */

--- a/src/cc65/preproc.c
+++ b/src/cc65/preproc.c
@@ -2573,7 +2573,7 @@ static void DoDefine (void)
     CheckForBadIdent (Ident, Std, 0);
 
     /* Create a new macro definition */
-    M = NewMacro (Ident);
+    M = NewMacro (Ident, 0);
 
     /* Check if this is a function-like macro */
     if (CurC == '(') {


### PR DESCRIPTION
This is a much improved version of #2689 and fixes #1640. It adds three command line options that work similar to the ones in gcc:

* `-dD` outputs all user macro definitions to the output file.
* `-dM` outputs all macro definitions to the output file. Includes predefined macros.
* `-dN` outputs all user macros to the output file. Does not include the replacement.

All three require the `-E` switch and do not touch the existing `-d` command line option.

I do not consider this PR really finished, since the options are mostly gcc compatible, but gcc is itself not consistent between the options, so we might want to change the behavior and discuss the following:

* Currently the output is to the file that contains the preprocessed source. This is consistent with gcc but gcc uses stdout by default while cc65 outputs to a file instead. Would it be better to have cc65 output the macros to stdout?

* gcc is inconsistent in suppressing normal preprocessed output when `-dM` is given, but not for `-dD` and `dN`. I haven't followed this behavior so cc65 will always output the preprocessed source followed by the macros. Should this be changed to be more gcc compatible?

* Would it be better to suppress normal output completely and just output the macro lists when any of the switches are given?

* Does having `-dN` actually make sense? I have added it since gcc has it, but I cannot really see a use case, so it might also be dropped.

I will be away over the weekend starting tomorrow, so if you come to any conclusions until I'm back, I can make the necessary changes (if any) next week.