### PR TITLE
Added correct capabilities to W65C02 and 65CE02 CPUs

### DIFF
--- a/src/common/cpu.c
+++ b/src/common/cpu.c
@@ -154,13 +154,17 @@ const unsigned CPUIsets[CPU_COUNT] = {
      CAP_BIT (CAP_CPU_HAS_INA)          |       \
      CAP_BIT (CAP_CPU_HAS_PUSHXY))
 #define CAP_W65C02                              \
-    (CAP_BIT (CAP_CPU_HAS_BRA8)         |       \
+    (CAP_BIT (CAP_CPU_HAS_BITIMM)       |       \
+     CAP_BIT (CAP_CPU_HAS_BRA8)         |       \
      CAP_BIT (CAP_CPU_HAS_INA)          |       \
-     CAP_BIT (CAP_CPU_HAS_PUSHXY))
+     CAP_BIT (CAP_CPU_HAS_PUSHXY)       |       \
+     CAP_BIT (CAP_CPU_HAS_ZPIND)        |       \
+     CAP_BIT (CAP_CPU_HAS_STZ))
 #define CAP_65CE02                              \
     (CAP_BIT (CAP_CPU_HAS_BRA8)         |       \
      CAP_BIT (CAP_CPU_HAS_INA)          |       \
-     CAP_BIT (CAP_CPU_HAS_PUSHXY))
+     CAP_BIT (CAP_CPU_HAS_PUSHXY)       |       \
+     CAP_BIT (CAP_CPU_HAS_STZ))
 
 /* Table containing one capability entry per CPU */
 static const uint32_t CPUCaps[CPU_COUNT] = {


### PR DESCRIPTION
In response to https://github.com/cc65/cc65/issues/2806
Added capabilities to the W65C02 and 65CE02 CPUs. To the best of my knowledge the W65C02 CPU is now complete, but the 65CE02 have plenty of capabilities that are not listed in common/capability.c