### PR TITLE
Apple2: Don't consider STARTUP when computing available iobufs

### DIFF
--- a/libsrc/apple2/crt0.s
+++ b/libsrc/apple2/crt0.s
@@ -7,6 +7,7 @@
         .export         done, return
         .export         zpsave, rvsave, reset
         .export         __STARTUP__ : absolute = 1      ; Mark as startup
+        .export         __STARTUP_SEGMENT_START__
 
         .import         initlib, _exit
         .import         zerobss, callmain
@@ -21,6 +22,7 @@
 
         .segment        "STARTUP"
 
+        __STARTUP_SEGMENT_START__ = *
         ; ProDOS TechRefMan, chapter 5.2.1:
         ; "For maximum interrupt efficiency, a system program should not
         ;  use more than the upper 3/4 of the stack."
@@ -36,6 +38,7 @@
 
         ; Push the command-line arguments; and, call main().
         jmp     callmain
+        __STARTUP_SEGMENT_SIZE__ = * - __STARTUP_SEGMENT_START__
 
 ; ------------------------------------------------------------------------
 

--- a/libsrc/apple2/extra/iobuf-0800.s
+++ b/libsrc/apple2/extra/iobuf-0800.s
@@ -2,12 +2,13 @@
 ; Oliver Schmidt, 15.09.2009
 ;
 ; ProDOS 8 I/O buffer management for memory between
-; location $0800 and the cc65 program start address
-;
+; location $0800 and the cc65 program start address,
+; ignoring the STARTUP segment that is outlived at the
+; time we can do I/O.
 
         .constructor    initiobuf
         .export         iobuf_alloc, iobuf_free
-        .import         __MAIN_START__
+        .import         __MAIN_START__, __STARTUP_SEGMENT_START__
         .import         incsp2, popptr1
 
         .include        "zeropage.inc"
@@ -18,7 +19,7 @@
 
 initiobuf:
         ; Convert end address highbyte to table index
-        lda     #>__MAIN_START__
+        lda     #>(__MAIN_START__+__STARTUP_SEGMENT_START__)
         sec
         sbc     #>$0800
         lsr


### PR DESCRIPTION
## Summary

When using --start-addr 0xBF4, we get a nicely aligned LOWCODE at $C00:
```
Name                   Start     End    Size  Align
----------------------------------------------------
NULL                  000000  000000  000000  00001
ZEROPAGE              000080  000099  00001A  00001
EXEHDR                000BBA  000BF3  00003A  00001
STARTUP               000BF4  000BFF  00000C  00001
LOWCODE               000C00  001FD9  0013DA  00100
```

But if using `iobuf-0800`, the computation considers the STARTUP as __MAIN_START__ = start-addr - STARTUP size, and refuses to allocate a buffer.

At the time one can actually use iobuf-0800 for IO, the STARTUP segment has become useless.

## Checklist

- [x] The fix meets the codestyle requirements
