### PR TITLE
added reporting of fatal/error/warning/note location generation with …

### DIFF
--- a/src/cc65/error.c
+++ b/src/cc65/error.c
@@ -39,6 +39,7 @@
 
 /* common */
 #include "coll.h"
+#include "debugflag.h"
 #include "print.h"
 #include "strbuf.h"
 
@@ -183,10 +184,14 @@ static unsigned GetDiagnosticLineNum (void)
 
 
 
-void Fatal (const char* Format, ...)
+void _Fatal (const char *file, int line, const char* Format, ...)
 /* Print a message about a fatal error and die */
 {
     va_list ap;
+
+    if (Debug) {
+        fprintf(stderr, "[%s:%d] ", file, line);
+    }
 
     fprintf (stderr, "%s:%u: Fatal: ", GetDiagnosticFileName (), GetDiagnosticLineNum ());
 
@@ -203,10 +208,14 @@ void Fatal (const char* Format, ...)
 
 
 
-void Internal (const char* Format, ...)
+void _Internal (const char *file, int line, const char* Format, ...)
 /* Print a message about an internal compiler error and die */
 {
     va_list ap;
+
+    if (Debug) {
+        fprintf(stderr, "[%s:%d] ", file, line);
+    }
 
     fprintf (stderr, "%s:%u: Internal compiler error:\n",
              GetDiagnosticFileName (), GetDiagnosticLineNum ());
@@ -270,10 +279,15 @@ static void IntError (errcat_t EC, LineInfo* LI, const char* Msg, va_list ap)
 
 
 
-void LIError (errcat_t EC, LineInfo* LI, const char* Format, ...)
+void _LIError (const char *file, int line, errcat_t EC, LineInfo* LI, const char* Format, ...)
 /* Print an error message with the line info given explicitly */
 {
     va_list ap;
+
+    if (Debug) {
+        fprintf(stderr, "[%s:%d] ", file, line);
+    }
+
     va_start (ap, Format);
     IntError (EC, LI, Format, ap);
     va_end (ap);
@@ -281,10 +295,15 @@ void LIError (errcat_t EC, LineInfo* LI, const char* Format, ...)
 
 
 
-void Error (const char* Format, ...)
+void _Error (const char *file, int line, const char* Format, ...)
 /* Print an error message */
 {
     va_list ap;
+
+    if (Debug) {
+        fprintf(stderr, "[%s:%d] ", file, line);
+    }
+
     va_start (ap, Format);
     IntError (EC_PARSER, GetDiagnosticLI (), Format, ap);
     va_end (ap);
@@ -292,10 +311,15 @@ void Error (const char* Format, ...)
 
 
 
-void PPError (const char* Format, ...)
+void _PPError (const char *file, int line, const char* Format, ...)
 /* Print an error message. For use within the preprocessor */
 {
     va_list ap;
+
+    if (Debug) {
+        fprintf(stderr, "[%s:%d] ", file, line);
+    }
+
     va_start (ap, Format);
     IntError (EC_PP, GetCurLineInfo (), Format, ap);
     va_end (ap);
@@ -346,10 +370,15 @@ static void IntWarning (errcat_t EC, LineInfo* LI, const char* Msg, va_list ap)
 
 
 
-void LIWarning (errcat_t EC, LineInfo* LI, const char* Format, ...)
+void _LIWarning (const char *file, int line, errcat_t EC, LineInfo* LI, const char* Format, ...)
 /* Print a warning message with the line info given explicitly */
 {
     va_list ap;
+
+    if (Debug) {
+        fprintf(stderr, "[%s:%d] ", file, line);
+    }
+
     va_start (ap, Format);
     IntWarning (EC, LI, Format, ap);
     va_end (ap);
@@ -357,10 +386,15 @@ void LIWarning (errcat_t EC, LineInfo* LI, const char* Format, ...)
 
 
 
-void Warning (const char* Format, ...)
+void _Warning (const char *file, int line, const char* Format, ...)
 /* Print a warning message */
 {
     va_list ap;
+
+    if (Debug) {
+        fprintf(stderr, "[%s:%d] ", file, line);
+    }
+
     va_start (ap, Format);
     IntWarning (EC_PARSER, GetDiagnosticLI (), Format, ap);
     va_end (ap);
@@ -368,10 +402,15 @@ void Warning (const char* Format, ...)
 
 
 
-void PPWarning (const char* Format, ...)
+void _PPWarning (const char *file, int line, const char* Format, ...)
 /* Print a warning message. For use within the preprocessor */
 {
     va_list ap;
+
+    if (Debug) {
+        fprintf(stderr, "[%s:%d] ", file, line);
+    }
+
     va_start (ap, Format);
     IntWarning (EC_PP, GetCurLineInfo (), Format, ap);
     va_end (ap);
@@ -436,10 +475,15 @@ static void IntNote (const LineInfo* LI, const char* Msg, va_list ap)
 
 
 
-void LINote (const LineInfo* LI, const char* Format, ...)
+void _LINote (const char *file, int line, const LineInfo* LI, const char* Format, ...)
 /* Print a note message with the line info given explicitly */
 {
     va_list ap;
+
+    if (Debug) {
+        fprintf(stderr, "[%s:%d] ", file, line);
+    }
+
     va_start (ap, Format);
     IntNote (LI, Format, ap);
     va_end (ap);
@@ -447,10 +491,15 @@ void LINote (const LineInfo* LI, const char* Format, ...)
 
 
 
-void Note (const char* Format, ...)
+void _Note (const char *file, int line, const char* Format, ...)
 /* Print a note message */
 {
     va_list ap;
+
+    if (Debug) {
+        fprintf(stderr, "[%s:%d] ", file, line);
+    }
+
     va_start (ap, Format);
     IntNote (GetDiagnosticLI (), Format, ap);
     va_end (ap);
@@ -458,10 +507,15 @@ void Note (const char* Format, ...)
 
 
 
-void PPNote (const char* Format, ...)
+void _PPNote (const char *file, int line, const char* Format, ...)
 /* Print a note message. For use within the preprocessor */
 {
     va_list ap;
+
+    if (Debug) {
+        fprintf(stderr, "[%s:%d] ", file, line);
+    }
+
     va_start (ap, Format);
     IntNote (GetDiagnosticLI (), Format, ap);
     va_end (ap);

--- a/src/cc65/error.c
+++ b/src/cc65/error.c
@@ -184,7 +184,7 @@ static unsigned GetDiagnosticLineNum (void)
 
 
 
-void _Fatal (const char *file, int line, const char* Format, ...)
+void Fatal_ (const char *file, int line, const char* Format, ...)
 /* Print a message about a fatal error and die */
 {
     va_list ap;
@@ -208,7 +208,7 @@ void _Fatal (const char *file, int line, const char* Format, ...)
 
 
 
-void _Internal (const char *file, int line, const char* Format, ...)
+void Internal_ (const char *file, int line, const char* Format, ...)
 /* Print a message about an internal compiler error and die */
 {
     va_list ap;
@@ -279,7 +279,7 @@ static void IntError (errcat_t EC, LineInfo* LI, const char* Msg, va_list ap)
 
 
 
-void _LIError (const char *file, int line, errcat_t EC, LineInfo* LI, const char* Format, ...)
+void LIError_ (const char *file, int line, errcat_t EC, LineInfo* LI, const char* Format, ...)
 /* Print an error message with the line info given explicitly */
 {
     va_list ap;
@@ -295,7 +295,7 @@ void _LIError (const char *file, int line, errcat_t EC, LineInfo* LI, const char
 
 
 
-void _Error (const char *file, int line, const char* Format, ...)
+void Error_ (const char *file, int line, const char* Format, ...)
 /* Print an error message */
 {
     va_list ap;
@@ -311,7 +311,7 @@ void _Error (const char *file, int line, const char* Format, ...)
 
 
 
-void _PPError (const char *file, int line, const char* Format, ...)
+void PPError_ (const char *file, int line, const char* Format, ...)
 /* Print an error message. For use within the preprocessor */
 {
     va_list ap;
@@ -370,7 +370,7 @@ static void IntWarning (errcat_t EC, LineInfo* LI, const char* Msg, va_list ap)
 
 
 
-void _LIWarning (const char *file, int line, errcat_t EC, LineInfo* LI, const char* Format, ...)
+void LIWarning_ (const char *file, int line, errcat_t EC, LineInfo* LI, const char* Format, ...)
 /* Print a warning message with the line info given explicitly */
 {
     va_list ap;
@@ -386,7 +386,7 @@ void _LIWarning (const char *file, int line, errcat_t EC, LineInfo* LI, const ch
 
 
 
-void _Warning (const char *file, int line, const char* Format, ...)
+void Warning_ (const char *file, int line, const char* Format, ...)
 /* Print a warning message */
 {
     va_list ap;
@@ -402,7 +402,7 @@ void _Warning (const char *file, int line, const char* Format, ...)
 
 
 
-void _PPWarning (const char *file, int line, const char* Format, ...)
+void PPWarning_ (const char *file, int line, const char* Format, ...)
 /* Print a warning message. For use within the preprocessor */
 {
     va_list ap;
@@ -475,7 +475,7 @@ static void IntNote (const LineInfo* LI, const char* Msg, va_list ap)
 
 
 
-void _LINote (const char *file, int line, const LineInfo* LI, const char* Format, ...)
+void LINote_ (const char *file, int line, const LineInfo* LI, const char* Format, ...)
 /* Print a note message with the line info given explicitly */
 {
     va_list ap;
@@ -491,7 +491,7 @@ void _LINote (const char *file, int line, const LineInfo* LI, const char* Format
 
 
 
-void _Note (const char *file, int line, const char* Format, ...)
+void Note_ (const char *file, int line, const char* Format, ...)
 /* Print a note message */
 {
     va_list ap;
@@ -507,7 +507,7 @@ void _Note (const char *file, int line, const char* Format, ...)
 
 
 
-void _PPNote (const char *file, int line, const char* Format, ...)
+void PPNote_ (const char *file, int line, const char* Format, ...)
 /* Print a note message. For use within the preprocessor */
 {
     va_list ap;

--- a/src/cc65/error.h
+++ b/src/cc65/error.h
@@ -103,28 +103,36 @@ struct StrBuf;
 void PrintFileInclusionInfo (const LineInfo* LI);
 /* Print hierarchy of file inclusion */
 
-void Fatal (const char* Format, ...) attribute ((noreturn, format (printf, 1, 2)));
+void _Fatal (const char *file, int line, const char* Format, ...) attribute ((noreturn, format (printf, 3, 4)));
+#define Fatal(...) _Fatal(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a message about a fatal error and die */
 
-void Internal (const char* Format, ...) attribute ((noreturn, format (printf, 1, 2)));
+void _Internal (const char *file, int line, const char* Format, ...) attribute ((noreturn, format (printf, 3, 4)));
+#define Internal(...) _Internal(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a message about an internal compiler error and die */
 
-void Error (const char* Format, ...) attribute ((format (printf, 1, 2)));
+void _Error (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
+#define Error(...) _Error(__FILE__, __LINE__, __VA_ARGS__)
 /* Print an error message */
 
-void LIError (errcat_t EC, LineInfo* LI, const char* Format, ...) attribute ((format (printf, 3, 4)));
+void _LIError (const char *file, int line, errcat_t EC, LineInfo* LI, const char* Format, ...) attribute ((format (printf, 5, 6)));
+#define LIError(...) _LIError(__FILE__, __LINE__, __VA_ARGS__)
 /* Print an error message with the line info given explicitly */
 
-void PPError (const char* Format, ...) attribute ((format (printf, 1, 2)));
+void _PPError (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
+#define PPError(...) _PPError(__FILE__, __LINE__, __VA_ARGS__)
 /* Print an error message. For use within the preprocessor */
 
-void Warning (const char* Format, ...) attribute ((format (printf, 1, 2)));
+void _Warning (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
+#define Warning(...) _Warning(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a warning message */
 
-void LIWarning (errcat_t EC, LineInfo* LI, const char* Format, ...) attribute ((format (printf, 3, 4)));
+void _LIWarning (const char *file, int line, errcat_t EC, LineInfo* LI, const char* Format, ...) attribute ((format (printf, 5, 6)));
+#define LIWarning(...) _LIWarning(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a warning message with the line info given explicitly */
 
-void PPWarning (const char* Format, ...) attribute ((format (printf, 1, 2)));
+void _PPWarning (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
+#define PPWarning(...) _PPWarning(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a warning message. For use within the preprocessor */
 
 void UnreachableCodeWarning (void);
@@ -140,13 +148,16 @@ IntStack* FindWarning (const char* Name);
 void ListWarnings (FILE* F);
 /* Print a list of warning types/names to the given file */
 
-void Note (const char* Format, ...) attribute ((format (printf, 1, 2)));
+void _Note (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
+#define Note(...) _Note(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a note message */
 
-void LINote (const LineInfo* LI, const char* Format, ...) attribute ((format (printf, 2, 3)));
+void _LINote (const char *file, int line, const LineInfo* LI, const char* Format, ...) attribute ((format (printf, 4, 5)));
+#define LINote(...) _LINote(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a note message with the line info given explicitly */
 
-void PPNote (const char* Format, ...) attribute ((format (printf, 1, 2)));
+void _PPNote (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
+#define PPNote(...) _PPNote(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a note message. For use within the preprocessor */
 
 unsigned GetTotalErrors (void);

--- a/src/cc65/error.h
+++ b/src/cc65/error.h
@@ -103,36 +103,36 @@ struct StrBuf;
 void PrintFileInclusionInfo (const LineInfo* LI);
 /* Print hierarchy of file inclusion */
 
-void _Fatal (const char *file, int line, const char* Format, ...) attribute ((noreturn, format (printf, 3, 4)));
-#define Fatal(...) _Fatal(__FILE__, __LINE__, __VA_ARGS__)
+void Fatal_ (const char *file, int line, const char* Format, ...) attribute ((noreturn, format (printf, 3, 4)));
+#define Fatal(...) Fatal_(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a message about a fatal error and die */
 
-void _Internal (const char *file, int line, const char* Format, ...) attribute ((noreturn, format (printf, 3, 4)));
-#define Internal(...) _Internal(__FILE__, __LINE__, __VA_ARGS__)
+void Internal_ (const char *file, int line, const char* Format, ...) attribute ((noreturn, format (printf, 3, 4)));
+#define Internal(...) Internal_(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a message about an internal compiler error and die */
 
-void _Error (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
-#define Error(...) _Error(__FILE__, __LINE__, __VA_ARGS__)
+void Error_ (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
+#define Error(...) Error_(__FILE__, __LINE__, __VA_ARGS__)
 /* Print an error message */
 
-void _LIError (const char *file, int line, errcat_t EC, LineInfo* LI, const char* Format, ...) attribute ((format (printf, 5, 6)));
-#define LIError(...) _LIError(__FILE__, __LINE__, __VA_ARGS__)
+void LIError_ (const char *file, int line, errcat_t EC, LineInfo* LI, const char* Format, ...) attribute ((format (printf, 5, 6)));
+#define LIError(...) LIError_(__FILE__, __LINE__, __VA_ARGS__)
 /* Print an error message with the line info given explicitly */
 
-void _PPError (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
-#define PPError(...) _PPError(__FILE__, __LINE__, __VA_ARGS__)
+void PPError_ (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
+#define PPError(...) PPError_(__FILE__, __LINE__, __VA_ARGS__)
 /* Print an error message. For use within the preprocessor */
 
-void _Warning (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
-#define Warning(...) _Warning(__FILE__, __LINE__, __VA_ARGS__)
+void Warning_ (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
+#define Warning(...) Warning_(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a warning message */
 
-void _LIWarning (const char *file, int line, errcat_t EC, LineInfo* LI, const char* Format, ...) attribute ((format (printf, 5, 6)));
-#define LIWarning(...) _LIWarning(__FILE__, __LINE__, __VA_ARGS__)
+void LIWarning_ (const char *file, int line, errcat_t EC, LineInfo* LI, const char* Format, ...) attribute ((format (printf, 5, 6)));
+#define LIWarning(...) LIWarning_(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a warning message with the line info given explicitly */
 
-void _PPWarning (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
-#define PPWarning(...) _PPWarning(__FILE__, __LINE__, __VA_ARGS__)
+void PPWarning_ (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
+#define PPWarning(...) PPWarning_(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a warning message. For use within the preprocessor */
 
 void UnreachableCodeWarning (void);
@@ -148,16 +148,16 @@ IntStack* FindWarning (const char* Name);
 void ListWarnings (FILE* F);
 /* Print a list of warning types/names to the given file */
 
-void _Note (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
-#define Note(...) _Note(__FILE__, __LINE__, __VA_ARGS__)
+void Note_ (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
+#define Note(...) Note_(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a note message */
 
-void _LINote (const char *file, int line, const LineInfo* LI, const char* Format, ...) attribute ((format (printf, 4, 5)));
-#define LINote(...) _LINote(__FILE__, __LINE__, __VA_ARGS__)
+void LINote_ (const char *file, int line, const LineInfo* LI, const char* Format, ...) attribute ((format (printf, 4, 5)));
+#define LINote(...) LINote_(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a note message with the line info given explicitly */
 
-void _PPNote (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
-#define PPNote(...) _PPNote(__FILE__, __LINE__, __VA_ARGS__)
+void PPNote_ (const char *file, int line, const char* Format, ...) attribute ((format (printf, 3, 4)));
+#define PPNote(...) PPNote_(__FILE__, __LINE__, __VA_ARGS__)
 /* Print a note message. For use within the preprocessor */
 
 unsigned GetTotalErrors (void);


### PR DESCRIPTION
…"-d"

debugging some other work, i found there are many Fatal() / Error() / Warning() / Note() calls with identical or substantially similar verbiage.  tracing down where exactly the error messages were coming from was a bit tedious, especially since printf style formatting frustrates simple grep in some cases.  i thought "wouldn't it be nice if i could turn on a debug flag, and get the location in the compiler where the message was generated."

here it is.

without "-d", business as usual, nothing changed
<pre>
gorilla@guest:~/cc65 (gps4bugs)$ bin/cc65 foo.c
foo.c:18: Fatal: Floating point type is currently unsupported
</pre>

with "-d", also prints the file and line in the compiler where the message was generated.
<pre>
gorilla@guest:~/cc65 (gps4bugs)$ bin/cc65 -d foo.c
[cc65/codegen.c:90] foo.c:18: Fatal: Floating point type is currently unsupported
</pre>