### PR TITLE
also test DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,9 @@ zip:
 
 install:
 ifndef PREFIX
-	$(error Error: PREFIX must be set for install to work)
+ifndef DESTDIR
+	$(error Error: PREFIX or DESTDIR must be set for install to work)
+endif
 endif
 	@$(MAKE) -C src        --no-print-directory $@
 	@$(MAKE) -C libsrc     --no-print-directory $@
@@ -73,7 +75,9 @@ util:
 
 checkprefix:
 ifndef PREFIX
-	$(warning Warning: PREFIX is empty - make install will not work)
+ifndef DESTDIR
+	$(warning Warning: PREFIX and DESTDIR are empty - make install will not work)
+endif
 endif
 
 # check the code style

--- a/src/Makefile
+++ b/src/Makefile
@@ -103,7 +103,9 @@ endif
 all bin: $(PROGS)
 ifeq ($(MAKELEVEL),0)
 ifndef PREFIX
-	$(warning Warning: PREFIX is empty - make install will not work)
+ifndef DESTDIR
+	$(warning Warning: PREFIX and DESTDIR are empty - make install will not work)
+endif
 endif
 endif
 


### PR DESCRIPTION
should fix this

@rofl0r in #2755
> this breaks a valid usecase i implemented in #1735
> 
> ```
> ~/tmp/cc65[master]$ make PREFIX= DESTDIR=foo install
> Using Makefile: /home/rofl/tmp/cc65/Makefile install
> Makefile:28: *** Error: PREFIX must be set for install to work.  Stop.
> ```

