### PR TITLE
fix debugger

### DIFF
--- a/doc/funcref.sgml
+++ b/doc/funcref.sgml
@@ -369,9 +369,14 @@ function.
 
 <sect1><tt/dbg.h/<label id="dbg.h"><p>
 
-<!-- <itemize> -->
-<!-- <item><ref id="DbgInit" name="DbgInit"> -->
-<!-- </itemize> -->
+<itemize>
+<item><ref id="DbgInit" name="DbgInit">
+<!-- <item><ref id="BREAK" name="BREAK"> -->
+<!-- <item><ref id="DbgDisAsm" name="DbgDisAsm"> -->
+<!-- <item><ref id="DbgDisAsmLen" name="DbgDisAsmLen"> -->
+<!-- <item><ref id="DbgIsRAM" name="DbgIsRAM"> -->
+<!-- <item><ref id="DbgMemDump" name="DbgMemDump"> -->
+</itemize>
 
 (incomplete)
 
@@ -3467,6 +3472,24 @@ used in presence of a prototype.
 <ref id="chline" name="chline">,
 <ref id="chlinexy" name="chlinexy">,
 <ref id="cvline" name="cvline">
+<tag/Example/None.
+</descrip>
+</quote>
+
+
+<sect1>DbgInit<label id="DbgInit"><p>
+
+<quote>
+<descrip>
+<tag/Function/Initialize the debugger.
+<tag/Header/<tt/<ref id="dbg.h" name="dbg.h">/
+<tag/Declaration/<tt/void __fastcall__ DbgInit (unsigned unused);/
+<tag/Description/<tt/DbgInit/ initializes the debugger.
+<tag/Notes/<itemize>
+<item>Use 0 as parameter.
+<item>The debugger will popup on next brk encountered.
+</itemize>
+<tag/Availability/cc65
 <tag/Example/None.
 </descrip>
 </quote>

--- a/libsrc/dbg/dbg.c
+++ b/libsrc/dbg/dbg.c
@@ -332,7 +332,7 @@ BreakPoint DbgBreaks [MAX_USERBREAKS+2];
 BreakPoint* DbgGetBreakSlot (void);
 /* Search for a free breakpoint slot. Return a pointer to the slot or 0 */
 
-BreakPoint* DbgIsBreak (unsigned Addr);
+BreakPoint* __cdecl__ DbgIsBreak (unsigned Addr);
 /* Check if there is a user breakpoint at the given address, if so, return
 ** a pointer to the slot, else return 0.
 */

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -193,6 +193,7 @@ EXELIST_agat =     \
 EXELIST_apple2 =   \
         ascii      \
         checkversion \
+        debug      \
         diodemo    \
         enumdevdir \
         gunzip65   \
@@ -212,6 +213,7 @@ EXELIST_apple2enh = $(EXELIST_apple2)
 EXELIST_atari =    \
         ascii      \
         checkversion \
+        debug      \
         gunzip65   \
         hello      \
         mandelbrot \
@@ -250,6 +252,7 @@ EXELIST_bbc = \
 EXELIST_c64 =      \
         ascii      \
         checkversion \
+        debug      \
         enumdevdir \
         gunzip65   \
         hello      \
@@ -275,6 +278,7 @@ EXELIST_c65 = \
 EXELIST_c128 =     \
         ascii      \
         checkversion \
+        debug      \
         enumdevdir \
         gunzip65   \
         hello      \
@@ -289,6 +293,7 @@ EXELIST_c128 =     \
 EXELIST_c16 =      \
         ascii      \
         checkversion \
+        debug      \
         enumdevdir \
         tinyshell  \
         hello      \
@@ -297,6 +302,7 @@ EXELIST_c16 =      \
 EXELIST_cbm510 =   \
         ascii      \
         checkversion \
+        debug      \
         enumdevdir \
         gunzip65   \
         hello      \
@@ -309,6 +315,7 @@ EXELIST_cbm510 =   \
 EXELIST_cbm610 =   \
         ascii      \
         checkversion \
+        debug      \
         enumdevdir \
         gunzip65   \
         hello      \
@@ -323,6 +330,7 @@ EXELIST_creativision = \
 EXELIST_cx16 =     \
         ascii      \
         checkversion \
+        debug      \
         enumdevdir \
         gunzip65   \
         hello      \
@@ -371,6 +379,7 @@ EXELIST_pce = \
 EXELIST_pet =      \
         ascii      \
         checkversion \
+        debug      \
         enumdevdir \
         hello      \
         joydemo    \
@@ -380,6 +389,7 @@ EXELIST_pet =      \
 EXELIST_plus4 =    \
         ascii      \
         checkversion \
+        debug      \
         enumdevdir \
         gunzip65   \
         hello      \
@@ -421,6 +431,7 @@ EXELIST_telestrat = \
 EXELIST_vic20 =    \
         ascii      \
         checkversion \
+        debug      \
         enumdevdir \
         hello      \
         joydemo    \

--- a/samples/debug.c
+++ b/samples/debug.c
@@ -1,0 +1,12 @@
+
+#include <dbg.h>
+
+int main(void)
+{
+    /* DbgInit has to be called once, to install the BRK handler */
+    DbgInit(0);
+
+    /* now to break into the debugger, use the BREAK macro */
+    BREAK();
+    return 0;
+}


### PR DESCRIPTION
## Summary

Apparently the debugger broken for a long time, since the default calling convention was changed :)

## Checklist

- [ ] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
- [ ] The documentation has been updated if necessary
