### PR TITLE
Fix typo in ca65 documentation

### DIFF
--- a/doc/ca65.sgml
+++ b/doc/ca65.sgml
@@ -1167,7 +1167,7 @@ cause any errors.
 
 A nested procedure is created by use of <tt/<ref id=".PROC" name=".PROC">/. It
 differs from a <tt/<ref id=".SCOPE" name=".SCOPE">/ in that it must have a
-name, and a it will introduce a symbol with this name in the enclosing scope.
+name, and it will introduce a symbol with this name in the enclosing scope.
 So
 
 <tscreen><verb>


### PR DESCRIPTION
## Summary

Fixed a typo in 7.4 Nested Procedures.

## Checklist

- [x] The fix meets the codestyle requirements
- [x] New unit tests have been added to prevent future regressions
- [x] The documentation has been updated if necessary
