### PR TITLE
Fix "constant expression expected" when using .CPU_ISET_xxx with no target system set

### DIFF
--- a/src/ca65/main.c
+++ b/src/ca65/main.c
@@ -411,9 +411,6 @@ static void SetSys (const char* Sys)
 
     }
 
-    /* Define the symbols for evaluating .cpu */
-    DefineCpuSymbols ();
-
     /* Initialize the translation tables for the target system */
     TgtTranslateInit ();
 }
@@ -1253,6 +1250,9 @@ int main (int argc, char* argv [])
     if (MemoryModel == MMODEL_UNKNOWN) {
         SetMemoryModel (MMODEL_NEAR);
     }
+
+    /* Define the symbols for evaluating .cpu */
+    DefineCpuSymbols ();
 
     /* Set the default segment sizes according to the memory model */
     SetSegmentSizes ();


### PR DESCRIPTION
## Summary

CPU constants must always be defined, not only if a target system was given. This fixes #2850.

## Checklist

- [x] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
- [ ] The documentation has been updated if necessary
