### PR TITLE
Add comments about cputs() relying on cputc() not to clobber ptr1

### DIFF
--- a/libsrc/agat/cputc.s
+++ b/libsrc/agat/cputc.s
@@ -5,6 +5,8 @@
 ; void __fastcall__ cputcxy (unsigned char x, unsigned char y, char c);
 ; void __fastcall__ cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
     .import     COUT
     .export     _cputcxy, _cputc, newline, putchar,putchardirect

--- a/libsrc/apple2/cputc.s
+++ b/libsrc/apple2/cputc.s
@@ -4,6 +4,8 @@
 ; void __fastcall__ cputcxy (unsigned char x, unsigned char y, char c);
 ; void __fastcall__ cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .constructor    initconio
         .export         _cputcxy, _cputc

--- a/libsrc/atari/cputc.s
+++ b/libsrc/atari/cputc.s
@@ -4,6 +4,8 @@
 ; void cputcxy (unsigned char x, unsigned char y, char c);
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc
         .export         plot, cputdirect, putchar

--- a/libsrc/atari5200/cputc.s
+++ b/libsrc/atari5200/cputc.s
@@ -5,6 +5,8 @@
 ; void cputcxy (unsigned char x, unsigned char y, char c);
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .include        "atari5200.inc"
 

--- a/libsrc/atari7800/cputc.s
+++ b/libsrc/atari7800/cputc.s
@@ -4,6 +4,8 @@
 ; void cputcxy (unsigned char x, unsigned char y, char c);
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputc
         .import         gotox, gotoy, pusha0

--- a/libsrc/atmos/cputc.s
+++ b/libsrc/atmos/cputc.s
@@ -5,6 +5,8 @@
 ; void cputcxy (unsigned char x, unsigned char y, char c);
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc
         .export         setscrptr, cputdirect, putchar

--- a/libsrc/c128/cputc.s
+++ b/libsrc/c128/cputc.s
@@ -5,6 +5,8 @@
 ; void cputcxy (unsigned char x, unsigned char y, char c);
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc, cputdirect, putchar
         .export         newline, plot

--- a/libsrc/c64/cputc.s
+++ b/libsrc/c64/cputc.s
@@ -4,6 +4,8 @@
 ; void __fastcall__ cputcxy (unsigned char x, unsigned char y, char c);
 ; void __fastcall__ cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc, cputdirect, putchar
         .export         newline, plot

--- a/libsrc/c65/cputc.s
+++ b/libsrc/c65/cputc.s
@@ -4,6 +4,8 @@
 ; void __fastcall__ cputcxy (unsigned char x, unsigned char y, char c);
 ; void __fastcall__ cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc, cputdirect, putchar
         .export         newline, plot

--- a/libsrc/cbm510/cputc.s
+++ b/libsrc/cbm510/cputc.s
@@ -4,6 +4,8 @@
 ; void cputcxy (unsigned char x, unsigned char y, char c);
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc, cputdirect, putchar
         .export         newline, plot

--- a/libsrc/cbm610/cputc.s
+++ b/libsrc/cbm610/cputc.s
@@ -4,6 +4,8 @@
 ; void cputcxy (unsigned char x, unsigned char y, char c);
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc, cputdirect, putchar
         .export         newline, plot

--- a/libsrc/conio/cputs.s
+++ b/libsrc/conio/cputs.s
@@ -22,6 +22,10 @@ _cputsxy:
 _cputs: sta     ptr1            ; Save s
         stx     ptr1+1
 
+; Important note: The implementation below relies on the _cputc() function not
+; clobbering ptr1. This might not be the case when rewriting this function so
+; beware!
+
 L0:
 .if .cap(CPU_HAS_ZPIND)
         lda     (ptr1)          ; (5)

--- a/libsrc/creativision/cputc.s
+++ b/libsrc/creativision/cputc.s
@@ -5,6 +5,8 @@
 ; void cputcxy (unsigned char x, unsigned char y, char c);
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc, cputdirect, putchar
         .export         newline

--- a/libsrc/cx16/cputc.s
+++ b/libsrc/cx16/cputc.s
@@ -4,6 +4,8 @@
 ; void __fastcall__ cputcxy (unsigned char x, unsigned char y, char c);
 ; void __fastcall__ cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc, cputdirect, putchar
         .export         newline, plot

--- a/libsrc/gamate/cputc.s
+++ b/libsrc/gamate/cputc.s
@@ -2,6 +2,8 @@
 ; void cputcxy (unsigned char x, unsigned char y, char c);
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc, cputdirect, putchar
         .export         newline, plot

--- a/libsrc/geos-common/conio/cputc.s
+++ b/libsrc/geos-common/conio/cputc.s
@@ -21,6 +21,9 @@
 ; note that there are conflicts between control characters and keyboard:
 ; HOME = KEY_ENTER, KEY_HOME = REV_ON,
 ; UPLINE = ?, KEY_UPARROW = GOTOY, ...
+;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
             .export _cputcxy, _cputc
             .import gotoxy, fixcursor

--- a/libsrc/mega65/cputc.s
+++ b/libsrc/mega65/cputc.s
@@ -4,6 +4,8 @@
 ; void __fastcall__ cputcxy (unsigned char x, unsigned char y, char c);
 ; void __fastcall__ cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc, cputdirect, putchar
         .export         newline, plot

--- a/libsrc/nes/cputc.s
+++ b/libsrc/nes/cputc.s
@@ -5,6 +5,8 @@
 ; void cputcxy (unsigned char x, unsigned char y, char c);
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc, cputdirect, putchar
         .export         newline

--- a/libsrc/pce/cputc.s
+++ b/libsrc/pce/cputc.s
@@ -2,6 +2,8 @@
 ; void cputcxy (unsigned char x, unsigned char y, char c);
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc, cputdirect, putchar
         .export         newline, plot

--- a/libsrc/pet/cputc.s
+++ b/libsrc/pet/cputc.s
@@ -4,6 +4,8 @@
 ; void cputcxy (unsigned char x, unsigned char y, char c);
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc, cputdirect, putchar
         .export         newline, plot

--- a/libsrc/plus4/cputc.s
+++ b/libsrc/plus4/cputc.s
@@ -4,6 +4,8 @@
 ; void cputcxy (unsigned char x, unsigned char y, char c);
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc, cputdirect, putchar
         .export         newline, plot

--- a/libsrc/telestrat/cputc.s
+++ b/libsrc/telestrat/cputc.s
@@ -1,8 +1,10 @@
 ; 2018-04-13, Jede (jede@oric.org)
 ;
-
+;
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputc, _cputcxy, cputdirect, display_conio
         .export         CHARCOLOR, OLD_CHARCOLOR, BGCOLOR, OLD_BGCOLOR

--- a/libsrc/vic20/cputc.s
+++ b/libsrc/vic20/cputc.s
@@ -5,6 +5,8 @@
 ; void cputcxy (unsigned char x, unsigned char y, char c);
 ; void cputc (char c);
 ;
+; Important note: The implementation of cputs() relies on the cputc() function
+; not clobbering ptr1. Beware when rewriting or changing this function!
 
         .export         _cputcxy, _cputc, cputdirect, putchar
         .export         newline, plot


### PR DESCRIPTION
## Summary

The implementation of `cputs()` calls `cputc()` repeatedly and relies on it not to clobber `ptr1`. This results in shorter code but might be problematic if someone changes the code or creates a `cputc()` function for a new target.

As discusses in #1557 this PR adds comments to the relevant sources describing the dependency.

Fixes #1557.

## Checklist

- [ ] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
- [ ] The documentation has been updated if necessary
