### PR TITLE
c65 target: conio accesses all color RAM in 80x25 text mode

### DIFF
--- a/libsrc/c65/cpeekcolor.s
+++ b/libsrc/c65/cpeekcolor.s
@@ -18,6 +18,7 @@ _cpeekcolor:
         lda     SCREEN_PTR
         sta     ptr1
 
+        php
         sei
         lda     $D030
         ora     #$01
@@ -28,8 +29,8 @@ _cpeekcolor:
         lda     $D030
         and     #$FE
         sta     $D030
-        cli
         tya
+        plp
 
         ldx     #>$0000
         rts

--- a/libsrc/c65/cputc.s
+++ b/libsrc/c65/cputc.s
@@ -116,6 +116,7 @@ putchar:
         adc     #>$D000
         sta     ptr4 + 1
 
+        php
         sei
         lda     $D030
         ora     #$01
@@ -125,6 +126,6 @@ putchar:
         lda     $D030
         and     #$FE
         sta     $D030
-        cli
+        plp
 
         rts


### PR DESCRIPTION
## Summary

For the Commodore 65 (c65) target, conio's cputc and cpeekcolor can now access color RAM for the bottom half of the 80x25 text screen. Previously, it could only access the top half, causing the bottom half to appear in the foreground color set prior to running the program. The C65 puts the first 1,000 bytes of color RAM at $D800 similar to the C64, and uses a bank switching register CRAM2K to expose the next 1,000 bytes, shadowing the I/O registers.

For this fix I decided to always flip the Interrupts flag and CRAM2K when setting or reading color RAM, instead of trying to decide whether or not the bottom half of the screen was being accessed. There might be cycles that can be shaved with a branching path, and it might be worth considering for cputc given how frequently it is called. With this version it looks to be about +20 cycles per character on a 3.5 MHz CPU.

I did not implement this fix for the mega65 target because there's a better option available for that platform. It'll require a bit more work to implement, but the result will be able to support the MEGA65's 80x50 text mode as well. I'll consider that separately.

Fixes https://github.com/cc65/cc65/issues/2861

## Checklist

- [X] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
- [ ] The documentation has been updated if necessary
