### PR TITLE
Fix -s vs QUIET in the makefiles

### DIFF
--- a/targettest/Makefile
+++ b/targettest/Makefile
@@ -47,6 +47,16 @@ else
   LD := $(if $(wildcard ../bin/ld65*),../bin/ld65,ld65)
 endif
 
+ifeq ($(SILENT),s)
+    QUIET = 1
+endif
+
+ifdef QUIET
+    .SILENT:
+    PQ = "QUIET=1"
+    PD = --no-print-directory
+endif
+
 ifneq ($(filter disk testcode.%,$(MAKECMDGOALS)),)
   ifdef CC65_HOME
     TARGET_PATH = $(CC65_HOME)/target
@@ -120,10 +130,12 @@ DISK_atarixl   = testcode.atr
 %: %.s
 
 .c.o:
+	$(if $(QUIET),echo targettest/$*.c)
 	$(CC) $(CFLAGS) -Ors --codesize 500 -T -g -t $(SYS) $<
 	$(AS) $(<:.c=.s)
 
 .s.o:
+	$(if $(QUIET),echo targettest/$*.s)
 	$(AS) $(ASFLAGS) -t $(SYS) $<
 
 .PRECIOUS: %.o
@@ -721,7 +733,7 @@ endif
 
 define SUBDIR_recipe
 
-@+$(MAKE) -C $(dir) --no-print-directory $@
+@+$(MAKE) -C $(dir) $(PD) $@ $(PQ)
 
 endef # SUBDIR_recipe
 
@@ -783,7 +795,7 @@ define TARGET_recipe
 
 @echo making targettest for: $(T)
 @$(MAKE) -j2 SYS:=$(T)
-@$(MAKE) --no-print-directory clean SYS:=$(T)
+@$(MAKE) $(PD) clean SYS:=$(T)
 
 endef # TARGET_recipe
 

--- a/targettest/accelerator/Makefile
+++ b/targettest/accelerator/Makefile
@@ -36,6 +36,14 @@ else
   LD := $(if $(wildcard ../../bin/ld65*),../../bin/ld65,ld65)
 endif
 
+ifeq ($(SILENT),s)
+    QUIET = 1
+endif
+
+ifdef QUIET
+    .SILENT:
+endif
+
 EXELIST_c64 = \
 	c64-scpu-test.prg \
 	c64dtv-test.prg \
@@ -64,27 +72,35 @@ else
 endif
 
 c64-scpu-test.prg: c64-c128-scpu-test.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t c64 c64-c128-scpu-test.c -o c64-scpu-test.prg
 
 c128-scpu-test.prg: c64-c128-scpu-test.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t c128 c64-c128-scpu-test.c -o c128-scpu-test.prg
 
 c64dtv-test.prg: c64dtv-test.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t c64 c64dtv-test.c -o c64dtv-test.prg
 
 c64-test.prg: c64-c128-test.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t c64 c64-c128-test.c -o c64-test.prg
 
 c128-test.prg: c64-c128-test.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t c128 c64-c128-test.c -o c128-test.prg
 
 chameleon-test.prg: chameleon-test.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t c64 chameleon-test.c -o chameleon-test.prg
 
 c65-test.prg: c65-test.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t c64 c65-test.c -o c65-test.prg
 
 turbomaster-test.prg: turbomaster-test.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t c64 turbomaster-test.c -o turbomaster-test.prg
 
 clean:

--- a/targettest/atari/Makefile
+++ b/targettest/atari/Makefile
@@ -37,6 +37,14 @@ else
   LD := $(if $(wildcard ../../bin/ld65*),../../bin/ld65,ld65)
 endif
 
+ifeq ($(SILENT),s)
+    QUIET = 1
+endif
+
+ifdef QUIET
+    .SILENT:
+endif
+
 EXELIST_atari = \
         charmapping.xex \
         defdev.xex \
@@ -64,24 +72,33 @@ else
 endif
 
 charmapping.xex: charmapping.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t atari -o charmapping.xex charmapping.c
 defdev.xex: defdev.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t atari -o defdev.xex defdev.c
 displaylist.xex: displaylist.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t atari -o displaylist.xex displaylist.c
 mem.xex: mem.c ../getsp.s
+	$(if $(QUIET),echo $@)
 	$(CL) -t atari -o mem.xex mem.c ../getsp.s
 multi.xex: multi-xex.s multi-xex.cfg
+	$(if $(QUIET),echo $@)
 	$(CL) -t atari -C multi-xex.cfg multi-xex.s -o multi.xex
 ostype.xex: ostype.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t atari -o ostype.xex ostype.c
 scrcode.com: scrcode.s
+	$(if $(QUIET),echo $@)
 #	ca65 -t atari -o scrcode.o scrcode.s
 #	ld65 -C atari-asm.cfg -o scrcode.com scrcode.o
 	$(CL) -t atari -C atari-asm.cfg -o scrcode.com scrcode.s
 sys.xex: sys.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t atari -o sys.xex sys.c
 sound.xex: sound.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t atari -o sound.xex sound.c
 clean:
 	@$(DEL) charmapping.xex 2>$(NULLDEV)

--- a/targettest/cbm/Makefile
+++ b/targettest/cbm/Makefile
@@ -40,6 +40,14 @@ else
   LD := $(if $(wildcard ../../bin/ld65*),../../bin/ld65,ld65)
 endif
 
+ifeq ($(SILENT),s)
+    QUIET = 1
+endif
+
+ifdef QUIET
+    .SILENT:
+endif
+
 EXELIST_c64 = \
         petscii.prg \
         cbmdir-test.prg \
@@ -73,12 +81,14 @@ endif
 
 ifeq ($(SYS),c64)
 petscii.prg: petscii.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t $(SYS) -O -o petscii.prg petscii.c
 else
 petscii.prg:
 endif
 
 cbmdir-test.prg: cbmdir-test.c
+	$(if $(QUIET),echo $@)
 ifeq ($(SYS),vic20)
 	$(CL) -t $(SYS) -C vic20-32k.cfg -Oris -o $@ $<
 else
@@ -86,6 +96,7 @@ else
 endif
 
 cbmread.prg: cbmread.c
+	$(if $(QUIET),echo $@)
 ifeq ($(SYS),vic20)
 	$(CL) -t $(SYS) -C vic20-32k.cfg -Oris -o $@ $<
 else

--- a/targettest/gamate/Makefile
+++ b/targettest/gamate/Makefile
@@ -37,6 +37,14 @@ else
   LD := $(if $(wildcard ../../bin/ld65*),../../bin/ld65,ld65)
 endif
 
+ifeq ($(SILENT),s)
+    QUIET = 1
+endif
+
+ifdef QUIET
+    .SILENT:
+endif
+
 EXELIST_gamate = \
         audiotest.bin lcdtest.bin ctest.bin
 
@@ -56,10 +64,13 @@ else
 endif
 
 audiotest.bin: audiotest.s
+	$(if $(QUIET),echo $@)
 	$(CL) -l audiotest.lst -t gamate -o audiotest.bin audiotest.s
 lcdtest.bin: lcdtest.s
+	$(if $(QUIET),echo $@)
 	$(CL) -l lcdtest.lst -t gamate -o lcdtest.bin lcdtest.s
 ctest.bin: ctest.c
+	$(if $(QUIET),echo $@)
 	$(CL) -l ctest.lst -t gamate -o ctest.bin ctest.c
 
 clean:

--- a/targettest/pce/Makefile
+++ b/targettest/pce/Makefile
@@ -37,6 +37,14 @@ else
   LD := $(if $(wildcard ../../bin/ld65*),../../bin/ld65,ld65)
 endif
 
+ifeq ($(SILENT),s)
+    QUIET = 1
+endif
+
+ifdef QUIET
+    .SILENT:
+endif
+
 .PHONY: all clean test
 
 # Size of cartridge to generate.
@@ -71,8 +79,11 @@ else
 endif
 
 %.bin: %.c
+	$(if $(QUIET),echo $@)
 	$(CL) -t pce $< -Wl -D__CARTSIZE__=${CARTSIZE} -m $*.map -o $@
+ifndef QUIET
 	@echo "use 'make conio.pce' to produce a .pce file using dd"
+endif
 
 %.pce: %.bin
 	dd if=$< bs=8K skip=${COUNT} > $@

--- a/test/Makefile
+++ b/test/Makefile
@@ -17,11 +17,12 @@ else
 endif
 
 ifeq ($(SILENT),s)
-    QUIET := 1
+    QUIET = 1
 endif
 
-ifneq ($(QUIET),1)
-    QUIET := 0
+ifdef QUIET
+    PQ = "QUIET=1"
+    PD = --no-print-directory
 endif
 
 WORKDIR = ../testwrk
@@ -33,15 +34,15 @@ test:
 	@$(MAKE) continue
 
 continue:
-	@$(MAKE) -C asm all QUIET=$(QUIET)
-	@$(MAKE) -C dasm all QUIET=$(QUIET)
-	@$(MAKE) -C val all QUIET=$(QUIET)
-	@$(MAKE) -C ref all QUIET=$(QUIET)
-	@$(MAKE) -C err all QUIET=$(QUIET)
-	@$(MAKE) -C standard all QUIET=$(QUIET)
-	@$(MAKE) -C standard_err all QUIET=$(QUIET)
-	@$(MAKE) -C misc all QUIET=$(QUIET)
-	@$(MAKE) -C todo all QUIET=$(QUIET)
+	@$(MAKE) $(PD) -C asm all $(PQ)
+	@$(MAKE) $(PD) -C dasm all $(PQ)
+	@$(MAKE) $(PD) -C val all $(PQ)
+	@$(MAKE) $(PD) -C ref all $(PQ)
+	@$(MAKE) $(PD) -C err all $(PQ)
+	@$(MAKE) $(PD) -C standard all $(PQ)
+	@$(MAKE) $(PD) -C standard_err all $(PQ)
+	@$(MAKE) $(PD) -C misc all $(PQ)
+	@$(MAKE) $(PD) -C todo all $(PQ)
 	@$(MAKE) success_message
 
 success_message:
@@ -50,15 +51,15 @@ success_message:
 	$(info ###################################)
 
 mostlyclean:
-	@$(MAKE) -C asm clean QUIET=$(QUIET)
-	@$(MAKE) -C dasm clean QUIET=$(QUIET)
-	@$(MAKE) -C val clean QUIET=$(QUIET)
-	@$(MAKE) -C ref clean QUIET=$(QUIET)
-	@$(MAKE) -C err clean QUIET=$(QUIET)
-	@$(MAKE) -C standard clean QUIET=$(QUIET)
-	@$(MAKE) -C standard_err clean QUIET=$(QUIET)
-	@$(MAKE) -C misc clean QUIET=$(QUIET)
-	@$(MAKE) -C todo clean QUIET=$(QUIET)
+	@$(MAKE) $(PD) -C asm clean $(PQ)
+	@$(MAKE) $(PD) -C dasm clean $(PQ)
+	@$(MAKE) $(PD) -C val clean $(PQ)
+	@$(MAKE) $(PD) -C ref clean $(PQ)
+	@$(MAKE) $(PD) -C err clean $(PQ)
+	@$(MAKE) $(PD) -C standard clean $(PQ)
+	@$(MAKE) $(PD) -C standard_err clean $(PQ)
+	@$(MAKE) $(PD) -C misc clean $(PQ)
+	@$(MAKE) $(PD) -C todo clean $(PQ)
 
 clean: mostlyclean
 	@$(call RMDIR,$(WORKDIR))

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,6 +16,14 @@ else
   RMDIR = $(RM) -r $1
 endif
 
+ifeq ($(SILENT),s)
+    QUIET := 1
+endif
+
+ifneq ($(QUIET),1)
+    QUIET := 0
+endif
+
 WORKDIR = ../testwrk
 
 .PHONY: test continue mostlyclean clean success_message
@@ -25,15 +33,15 @@ test:
 	@$(MAKE) continue
 
 continue:
-	@$(MAKE) -C asm all
-	@$(MAKE) -C dasm all
-	@$(MAKE) -C val all
-	@$(MAKE) -C ref all
-	@$(MAKE) -C err all
-	@$(MAKE) -C standard all
-	@$(MAKE) -C standard_err all
-	@$(MAKE) -C misc all
-	@$(MAKE) -C todo all
+	@$(MAKE) -C asm all QUIET=$(QUIET)
+	@$(MAKE) -C dasm all QUIET=$(QUIET)
+	@$(MAKE) -C val all QUIET=$(QUIET)
+	@$(MAKE) -C ref all QUIET=$(QUIET)
+	@$(MAKE) -C err all QUIET=$(QUIET)
+	@$(MAKE) -C standard all QUIET=$(QUIET)
+	@$(MAKE) -C standard_err all QUIET=$(QUIET)
+	@$(MAKE) -C misc all QUIET=$(QUIET)
+	@$(MAKE) -C todo all QUIET=$(QUIET)
 	@$(MAKE) success_message
 
 success_message:
@@ -42,15 +50,15 @@ success_message:
 	$(info ###################################)
 
 mostlyclean:
-	@$(MAKE) -C asm clean
-	@$(MAKE) -C dasm clean
-	@$(MAKE) -C val clean
-	@$(MAKE) -C ref clean
-	@$(MAKE) -C err clean
-	@$(MAKE) -C standard clean
-	@$(MAKE) -C standard_err clean
-	@$(MAKE) -C misc clean
-	@$(MAKE) -C todo clean
+	@$(MAKE) -C asm clean QUIET=$(QUIET)
+	@$(MAKE) -C dasm clean QUIET=$(QUIET)
+	@$(MAKE) -C val clean QUIET=$(QUIET)
+	@$(MAKE) -C ref clean QUIET=$(QUIET)
+	@$(MAKE) -C err clean QUIET=$(QUIET)
+	@$(MAKE) -C standard clean QUIET=$(QUIET)
+	@$(MAKE) -C standard_err clean QUIET=$(QUIET)
+	@$(MAKE) -C misc clean QUIET=$(QUIET)
+	@$(MAKE) -C todo clean QUIET=$(QUIET)
 
 clean: mostlyclean
 	@$(call RMDIR,$(WORKDIR))

--- a/test/asm/Makefile
+++ b/test/asm/Makefile
@@ -16,6 +16,14 @@ else
   RMDIR = $(RM) -r $1
 endif
 
+ifeq ($(SILENT),s)
+    QUIET := 1
+endif
+
+ifneq ($(QUIET),1)
+    QUIET := 0
+endif
+
 WORKDIR = ../testwrk/asm
 
 .PHONY: all continue mostlyclean clean
@@ -23,20 +31,20 @@ WORKDIR = ../testwrk/asm
 all: mostlyclean continue
 
 continue: mostlyclean
-	@$(MAKE) -C cpudetect all
-	@$(MAKE) -C opcodes all
-	@$(MAKE) -C listing all
-	@$(MAKE) -C val all
-	@$(MAKE) -C err all
-	@$(MAKE) -C misc all
+	@$(MAKE) --no-print-directory -C cpudetect all QUIET=$(QUIET)
+	@$(MAKE) --no-print-directory -C opcodes all QUIET=$(QUIET)
+	@$(MAKE) --no-print-directory -C listing all QUIET=$(QUIET)
+	@$(MAKE) --no-print-directory -C val all QUIET=$(QUIET)
+	@$(MAKE) --no-print-directory -C err all QUIET=$(QUIET)
+	@$(MAKE) --no-print-directory -C misc all QUIET=$(QUIET)
 
 mostlyclean:
-	@$(MAKE) -C cpudetect clean
-	@$(MAKE) -C opcodes clean
-	@$(MAKE) -C listing clean
-	@$(MAKE) -C val clean
-	@$(MAKE) -C err clean
-	@$(MAKE) -C misc clean
+	@$(MAKE) --no-print-directory -C cpudetect clean
+	@$(MAKE) --no-print-directory -C opcodes clean
+	@$(MAKE) --no-print-directory -C listing clean
+	@$(MAKE) --no-print-directory -C val clean
+	@$(MAKE) --no-print-directory -C err clean
+	@$(MAKE) --no-print-directory -C misc clean
 
 clean: mostlyclean
 	@$(call RMDIR,$(WORKDIR))

--- a/test/asm/Makefile
+++ b/test/asm/Makefile
@@ -20,8 +20,9 @@ ifeq ($(SILENT),s)
     QUIET := 1
 endif
 
-ifneq ($(QUIET),1)
-    QUIET := 0
+ifdef QUIET
+    PQ = "QUIET=1"
+    PD = --no-print-directory
 endif
 
 WORKDIR = ../testwrk/asm
@@ -31,20 +32,20 @@ WORKDIR = ../testwrk/asm
 all: mostlyclean continue
 
 continue: mostlyclean
-	@$(MAKE) --no-print-directory -C cpudetect all QUIET=$(QUIET)
-	@$(MAKE) --no-print-directory -C opcodes all QUIET=$(QUIET)
-	@$(MAKE) --no-print-directory -C listing all QUIET=$(QUIET)
-	@$(MAKE) --no-print-directory -C val all QUIET=$(QUIET)
-	@$(MAKE) --no-print-directory -C err all QUIET=$(QUIET)
-	@$(MAKE) --no-print-directory -C misc all QUIET=$(QUIET)
+	@$(MAKE) $(PD) -C cpudetect all $(PQ)
+	@$(MAKE) $(PD) -C opcodes all $(PQ)
+	@$(MAKE) $(PD) -C listing all $(PQ)
+	@$(MAKE) $(PD) -C val all $(PQ)
+	@$(MAKE) $(PD) -C err all $(PQ)
+	@$(MAKE) $(PD) -C misc all $(PQ)
 
 mostlyclean:
-	@$(MAKE) --no-print-directory -C cpudetect clean
-	@$(MAKE) --no-print-directory -C opcodes clean
-	@$(MAKE) --no-print-directory -C listing clean
-	@$(MAKE) --no-print-directory -C val clean
-	@$(MAKE) --no-print-directory -C err clean
-	@$(MAKE) --no-print-directory -C misc clean
+	@$(MAKE) $(PD) -C cpudetect clean $(PQ)
+	@$(MAKE) $(PD) -C opcodes clean $(PQ)
+	@$(MAKE) $(PD) -C listing clean $(PQ)
+	@$(MAKE) $(PD) -C val clean $(PQ)
+	@$(MAKE) $(PD) -C err clean $(PQ)
+	@$(MAKE) $(PD) -C misc clean $(PQ)
 
 clean: mostlyclean
 	@$(call RMDIR,$(WORKDIR))

--- a/test/asm/cpudetect/Makefile
+++ b/test/asm/cpudetect/Makefile
@@ -20,8 +20,12 @@ else
   RMDIR = $(RM) -r $1
 endif
 
+
 ifdef QUIET
   .SILENT:
+  NULLOUT = >$(NULLDEV)
+  NULLERR = 2>$(NULLDEV)
+  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
 endif
 
 CA65 := $(if $(wildcard ../../../bin/ca65*),../../../bin/ca65,ca65)
@@ -52,8 +56,8 @@ define CPUDETECT_template
 
 $(WORKDIR)/$1-cpudetect.bin: cpudetect.s $1-cpudetect.ref $(ISEQUAL)
 	$(if $(QUIET),echo asm/$1-cpudetect.bin)
-	$(CA65) -t none --cpu $1 -l $$(@:.bin=.lst) -o $$(@:.bin=.o) $$<
-	$(LD65) -t none -o $$@ $$(@:.bin=.o) none.lib
+	$(CA65) -t none --cpu $1 -l $$(@:.bin=.lst) -o $$(@:.bin=.o) $$< $(CATERR)
+	$(LD65) -t none -o $$@ $$(@:.bin=.o) none.lib $(CATERR)
 	$(ISEQUAL) $1-cpudetect.ref $$@
 
 endef # CPUDETECT_template
@@ -61,7 +65,7 @@ endef # CPUDETECT_template
 $(foreach cpu,$(CPUDETECT_CPUS),$(eval $(call CPUDETECT_template,$(cpu))))
 
 $(WORKDIR)/%.o: %.s | $(WORKDIR)
-	$(CA65) -l $(@:.o=.lst) -o $@ $<
+	$(CA65) -l $(@:.o=.lst) -o $@ $< $(NULLOUT) $(CATERR)
 
 clean:
 	@$(call RMDIR,$(WORKDIR))

--- a/test/asm/err/Makefile
+++ b/test/asm/err/Makefile
@@ -26,7 +26,9 @@ endif
 
 ifdef QUIET
   .SILENT:
+  NULLOUT = >$(NULLDEV)
   NULLERR = 2>$(NULLDEV)
+  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
 endif
 
 CA65 := $(if $(wildcard ../../../bin/ca65*),..$S..$S..$Sbin$Sca65,ca65)

--- a/test/asm/listing/Makefile
+++ b/test/asm/listing/Makefile
@@ -17,6 +17,7 @@ ifdef CMD_EXE
   RMDIR = -rmdir /q /s $(subst /,\,$1)
   TRUE = exit 0
   CAT = type $(subst /,\,$1)
+  NULLDEV = nul:
 else
   S = /
   EXE =
@@ -24,10 +25,14 @@ else
   RMDIR = $(RM) -r $1
   TRUE = true
   CAT = cat $1
+  NULLDEV = /dev/null
 endif
 
 ifdef QUIET
   .SILENT:
+  NULLOUT = >$(NULLDEV)
+  NULLERR = 2>$(NULLDEV)
+  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
 endif
 
 CA65 := $(if $(wildcard ../../../bin/ca65*),..$S..$S..$Sbin$Sca65,ca65)
@@ -82,48 +87,52 @@ endif
 endif
 
 ifneq ($(wildcard ref/$1.err-ref),)
-	$(ISEQUAL) ref/$1.err-ref $$(@:.bin=.err)
+	$(ISEQUAL) ref/$1.err-ref $$(@:.bin=.err) $(NULLERR)
 else
-	$(ISEQUAL) --empty $$(@:.bin=.err)
+	$(ISEQUAL) --empty $$(@:.bin=.err) $(NULLERR)
 endif
 
 ifneq ($(wildcard ref/$1.err2-ref),)
-	$(ISEQUAL) ref/$1.err2-ref $$(@:.bin=.err2)
+	$(ISEQUAL) ref/$1.err2-ref $$(@:.bin=.err2) $(NULLERR)
 else
-	$(ISEQUAL) --empty $$(@:.bin=.err2)
+	$(ISEQUAL) --empty $$(@:.bin=.err2) $(NULLERR)
 endif
 
 ifneq ($(wildcard ref/$1.bin-ref),)
-	$(ISEQUAL) --binary ref/$1.bin-ref $$@
+	$(ISEQUAL) --binary ref/$1.bin-ref $$@ $(NULLERR)
 endif
 
 #	rem $(indfo $(CAT) $(subst /,$$S,$$$(@:.bin=.ld65-err)))
 
 ifneq ($(wildcard ref/$1.ld65err-ref),)
+ifndef QUIET
 	@echo $(CAT) $$(@:.bin=.ld65-err)
 # FIXME: somehow this refuses to work in cmd.exe
 ifndef CMD_EXE
 	$(call CAT,$$(@:.bin=.ld65-err))
 	-diff -u ref/$1.ld65err-ref $$(@:.bin=.ld65-err)
 endif
-	$(ISEQUAL) --wildcards ref/$1.ld65err-ref $$(@:.bin=.ld65-err)
+endif
+	$(ISEQUAL) --wildcards ref/$1.ld65err-ref $$(@:.bin=.ld65-err) $(NULLERR)
 else
 ifneq ($(wildcard $(WORKDIR)/$1.ld65-err),)
-	$(ISEQUAL) --empty $$(@:.bin=.ld65-err)
+	$(ISEQUAL) --empty $$(@:.bin=.ld65-err) $(NULLERR)
 endif
 endif
 
 ifneq ($(wildcard ref/$1.ld65err2-ref),)
+ifndef QUIET
 	@echo $(CAT) $$(@:.bin=.ld65-err2)
 # FIXME: somehow this refuses to work in cmd.exe
 ifndef CMD_EXE
 	$(call CAT,$$(@:.bin=.ld65-err2))
 	-diff -u ref/$1.ld65err2-ref $$(@:.bin=.ld65-err2)
 endif
-	$(ISEQUAL) --wildcards ref/$1.ld65err2-ref $$(@:.bin=.ld65-err2)
+endif
+	$(ISEQUAL) --wildcards ref/$1.ld65err2-ref $$(@:.bin=.ld65-err2) $(NULLERR)
 else
 ifneq ($(wildcard $(WORKDIR)/$1.ld65-err2),)
-	$(ISEQUAL) --empty $$(@:.bin=.ld65-err2)
+	$(ISEQUAL) --empty $$(@:.bin=.ld65-err2) $(NULLERR)
 endif
 endif
 
@@ -149,37 +158,37 @@ endif
 endif
 
 ifneq ($(wildcard ref/$1.err-ref),)
-	$(ISEQUAL) ref/$1.err-ref $$(@:.bin=.list-err)
+	$(ISEQUAL) ref/$1.err-ref $$(@:.bin=.list-err) $(NULLERR)
 else
-	$(ISEQUAL) --empty $$(@:.bin=.list-err)
+	$(ISEQUAL) --empty $$(@:.bin=.list-err) $(NULLERR)
 endif
 
 ifneq ($(wildcard ref/$1.ld65err-ref),)
-	$(ISEQUAL) --wildcards ref/$1.ld65err-ref $$(@:.bin=.list-ld65-err)
+	$(ISEQUAL) --wildcards ref/$1.ld65err-ref $$(@:.bin=.list-ld65-err) $(NULLERR)
 else
 ifneq ($(wildcard $(WORKDIR)/$1.list-ld65-err),)
-	$(ISEQUAL) --empty $$(@:.bin=.list-ld65-err)
+	$(ISEQUAL) --empty $$(@:.bin=.list-ld65-err) $(NULLERR)
 endif
 endif
 
 ifneq ($(wildcard ref/$1.err2-ref),)
-	$(ISEQUAL) ref/$1.err2-ref $$(@:.bin=.list-err2)
+	$(ISEQUAL) ref/$1.err2-ref $$(@:.bin=.list-err2) $(NULLERR)
 else
-	$(ISEQUAL) --empty $$(@:.bin=.list-err2)
+	$(ISEQUAL) --empty $$(@:.bin=.list-err2) $(NULLERR)
 endif
 
 ifneq ($(wildcard ref/$1.ld65err2-ref),)
-	$(ISEQUAL) --wildcards ref/$1.ld65err2-ref $$(@:.bin=.list-ld65-err2)
+	$(ISEQUAL) --wildcards ref/$1.ld65err2-ref $$(@:.bin=.list-ld65-err2) $(NULLERR)
 else
 ifneq ($(wildcard $(WORKDIR)/$1.list-ld65-err2),)
-	$(ISEQUAL) --empty $$(@:.bin=.list-ld65-err2)
+	$(ISEQUAL) --empty $$(@:.bin=.list-ld65-err2) $(NULLERR)
 endif
 endif
 
 #	check if the result bin is the same as without listing file
 ifeq ($(wildcard control/$1.err),)
 ifeq ($(wildcard control/$1.err2),)
-	$(ISEQUAL) $$@ $$(@:.bin=.list-bin)
+	$(ISEQUAL) $$@ $$(@:.bin=.list-bin) $(NULLERR)
 endif
 endif
 
@@ -187,7 +196,7 @@ ifneq ($(wildcard ref/$1.list-ref),)
 #	we have a reference file, compare that, too
 
 #	remove first line which contains a version number
-	$(ISEQUAL) --skip=1 ref/$1.list-ref $$(@:.bin=.list-lst)
+	$(ISEQUAL) --skip=1 ref/$1.list-ref $$(@:.bin=.list-lst) $(NULLERR)
 endif
 
 endef # LISTING_template

--- a/test/asm/listing/Makefile
+++ b/test/asm/listing/Makefile
@@ -27,7 +27,7 @@ else
 endif
 
 ifdef QUIET
-#  .SILENT:
+  .SILENT:
 endif
 
 CA65 := $(if $(wildcard ../../../bin/ca65*),..$S..$S..$Sbin$Sca65,ca65)

--- a/test/asm/misc/Makefile
+++ b/test/asm/misc/Makefile
@@ -30,6 +30,7 @@ ifdef QUIET
   .SILENT:
   NULLOUT = >$(NULLDEV)
   NULLERR = 2>$(NULLDEV)
+  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
 endif
 
 SIM65FLAGS = -x 200000000

--- a/test/asm/opcodes/Makefile
+++ b/test/asm/opcodes/Makefile
@@ -22,6 +22,9 @@ endif
 
 ifdef QUIET
   .SILENT:
+  NULLOUT = >$(NULLDEV)
+  NULLERR = 2>$(NULLDEV)
+  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
 endif
 
 CA65 := $(if $(wildcard ../../../bin/ca65*),../../../bin/ca65,ca65)

--- a/test/asm/val/Makefile
+++ b/test/asm/val/Makefile
@@ -51,8 +51,8 @@ define PRG_template
 
 $(WORKDIR)/%.$1.prg: %.s | $(WORKDIR)
 	$(if $(QUIET),echo asm/val/$$*.$1.prg)
-	$(CA65) -t sim$1 -o $$(@:.prg=.o) $$< $(NULLERR)
-	$(LD65) -C sim6502-asmtest.cfg -o $$@ $$(@:.prg=.o) sim$1.lib $(NULLERR)
+	$(CA65) -t sim$1 -o $$(@:.prg=.o) $$< $(NULLOUT) $(NULLERR)
+	$(LD65) -C sim6502-asmtest.cfg -o $$@ $$(@:.prg=.o) sim$1.lib $(NULLOUT) $(NULLERR)
 	$(SIM65) $(SIM65FLAGS) $$@ $(NULLOUT)
 
 endef # PRG_template

--- a/test/dasm/Makefile
+++ b/test/dasm/Makefile
@@ -14,14 +14,19 @@ ifdef CMD_EXE
   EXE = .exe
   MKDIR = mkdir $(subst /,\,$1)
   RMDIR = -rmdir /q /s $(subst /,\,$1)
+  NULLDEV = nul:
 else
   EXE =
   MKDIR = mkdir -p $1
   RMDIR = $(RM) -r $1
+  NULLDEV = /dev/null
 endif
 
 ifdef QUIET
   .SILENT:
+  NULLOUT = >$(NULLDEV)
+  NULLERR = 2>$(NULLDEV)
+  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
 endif
 
 CL65 := $(if $(wildcard ../../bin/cl65*),../../bin/cl65,cl65)

--- a/test/err/Makefile
+++ b/test/err/Makefile
@@ -26,8 +26,11 @@ endif
 
 ifdef QUIET
   .SILENT:
+  NULLOUT = >$(NULLDEV)
   NULLERR = 2>$(NULLDEV)
+  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
 endif
+
 
 CC65 := $(if $(wildcard ../../bin/cc65*),..$S..$Sbin$Scc65,cc65)
 
@@ -45,7 +48,7 @@ $(WORKDIR):
 
 $(WORKDIR)/%.s: %.c | $(WORKDIR)
 	$(if $(QUIET),echo err/$*.s)
-	$(NOT) $(CC65) -o $@ $< $(NULLERR)
+	$(NOT) $(CC65) -o $@ $< $(NULLOUT) $(CATERR)
 
 clean:
 	@$(call RMDIR,$(WORKDIR))

--- a/test/misc/Makefile
+++ b/test/misc/Makefile
@@ -30,6 +30,7 @@ ifdef QUIET
   .SILENT:
   NULLOUT = >$(NULLDEV)
   NULLERR = 2>$(NULLDEV)
+  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
 endif
 
 SIM65FLAGS = -x 200000000
@@ -68,7 +69,7 @@ define PRG_template
 $(WORKDIR)/bug1209-ind-goto-rev.$1.$2.prg: bug1209-ind-goto-rev.c | $(WORKDIR)
 	@echo "FIXME: " $$@ "currently does not compile."
 	$(if $(QUIET),echo misc/bug1209-ind-goto-rev.$1.$2.prg)
-	$(CC65) -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLERR)
+	$(CC65) -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLOUT) $(CATERR)
 	$(CA65) -t sim$2 -o $$(@:.prg=.o) $$(@:.prg=.s) $(NULLERR)
 	$(NOT) $(LD65) -t sim$2 -o $$@ $$(@:.prg=.o) sim$2.lib $(NULLERR)
 
@@ -76,7 +77,7 @@ $(WORKDIR)/bug1209-ind-goto-rev.$1.$2.prg: bug1209-ind-goto-rev.c | $(WORKDIR)
 $(WORKDIR)/bug1209-ind-goto-rev-2.$1.$2.prg: bug1209-ind-goto-rev-2.c | $(WORKDIR)
 	@echo "FIXME: " $$@ "currently does not compile."
 	$(if $(QUIET),echo misc/bug1209-ind-goto-rev-2.$1.$2.prg)
-	$(CC65) -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLERR)
+	$(CC65) -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLOUT) $(CATERR)
 	$(CA65) -t sim$2 -o $$(@:.prg=.o) $$(@:.prg=.s) $(NULLERR)
 	$(NOT) $(LD65) -t sim$2 -o $$@ $$(@:.prg=.o) sim$2.lib $(NULLERR)
 
@@ -84,7 +85,7 @@ $(WORKDIR)/bug1209-ind-goto-rev-2.$1.$2.prg: bug1209-ind-goto-rev-2.c | $(WORKDI
 $(WORKDIR)/bug1209-ind-goto-rev-3.$1.$2.prg: bug1209-ind-goto-rev-3.c | $(WORKDIR)
 	@echo "FIXME: " $$@ "currently does not compile."
 	$(if $(QUIET),echo misc/bug1209-ind-goto-rev-3.$1.$2.prg)
-	$(CC65) -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLERR)
+	$(CC65) -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLOUT) $(CATERR)
 	$(CA65) -t sim$2 -o $$(@:.prg=.o) $$(@:.prg=.s) $(NULLERR)
 	$(NOT) $(LD65) -t sim$2 -o $$@ $$(@:.prg=.o) sim$2.lib $(NULLERR)
 
@@ -92,40 +93,40 @@ $(WORKDIR)/bug1209-ind-goto-rev-3.$1.$2.prg: bug1209-ind-goto-rev-3.c | $(WORKDI
 $(WORKDIR)/pptest2.$1.$2.prg: pptest2.c | $(WORKDIR)
 	@echo "FIXME: " $$@ "currently does not compile."
 	$(if $(QUIET),echo misc/pptest2.$1.$2.prg)
-	$(NOT) $(CC65) -t sim$2 -$1 -o $$@ $$< $(NULLERR)
+	$(NOT) $(CC65) -t sim$2 -$1 -o $$@ $$< $(NULLOUT) $(CATERR)
 
 # should compile, but compiler exits with internal error
 $(WORKDIR)/bug1211-ice-move-refs-2.$1.$2.prg: bug1211-ice-move-refs-2.c | $(WORKDIR)
 	@echo "FIXME: " $$@ "currently does not compile."
 	$(if $(QUIET),echo misc/bug1211-ice-move-refs-2.$1.$2.prg)
-	$(NOT) $(CC65) -t sim$2 -$1 -o $$@ $$< $(NULLERR)
+	$(NOT) $(CC65) -t sim$2 -$1 -o $$@ $$< $(NULLOUT) $(CATERR)
 
 # this one requires --std=c89, it fails with --std=c99
 $(WORKDIR)/bug1265.$1.$2.prg: bug1265.c | $(WORKDIR)
 	$(if $(QUIET),echo misc/bug1265.$1.$2.prg)
-	$(CC65) --standard c89 -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLERR)
+	$(CC65) --standard c89 -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLOUT) $(CATERR)
 	$(CA65) -t sim$2 -o $$(@:.prg=.o) $$(@:.prg=.s) $(NULLERR)
 	$(LD65) -t sim$2 -o $$@ $$(@:.prg=.o) sim$2.lib $(NULLERR)
 	$(SIM65) $(SIM65FLAGS) $$@ $(NULLOUT) $(NULLERR)
 
 # should not compile, but gives different diagnostics in C99 mode than in others
-$(WORKDIR)/bug2515.$1.$2.prg: bug2515.c | $(WORKDIR)
+$(WORKDIR)/bug2515.$1.$2.prg: bug2515.c $(ISEQUAL) | $(WORKDIR)
 	$(if $(QUIET),echo misc/bug2515.$1.$2.prg)
-	$(NOT) $(CC65) --standard c99 -t sim$2 -$1 -o $$(@:.prg=.s) $$< 2>$(WORKDIR)/bug2515.$1.$2.out
+	$(NOT) $(CC65) --standard c99 -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLOUT) 2>$(WORKDIR)/bug2515.$1.$2.out
 	$(ISEQUAL) $(WORKDIR)/bug2515.$1.$2.out bug2515.c99.ref
-	$(NOT) $(CC65) -t sim$2 -$1 -o $$(@:.prg=.s) $$< 2>$(WORKDIR)/bug2515.$1.$2.out
+	$(NOT) $(CC65) -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLOUT) 2>$(WORKDIR)/bug2515.$1.$2.out
 	$(ISEQUAL) $(WORKDIR)/bug2515.$1.$2.out bug2515.ref
 
 # should not issue any warnings in C99 mode
-$(WORKDIR)/bug2637.$1.$2.prg: bug2637.c | $(WORKDIR)
+$(WORKDIR)/bug2637.$1.$2.prg: bug2637.c $(ISEQUAL) | $(WORKDIR)
 	$(if $(QUIET),echo misc/bug2637.$1.$2.prg)
-	$(CC65) --standard c99 -t sim$2 -$1 -o $$(@:.prg=.s) $$< 2>$(WORKDIR)/bug2637.$1.$2.out
+	$(CC65) --standard c99 -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLOUT) 2>$(WORKDIR)/bug2637.$1.$2.out
 	$(ISEQUAL) $(WORKDIR)/bug2637.$1.$2.out bug2637.ref
 
 # this one requires -Werror
 $(WORKDIR)/bug1768.$1.$2.prg: bug1768.c | $(WORKDIR)
 	$(if $(QUIET),echo misc/bug1768.$1.$2.prg)
-	$(CC65) -Werror -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLERR)
+	$(CC65) -Werror -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLOUT) $(CATERR)
 	$(CA65) -t sim$2 -o $$(@:.prg=.o) $$(@:.prg=.s) $(NULLERR)
 	$(LD65) -t sim$2 -o $$@ $$(@:.prg=.o) sim$2.lib $(NULLERR)
 	$(SIM65) $(SIM65FLAGS) $$@ $(NULLOUT) $(NULLERR)
@@ -133,7 +134,7 @@ $(WORKDIR)/bug1768.$1.$2.prg: bug1768.c | $(WORKDIR)
 # should compile, but then hangs in an endless loop
 $(WORKDIR)/endless.$1.$2.prg: endless.c | $(WORKDIR)
 	$(if $(QUIET),echo misc/endless.$1.$2.prg)
-	$(CC65) -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLERR)
+	$(CC65) -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLOUT) $(CATERR)
 	$(CA65) -t sim$2 -o $$(@:.prg=.o) $$(@:.prg=.s) $(NULLERR)
 	$(LD65) -t sim$2 -o $$@ $$(@:.prg=.o) sim$2.lib $(NULLERR)
 	$(NOT) $(SIM65) $(SIM65FLAGS) $$@ $(NULLOUT) $(NULLERR)
@@ -142,12 +143,12 @@ $(WORKDIR)/endless.$1.$2.prg: endless.c | $(WORKDIR)
 # in a useful way
 $(WORKDIR)/bug2655.$1.$2.prg: bug2655.c $(ISEQUAL) | $(WORKDIR)
 	$(if $(QUIET),echo misc/bug2655.$1.$2.prg)
-	$(CC65) -t sim$2 -$1 -o $$@ $$< 2>$(WORKDIR)/bug2655.$1.$2.out
+	$(CC65) -t sim$2 -$1 -o $$@ $$< $(NULLOUT) 2>$(WORKDIR)/bug2655.$1.$2.out
 	$(ISEQUAL) $(WORKDIR)/bug2655.$1.$2.out bug2655.ref
 
 $(WORKDIR)/limits.$1.$2.prg: limits.c $(ISEQUAL) | $(WORKDIR)
 	$(if $(QUIET),echo misc/limits.$1.$2.prg)
-	$(CC65) -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLERR)
+	$(CC65) -t sim$2 -$1 -o $$(@:.prg=.s) $$< $(NULLOUT) $(CATERR)
 	$(CA65) -t sim$2 -o $$(@:.prg=.o) $$(@:.prg=.s) $(NULLERR)
 	$(LD65) -t sim$2 -o $$@ $$(@:.prg=.o) sim$2.lib $(NULLERR)
 	$(SIM65) $(SIM65FLAGS) $$@ > $(WORKDIR)/limits.$1.$2.out
@@ -155,24 +156,24 @@ $(WORKDIR)/limits.$1.$2.prg: limits.c $(ISEQUAL) | $(WORKDIR)
 
 $(WORKDIR)/goto.$1.$2.prg: goto.c $(ISEQUAL) | $(WORKDIR)
 	$(if $(QUIET),echo misc/goto.$1.$2.prg)
-	$(CC65) -t sim$2 -$1 -o $$@ $$< 2>$(WORKDIR)/goto.$1.$2.out
+	$(CC65) -t sim$2 -$1 -o $$@ $$< $(NULLOUT) 2>$(WORKDIR)/goto.$1.$2.out
 	$(ISEQUAL) $(WORKDIR)/goto.$1.$2.out goto.ref
 
 # this one requires failure with --std=c89, it fails with --std=cc65 due to
 # stricter checks
 $(WORKDIR)/bug2304-implicit-func.$1.$2.prg: bug2304-implicit-func.c | $(WORKDIR)
 	$(if $(QUIET),echo misc/bug2304-implicit-func.$1.$2.prg)
-	$(NOT) $(CC65) --standard c89 -t sim$2 -$1 -o $$@ $$< $(NULLERR)
+	$(NOT) $(CC65) --standard c89 -t sim$2 -$1 -o $$@ $$< $(NULLOUT) $(CATERR)
 
 # should not compile until 3-byte struct by value tests are re-enabled
 $(WORKDIR)/struct-by-value.$1.$2.prg: struct-by-value.c | $(WORKDIR)
 	$(if $(QUIET),echo misc/struct-by-value.$1.$2.prg)
-	$(NOT) $(CC65) -t sim$2 -$1 -o $$@ $$< $(NULLERR)
+	$(NOT) $(CC65) -t sim$2 -$1 -o $$@ $$< $(NULLOUT) $(CATERR)
 
 # the rest are tests that fail currently for one reason or another
 $(WORKDIR)/sitest.$1.$2.prg: sitest.c | $(WORKDIR)
 	@echo "FIXME: " $$@ "currently does not compile."
-	$(NOT) $(CC65) -t sim$2 -$1 -o $$@ $$< $(NULLERR)
+	$(NOT) $(CC65) -t sim$2 -$1 -o $$@ $$< $(NULLOUT) $(CATERR)
 #	$(SIM65) $(SIM65FLAGS) $$@ $(NULLOUT)
 
 endef # PRG_template

--- a/test/ref/Makefile
+++ b/test/ref/Makefile
@@ -29,7 +29,9 @@ endif
 
 ifdef QUIET
   .SILENT:
+  NULLOUT = >$(NULLDEV)
   NULLERR = 2>$(NULLDEV)
+  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
 endif
 
 SIM65FLAGS = -x 200000000

--- a/test/standard/Makefile
+++ b/test/standard/Makefile
@@ -26,6 +26,7 @@ ifdef QUIET
   .SILENT:
   NULLOUT = >$(NULLDEV)
   NULLERR = 2>$(NULLDEV)
+  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
 endif
 
 SIM65FLAGS = -x 4000000000 -c

--- a/test/standard_err/Makefile
+++ b/test/standard_err/Makefile
@@ -26,8 +26,11 @@ endif
 
 ifdef QUIET
   .SILENT:
+  NULLOUT = >$(NULLDEV)
   NULLERR = 2>$(NULLDEV)
+  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
 endif
+
 
 CC65 := $(if $(wildcard ../../bin/cc65*),..$S..$Sbin$Scc65,cc65)
 
@@ -49,7 +52,7 @@ define PRG_template
 
 $(WORKDIR)/%.$1.$2.prg: %.c | $(WORKDIR)
 	$(if $(QUIET),echo standard_err/$$*.$1.$2.prg)
-	$(NOT) $(CC65) -t sim$2 $$(CC65FLAGS) -Osir --add-source --standard $1 -o $$(@:.prg=.s) $$< $(NULLERR)
+	$(NOT) $(CC65) -t sim$2 $$(CC65FLAGS) -Osir --add-source --standard $1 -o $$(@:.prg=.s) $$< $(NULLOUT) $(CATERR)
 
 endef # PRG_template
 

--- a/test/todo/Makefile
+++ b/test/todo/Makefile
@@ -28,7 +28,9 @@ ifdef QUIET
   .SILENT:
   NULLOUT = >$(NULLDEV)
   NULLERR = 2>$(NULLDEV)
+  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
 endif
+
 
 SIM65FLAGS = -x 200000000
 

--- a/test/val/Makefile
+++ b/test/val/Makefile
@@ -28,6 +28,7 @@ ifdef QUIET
   .SILENT:
   NULLOUT = >$(NULLDEV)
   NULLERR = 2>$(NULLDEV)
+  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
 endif
 
 SIM65FLAGS = -x 4000000000 -c
@@ -56,10 +57,10 @@ define PRG_template
 
 $(WORKDIR)/%.$1.$2.prg: %.c | $(WORKDIR)
 	$(if $(QUIET),echo val/$$*.$1.$2.prg)
-	$(CC65) -t sim$2 $$(CC65FLAGS) --add-source -$1 -o $$(@:.prg=.s) $$< $(NULLERR)
-	$(CA65) -t sim$2 -o $$(@:.prg=.o) $$(@:.prg=.s) $(NULLERR)
-	$(LD65) -t sim$2 -o $$@ $$(@:.prg=.o) sim$2.lib $(NULLERR)
-	$(SIM65) $(SIM65FLAGS) $$@ > $(WORKDIR)/$$@.out $(CATRES)
+	$(CC65) -t sim$2 $$(CC65FLAGS) --add-source -$1 -o $$(@:.prg=.s) $$< $(NULLOUT) $(CATERR)
+	$(CA65) -t sim$2 -o $$(@:.prg=.o) $$(@:.prg=.s) $(NULLOUT) $(CATERR)
+	$(LD65) -t sim$2 -o $$@ $$(@:.prg=.o) sim$2.lib $(NULLOUT) $(CATERR)
+	$(SIM65) $(SIM65FLAGS) $$@ > $(WORKDIR)/$$@.out 2> $(WORKDIR)/$$@.out $(CATRES)
 
 endef # PRG_template
 


### PR DESCRIPTION
Inspired by #2119

The idea is that:

```make``` gives most "clean", but "all" output. in particular no stdout or stderr messages are suppressed, unless they are absolutely useless
```make QUIET=1``` gives a much less verbose output, it will suppress most output by the various tools, BUT when a tool errors out unexpectedly (!) and/or a test failed, then the output should be dumped to the console (*). Usually one status message per test is printed, to give some indicator of progress. This is the mode the CI/GHA uses
```make -s``` is really the "no messages unless errors" mode, it inherits "QUIET=1", and supresses some more messages. Usually one status message per test is printed, to give some indicator of progress. And of course on errors all related info should still be dumped to console.

(*) If some people could break random tests locally and see if that works as intended, that would be nice

PS: some of this may not work as advertised with cmd.exe - i have no idea. i tried to make the changes in a way that it would at least not break

done so far are "test" and "targettest" directories (most of "test" already worked that way), will check the rest as well and try to unify the behaviour a bit