### PR TITLE
telestrat target : lseek now returns position as it should

### DIFF
--- a/libsrc/telestrat/lseek.s
+++ b/libsrc/telestrat/lseek.s
@@ -38,11 +38,9 @@
         ; A & X contains position (from 0 to 15 bits)
         ; RES (2 bytes) contains position (from 16 to 31 bits)
         ; Returns long
-        pha
-        lda     RES+1
-        sta     sreg+1
-        lda     RES
-        sta     sreg
-        pla
+        ldy     RES+1
+        sty     sreg+1
+        ldy     RES
+        sty     sreg
         rts
 .endproc

--- a/libsrc/telestrat/lseek.s
+++ b/libsrc/telestrat/lseek.s
@@ -35,5 +35,14 @@
         ldy     tmp3
         ldx     tmp1          ; Get whence
         BRK_TELEMON XFSEEK
+        ; A & X contains position (from 0 to 15 bits)
+        ; RES (2 bytes) contains position (from 16 to 31 bits)
+        ; Returns long
+        pha
+        lda     RES+1
+        sta     sreg+1
+        lda     RES
+        sta     sreg
+        pla
         rts
 .endproc


### PR DESCRIPTION
## Summary

lseek did not return any file position. If fseek was tested as : 

"if (fseek(..) == 0)" the behavior of this test should not work as expected.

This PR send the "long int" position into AX and sreg which should be right management for long int return value. Let me know, if it's not the way to returns a long int.

This PR can now work with ftell() function as expected now.

## Checklist

- [X] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
- [ ] The documentation has been updated if necessary
