### PR TITLE
When studying a symbol expression use its address size if its smaller than that of the symbol

### DIFF
--- a/src/ca65/studyexpr.c
+++ b/src/ca65/studyexpr.c
@@ -610,12 +610,13 @@ static void StudySymbol (ExprNode* Expr, ExprDesc* D)
                 DumpExpr (Expr, SymResolve);
             }
 
-            /* If the symbol has an explicit address size, use it. This may
-            ** lead to range errors later (maybe even in the linker stage), if
-            ** the user lied about the address size, but for now we trust him.
+            /* If the symbol has an explicit address size that is smaller than
+            ** the one found, use it. This may lead to range errors later
+            ** (maybe even in the linker stage) if the user lied about the
+            ** address size, but for now we trust him.
             */
             AddrSize = GetSymAddrSize (Sym);
-            if (AddrSize != ADDR_SIZE_DEFAULT) {
+            if (AddrSize != ADDR_SIZE_DEFAULT && AddrSize < D->AddrSize) {
                 D->AddrSize = AddrSize;
             }
         }


### PR DESCRIPTION
This works around [a piece of code known to be problematic](https://github.com/cc65/cc65/blob/d3336270814cca2070795a391ed37e6b4742cf76/src/ca65/symentry.c#L249). When a symbol is defined, the assembler studies it to determine its address size. This fails if the expression contains forward references in which case "absolute" is assumed. When later studying expressions containing this symbol, the code let the address size for the symbol override that of the actual expression. So if it was later found that a symbol expression evaluated to 8 bit ("zeropage"), since now all references could be resolved, the study function let the "absolute" value from the symbol override what it found out by evaluating the expression.

I've changed the code so that the override takes place only if the symbol has a smaller address size than what was found when evaluating the symbol expression. This might happen if a symbol is declared explicitly as zero page. On the other side, values are always enlarged as needed, so if studying a symbol results in a "zeropage" address size, the assembler will extend it to "absolute" whenever necessary. Which means that this change should be unproblematic.

Fixes #2208.