### PR TITLE
longer more meaningful version information

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -73,6 +73,7 @@ ifdef USER_CFLAGS
   $(info USER_CFLAGS: $(USER_CFLAGS))
 endif
 
+# short, used to add a comment to the zip file
 ifndef BUILD_ID
   BUILD_ID := Git $(shell git rev-parse --short HEAD 2>$(NULLDEV) || svnversion 2>$(NULLDEV))
   ifneq ($(words $(BUILD_ID)),2)
@@ -80,15 +81,35 @@ ifndef BUILD_ID
   endif
 endif
 
+# long, to give humans more details
+ifndef BUILD_DETAILS
+  ifeq ($(shell git rev-parse --is-inside-work-tree 2>$(NULLDEV)),true)
+    BUILD_HASH   := $(shell git rev-parse --short HEAD 2>$(NULLDEV))
+    BUILD_DATE   := $(shell git show -s --format=%cd --date=format:%Y.%m.%d HEAD 2>$(NULLDEV))
+    BUILD_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>$(NULLDEV))
+    GIT_DIRTY    := $(shell git diff --quiet --ignore-submodules HEAD 2>$(NULLDEV) || echo -dirty)
+
+    ifeq ($(BUILD_BRANCH),master)
+      BUILD_DETAILS := Git $(BUILD_HASH)-$(BUILD_DATE)$(GIT_DIRTY)
+    else
+      BUILD_BRANCH_SAFE := $(subst /,-,$(BUILD_BRANCH))
+      BUILD_DETAILS := Git $(BUILD_HASH)-$(BUILD_DATE)-$(BUILD_BRANCH_SAFE)$(GIT_DIRTY)
+    endif
+  else
+    BUILD_DETAILS := N/A
+  endif
+endif
+
 ifneq ($(SILENT),s)
   $(info BUILD_ID: $(BUILD_ID))
+  $(info BUILD_DETAILS: $(BUILD_DETAILS))
 endif
 
 CFLAGS += -MMD -MP -O3 -I common \
           -Wall -Wextra -Wno-char-subscripts $(USER_CFLAGS) \
           -DCA65_INC="\"$(CA65_INC)\"" -DCC65_INC="\"$(CC65_INC)\"" -DCL65_TGT="\"$(CL65_TGT)\"" \
           -DLD65_LIB="\"$(LD65_LIB)\"" -DLD65_OBJ="\"$(LD65_OBJ)\"" -DLD65_CFG="\"$(LD65_CFG)\"" \
-          -DBUILD_ID="\"$(BUILD_ID)\""
+          -DBUILD_ID="\"$(BUILD_DETAILS)\""
 
 LDLIBS += -lm
 

--- a/src/common/version.c
+++ b/src/common/version.c
@@ -99,7 +99,7 @@
 const char* GetVersionAsString (void)
 /* Returns the version number as a string in a static buffer */
 {
-    static char Buf[60];
+    static char Buf[256];
 #if defined(BUILD_ID)
     xsnprintf (Buf, sizeof (Buf), "%u.%u - %s", VER_MAJOR, VER_MINOR, BUILD_ID);
 #else


### PR DESCRIPTION
since it seems we will be at "version 2.19" forever, i'd like to see more meaningful output from "cc65 --version".
<pre>
$ cc65 --version
cc65 V2.19 - Git 84858ef07
</pre>
is fine if you're a developer with mad git skillz, but less useful if you want to know quickly how recently your binary was made.
this adds the date (of the git commit, NOT the build date), the branch name (if not "master"), and "-dirty" if the build tree has uncommitted files.
<pre>
$ cc65 --version
cc65 V2.19 - Git 84858ef07-2025.06.30-meaningful_versioning
</pre>
so in the normal build case you would see <pre>cc65 V2.19 - Git 84858ef07-2025.06.30</pre> if it was a regular build from master,
but <pre>cc65 V2.19 - Git 84858ef07-2025.06.30-branchname-dirty</pre> if it was a build from branchname with uncommitted code.