### PR TITLE
Fix temporary filenames again.

### DIFF
--- a/src/common/fname.c
+++ b/src/common/fname.c
@@ -156,15 +156,22 @@ char* MakeTmpFilename (const char *Directory, const char *Origin, const char* Ex
 {
     char* Out;
     size_t Len = 0;
+    static unsigned int Counter = 0;
 
-    /* Allocate template */
+    /* Allocate enough for the directory, ... */
     if (Directory != NULL) {
       Len = strlen (Directory);
     }
-    Len += strlen (Origin) + strlen (".2147483648") + strlen (Ext) + 1;
+
+    /* ... plus the the original name, the maximum length of the PID, the
+     * maximum length of the counter, the extension, and the terminator.
+     */
+    Len += strlen (Origin) + (strlen (".2147483648") * 2) + strlen (Ext) + 1;
     Out = xmalloc (Len);
 
-    snprintf (Out, Len, "%s%s.%u%s", (Directory != NULL ? Directory : ""),
-                                     FindName(Origin), getpid(), Ext);
+    snprintf (Out, Len, "%s%s.%u%u%s", (Directory != NULL ? Directory : ""),
+                                     FindName(Origin), getpid(), Counter, Ext);
+    Counter++;
+
     return Out;
 }


### PR DESCRIPTION
Outputting temp files in the output directory means we have to distinguish source files in different source directories that happen to have the same name:

```
cl65 ... api/compose.c ... cli/compose.c ...

cl65: Duplicate file in argument list: 'compose.c.256412.o'
cl65: Duplicate file in argument list: 'compose.c.256412.o'
```
We can't have input files with the same name in different directories anymore. How should we fix it?
One suggestion: this PR. Keep the path, replacing the separators with _, so that temp files are still created in the output directory, but in the above case, with names like api_compose.c.256412.o and cli_compose.c.256412.o