### PR TITLE
Fix an error in the sort check scripts.

### DIFF
--- a/.github/checks/sorted.sh
+++ b/.github/checks/sorted.sh
@@ -33,7 +33,8 @@ function checkarray_quoted_name
 }
 
 
-find "$CHECK_DIR" -name \*.\[ch\] -print | while read N; do
+FILES=$(find "$CHECK_DIR" -name \*.\[ch\] -print)
+for N in $FILES; do
     grep -q "BEGIN SORTED.SH" "$N" && checkarray_quoted_name "$N"
 done
 exit 0

--- a/.github/checks/sorted_codeopt.sh
+++ b/.github/checks/sorted_codeopt.sh
@@ -63,7 +63,8 @@ function checkarray
 }
 
 
-find "$CHECK_DIR" -name \*.\[ch\] -print | while read N; do
+FILES=$(find "$CHECK_DIR" -name \*.\[ch\] -print)
+for N in $FILES; do
     grep -q "BEGIN DECL SORTED_CODEOPT.SH" "$N" && checkarray "$N"
 done
 exit 0

--- a/.github/checks/sorted_opcodes.sh
+++ b/.github/checks/sorted_opcodes.sh
@@ -34,7 +34,8 @@ function checkarray_quoted_name
     rm -rf .a.tmp
 }
 
-find "$CHECK_DIR" -name \*.\[ch\] -print | while read N; do
+FILES=$(find "$CHECK_DIR" -name \*.\[ch\] -print)
+for N in $FILES; do
     grep -q "BEGIN SORTED_OPCODES.SH" "$N" && checkarray_quoted_name "$N"
 done
 exit 0

--- a/src/cc65/codeopt.c
+++ b/src/cc65/codeopt.c
@@ -107,14 +107,14 @@ struct OptFunc {
 static OptFunc DOpt65C02BitOps  = { Opt65C02BitOps,  "Opt65C02BitOps",   66, 0, 0, 0, 0, 0 };
 static OptFunc DOpt65C02Ind     = { Opt65C02Ind,     "Opt65C02Ind",     100, 0, 0, 0, 0, 0 };
 static OptFunc DOpt65C02Stores  = { Opt65C02Stores,  "Opt65C02Stores",  100, 0, 0, 0, 0, 0 };
+static OptFunc DOptAXLoad       = { OptAXLoad,       "OptAXLoad",        50, 0, 0, 0, 0, 0 };
+static OptFunc DOptAXOps        = { OptAXOps,        "OptAXOps",         50, 0, 0, 0, 0, 0 };
 static OptFunc DOptAdd1         = { OptAdd1,         "OptAdd1",         125, 0, 0, 0, 0, 0 };
 static OptFunc DOptAdd2         = { OptAdd2,         "OptAdd2",         200, 0, 0, 0, 0, 0 };
 static OptFunc DOptAdd3         = { OptAdd3,         "OptAdd3",          65, 0, 0, 0, 0, 0 };
 static OptFunc DOptAdd4         = { OptAdd4,         "OptAdd4",          90, 0, 0, 0, 0, 0 };
 static OptFunc DOptAdd5         = { OptAdd5,         "OptAdd5",         100, 0, 0, 0, 0, 0 };
 static OptFunc DOptAdd6         = { OptAdd6,         "OptAdd6",          40, 0, 0, 0, 0, 0 };
-static OptFunc DOptAXLoad       = { OptAXLoad,       "OptAXLoad",        50, 0, 0, 0, 0, 0 };
-static OptFunc DOptAXOps        = { OptAXOps,        "OptAXOps",         50, 0, 0, 0, 0, 0 };
 static OptFunc DOptBNegA1       = { OptBNegA1,       "OptBNegA1",       100, 0, 0, 0, 0, 0 };
 static OptFunc DOptBNegA2       = { OptBNegA2,       "OptBNegA2",       100, 0, 0, 0, 0, 0 };
 static OptFunc DOptBNegAX1      = { OptBNegAX1,      "OptBNegAX1",      100, 0, 0, 0, 0, 0 };
@@ -232,13 +232,14 @@ static OptFunc* OptFuncs[] = {
     &DOpt65C02BitOps,
     &DOpt65C02Ind,
     &DOpt65C02Stores,
+    &DOptAXLoad,
+    &DOptAXOps,
     &DOptAdd1,
     &DOptAdd2,
     &DOptAdd3,
     &DOptAdd4,
     &DOptAdd5,
     &DOptAdd6,
-    &DOptAXOps,
     &DOptBNegA1,
     &DOptBNegA2,
     &DOptBNegAX1,


### PR DESCRIPTION
## Summary

Fix an error that was introduced by me in a4a24280f26ddb3e319678db7a531320df7125fe: 

Using a pipe causes a subshell to be generated so the "exit" statements will just leave the subshell. As a consequence, the sortedxxx.sh scripts produced output but no error exit code. Which in turn caused an error in #2778 to slip through undetected.

## Checklist

- [ ] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
- [ ] The documentation has been updated if necessary
