### PR TITLE
Small cleanup for da65

### DIFF
--- a/src/da65/data.c
+++ b/src/da65/data.c
@@ -63,7 +63,7 @@ static uint32_t GetSpan (attr_t Style)
     uint32_t Count = 1;
     while (Count < RemainingBytes) {
         attr_t Attr;
-        if (MustDefLabel(PC+Count)) {
+        if (MustDefLabel (PC+Count)) {
             break;
         }
         Attr = GetAttr (PC+Count);
@@ -119,7 +119,7 @@ static unsigned DoTable (attr_t Style, unsigned MemberSize, void (*TableFunc) (u
     }
 
     /* If the next line is not the same style, add a separator */
-    if (CodeLeft() && GetStyleAttr (PC) != Style) {
+    if (CodeLeft () && GetStyleAttr (PC) != Style) {
         SeparatorLine ();
     }
 
@@ -221,7 +221,7 @@ uint32_t AddrTable (void)
     }
 
     /* If the next line is not an address table line, add a separator */
-    if (CodeLeft() && GetStyleAttr (PC) != atAddrTab) {
+    if (CodeLeft () && GetStyleAttr (PC) != atAddrTab) {
         SeparatorLine ();
     }
 
@@ -287,7 +287,7 @@ uint32_t RtsTable (void)
     }
 
     /* If the next line is not a return address table line, add a separator */
-    if (CodeLeft() && GetStyleAttr (PC) != atRtsTab) {
+    if (CodeLeft () && GetStyleAttr (PC) != atRtsTab) {
         SeparatorLine ();
     }
 
@@ -366,7 +366,7 @@ uint32_t TextTable (void)
     }
 
     /* If the next line is not a byte table line, add a separator */
-    if (CodeLeft() && GetStyleAttr (PC) != atTextTab) {
+    if (CodeLeft () && GetStyleAttr (PC) != atTextTab) {
         SeparatorLine ();
     }
 

--- a/src/da65/handler.c
+++ b/src/da65/handler.c
@@ -962,7 +962,7 @@ void OH_Rts (const OpcDesc* D)
     if (NewlineAfterRTS) {
         LineFeed ();
     }
-    SeparatorLine();
+    SeparatorLine ();
 }
 
 

--- a/src/da65/handler.c
+++ b/src/da65/handler.c
@@ -518,11 +518,11 @@ void OH_Relative (const OpcDesc* D)
     GenerateLabel (D->Flags, Addr);
 
     /* Output the line */
-    if (HaveLabel(Addr)) {
+    if (HaveLabel (Addr)) {
         OneLine (D, "%s", GetAddrArg (D->Flags, Addr));
     } else {
         /* No label -- make a relative address expression */
-        OneLine (D, "* + (%d)", (int) Offs + 2);
+        OneLine (D, "*%+d", (int) Offs + 2);
     }
 }
 

--- a/src/da65/infofile.c
+++ b/src/da65/infofile.c
@@ -666,7 +666,7 @@ static void RangeSection (void)
                 if (InfoSVal[1] == '\0') {
                     InfoError ("AddrMode must be two characters long");
                 }
-                if (tolower(InfoSVal[0]) == 'm') {
+                if (tolower (InfoSVal[0]) == 'm') {
                     if (InfoSVal[0] == 'm') {
                         AddrMode = atMem16;
                     } else {
@@ -675,7 +675,7 @@ static void RangeSection (void)
                 } else {
                     InfoError ("AddrMode syntax: mx");
                 }
-                if (tolower(InfoSVal[1]) == 'x') {
+                if (tolower (InfoSVal[1]) == 'x') {
                     if (InfoSVal[1] == 'x') {
                         AddrMode |= atIdx16;
                     } else {
@@ -735,7 +735,7 @@ static void RangeSection (void)
     if (Attributes & tUnit) {
         unsigned i;
         for (i = Start; i < End; i += Unit) {
-            MarkAddr(i, atTableUnit);
+            MarkAddr (i, atTableUnit);
         }
     }
 
@@ -928,7 +928,7 @@ void ReadInfoFile (void)
 /* Read the info file */
 {
     /* Check if we have a info file given */
-    if (InfoAvail()) {
+    if (InfoAvail ()) {
         /* Open the config file */
         InfoOpenInput ();
 

--- a/src/da65/main.c
+++ b/src/da65/main.c
@@ -357,7 +357,7 @@ static void OptVersion (const char* Opt attribute ((unused)),
 /* Print the disassembler version */
 {
     fprintf (stderr, "%s V%s\n", ProgName, GetVersionAsString ());
-    exit(EXIT_SUCCESS);
+    exit (EXIT_SUCCESS);
 }
 
 
@@ -497,11 +497,11 @@ static void OneOpcode (unsigned RemainingBytes)
                     if (PrevAddrMode != AddrMode) {
                         if ((PrevAddrMode & atMem8) != (AddrMode & atMem8) ||
                             (PrevAddrMode & atMem16) != (AddrMode & atMem16)) {
-                            OutputMFlag(!!(AddrMode & atMem8));
+                            OutputMFlag (!!(AddrMode & atMem8));
                         }
                         if ((PrevAddrMode & atIdx8) != (AddrMode & atIdx8) ||
                             (PrevAddrMode & atIdx16) != (AddrMode & atIdx16)) {
-                            OutputXFlag(!!(AddrMode & atIdx8));
+                            OutputXFlag (!!(AddrMode & atIdx8));
                         }
 
                         PrevAddrMode = AddrMode;
@@ -580,7 +580,7 @@ static void OnePass (void)
     PrevAddrMode = 0;
 
     /* Disassemble until nothing left */
-    while ((Count = GetRemainingBytes()) > 0) {
+    while ((Count = GetRemainingBytes ()) > 0) {
         OneOpcode (Count);
     }
 }

--- a/src/da65/scanner.c
+++ b/src/da65/scanner.c
@@ -671,8 +671,8 @@ void InfoSetName (const char* Name)
 /* Set a name for a config file */
 {
     InfoFile = Name;
-    xfree(InputSrcName);
-    InputSrcName = xstrdup(Name);
+    xfree (InputSrcName);
+    InputSrcName = xstrdup (Name);
 }
 
 


### PR DESCRIPTION
Changes the output for relative branch targets without a label from `* + (-30)` to the better readable `*-30`.
Does also some coding style fixes (space before brace in function calls).

