### PR TITLE
Fixmakefiles

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -57,7 +57,7 @@ ifdef QUIET
     PQ = "QUIET=1"
     PD = --no-print-directory
 ifndef CMD_EXE
-    CATERR = 2> ../wrk/common/$$@.errlog || (cat ../wrk/common/$$@.errlog && false)
+    CATERR = 2> $@.errlog || (cat $@.errlog && false)
 endif
 endif
 

--- a/test/asm/err/Makefile
+++ b/test/asm/err/Makefile
@@ -33,7 +33,7 @@ ifdef QUIET
   NULLOUT = >$(NULLDEV)
   NULLERR = 2>$(NULLDEV)
 ifndef CMD_EXE
-  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
+  CATERR = 2> $@.errlog && (cat $@.errlog && true)
 endif
 endif
 
@@ -53,7 +53,7 @@ $(WORKDIR):
 
 $(WORKDIR)/%.prg: %.s | $(WORKDIR)
 	$(if $(QUIET),echo asm/err/$*.s)
-	$(NOT) $(CA65) -o $@ $< $(NULLERR)
+	$(NOT) $(CA65) -o $@ $< $(CATERR)
 
 clean:
 	@$(call RMDIR,$(WORKDIR))

--- a/test/err/Makefile
+++ b/test/err/Makefile
@@ -33,7 +33,7 @@ ifdef QUIET
   NULLOUT = >$(NULLDEV)
   NULLERR = 2>$(NULLDEV)
 ifndef CMD_EXE
-  CATERR = 2> $(WORKDIR)/$$@.errlog || (cat $(WORKDIR)/$$@.errlog && false)
+  CATERR = 2> $@.errlog && (cat $@.errlog && true)
 endif
 endif
 


### PR DESCRIPTION
## Summary

In some (test) makefiles redirecting stderr did not work as wanted, either creating .errlog for each file (which kind of works unless using -j) or no file at all. #2784 fixes the Makefile in targettest, this PR fixes the others.

Careful when copypasting apparently working things from one Makefile to another - things work differently in a regular recipe and in a template :)

## Checklist

- [ ] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
- [ ] The documentation has been updated if necessary
