### PR TITLE
Add terminating NUL after __func__ string literal #2920

### DIFF
--- a/src/cc65/litpool.c
+++ b/src/cc65/litpool.c
@@ -470,6 +470,7 @@ Literal* AddLiteral (const char* S)
 {
     StrBuf SB;
     SB_InitFromString(&SB, S);
+    SB_AppendChar(&SB, '\0');
     return AddLiteralStr(&SB);
 }
 

--- a/test/val/bug2920.c
+++ b/test/val/bug2920.c
@@ -1,0 +1,20 @@
+#include "unittest.h"
+
+TEST {
+    /* The bug causes __func__ to be not null terminated. */
+    const char *f = __func__;
+    size_t size = sizeof(__func__);
+    size_t i;
+
+    /* Ensure the size is correct (5 for "main" + null terminator) */
+    ASSERT_AreEqual((unsigned)size, 5u, "%u", "Sizeof __func__ should be 5");
+
+    /* Check content */
+    for (i = 0; i < size - 1; ++i) {
+        ASSERT_AreEqual(f[i], "main"[i], "%c", "Character mismatch");
+    }
+
+    /* Check null terminator specifically */
+    ASSERT_AreEqual(f[size - 1], '\0', "%02X", "Null terminator missing");
+}
+ENDTEST


### PR DESCRIPTION
## Summary

Fixes the issue of `__func__` not being NUL-terminated by adding the NUL in `AddLiteral`. This function only seems to be used when the compiler wants to add a literal *defined by the compiler*. Literals defined in the program being compiled go through `StringConst`, which adds the NUL just after `ExitPoint`.

## Checklist

- [X] The fix meets the codestyle requirements
- [X] New unit tests have been added to prevent future regressions
- [ ] ~The documentation has been updated if necessary~ (N/A)
