### PR TITLE
Move AssignIds to before we print the info line…

### DIFF
--- a/src/ld65/dbgfile.c
+++ b/src/ld65/dbgfile.c
@@ -113,6 +113,9 @@ void CreateDbgFile (void)
     /* Output version information */
     fprintf (F, "version\tmajor=2,minor=0\n");
 
+    /* Assign the ids to the items: this must occur before info, as it removes unused items */
+    AssignIds ();
+
     /* Output a line with the item numbers so the debug info module is able
     ** to preallocate the required memory.
     */
@@ -130,9 +133,6 @@ void CreateDbgFile (void)
         DbgSymCount (),
         TypeCount ()
     );
-
-    /* Assign the ids to the items */
-    AssignIds ();
 
     /* Output high level language symbols */
     PrintHLLDbgSyms (F);


### PR DESCRIPTION
…in order to ensure that we write the correct file count.

## Summary

Fixes https://github.com/cc65/cc65/issues/2930

## Checklist

- [X] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
- [ ] The documentation has been updated if necessary

Note: unit tests for the dbg file output are in a separate PR: https://github.com/cc65/cc65/pull/2928

Verified file=94 matches 94 file lines:

```
$ head name.dbg
version	major=2,minor=0
info	csym=26,file=94,lib=1,line=3721,mod=67,scope=117,seg=9,span=2740,sym=2963,type=9
csym	id=0,name="main",scope=1,type=0,sc=static,sym=5
csym	id=1,name="_scanf",scope=10,type=0,sc=static,sym=559
csym	id=2,name="D",scope=10,type=0,sc=auto,offs=4
...

$ egrep '^file' name.dbg|wc
      94     188    6985
```
