### PR TITLE
disable the basic interrupt before main(), fixes #2764

### DIFF
--- a/libsrc/c128/crt0.s
+++ b/libsrc/c128/crt0.s
@@ -65,6 +65,15 @@ L1:     lda     c_sp,x
 
         jsr     initlib
 
+; Disable the BASIC part of the IRQ handler. It would usually (once per frame)
+; copy the VIC shadow register, move sprites, play music. This would only get
+; in the way, so we turn it off.
+
+        lda     INIT_STATUS
+        sta     initsave
+        and     #$fe
+        sta     INIT_STATUS
+
 ; Set the bank for the file name to our execution bank. We must do this
 ; *after* calling the constructors because some of them might depend on
 ; the original value of this register.
@@ -88,6 +97,11 @@ L2:     lda     zpsave,x
         sta     c_sp,x
         dex
         bpl     L2
+
+; Enable the BASIC interrupt again
+
+        lda     initsave
+        sta     INIT_STATUS
 
 ; Place the program return code into BASIC's status variable.
 
@@ -116,5 +130,6 @@ zpsave: .res    zpspace
 
 .bss
 
-spsave: .res    1
-mmusave:.res    1
+spsave:   .res    1
+mmusave:  .res    1
+initsave: .res    1


### PR DESCRIPTION
## Summary

The C128 BASIC does a bunch of things at vblank: it copies shadow registers to VIC registers, it moves sprites and plays music. All of this is not needed (and gets in the way) when our code runs, so it is disabled before main() and restored after.

It looks like the C65 and Mega65 libs will need the same fix, will look at that next and sneak into this PR before merge :)

## Checklist

- [ ] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
- [ ] The documentation has been updated if necessary
