### PR TITLE
Fix uncatalogued name clash with libsrc/runtime/leave.s

### DIFF
--- a/libsrc/common/memset.s
+++ b/libsrc/common/memset.s
@@ -81,13 +81,13 @@ L1:     .repeat 2               ; Unroll this a bit to make it faster
 ; Set the remaining bytes if any
 
 L2:     ldy     ptr3            ; Get the low byte of n
-        beq     leave           ; something to set? No -> leave
+        beq     @leave          ; something to set? No -> leave
 
-L3:     dey
+@L3:    dey
         sta     (ptr1),y                ; set bytes in low
         sta     (ptr2),y                ; and high section
-        bne     L3              ; flags still up to date from dey!
-leave:
+        bne     @L3             ; flags still up to date from dey!
+@leave:
         jmp     popax           ; Pop ptr and return as result
 
 

--- a/libsrc/common/strcspn.s
+++ b/libsrc/common/strcspn.s
@@ -27,21 +27,21 @@ _strcspn:
 loadChar:
         ldy #0
         lda (ptr1),y        ; get next char from s1
-        beq leave           ; handly byte of s1
-advance:
+        beq @leave          ; handly byte of s1
+@advance:
         inc ptr1            ; advance string position to test
-        bne check
+        bne @check
         inc ptr1+1
         dey                 ; correct next iny (faster/shorter than bne...)
 
-checkNext:
+@checkNext:
         iny
-check:  cpy tmp1            ; compare with length of test character string
+@check: cpy tmp1            ; compare with length of test character string
         beq endOfTestChars
         cmp (ptr4),y        ; found matching char?
-        bne checkNext
+        bne @checkNext
 
-leave:  txa                 ; restore position of finding
+@leave: txa                 ; restore position of finding
         ldx tmp2            ; and return
         rts
 

--- a/libsrc/common/strspn.s
+++ b/libsrc/common/strspn.s
@@ -27,26 +27,26 @@ _strspn:
 loadChar:
         ldy #0
         lda (ptr1),y        ; get next char from s1
-        beq leave           ; handly byte of s1
-advance:
+        beq @leave          ; handly byte of s1
+@advance:
         inc ptr1            ; advance string position to test
-        bne check
+        bne @check
         inc ptr1+1
         dey                 ; correct next iny (faster/shorter than bne...)
 
-checkNext:
+@checkNext:
         iny
-check:  cpy tmp1            ; compare with length of test character string
-        beq leave
+@check: cpy tmp1            ; compare with length of test character string
+        beq @leave
         cmp (ptr4),y        ; found matching char?
-        bne checkNext
+        bne @checkNext
 
-foundTestChar:
+@foundTestChar:
         inx
         bne loadChar
         inc tmp2
         bne loadChar        ; like bra...
 
-leave:  txa                 ; restore position of finding
+@leave: txa                 ; restore position of finding
         ldx tmp2            ; and return
         rts


### PR DESCRIPTION
Even though these labels are not exported, they can show up in linker maps and thus break o65 modules.

## Summary

Provide description of the bug (if an issue exists, link to it) and the fix.

## Checklist

- [x] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
- [ ] The documentation has been updated if necessary
