### PR TITLE
Atari 7800: Make the EXTZP segment optional

### DIFF
--- a/cfg/atari7800.cfg
+++ b/cfg/atari7800.cfg
@@ -39,7 +39,7 @@ MEMORY {
 
 SEGMENTS {
     ZEROPAGE:   load = ZP,              type = zp;
-    EXTZP:      load = ZP,              type = zp;
+    EXTZP:      load = ZP,              type = zp,  optional = yes;
     EXEHDR:     load = HEADER,          type = ro,  optional = yes;
     STARTUP:    load = ROMS,            type = ro,  define = yes;
     ONCE:       load = ROMS,            type = ro,  define = yes;


### PR DESCRIPTION
## Summary

The `EXTZP` segment is not required but not being marked as `optional`. That causes warnings when compiling the samples (and probably user programs).

## Checklist

- [ ] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
- [ ] The documentation has been updated if necessary
