### PR TITLE
Make the scrcode macros handle identifiers

### DIFF
--- a/asminc/apple2.mac
+++ b/asminc/apple2.mac
@@ -36,6 +36,12 @@
                 ; Just output the character
                 _scrcode        arg1
 
+        ; Check for an identifier
+        .elseif .match (.left (1, {arg1}), identifier)
+
+                ; Just output the identifier
+                _scrcode        arg1
+
         ; Anything else is an error
         .else
 

--- a/asminc/atari.mac
+++ b/asminc/atari.mac
@@ -46,6 +46,12 @@
                 ; Just output the character
                 _scrcode        arg1
 
+        ; Check for an identifier
+        .elseif .match (.left (1, {arg1}), identifier)
+
+                ; Just output the identifier
+                _scrcode        arg1
+
         ; Anything else is an error
         .else
 

--- a/asminc/cbm.mac
+++ b/asminc/cbm.mac
@@ -40,6 +40,12 @@
                 ; Just output the character
                 _scrcode        arg1
 
+        ; Check for an identifier
+        .elseif .match (.left (1, {arg1}), identifier)
+
+                ; Just output the identifier
+                _scrcode        arg1
+
         ; Anything else is an error
         .else
                 .error  "scrcode: invalid argument type"


### PR DESCRIPTION
This fixes #534.

Tested with this program:

```asm
.ifdef __ATARI__
        .macpack        atari
.endif
.ifdef __CBM__
        .macpack        cbm
.endif
.ifdef __APPLE2__
        .macpack        apple2
.endif

CR = $D
BELL = $7
scrcode "hello", CR, "world", BELL
```
No idea how to add this to the tests so it's assembled and checked for Atari, cbm,  and Apple2.