### PR TITLE
#2772 - Fixed default CPU for CX16

### DIFF
--- a/src/common/target.c
+++ b/src/common/target.c
@@ -243,7 +243,7 @@ static const TargetProperties PropertyTable[TGT_COUNT] = {
     { "pce",            CPU_HUC6280,    BINFMT_BINARY,      CTNone  },
     { "gamate",         CPU_6502,       BINFMT_BINARY,      CTNone  },
     { "c65",            CPU_4510,       BINFMT_BINARY,      CTPET   },
-    { "cx16",           CPU_65C02,      BINFMT_BINARY,      CTPET   },
+    { "cx16",           CPU_W65C02,     BINFMT_BINARY,      CTPET   },
     { "sym1",           CPU_6502,       BINFMT_BINARY,      CTNone  },
     { "mega65",         CPU_45GS02,     BINFMT_BINARY,      CTPET   },
     { "kim1",           CPU_6502,       BINFMT_BINARY,      CTNone  },


### PR DESCRIPTION
## Summary

Target cx16 (Commander X16) needs to have the W65C02 CPU as default, not the standard 65C02.

## Checklist

- [X] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions (not applicable)
- [ ] The documentation has been updated if necessary (not applicable - this PR fixes code to match existing doc)
