### PR TITLE
Fixed overflow

### DIFF
--- a/src/common/gentype.c
+++ b/src/common/gentype.c
@@ -102,10 +102,7 @@ const char* GT_AsString (const StrBuf* Type, StrBuf* String)
 ** will be zero terminated and a pointer to the contents are returned.
 */
 {
-    static const char HexTab[16] = {
-        '0','1','2','3','4','5','6','7',
-        '8','9','A','B','C','D','E','F'
-    };
+    static const char HexTab[] = "0123456789ABCDEF";
     unsigned I;
 
     /* Convert Type into readable hex. String will have twice then length

--- a/src/common/gentype.c
+++ b/src/common/gentype.c
@@ -102,7 +102,10 @@ const char* GT_AsString (const StrBuf* Type, StrBuf* String)
 ** will be zero terminated and a pointer to the contents are returned.
 */
 {
-    static const char HexTab[16] = "0123456789ABCDEF";
+    static const char HexTab[16] = {
+        '0','1','2','3','4','5','6','7',
+        '8','9','A','B','C','D','E','F'
+    };
     unsigned I;
 
     /* Convert Type into readable hex. String will have twice then length


### PR DESCRIPTION
## Summary

A C string like "0123456789ABCDEF" is 17 bytes long, including the null terminator '\0'.
```
common/gentype.c: In function 'GT_AsString':
common/gentype.c:105:36: warning: initializer-string for array of 'char' truncates NUL terminator but destination lacks 'nonstring' attribute (17 chars into 16 available) [-Wunterminated-string-initialization]
  105 |     static const char HexTab[16] = "0123456789ABCDEF";
      |                                    ^~~~~~~~~~~~~~~~~~
```
## Checklist

- [X] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
- [ ] The documentation has been updated if necessary
