### PR TITLE
Optimize jsr ldax0sp/incsp2

### DIFF
--- a/src/cc65/codeent.h
+++ b/src/cc65/codeent.h
@@ -244,6 +244,12 @@ static inline int CE_IsCallTo (const CodeEntry* E, const char* Name)
     return (E->OPC == OP65_JSR && strcmp (E->Arg, Name) == 0);
 }
 
+static inline int CE_IsJumpTo (const CodeEntry* E, const char* Name)
+/* Check if this is a jump to the given function */
+{
+    return (E->OPC == OP65_JMP && strcmp (E->Arg, Name) == 0);
+}
+
 int CE_UseLoadFlags (CodeEntry* E);
 /* Return true if the instruction uses any flags that are set by a load of
 ** a register (N and Z).

--- a/src/cc65/codeopt.c
+++ b/src/cc65/codeopt.c
@@ -217,6 +217,7 @@ static OptFunc DOptSub2         = { OptSub2,         "OptSub2",         100, 0, 
 static OptFunc DOptSub3         = { OptSub3,         "OptSub3",         100, 0, 0, 0, 0, 0 };
 static OptFunc DOptTest1        = { OptTest1,        "OptTest1",         65, 0, 0, 0, 0, 0 };
 static OptFunc DOptTest2        = { OptTest2,        "OptTest2",         50, 0, 0, 0, 0, 0 };
+static OptFunc DOptTosLoadPop   = { OptTosLoadPop,   "OptTosLoadPop",    50, 0, 0, 0, 0, 0 };
 static OptFunc DOptTransfers1   = { OptTransfers1,   "OptTransfers1",     0, 0, 0, 0, 0, 0 };
 static OptFunc DOptTransfers2   = { OptTransfers2,   "OptTransfers2",    60, 0, 0, 0, 0, 0 };
 static OptFunc DOptTransfers3   = { OptTransfers3,   "OptTransfers3",    65, 0, 0, 0, 0, 0 };
@@ -347,6 +348,7 @@ static OptFunc* OptFuncs[] = {
     &DOptTransfers2,
     &DOptTransfers3,
     &DOptTransfers4,
+    &DOptTosLoadPop,
     &DOptUnusedLoads,
     &DOptUnusedStores,
 /* END SORTED_CODEOPT.SH */
@@ -635,6 +637,7 @@ static unsigned RunOptGroup1 (CodeSeg* S)
 
     Changes += RunOptFunc (S, &DOptGotoSPAdj, 1);
     Changes += RunOptFunc (S, &DOptStackPtrOps, 5);
+    Changes += RunOptFunc (S, &DOptTosLoadPop, 5);
     Changes += RunOptFunc (S, &DOptAXOps, 5);
     Changes += RunOptFunc (S, &DOptAdd3, 1);    /* Before OptPtrLoad5! */
     Changes += RunOptFunc (S, &DOptPtrStore1, 1);
@@ -920,6 +923,7 @@ static unsigned RunOptGroup7 (CodeSeg* S)
     C += RunOptFunc (S, &DOptStackPtrOps, 5);
     /* Re-optimize JSR/RTS that may now be grouped */
     C += RunOptFunc (S, &DOptRTS, 1);
+    C += RunOptFunc (S, &DOptTosLoadPop, 5);
 
     Changes += C;
     /* If we had changes, we must run dead code elimination again,

--- a/src/cc65/codeopt.c
+++ b/src/cc65/codeopt.c
@@ -218,6 +218,7 @@ static OptFunc DOptSub3         = { OptSub3,         "OptSub3",         100, 0, 
 static OptFunc DOptTest1        = { OptTest1,        "OptTest1",         65, 0, 0, 0, 0, 0 };
 static OptFunc DOptTest2        = { OptTest2,        "OptTest2",         50, 0, 0, 0, 0, 0 };
 static OptFunc DOptTosLoadPop   = { OptTosLoadPop,   "OptTosLoadPop",    50, 0, 0, 0, 0, 0 };
+static OptFunc DOptTosPushPop   = { OptTosPushPop,   "OptTosPushPop",    33, 0, 0, 0, 0, 0 };
 static OptFunc DOptTransfers1   = { OptTransfers1,   "OptTransfers1",     0, 0, 0, 0, 0, 0 };
 static OptFunc DOptTransfers2   = { OptTransfers2,   "OptTransfers2",    60, 0, 0, 0, 0, 0 };
 static OptFunc DOptTransfers3   = { OptTransfers3,   "OptTransfers3",    65, 0, 0, 0, 0, 0 };
@@ -344,11 +345,12 @@ static OptFunc* OptFuncs[] = {
     &DOptSub3,
     &DOptTest1,
     &DOptTest2,
+    &DOptTosLoadPop,
+    &DOptTosPushPop,
     &DOptTransfers1,
     &DOptTransfers2,
     &DOptTransfers3,
     &DOptTransfers4,
-    &DOptTosLoadPop,
     &DOptUnusedLoads,
     &DOptUnusedStores,
 /* END SORTED_CODEOPT.SH */
@@ -924,6 +926,7 @@ static unsigned RunOptGroup7 (CodeSeg* S)
     /* Re-optimize JSR/RTS that may now be grouped */
     C += RunOptFunc (S, &DOptRTS, 1);
     C += RunOptFunc (S, &DOptTosLoadPop, 5);
+    C += RunOptFunc (S, &DOptTosPushPop, 5);
 
     Changes += C;
     /* If we had changes, we must run dead code elimination again,

--- a/src/cc65/coptmisc.c
+++ b/src/cc65/coptmisc.c
@@ -1226,14 +1226,14 @@ unsigned OptTosPushPop(CodeSeg *S)
             strcmp(N->Arg, "popax") == 0                  &&
             !CE_HasLabel (N)) {
 
-            /* Delete the old code */
-            CS_DelEntries (S, I, 2);
-
             /* Insert an rts if jmp popax */
             if (N->OPC == OP65_JMP) {
               CodeEntry* X = NewCodeEntry (OP65_RTS, AM65_IMP, 0, 0, E->LI);
               CS_InsertEntry (S, X, I);
             }
+
+            /* Delete the old code */
+            CS_DelEntries (S, I+1, 2);
 
             /* Regenerate register info */
             CS_GenRegInfo (S);

--- a/src/cc65/coptmisc.h
+++ b/src/cc65/coptmisc.h
@@ -134,7 +134,7 @@ unsigned OptBinOps2 (CodeSeg* S);
 unsigned OptTosLoadPop (CodeSeg* S);
 /* Merge jsr ldax0sp / jsr|jmp incsp2 into jsr|jmp popax */
 
-unsigned OptTosPushPop(CodeSeg *S);
+unsigned OptTosPushPop (CodeSeg* S);
 /* Merge jsr pushax/j?? popax */
 
 /* End of coptmisc.h */

--- a/src/cc65/coptmisc.h
+++ b/src/cc65/coptmisc.h
@@ -131,6 +131,9 @@ unsigned OptBinOps2 (CodeSeg* S);
 ** by something simpler.
 */
 
+unsigned OptTosLoadPop (CodeSeg* S);
+/* Merge jsr ldax0sp / jsr|jmp incsp2 into jsr|jmp popax */
+
 
 
 /* End of coptmisc.h */

--- a/src/cc65/coptmisc.h
+++ b/src/cc65/coptmisc.h
@@ -134,7 +134,8 @@ unsigned OptBinOps2 (CodeSeg* S);
 unsigned OptTosLoadPop (CodeSeg* S);
 /* Merge jsr ldax0sp / jsr|jmp incsp2 into jsr|jmp popax */
 
-
+unsigned OptTosPushPop(CodeSeg *S);
+/* Merge jsr pushax/j?? popax */
 
 /* End of coptmisc.h */
 


### PR DESCRIPTION
## Summary

A lot of functions end with jsr ldax0sp / jmp incsp2, returning AX from top of stack and popping it. jmp popax is shorter and quicker.

The attached diff of testwrk show that it will be nice to add a merging of jsr pushax/jmp popax in a second time.
[OptTosLoadPop.diff.txt](https://github.com/user-attachments/files/21334183/OptTosLoadPop.diff.txt)

Second commit adds it, the new diff shows more useless code removal
[OptPushPop.diff.txt](https://github.com/user-attachments/files/21334430/OptPushPop.diff.txt)

## Checklist

- [x] The fix meets the codestyle requirements