### PR TITLE
fix version in sysuname for all targets

### DIFF
--- a/libsrc/agat/sysuname.s
+++ b/libsrc/agat/sysuname.s
@@ -1,6 +1,5 @@
 ;
-; 2003-08-12, Ullrich von Bassewitz
-; 2019-09-08, Greg King
+; Ullrich von Bassewitz, 2003-08-12
 ;
 ; unsigned char __fastcall__ _sysuname (struct utsname* buf);
 ;
@@ -9,10 +8,10 @@
 
         .import         utscopy
 
-__sysuname      :=      utscopy
+        __sysuname = utscopy
 
 ;--------------------------------------------------------------------------
-; Data. We define a fixed utsname struct here, and just copy it.
+; Data. We define a fixed utsname struct here and just copy it.
 
 .rodata
 
@@ -34,4 +33,5 @@ utsdata:
         .byte           $00
 
         ; machine
-        .asciiz         "Commander X16"
+        .asciiz         "Agat"
+

--- a/libsrc/apple2/sysuname.s
+++ b/libsrc/apple2/sysuname.s
@@ -23,13 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .byte           ((.VERSION >> 4) & $0F) + '0'
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .byte           (.VERSION & $0F) + '0'
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/atari/sysuname.s
+++ b/libsrc/atari/sysuname.s
@@ -23,13 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .byte           ((.VERSION >> 4) & $0F) + '0'
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .byte           (.VERSION & $0F) + '0'
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/atari5200/sysuname.s
+++ b/libsrc/atari5200/sysuname.s
@@ -23,13 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .byte           ((.VERSION >> 4) & $0F) + '0'
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .byte           (.VERSION & $0F) + '0'
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/atmos/sysuname.s
+++ b/libsrc/atmos/sysuname.s
@@ -23,23 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .if             ((.VERSION >> 4) & $0F) > 9
-        .byte           ((.VERSION >> 4) & $0F) / 10 + '0'
-        .byte           ((.VERSION >> 4) & $0F) .MOD 10 + '0'
-        .else
-        .byte           ((.VERSION >> 4) & $0F) + '0'
-        .endif
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .if             (.VERSION & $0F) > 9
-        .byte           (.VERSION & $0F) / 10 + '0'
-        .byte           (.VERSION & $0F) .MOD 10 + '0'
-        .else
-        .byte           (.VERSION & $0F) + '0'
-        .endif
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/c128/sysuname.s
+++ b/libsrc/c128/sysuname.s
@@ -23,13 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .byte           ((.VERSION >> 4) & $0F) + '0'
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .byte           (.VERSION & $0F) + '0'
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/c16/sysuname.s
+++ b/libsrc/c16/sysuname.s
@@ -23,13 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .byte           ((.VERSION >> 4) & $0F) + '0'
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .byte           (.VERSION & $0F) + '0'
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/c64/sysuname.s
+++ b/libsrc/c64/sysuname.s
@@ -23,13 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .byte           ((.VERSION >> 4) & $0F) + '0'
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .byte           (.VERSION & $0F) + '0'
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/cbm510/sysuname.s
+++ b/libsrc/cbm510/sysuname.s
@@ -23,13 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .byte           ((.VERSION >> 4) & $0F) + '0'
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .byte           (.VERSION & $0F) + '0'
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/cbm610/sysuname.s
+++ b/libsrc/cbm610/sysuname.s
@@ -23,13 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .byte           ((.VERSION >> 4) & $0F) + '0'
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .byte           (.VERSION & $0F) + '0'
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/creativision/sysuname.s
+++ b/libsrc/creativision/sysuname.s
@@ -23,13 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .byte           ((.VERSION >> 4) & $0F) + '0'
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .byte           (.VERSION & $0F) + '0'
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/geos-common/system/sysuname.s
+++ b/libsrc/geos-common/system/sysuname.s
@@ -22,14 +22,14 @@ utsdata:
         .asciiz ""
 
         ; release
-        .byte ((.VERSION >> 8) & $0F) + '0'
-        .byte '.'
-        .byte ((.VERSION >> 4) & $0F) + '0'
-        .byte $00
+        .byte           .string (>.version)
+        .byte           '.'
+        .byte           .string (<.version)
+        .byte           $00
 
         ; version
-        .byte (.VERSION & $0F) + '0'
-        .byte $00
+        .byte           '0'     ; unused
+        .byte           $00
 
         ; machine
         .asciiz "GEOS"

--- a/libsrc/lynx/sysuname.s
+++ b/libsrc/lynx/sysuname.s
@@ -23,13 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .byte           ((.VERSION >> 4) & $0F) + '0'
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .byte           (.VERSION & $0F) + '0'
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/nes/sysuname.s
+++ b/libsrc/nes/sysuname.s
@@ -23,13 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .byte           ((.VERSION >> 4) & $0F) + '0'
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .byte           (.VERSION & $0F) + '0'
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/pet/sysuname.s
+++ b/libsrc/pet/sysuname.s
@@ -23,13 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .byte           ((.VERSION >> 4) & $0F) + '0'
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .byte           (.VERSION & $0F) + '0'
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/plus4/sysuname.s
+++ b/libsrc/plus4/sysuname.s
@@ -23,13 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .byte           ((.VERSION >> 4) & $0F) + '0'
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .byte           (.VERSION & $0F) + '0'
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/telestrat/sysuname.s
+++ b/libsrc/telestrat/sysuname.s
@@ -23,23 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .if             ((.VERSION >> 4) & $0F) > 9
-        .byte           ((.VERSION >> 4) & $0F) / 10 + '0'
-        .byte           ((.VERSION >> 4) & $0F) .MOD 10 + '0'
-        .else
-        .byte           ((.VERSION >> 4) & $0F) + '0'
-        .endif
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .if             (.VERSION & $0F) > 9
-        .byte           (.VERSION & $0F) / 10 + '0'
-        .byte           (.VERSION & $0F) .MOD 10 + '0'
-        .else
-        .byte           (.VERSION & $0F) + '0'
-        .endif
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/libsrc/vic20/sysuname.s
+++ b/libsrc/vic20/sysuname.s
@@ -23,13 +23,13 @@ utsdata:
         .asciiz         ""
 
         ; release
-        .byte           ((.VERSION >> 8) & $0F) + '0'
+        .byte           .string (>.version)
         .byte           '.'
-        .byte           ((.VERSION >> 4) & $0F) + '0'
+        .byte           .string (<.version)
         .byte           $00
 
         ; version
-        .byte           (.VERSION & $0F) + '0'
+        .byte           '0'     ; unused
         .byte           $00
 
         ; machine

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -213,6 +213,9 @@ EXELIST_atari2600 = \
 EXELIST_atari5200 = \
         notavailable
 
+EXELIST_atari7800 = \
+        notavailable
+
 EXELIST_atmos =    \
         ascii      \
         checkversion \
@@ -299,9 +302,7 @@ EXELIST_gamate =   \
         hello
 
 EXELIST_geos-cbm = \
-        ascii      \
-        checkversion \
-        diodemo
+        ascii
 
 EXELIST_geos-apple = \
         ascii
@@ -346,6 +347,9 @@ EXELIST_sim6502 =  \
         gunzip65
 
 EXELIST_sim65c02 = $(EXELIST_sim6502)
+
+EXELIST_rp6502 = \
+        notavailable
 
 EXELIST_supervision = \
         notavailable
@@ -413,6 +417,7 @@ TARGETS :=     \
   atarixl      \
   atari2600    \
   atari5200    \
+  atari7800    \
   atmos        \
   bbc          \
   c128         \
@@ -423,6 +428,8 @@ TARGETS :=     \
   creativision \
   cx16         \
   gamate       \
+  geos-apple   \
+  geos-cbm     \
   kim1         \
   lunix        \
   lynx         \
@@ -431,6 +438,7 @@ TARGETS :=     \
   pce          \
   pet          \
   plus4        \
+  rp6502       \
   sim6502      \
   sim65c02     \
   supervision  \
@@ -438,12 +446,14 @@ TARGETS :=     \
   telestrat    \
   vic20
 
+
 # --------------------------------------------------------------------------
 # Rule to make the binaries for every platform
 
 define TARGET_recipe
 
 @echo making samples for: $(T)
+@$(MAKE) --no-print-directory clean SYS:=$(T)
 @$(MAKE) -j2 SYS:=$(T)
 @$(MAKE) --no-print-directory clean SYS:=$(T)
 

--- a/samples/checkversion.c
+++ b/samples/checkversion.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/utsname.h>
 
 #if ((__CC65__ >> 8) > 3) || ((__CC65__ & 0x000f) > 0)
 /* compiler version is 2.19-git or higher */
@@ -29,6 +30,17 @@
 
 int main(void)
 {
+#if !defined(__SIM6502__) && !defined(__SIM65C02__) && !defined(__AGAT__)
+    struct utsname buf;
+    uname (&buf);
+
+    printf("utsname.sysname: %s\n", buf.sysname);
+    printf("utsname.nodename: %s\n", buf.nodename);
+    printf("utsname.release: %s\n", buf.release);
+    printf("utsname.version: %s\n", buf.version);
+    printf("utsname.machine: %s\n", buf.machine);
+#endif
+
     printf("__CC65__ defined as %04x\n", __CC65__);
     printf("compiler version is %u.%u\n", VER_MAJOR, VER_MINOR);
     if (__CC65__ == VERSION) {

--- a/samples/tutorial/Makefile
+++ b/samples/tutorial/Makefile
@@ -43,6 +43,9 @@ EXELIST_atari2600 = \
 EXELIST_atari5200 = \
 	notavailable
 
+EXELIST_atari7800 = \
+	notavailable
+
 EXELIST_bbc = \
 	notavailable
 


### PR DESCRIPTION
somehow this was forgotten back when the version "encoding" was fixed, see samples/checkversion.c for some info