### PR TITLE
ca65 Fixing segfault when using `--expend-macros` without `--listing`

### DIFF
--- a/src/ca65/macro.c
+++ b/src/ca65/macro.c
@@ -728,7 +728,7 @@ ExpandParam:
 
         /* Use next macro token */
         TokSet (Mac->Exp);
-        if (ExpandMacros) {
+        if (ExpandMacros && SB_GetLen (&ListingName) > 0) {
             if (new_expand_line) {
                 /* Suppress unneeded lines if short expansion
                 ** the ExpandStart is used to ensure that

--- a/src/ca65/toklist.c
+++ b/src/ca65/toklist.c
@@ -252,7 +252,7 @@ static int ReplayTokList (void* List)
 
     /* see description in macro.c */
     static int new_expand_line = 1;
-    if (ExpandMacros) {
+    if (ExpandMacros && SB_GetLen (&ListingName) > 0) {
         if (new_expand_line) {
             if (LineLast->FragList == 0 && ExpandMacros==1) {
                 LineCur->Output--;


### PR DESCRIPTION
## Summary

With ca65, using `-x` / `--expand-macros` without `-l` / `--listing` will cause a segmentation fault when expending a macro:

```
;test.s
.macro test_mac

.endmacro

test_mac
```
Running
```
$ ca65 -x test.s
```
will result in a segmentation fault.
This is also the case with `.define`.

This fix will make `-x` have no effect if `-l` is omitted.

## Checklist

- [x] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
- [ ] The documentation has been updated if necessary