### PR TITLE
Fix an internal error in da65 when there are certain labels in a skipped section

### DIFF
--- a/src/da65/attrtab.c
+++ b/src/da65/attrtab.c
@@ -146,8 +146,7 @@ unsigned GetGranularity (attr_t Style)
         case atAddrTab:  return 2;
         case atRtsTab:   return 2;
         case atTextTab:  return 1;
-
-        case atSkip:
+        case atSkip:     return 1;
         default:
             Internal ("GetGranularity called for style = %d", Style);
             return 0;


### PR DESCRIPTION
Fixes #2649.