### PR TITLE
Remove useless code

### DIFF
--- a/libsrc/apple2/tgi/a2.hi.s
+++ b/libsrc/apple2/tgi/a2.hi.s
@@ -222,14 +222,9 @@ DONE:
         bit     TXTSET
         bit     LOWSCR
 
-        .ifndef __APPLE2ENH__
-        bit     machinetype
-        bpl     reset_wndtop
-        .endif
         ; Limit SET80COL-HISCR to text
         bit     LORES
 
-reset_wndtop:
         ; Reset the text window top
         lda     #$00
         sta     WNDTOP


### PR DESCRIPTION
LOSCR is a valid and safe softswitch on any Apple II. Thanks Oliver S!