### PR TITLE
Compare operator test suite ahead of cc65/coptstop.c refactoring (refer #2935)

### DIFF
--- a/test/val/compare-rev.h
+++ b/test/val/compare-rev.h
@@ -1,0 +1,92 @@
+/* Exercise compare operator cases in forward and reverse forms.
+** Common test framework and macros.
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+/* Total failures */
+static unsigned failures = 0;
+/* Something for compiler to do between tests */
+static int successes = 0;
+
+/* To track the asm code, search for marker value */
+static unsigned marker = 0;
+
+#define OP_MUST_FAIL(cond)      if (cond) { fail(#cond); } else { success(); }
+#define OP_MUST_SUCCEED(cond)   if (cond) { success(); } else { fail(#cond); }
+
+/* Expected fail in forward, success in reverse forms */
+#define MUST_FAIL_FORWARD(v1, op, v2, rev_op)  \
+    OP_MUST_FAIL((v1) op (v2)); \
+    OP_MUST_FAIL((v2) rev_op (v1)); \
+    OP_MUST_SUCCEED((v1) rev_op (v2)); \
+    OP_MUST_SUCCEED((v2) op (v1))
+
+/* Expected fail in forward, success in reverse forms for both < and <= */
+#define MUST_FAIL_FORWARD_ALL(v1, op1, op2, v2, rev_op1, rev_op2)  \
+    MUST_FAIL_FORWARD(v1, op1, v2, rev_op1); \
+    MUST_FAIL_FORWARD(v1, op2, v2, rev_op2)
+
+/* Expected fail in both forward and reverse forms (< and >); equality */
+#define MUST_FAIL_BOTH(v1, op, v2, rev_op)  \
+    OP_MUST_FAIL((v1) op (v2)); \
+    OP_MUST_FAIL((v2) rev_op (v1)); \
+    OP_MUST_FAIL((v1) rev_op (v2)); \
+    OP_MUST_FAIL((v2) op (v1))
+
+/* Expected success in forward, fail in reverse forms */
+#define MUST_SUCCEED_FORWARD(v1, op, v2, rev_op)  \
+    OP_MUST_SUCCEED((v1) op (v2)); \
+    OP_MUST_SUCCEED((v2) rev_op (v1)); \
+    OP_MUST_FAIL((v1) rev_op (v2)); \
+    OP_MUST_FAIL((v2) op (v1))
+
+/* Expected success in forward, fail in reverse forms for both < and <= */
+#define MUST_SUCCEED_FORWARD_ALL(v1, op1, op2, v2, rev_op1, rev_op2)  \
+    MUST_SUCCEED_FORWARD(v1, op1, v2, rev_op1); \
+    MUST_SUCCEED_FORWARD(v1, op2, v2, rev_op2)
+
+/* Expected success in both forward and reverse forms (<= and =>); equality */
+#define MUST_SUCCEED_BOTH(v1, op, v2, rev_op)  \
+    OP_MUST_SUCCEED((v1) op (v2)); \
+    OP_MUST_SUCCEED((v2) rev_op (v1)); \
+    OP_MUST_SUCCEED((v1) rev_op (v2)); \
+    OP_MUST_SUCCEED((v2) op (v1))
+
+/* Expected <, > fail / <=, => succeed -- equality */
+#define MUST_BE_EQUAL(v1, v2)  \
+    MUST_FAIL_BOTH(v1, <, v2, >); \
+    MUST_SUCCEED_BOTH(v1, <=, v2, >=)
+
+/* Expected <, <= fail / >, => succeed in forward form, and
+**  <, <= succeed / >, => fail in reverse form. */
+#define MUST_BE_GREATER_THAN(v1, v2)  \
+    MUST_FAIL_FORWARD_ALL(v1, <, <=, v2, >, >=)
+
+/* Expected <, <= succeed / >, => fail in forward form, and
+**  <, <= fail / >, => succeed in reverse form. */
+#define MUST_BE_LESS_THAN(v1, v2)  \
+    MUST_SUCCEED_FORWARD_ALL(v1, <, <=, v2, >, >=)
+
+/* Print a fail message and provide a primary barrier for next test */
+static void fail(const char* cond)
+{
+    failures += 1;
+    printf(TEST_NAME ": failure at marker $%04X, %s\n", marker, cond);
+    marker += 1;
+}
+
+/* Provide a primary barrier for next test */
+static void success()
+{
+    /* Trash the primary */
+    int var1 = failures + 1;
+    if (var1 != 0) {
+        successes += 1;
+    }
+    marker += 1;
+}

--- a/test/val/compare-rev11.c
+++ b/test/val/compare-rev11.c
@@ -1,0 +1,202 @@
+/* Exercise compare operator edge cases in forward and reverse forms;
+**   signed char: literals, autos.
+** Note: will cause many compiler warnings:
+** -- Result of comparison is always (true|false)
+** -- Unreachable code
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev11"
+
+#include "compare-rev.h"
+
+/* Compared values are signed int literals */
+#define N129    -129
+#define N128    -128
+#define N127    -127
+#define N1      -1
+#define ZERO    0
+#define P1      1
+#define P127    127
+#define P128    128
+#define P255    255
+#define P256    256
+
+/* signed char to signed literal compares */
+static void schar_loc_to_slit_11(void)
+{
+    signed char v;
+
+    v = -128;
+    marker = 0x1100; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N129);
+    MUST_BE_EQUAL(v, N128);
+    MUST_BE_LESS_THAN(v, N127);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+}
+
+static void schar_loc_to_slit_13(void)
+{
+    signed char v;
+
+    v = -127;
+    marker = 0x1300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N129);
+    MUST_BE_GREATER_THAN(v, N128);
+    MUST_BE_EQUAL(v, N127);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+}
+
+static void schar_loc_to_slit_15(void)
+{
+    signed char v;
+
+    v = -2;
+    marker = 0x1500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N129);
+    MUST_BE_GREATER_THAN(v, N128);
+    MUST_BE_GREATER_THAN(v, N127);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+}
+
+static void schar_loc_to_slit_17(void)
+{
+    signed char v;
+
+    v = -1;
+    marker = 0x1700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N129);
+    MUST_BE_GREATER_THAN(v, N128);
+    MUST_BE_GREATER_THAN(v, N127);
+    MUST_BE_EQUAL(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+}
+
+static void schar_loc_to_slit_19(void)
+{
+    signed char v;
+
+    v = 0;
+    marker = 0x1900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N129);
+    MUST_BE_GREATER_THAN(v, N128);
+    MUST_BE_GREATER_THAN(v, N127);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+}
+
+static void schar_loc_to_slit_1B(void)
+{
+    signed char v;
+
+    v = 1;
+    marker = 0x1B00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N129);
+    MUST_BE_GREATER_THAN(v, N128);
+    MUST_BE_GREATER_THAN(v, N127);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+}
+
+static void schar_loc_to_slit_1D(void)
+{
+    signed char v;
+
+    v = 2;
+    marker = 0x1D00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N129);
+    MUST_BE_GREATER_THAN(v, N128);
+    MUST_BE_GREATER_THAN(v, N127);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+}
+
+static void schar_loc_to_slit_1F(void)
+{
+    signed char v;
+
+    v = 127;
+    marker = 0x1F00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N129);
+    MUST_BE_GREATER_THAN(v, N128);
+    MUST_BE_GREATER_THAN(v, N127);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_EQUAL(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    schar_loc_to_slit_11();
+    schar_loc_to_slit_13();
+    schar_loc_to_slit_15();
+    schar_loc_to_slit_17();
+    schar_loc_to_slit_19();
+    schar_loc_to_slit_1B();
+    schar_loc_to_slit_1D();
+    schar_loc_to_slit_1F();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/val/compare-rev12.c
+++ b/test/val/compare-rev12.c
@@ -1,0 +1,270 @@
+/* Exercise compare operator edge cases in forward and reverse forms;
+**   signed char: autos, signed statics.
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev12"
+
+#include "compare-rev.h"
+
+static int stat_i_m32768 = -32767-1;
+static int stat_i_m32767 = -32767;
+static int stat_i_m257 = -257;
+static int stat_i_m256 = -256;
+static int stat_i_m255 = -255;
+static signed char stat_sc_m128 = -128;
+static signed char stat_sc_m127 = -127;
+static int stat_i_m1 = -1;
+static int stat_i_0 = 0;
+static int stat_i_1 = 1;
+static signed char stat_sc_127 = 127;
+static int stat_i_128 = 128;
+static int stat_i_255 = 255;
+static int stat_i_256 = 256;
+static int stat_i_257 = 257;
+static int stat_i_32767 = 32767;
+
+/* Compared values are signed int statics, with a couple exceptions */
+#define N32768  stat_i_m32768
+#define N32767  stat_i_m32767
+#define N257    stat_i_m257
+#define N256    stat_i_m256
+#define N255    stat_i_m255
+#define N128    stat_sc_m128
+#define N127    stat_sc_m127
+#define N1      stat_i_m1
+#define ZERO    stat_i_0
+#define P1      stat_i_1
+#define P127    stat_sc_127
+#define P128    stat_i_128
+#define P255    stat_i_255
+#define P256    stat_i_256
+#define P257    stat_i_257
+#define P32767  stat_i_32767
+
+/* signed char to signed int statics compares */
+static void schar_loc_to_sstat_11(void)
+{
+    signed char v;
+
+    v = -128;
+    marker = 0x1100; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_EQUAL(v, N128);
+    MUST_BE_LESS_THAN(v, N127);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void schar_loc_to_sstat_13(void)
+{
+    signed char v;
+
+    v = -127;
+    marker = 0x1300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N128);
+    MUST_BE_EQUAL(v, N127);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void schar_loc_to_sstat_15(void)
+{
+    signed char v;
+
+    v = -2;
+    marker = 0x1500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N128);
+    MUST_BE_GREATER_THAN(v, N127);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void schar_loc_to_sstat_17(void)
+{
+    signed char v;
+
+    v = -1;
+    marker = 0x1700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N128);
+    MUST_BE_GREATER_THAN(v, N127);
+    MUST_BE_EQUAL(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void schar_loc_to_sstat_19(void)
+{
+    signed char v;
+
+    v = 0;
+    marker = 0x1900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N128);
+    MUST_BE_GREATER_THAN(v, N127);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void schar_loc_to_sstat_1B(void)
+{
+    signed char v;
+
+    v = 1;
+    marker = 0x1B00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N128);
+    MUST_BE_GREATER_THAN(v, N127);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void schar_loc_to_sstat_1D(void)
+{
+    signed char v;
+
+    v = 2;
+    marker = 0x1D00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N128);
+    MUST_BE_GREATER_THAN(v, N127);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void schar_loc_to_sstat_1F(void)
+{
+    signed char v;
+
+    v = 127;
+    marker = 0x1F00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N128);
+    MUST_BE_GREATER_THAN(v, N127);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_EQUAL(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    schar_loc_to_sstat_11();
+    schar_loc_to_sstat_13();
+    schar_loc_to_sstat_15();
+    schar_loc_to_sstat_17();
+    schar_loc_to_sstat_19();
+    schar_loc_to_sstat_1B();
+    schar_loc_to_sstat_1D();
+    schar_loc_to_sstat_1F();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/val/compare-rev13.c
+++ b/test/val/compare-rev13.c
@@ -1,0 +1,232 @@
+/* Exercise compare operator edge cases in forward and reverse forms;
+**   signed char: autos, usigned statics.
+** Note: will cause some compiler warnings:
+** -- Result of comparison is constant
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev13"
+
+#include "compare-rev.h"
+
+static unsigned stat_u_0 = 0U;
+static unsigned stat_u_1 = 1U;
+static unsigned char stat_u_127 = 127U;
+static unsigned char stat_u_128 = 128U;
+static unsigned char stat_u_255 = 255U;
+static unsigned stat_u_256 = 256U;
+static unsigned stat_u_257 = 257U;
+static unsigned stat_u_32767 = 32767U;
+static unsigned stat_u_32768 = 32768U;
+static unsigned stat_u_65535 = 65535U;
+
+/* Compared values are unsigned statics */
+#define ZERO    stat_u_0
+#define P1      stat_u_1
+#define P127    stat_u_127
+#define P128    stat_u_128
+#define P255    stat_u_255
+#define P256    stat_u_256
+#define P257    stat_u_257
+#define P32767  stat_u_32767
+#define P32768  stat_u_32768
+#define P65535  stat_u_65535
+
+/* signed char to unsigned statics compares */
+static void schar_loc_to_ustat_11(void)
+{
+    signed char v;
+
+    v = -128;
+    marker = 0x1100; /* +8 for each macro */
+
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    /* Normal unsigned char promotion cases */
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32767);
+    MUST_BE_GREATER_THAN(v, P32768);
+    if (sizeof(P65535) == 2) {
+        MUST_BE_LESS_THAN(v, P65535);
+    }
+}
+
+static void schar_loc_to_ustat_13(void)
+{
+    signed char v;
+
+    v = -127;
+    marker = 0x1300; /* +8 for each macro */
+
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    /* Normal unsigned char promotion cases */
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32767);
+    MUST_BE_GREATER_THAN(v, P32768);
+    if (sizeof(P65535) == 2) {
+        MUST_BE_LESS_THAN(v, P65535);
+    }
+}
+
+static void schar_loc_to_ustat_15(void)
+{
+    signed char v;
+
+    v = -2;
+    marker = 0x1500; /* +8 for each macro */
+
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    /* Normal unsigned char promotion cases */
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32767);
+    MUST_BE_GREATER_THAN(v, P32768);
+    if (sizeof(P65535) == 2) {
+        MUST_BE_LESS_THAN(v, P65535);
+    }
+}
+
+static void schar_loc_to_ustat_17(void)
+{
+    signed char v;
+
+    v = -1;
+    marker = 0x1700; /* +8 for each macro */
+
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    /* Normal unsigned char promotion cases */
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32767);
+    MUST_BE_GREATER_THAN(v, P32768);
+    if (sizeof(P65535) == 2) {
+        MUST_BE_EQUAL(v, P65535); /* special case: -1 to uint promotion */
+    }
+}
+
+static void schar_loc_to_ustat_19(void)
+{
+    signed char v;
+
+    v = 0;
+    marker = 0x1900; /* +8 for each macro */
+
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void schar_loc_to_ustat_1B(void)
+{
+    signed char v;
+
+    v = 1;
+    marker = 0x1B00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void schar_loc_to_ustat_1D(void)
+{
+    signed char v;
+
+    v = 2;
+    marker = 0x1D00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void schar_loc_to_ustat_1F(void)
+{
+    signed char v;
+
+    v = 127;
+    marker = 0x1F00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_EQUAL(v, P127);
+    MUST_BE_LESS_THAN(v, P128);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    schar_loc_to_ustat_11();
+    schar_loc_to_ustat_13();
+    schar_loc_to_ustat_15();
+    schar_loc_to_ustat_17();
+    schar_loc_to_ustat_19();
+    schar_loc_to_ustat_1B();
+    schar_loc_to_ustat_1D();
+    schar_loc_to_ustat_1F();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/val/compare-rev21.c
+++ b/test/val/compare-rev21.c
@@ -1,0 +1,136 @@
+/* Exercise compare operator edge cases in forward and reverse forms;
+**   unsigned char: literals, autos.
+** Note: will cause many compiler warnings:
+** -- Result of comparison is always (true|false)
+** -- Unreachable code
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev21"
+
+#include "compare-rev.h"
+
+/* Compared values are signed int literals */
+#define N256    -256
+#define N255    -255
+#define N1      -1
+#define ZERO    0
+#define P1      1
+#define P255    255
+#define P256    256
+#define P257    257
+#define P32767  32767
+
+/* unsigned char to signed literal compares */
+static void uchar_loc_to_slit_11(void)
+{
+    unsigned char v;
+
+    v = 0;
+    marker = 0x1100; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void uchar_loc_to_slit_13(void)
+{
+    unsigned char v;
+
+    v = 1;
+    marker = 0x1300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void uchar_loc_to_slit_15(void)
+{
+    unsigned char v;
+
+    v = 2;
+    marker = 0x1500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void uchar_loc_to_slit_17(void)
+{
+    unsigned char v;
+
+    v = 254;
+    marker = 0x1700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void uchar_loc_to_slit_19(void)
+{
+    unsigned char v;
+
+    v = 255;
+    marker = 0x1900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_EQUAL(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    uchar_loc_to_slit_11();
+    uchar_loc_to_slit_13();
+    uchar_loc_to_slit_15();
+    uchar_loc_to_slit_17();
+    uchar_loc_to_slit_19();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/val/compare-rev22.c
+++ b/test/val/compare-rev22.c
@@ -1,0 +1,164 @@
+/* Exercise compare operator edge cases in forward and reverse forms;
+**   unsigned char: autos, signed statics.
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev22"
+
+#include "compare-rev.h"
+
+static int stat_i_m32768 = -32767-1;
+static int stat_i_m32767 = -32767;
+static int stat_i_m257 = -257;
+static int stat_i_m256 = -256;
+static int stat_i_m255 = -255;
+static int stat_i_m1 = -1;
+static int stat_i_0 = 0;
+static int stat_i_1 = 1;
+static int stat_i_255 = 255;
+static int stat_i_256 = 256;
+static int stat_i_257 = 257;
+static int stat_i_32767 = 32767;
+
+/* Compared values are signed int statics */
+#define N32768  stat_i_m32768
+#define N32767  stat_i_m32767
+#define N257    stat_i_m257
+#define N256    stat_i_m256
+#define N255    stat_i_m255
+#define N1      stat_i_m1
+#define ZERO    stat_i_0
+#define P1      stat_i_1
+#define P255    stat_i_255
+#define P256    stat_i_256
+#define P257    stat_i_257
+#define P32767  stat_i_32767
+
+/* unsigned char to signed int statics compares */
+static void uchar_loc_to_sstat_11(void)
+{
+    unsigned char v;
+
+    v = 0;
+    marker = 0x1100; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void uchar_loc_to_sstat_13(void)
+{
+    unsigned char v;
+
+    v = 1;
+    marker = 0x1300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void uchar_loc_to_sstat_15(void)
+{
+    unsigned char v;
+
+    v = 2;
+    marker = 0x1500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void uchar_loc_to_sstat_17(void)
+{
+    unsigned char v;
+
+    v = 254;
+    marker = 0x1700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void uchar_loc_to_sstat_19(void)
+{
+    unsigned char v;
+
+    v = 255;
+    marker = 0x1900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_EQUAL(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    uchar_loc_to_sstat_11();
+    uchar_loc_to_sstat_13();
+    uchar_loc_to_sstat_15();
+    uchar_loc_to_sstat_17();
+    uchar_loc_to_sstat_19();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/val/compare-rev23.c
+++ b/test/val/compare-rev23.c
@@ -1,0 +1,150 @@
+/* Exercise compare operator edge cases in forward and reverse forms;
+**   unsigned char: autos, unsigned statics.
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev23"
+
+#include "compare-rev.h"
+
+static unsigned stat_u_0 = 0U;
+static unsigned char stat_uc_1 = 1U;
+static unsigned stat_u_1 = 1U;
+static unsigned char stat_uc_255 = 255U;
+static unsigned stat_u_255 = 255U;
+static unsigned stat_u_256 = 256U;
+static unsigned stat_u_257 = 257U;
+static unsigned stat_u_32767 = 32767U;
+static unsigned stat_u_32768 = 32768U;
+static unsigned stat_u_65535 = 65535U;
+
+/* Compared values are unsigned statics */
+#define ZERO    stat_u_0
+#define P1_C    stat_uc_1
+#define P1      stat_u_1
+#define P255_C  stat_uc_255
+#define P255    stat_u_255
+#define P256    stat_u_256
+#define P257    stat_u_257
+#define P32767  stat_u_32767
+#define P32768  stat_u_32768
+#define P65535  stat_u_65535
+
+/* unsigned char to unsigned statics compares */
+static void uchar_loc_to_ustat_11(void)
+{
+    unsigned char v;
+
+    v = 0;
+    marker = 0x1100; /* +8 for each macro */
+
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1_C);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255_C);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void uchar_loc_to_ustat_13(void)
+{
+    unsigned char v;
+
+    v = 1;
+    marker = 0x1300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1_C);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P255_C);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void uchar_loc_to_ustat_15(void)
+{
+    unsigned char v;
+
+    v = 2;
+    marker = 0x1500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1_C);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255_C);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void uchar_loc_to_ustat_17(void)
+{
+    unsigned char v;
+
+    v = 254;
+    marker = 0x1700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1_C);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255_C);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void uchar_loc_to_ustat_19(void)
+{
+    unsigned char v;
+
+    v = 255;
+    marker = 0x1900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1_C);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_EQUAL(v, P255_C);
+    MUST_BE_EQUAL(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    uchar_loc_to_ustat_11();
+    uchar_loc_to_ustat_13();
+    uchar_loc_to_ustat_15();
+    uchar_loc_to_ustat_17();
+    uchar_loc_to_ustat_19();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/val/compare-rev24.c
+++ b/test/val/compare-rev24.c
@@ -1,0 +1,188 @@
+/* Exercise compare operator array expression cases in forward and reverse forms;
+**   unsigned char: autos, static arrays.
+** Note: will cause some compiler warnings:
+** -- 'x_yyy' is defined but never used   [not all defined values used]
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev24"
+
+#include "compare-rev.h"
+
+/* The indexes of compared values are kept the same across different types */
+static int stat_i[16] = {
+    -32767-1, -32767, -257, -256, -255, -1, 0, 1, 255, 256, 257, 32766, 32767, 0, 0, 0
+};
+
+static unsigned stat_u[16] = {
+    0, 0, 0, 0, 0, -1U, 0U, 1U, 255U, 256U, 257U, 32766U, 32767U, 32768U, 65534U, 65535U
+};
+
+static unsigned char stat_uc[16] = {
+    0, 0, 0, 0, 0, 0, 0, 1, 255, 0, 0, 0, 0, 0, 0, 0
+};
+
+/* The indexes of compared values */
+static unsigned char x_m32768 = 0;
+static unsigned char x_m32767 = 1;
+static unsigned char x_m257 = 2;
+static unsigned char x_m256 = 3;
+static unsigned char x_m255 = 4;
+static unsigned char x_m1 = 5;
+static unsigned char x_0 = 6;
+static unsigned char x_1 = 7;
+static unsigned char x_255 = 8;
+static unsigned char x_256 = 9;
+static unsigned char x_257 = 10;
+static unsigned char x_32766 = 11;
+static unsigned char x_32767 = 12;
+static unsigned char x_32768 = 13;
+static unsigned char x_65534 = 14;
+static unsigned char x_65535 = 15;
+
+/* Compared values are static arrays. The actual types used in comparisons
+** are controlled here by the defines.
+*/
+#define N32768  stat_i[x_m32768]
+#define N32767  stat_i[x_m32767]
+#define N257    stat_i[x_m257]
+#define N256    stat_i[x_m256]
+#define N255    stat_i[x_m255]
+#define N1      stat_i[x_m1]
+#define ZERO    stat_uc[x_0]
+#define P1      stat_uc[x_1]
+#define P255    stat_uc[x_255]
+#define P256    stat_i[x_256]
+#define U257    stat_u[x_257]
+#define P32766  stat_i[x_32766]
+#define P32767  stat_i[x_32767]
+#define U32768  stat_u[x_32768]
+#define U65534  stat_u[x_65534]
+#define U65535  stat_u[x_65535]
+
+/* unsigned char to static arrays compares */
+/* General form: if (loc >= array[x_val]) */
+static void uchar_loc_to_statarr_11(void)
+{
+    unsigned char v;
+
+    v = 0;
+    marker = 0x1100; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, U257);
+    MUST_BE_LESS_THAN(v, P32766);
+    MUST_BE_LESS_THAN(v, U32768);
+    MUST_BE_LESS_THAN(v, U65534);
+}
+
+static void uchar_loc_to_statarr_13(void)
+{
+    unsigned char v;
+
+    v = 1;
+    marker = 0x1300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, U257);
+    MUST_BE_LESS_THAN(v, P32766);
+    MUST_BE_LESS_THAN(v, U65534);
+}
+
+static void uchar_loc_to_statarr_15(void)
+{
+    unsigned char v;
+
+    v = 2;
+    marker = 0x1500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, U257);
+    MUST_BE_LESS_THAN(v, P32766);
+    MUST_BE_LESS_THAN(v, U65534);
+}
+
+static void uchar_loc_to_statarr_17(void)
+{
+    unsigned char v;
+
+    v = 254;
+    marker = 0x1700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, U257);
+    MUST_BE_LESS_THAN(v, P32766);
+    MUST_BE_LESS_THAN(v, U65534);
+}
+
+static void uchar_loc_to_statarr_19(void)
+{
+    unsigned char v;
+
+    v = 255;
+    marker = 0x1900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_EQUAL(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, U257);
+    MUST_BE_LESS_THAN(v, P32766);
+    MUST_BE_LESS_THAN(v, U65534);
+    MUST_BE_LESS_THAN(v, U65535);
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    uchar_loc_to_statarr_11();
+    uchar_loc_to_statarr_13();
+    uchar_loc_to_statarr_15();
+    uchar_loc_to_statarr_17();
+    uchar_loc_to_statarr_19();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/val/compare-rev31.c
+++ b/test/val/compare-rev31.c
@@ -1,0 +1,374 @@
+/* Exercise compare operator edge cases in forward and reverse forms;
+**   signed int: literals, autos.
+** Note: will cause many compiler warnings:
+** -- Result of comparison is always (true|false)
+** -- Unreachable code
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev31"
+
+#include "compare-rev.h"
+
+/* Compared values are signed int literals */
+#define N32768  -32767-1
+#define N32767  -32767
+#define N257    -257
+#define N256    -256
+#define N255    -255
+#define N1      -1
+#define ZERO    0
+#define P1      1
+#define P255    255
+#define P256    256
+#define P257    257
+#define P32767  32767
+
+/* signed int to signed literal compares */
+static void sint_loc_to_slit_11(void)
+{
+    signed int v;
+
+    v = -32767-1;
+    marker = 0x1100; /* +8 for each macro */
+
+    MUST_BE_EQUAL(v, N32768);
+    MUST_BE_LESS_THAN(v, N32767);
+    MUST_BE_LESS_THAN(v, N257);
+    MUST_BE_LESS_THAN(v, N256);
+    MUST_BE_LESS_THAN(v, N255);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_slit_13(void)
+{
+    signed int v;
+
+    v = -32767;
+    marker = 0x1300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_EQUAL(v, N32767);
+    MUST_BE_LESS_THAN(v, N257);
+    MUST_BE_LESS_THAN(v, N256);
+    MUST_BE_LESS_THAN(v, N255);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_slit_15(void)
+{
+    signed int v;
+
+    v = -257;
+    marker = 0x1500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_EQUAL(v, N257);
+    MUST_BE_LESS_THAN(v, N256);
+    MUST_BE_LESS_THAN(v, N255);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_slit_17(void)
+{
+    signed int v;
+
+    v = -256;
+    marker = 0x1700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_EQUAL(v, N256);
+    MUST_BE_LESS_THAN(v, N255);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_slit_19(void)
+{
+    signed int v;
+
+    v = -255;
+    marker = 0x1900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_EQUAL(v, N255);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_slit_1B(void)
+{
+    signed int v;
+
+    v = -2;
+    marker = 0x1B00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_slit_1D(void)
+{
+    signed int v;
+
+    v = -1;
+    marker = 0x1D00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_EQUAL(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_slit_1F(void)
+{
+    signed int v;
+
+    v = 0;
+    marker = 0x1F00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_slit_21(void)
+{
+    signed int v;
+
+    v = 1;
+    marker = 0x2100; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_slit_23(void)
+{
+    signed int v;
+
+    v = 2;
+    marker = 0x2300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_slit_25(void)
+{
+    signed int v;
+
+    v = 255;
+    marker = 0x2500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_EQUAL(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_slit_27(void)
+{
+    signed int v;
+
+    v = 256;
+    marker = 0x2700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_EQUAL(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_slit_29(void)
+{
+    signed int v;
+
+    v = 257;
+    marker = 0x2900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_EQUAL(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_slit_2B(void)
+{
+    signed int v;
+
+    v = 32766;
+    marker = 0x2B00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_slit_2D(void)
+{
+    signed int v;
+
+    v = 32767;
+    marker = 0x2D00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_EQUAL(v, P32767);
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    sint_loc_to_slit_11();
+    sint_loc_to_slit_13();
+    sint_loc_to_slit_15();
+    sint_loc_to_slit_17();
+    sint_loc_to_slit_19();
+    sint_loc_to_slit_1B();
+    sint_loc_to_slit_1D();
+    sint_loc_to_slit_1F();
+    sint_loc_to_slit_21();
+    sint_loc_to_slit_23();
+    sint_loc_to_slit_25();
+    sint_loc_to_slit_27();
+    sint_loc_to_slit_29();
+    sint_loc_to_slit_2B();
+    sint_loc_to_slit_2D();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/val/compare-rev32.c
+++ b/test/val/compare-rev32.c
@@ -1,0 +1,384 @@
+/* Exercise compare operator edge cases in forward and reverse forms;
+**   signed int: autos, signed statics.
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev32"
+
+#include "compare-rev.h"
+
+static int stat_i_m32768 = -32767-1;
+static int stat_i_m32767 = -32767;
+static int stat_i_m257 = -257;
+static int stat_i_m256 = -256;
+static int stat_i_m255 = -255;
+static int stat_i_m1 = -1;
+static int stat_i_0 = 0;
+static int stat_i_1 = 1;
+static int stat_i_255 = 255;
+static int stat_i_256 = 256;
+static int stat_i_257 = 257;
+static int stat_i_32767 = 32767;
+
+/* Compared values are signed int statics */
+#define N32768  stat_i_m32768
+#define N32767  stat_i_m32767
+#define N257    stat_i_m257
+#define N256    stat_i_m256
+#define N255    stat_i_m255
+#define N1      stat_i_m1
+#define ZERO    stat_i_0
+#define P1      stat_i_1
+#define P255    stat_i_255
+#define P256    stat_i_256
+#define P257    stat_i_257
+#define P32767  stat_i_32767
+
+/* signed int to signed int statics compares */
+static void sint_loc_to_sstat_11(void)
+{
+    signed int v;
+
+    v = -32767-1;
+    marker = 0x1100; /* +8 for each macro */
+
+    MUST_BE_EQUAL(v, N32768);
+    MUST_BE_LESS_THAN(v, N32767);
+    MUST_BE_LESS_THAN(v, N257);
+    MUST_BE_LESS_THAN(v, N256);
+    MUST_BE_LESS_THAN(v, N255);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_sstat_13(void)
+{
+    signed int v;
+
+    v = -32767;
+    marker = 0x1300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_EQUAL(v, N32767);
+    MUST_BE_LESS_THAN(v, N257);
+    MUST_BE_LESS_THAN(v, N256);
+    MUST_BE_LESS_THAN(v, N255);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_sstat_15(void)
+{
+    signed int v;
+
+    v = -257;
+    marker = 0x1500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_EQUAL(v, N257);
+    MUST_BE_LESS_THAN(v, N256);
+    MUST_BE_LESS_THAN(v, N255);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_sstat_17(void)
+{
+    signed int v;
+
+    v = -256;
+    marker = 0x1700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_EQUAL(v, N256);
+    MUST_BE_LESS_THAN(v, N255);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_sstat_19(void)
+{
+    signed int v;
+
+    v = -255;
+    marker = 0x1900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_EQUAL(v, N255);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_sstat_1B(void)
+{
+    signed int v;
+
+    v = -2;
+    marker = 0x1B00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_sstat_1D(void)
+{
+    signed int v;
+
+    v = -1;
+    marker = 0x1D00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_EQUAL(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_sstat_1F(void)
+{
+    signed int v;
+
+    v = 0;
+    marker = 0x1F00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_sstat_21(void)
+{
+    signed int v;
+
+    v = 1;
+    marker = 0x2100; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_sstat_23(void)
+{
+    signed int v;
+
+    v = 2;
+    marker = 0x2300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_sstat_25(void)
+{
+    signed int v;
+
+    v = 255;
+    marker = 0x2500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_EQUAL(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_sstat_27(void)
+{
+    signed int v;
+
+    v = 256;
+    marker = 0x2700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_EQUAL(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_sstat_29(void)
+{
+    signed int v;
+
+    v = 257;
+    marker = 0x2900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_EQUAL(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_sstat_2B(void)
+{
+    signed int v;
+
+    v = 32766;
+    marker = 0x2B00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_sstat_2D(void)
+{
+    signed int v;
+
+    v = 32767;
+    marker = 0x2D00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32768);
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_EQUAL(v, P32767);
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    sint_loc_to_sstat_11();
+    sint_loc_to_sstat_13();
+    sint_loc_to_sstat_15();
+    sint_loc_to_sstat_17();
+    sint_loc_to_sstat_19();
+    sint_loc_to_sstat_1B();
+    sint_loc_to_sstat_1D();
+    sint_loc_to_sstat_1F();
+    sint_loc_to_sstat_21();
+    sint_loc_to_sstat_23();
+    sint_loc_to_sstat_25();
+    sint_loc_to_sstat_27();
+    sint_loc_to_sstat_29();
+    sint_loc_to_sstat_2B();
+    sint_loc_to_sstat_2D();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/val/compare-rev33.c
+++ b/test/val/compare-rev33.c
@@ -1,0 +1,339 @@
+/* Exercise compare operator edge cases in forward and reverse forms;
+**   signed int: autos, unsigned statics.
+** Note: will cause some compiler warnings:
+** -- Result of comparison is constant
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev33"
+
+#include "compare-rev.h"
+
+static unsigned stat_u_0 = 0U;
+static unsigned stat_u_1 = 1U;
+static unsigned stat_u_255 = 255U;
+static unsigned stat_u_256 = 256U;
+static unsigned stat_u_257 = 257U;
+static unsigned stat_u_32767 = 32767U;
+static unsigned stat_u_32768 = 32768U;
+static unsigned stat_u_65535 = 65535U;
+
+/* Compared values are unsigned statics */
+#define ZERO    stat_u_0
+#define P1      stat_u_1
+#define P255    stat_u_255
+#define P256    stat_u_256
+#define P257    stat_u_257
+#define P32767  stat_u_32767
+#define P32768  stat_u_32768
+#define P65535  stat_u_65535
+
+/* signed int to unsigned statics compares */
+static void sint_loc_to_ustat_11(void)
+{
+    signed int v;
+
+    v = -32767-1;
+    marker = 0x1100; /* +8 for each macro */
+
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32767);
+    if (sizeof(v) == 2) {
+        MUST_BE_EQUAL(v, P32768);
+        MUST_BE_LESS_THAN(v, P65535);
+    }
+}
+
+static void sint_loc_to_ustat_13(void)
+{
+    signed int v;
+
+    v = -32767;
+    marker = 0x1300; /* +8 for each macro */
+
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    if (sizeof(v) == 2) {
+        MUST_BE_GREATER_THAN(v, P32767);
+        MUST_BE_GREATER_THAN(v, P32768);
+        MUST_BE_LESS_THAN(v, P65535);
+    }
+}
+
+static void sint_loc_to_ustat_15(void)
+{
+    signed int v;
+
+    v = -257;
+    marker = 0x1500; /* +8 for each macro */
+
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    if (sizeof(v) == 2) {
+        MUST_BE_GREATER_THAN(v, P257);
+        MUST_BE_GREATER_THAN(v, P32767);
+        MUST_BE_GREATER_THAN(v, P32768);
+        MUST_BE_LESS_THAN(v, P65535);
+    }
+}
+
+static void sint_loc_to_ustat_17(void)
+{
+    signed int v;
+
+    v = -256;
+    marker = 0x1700; /* +8 for each macro */
+
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    if (sizeof(v) == 2) {
+        MUST_BE_GREATER_THAN(v, P256);
+        MUST_BE_GREATER_THAN(v, P257);
+        MUST_BE_GREATER_THAN(v, P32767);
+        MUST_BE_GREATER_THAN(v, P32768);
+        MUST_BE_LESS_THAN(v, P65535);
+    }
+}
+
+static void sint_loc_to_ustat_19(void)
+{
+    signed int v;
+
+    v = -255;
+    marker = 0x1900; /* +8 for each macro */
+
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    if (sizeof(v) == 2) {
+        MUST_BE_GREATER_THAN(v, P255);
+        MUST_BE_GREATER_THAN(v, P256);
+        MUST_BE_GREATER_THAN(v, P257);
+        MUST_BE_GREATER_THAN(v, P32767);
+        MUST_BE_GREATER_THAN(v, P32768);
+        MUST_BE_LESS_THAN(v, P65535);
+    }
+}
+
+static void sint_loc_to_ustat_1B(void)
+{
+    signed int v;
+
+    v = -2;
+    marker = 0x1B00; /* +8 for each macro */
+
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    if (sizeof(v) == 2) {
+        MUST_BE_GREATER_THAN(v, P255);
+        MUST_BE_GREATER_THAN(v, P256);
+        MUST_BE_GREATER_THAN(v, P257);
+        MUST_BE_GREATER_THAN(v, P32767);
+        MUST_BE_GREATER_THAN(v, P32768);
+        MUST_BE_LESS_THAN(v, P65535);
+    }
+}
+
+static void sint_loc_to_ustat_1D(void)
+{
+    signed int v;
+
+    v = -1;
+    marker = 0x1D00; /* +8 for each macro */
+
+    /* Special signed to unsigned promotion cases */
+    MUST_BE_GREATER_THAN(v, ZERO);
+    if (sizeof(v) == 2) {
+        MUST_BE_GREATER_THAN(v, P1);
+        MUST_BE_GREATER_THAN(v, P255);
+        MUST_BE_GREATER_THAN(v, P256);
+        MUST_BE_GREATER_THAN(v, P257);
+        MUST_BE_GREATER_THAN(v, P32767);
+        MUST_BE_GREATER_THAN(v, P32768);
+        MUST_BE_EQUAL(v, P65535);
+    }
+}
+
+static void sint_loc_to_ustat_1F(void)
+{
+    signed int v;
+
+    v = 0;
+    marker = 0x1F00; /* +8 for each macro */
+
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void sint_loc_to_ustat_21(void)
+{
+    signed int v;
+
+    v = 1;
+    marker = 0x2100; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void sint_loc_to_ustat_23(void)
+{
+    signed int v;
+
+    v = 2;
+    marker = 0x2300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void sint_loc_to_ustat_25(void)
+{
+    signed int v;
+
+    v = 255;
+    marker = 0x2500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_EQUAL(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void sint_loc_to_ustat_27(void)
+{
+    signed int v;
+
+    v = 256;
+    marker = 0x2700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_EQUAL(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void sint_loc_to_ustat_29(void)
+{
+    signed int v;
+
+    v = 257;
+    marker = 0x2900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_EQUAL(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void sint_loc_to_ustat_2B(void)
+{
+    signed int v;
+
+    v = 32766;
+    marker = 0x2B00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void sint_loc_to_ustat_2D(void)
+{
+    signed int v;
+
+    v = 32767;
+    marker = 0x2D00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_EQUAL(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    sint_loc_to_ustat_11();
+    sint_loc_to_ustat_13();
+    sint_loc_to_ustat_15();
+    sint_loc_to_ustat_17();
+    sint_loc_to_ustat_19();
+    sint_loc_to_ustat_1B();
+    sint_loc_to_ustat_1D();
+    sint_loc_to_ustat_1F();
+    sint_loc_to_ustat_21();
+    sint_loc_to_ustat_23();
+    sint_loc_to_ustat_25();
+    sint_loc_to_ustat_27();
+    sint_loc_to_ustat_29();
+    sint_loc_to_ustat_2B();
+    sint_loc_to_ustat_2D();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/val/compare-rev34.c
+++ b/test/val/compare-rev34.c
@@ -1,0 +1,325 @@
+/* Exercise compare operator array expression cases in forward and reverse forms;
+**   signed int: autos, static arrays.
+** Note: will cause some compiler warnings:
+** -- Result of comparison is constant
+** -- 'x_yyy' is defined but never used   [not all defined values used]
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev34"
+
+#include "compare-rev.h"
+
+/* The indexes of compared values are kept the same across different types */
+static int stat_i[16] = {
+    -32767-1, -32767, -257, -256, -255, -1, 0, 1, 255, 256, 257, 32766, 32767, 0, 0, 0
+};
+
+static unsigned stat_u[16] = {
+    0, 0, 0, 0, 0, -1U, 0U, 1U, 255U, 256U, 257U, 32766U, 32767U, 32768U, 65534U, 65535U
+};
+
+static unsigned char stat_uc[16] = {
+    0, 0, 0, 0, 0, 0, 0, 1, 255, 0, 0, 0, 0, 0, 0, 0
+};
+
+/* The indexes of compared values */
+static unsigned char x_m32768 = 0;
+static unsigned char x_m32767 = 1;
+static unsigned char x_m257 = 2;
+static unsigned char x_m256 = 3;
+static unsigned char x_m255 = 4;
+static unsigned char x_m1 = 5;
+static unsigned char x_0 = 6;
+static unsigned char x_1 = 7;
+static unsigned char x_255 = 8;
+static unsigned char x_256 = 9;
+static unsigned char x_257 = 10;
+static unsigned char x_32766 = 11;
+static unsigned char x_32767 = 12;
+static unsigned char x_32768 = 13;
+static unsigned char x_65534 = 14;
+static unsigned char x_65535 = 15;
+
+/* Compared values are static arrays. The actual types used in comparisons
+** are controlled here by the defines.
+*/
+#define N32768  stat_i[x_m32768]
+#define N32767  stat_i[x_m32767]
+#define N257    stat_i[x_m257]
+#define N256    stat_i[x_m256]
+#define N255    stat_i[x_m255]
+#define N1      stat_i[x_m1]
+#define ZERO    stat_uc[x_0]
+#define P1      stat_uc[x_1]
+#define P255    stat_uc[x_255]
+#define P256    stat_i[x_256]
+#define U257    stat_u[x_257]
+#define P32766  stat_i[x_32766]
+#define P32767  stat_i[x_32767]
+#define U32768  stat_u[x_32768]
+#define U65534  stat_u[x_65534]
+#define U65535  stat_u[x_65535]
+
+/* signed int to static arrays compares */
+/* General form: if (loc >= array[x_val]) */
+static void sint_loc_to_statarr_11(void)
+{
+    signed int v;
+
+    v = -32767-1;
+    marker = 0x1100; /* +8 for each macro */
+
+    MUST_BE_LESS_THAN(v, N32767);
+    MUST_BE_LESS_THAN(v, N256);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_loc_to_statarr_13(void)
+{
+    signed int v;
+
+    v = -32767;
+    marker = 0x1300; /* +8 for each macro */
+
+    MUST_BE_EQUAL(v, N32767);
+    MUST_BE_LESS_THAN(v, N256);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P32766);
+    /* Special signed to unsigned promotion cases */
+    if (sizeof(v) == 2) {
+        MUST_BE_GREATER_THAN(v, U32768);
+        MUST_BE_LESS_THAN(v, U65535);
+    }
+}
+
+static void sint_loc_to_statarr_15(void)
+{
+    signed int v;
+
+    v = -257;
+    marker = 0x1500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_LESS_THAN(v, N256);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P32766);
+    /* Special signed to unsigned promotion cases */
+    if (sizeof(v) == 2) {
+        MUST_BE_GREATER_THAN(v, U257);
+        MUST_BE_GREATER_THAN(v, U32768);
+    }
+}
+
+static void sint_loc_to_statarr_17(void)
+{
+    signed int v;
+
+    v = -256;
+    marker = 0x1700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_EQUAL(v, N256);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P32766);
+}
+
+static void sint_loc_to_statarr_19(void)
+{
+    signed int v;
+
+    v = -2;
+    marker = 0x1900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P32766);
+}
+
+static void sint_loc_to_statarr_1B(void)
+{
+    signed int v;
+
+    v = -1;
+    marker = 0x1B00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_EQUAL(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P32766);
+    /* Special signed to unsigned promotion cases */
+    if (sizeof(v) == 2) {
+        MUST_BE_GREATER_THAN(v, U32768);
+        MUST_BE_GREATER_THAN(v, U65534);
+    }
+}
+
+static void sint_loc_to_statarr_1D(void)
+{
+    signed int v;
+
+    v = 0;
+    marker = 0x1D00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, U257);
+    MUST_BE_LESS_THAN(v, P32766);
+}
+
+static void sint_loc_to_statarr_1F(void)
+{
+    signed int v;
+
+    v = 1;
+    marker = 0x1F00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, U257);
+    MUST_BE_LESS_THAN(v, P32766);
+}
+
+static void sint_loc_to_statarr_21(void)
+{
+    signed int v;
+
+    v = 2;
+    marker = 0x2100; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, U257);
+    MUST_BE_LESS_THAN(v, P32766);
+}
+
+static void sint_loc_to_statarr_25(void)
+{
+    signed int v;
+
+    v = 256;
+    marker = 0x2500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_EQUAL(v, P256);
+    MUST_BE_LESS_THAN(v, U257);
+    MUST_BE_LESS_THAN(v, P32766);
+    MUST_BE_LESS_THAN(v, U65534);
+    MUST_BE_LESS_THAN(v, U65535);
+}
+
+static void sint_loc_to_statarr_27(void)
+{
+    signed int v;
+
+    v = 257;
+    marker = 0x2700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_EQUAL(v, U257);
+    MUST_BE_LESS_THAN(v, P32766);
+    MUST_BE_LESS_THAN(v, U65534);
+}
+
+static void sint_loc_to_statarr_29(void)
+{
+    signed int v;
+
+    v = 32766;
+    marker = 0x2900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, U257);
+    MUST_BE_EQUAL(v, P32766);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, U65534);
+    MUST_BE_LESS_THAN(v, U65535);
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    sint_loc_to_statarr_11();
+    sint_loc_to_statarr_13();
+    sint_loc_to_statarr_15();
+    sint_loc_to_statarr_17();
+    sint_loc_to_statarr_19();
+    sint_loc_to_statarr_1B();
+    sint_loc_to_statarr_1D();
+    sint_loc_to_statarr_1F();
+    sint_loc_to_statarr_21();
+    sint_loc_to_statarr_25();
+    sint_loc_to_statarr_27();
+    sint_loc_to_statarr_29();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/val/compare-rev41.c
+++ b/test/val/compare-rev41.c
@@ -1,0 +1,234 @@
+/* Exercise compare operator edge cases in forward and reverse forms;
+**   unsigned int: literals, autos.
+** Note: will cause many compiler warnings:
+** -- Result of comparison is always (true|false)
+** -- Unreachable code
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev41"
+
+#include "compare-rev.h"
+
+/* Compared values are signed int literals */
+#define N1      -1
+#define ZERO    0
+#define P1      1
+#define P255    255
+#define P256    256
+#define P257    257
+#define P32767  32767
+#define P32768  32768
+#define P65535  65535
+
+/* unsigned int to signed literal compares */
+static void uint_loc_to_slit_11(void)
+{
+    unsigned int v;
+
+    v = 0U;
+    marker = 0x1100; /* +8 for each macro */
+
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_slit_13(void)
+{
+    unsigned int v;
+
+    v = 1U;
+    marker = 0x1300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_slit_15(void)
+{
+    unsigned int v;
+
+    v = 2U;
+    marker = 0x1500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_slit_17(void)
+{
+    unsigned int v;
+
+    v = 255U;
+    marker = 0x1700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_EQUAL(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_slit_19(void)
+{
+    unsigned int v;
+
+    v = 256U;
+    marker = 0x1900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_EQUAL(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_slit_1B(void)
+{
+    unsigned int v;
+
+    v = 257U;
+    marker = 0x1B00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_EQUAL(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_slit_1D(void)
+{
+    unsigned int v;
+
+    v = 32767U;
+    marker = 0x1D00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_EQUAL(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_slit_1F(void)
+{
+    unsigned int v;
+
+    v = 32768U;
+    marker = 0x1F00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32767);
+    MUST_BE_EQUAL(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_slit_21(void)
+{
+    unsigned int v;
+
+    v = 65534U;
+    marker = 0x2100; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32767);
+    MUST_BE_GREATER_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_slit_23(void)
+{
+    unsigned int v;
+
+    v = 65535U;
+    marker = 0x2300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32767);
+    MUST_BE_GREATER_THAN(v, P32768);
+    MUST_BE_EQUAL(v, P65535);
+
+    if (sizeof(v) == 2) {
+        MUST_BE_EQUAL(v, N1); /* special case: -1 to uint promotion */
+    }
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    uint_loc_to_slit_11();
+    uint_loc_to_slit_13();
+    uint_loc_to_slit_15();
+    uint_loc_to_slit_17();
+    uint_loc_to_slit_19();
+    uint_loc_to_slit_1B();
+    uint_loc_to_slit_1D();
+    uint_loc_to_slit_1F();
+    uint_loc_to_slit_21();
+    uint_loc_to_slit_23();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/val/compare-rev42.c
+++ b/test/val/compare-rev42.c
@@ -1,0 +1,243 @@
+/* Exercise compare operator edge cases in forward and reverse forms;
+**   unsigned int: autos, signed statics.
+** Note: will cause some compiler warnings:
+** -- Result of comparison is constant
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev42"
+
+#include "compare-rev.h"
+
+static int stat_i_m1 = -1;
+static int stat_i_0 = 0;
+static int stat_i_1 = 1;
+static int stat_i_255 = 255;
+static int stat_i_256 = 256;
+static int stat_i_257 = 257;
+static int stat_i_32767 = 32767;
+static unsigned stat_u_32768 = 32768U;
+static unsigned stat_u_65535 = 65535U;
+
+/* Compared values are signed int statics, with some exceptions */
+#define N1      stat_i_m1
+#define ZERO    stat_i_0
+#define P1      stat_i_1
+#define P255    stat_i_255
+#define P256    stat_i_256
+#define P257    stat_i_257
+#define P32767  stat_i_32767
+#define P32768  stat_u_32768
+#define P65535  stat_u_65535
+
+/* unsigned int to signed int statics compares */
+static void uint_loc_to_sstat_11(void)
+{
+    unsigned int v;
+
+    v = 0U;
+    marker = 0x1100; /* +8 for each macro */
+
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_sstat_13(void)
+{
+    unsigned int v;
+
+    v = 1U;
+    marker = 0x1300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_sstat_15(void)
+{
+    unsigned int v;
+
+    v = 2U;
+    marker = 0x1500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_sstat_17(void)
+{
+    unsigned int v;
+
+    v = 255U;
+    marker = 0x1700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_EQUAL(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_sstat_19(void)
+{
+    unsigned int v;
+
+    v = 256U;
+    marker = 0x1900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_EQUAL(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_sstat_1B(void)
+{
+    unsigned int v;
+
+    v = 257U;
+    marker = 0x1B00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_EQUAL(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_sstat_1D(void)
+{
+    unsigned int v;
+
+    v = 32767U;
+    marker = 0x1D00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_EQUAL(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_sstat_1F(void)
+{
+    unsigned int v;
+
+    v = 32768U;
+    marker = 0x1F00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32767);
+    MUST_BE_EQUAL(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_sstat_21(void)
+{
+    unsigned int v;
+
+    v = 65534U;
+    marker = 0x2100; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32767);
+    MUST_BE_GREATER_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+    MUST_BE_LESS_THAN(v, N1); /* special case: -1 to uint promotion */
+}
+
+static void uint_loc_to_sstat_23(void)
+{
+    unsigned int v;
+
+    v = 65535U;
+    marker = 0x2300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32767);
+    MUST_BE_GREATER_THAN(v, P32768);
+    MUST_BE_EQUAL(v, P65535);
+
+    if (sizeof(v) == 2) {
+        MUST_BE_EQUAL(v, N1); /* special case: -1 to uint promotion */
+    }
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    uint_loc_to_sstat_11();
+    uint_loc_to_sstat_13();
+    uint_loc_to_sstat_15();
+    uint_loc_to_sstat_17();
+    uint_loc_to_sstat_19();
+    uint_loc_to_sstat_1B();
+    uint_loc_to_sstat_1D();
+    uint_loc_to_sstat_1F();
+    uint_loc_to_sstat_21();
+    uint_loc_to_sstat_23();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/val/compare-rev43.c
+++ b/test/val/compare-rev43.c
@@ -1,0 +1,226 @@
+/* Exercise compare operator edge cases in forward and reverse forms;
+**   unsigned int: autos, unsigned statics.
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev43"
+
+#include "compare-rev.h"
+
+static unsigned stat_u_0 = 0U;
+static unsigned stat_u_1 = 1U;
+static unsigned stat_u_255 = 255U;
+static unsigned stat_u_256 = 256U;
+static unsigned stat_u_257 = 257U;
+static unsigned stat_u_32767 = 32767U;
+static unsigned stat_u_32768 = 32768U;
+static unsigned stat_u_65535 = 65535U;
+
+/* Compared values are unsigned statics */
+#define ZERO    stat_u_0
+#define P1      stat_u_1
+#define P255    stat_u_255
+#define P256    stat_u_256
+#define P257    stat_u_257
+#define P32767  stat_u_32767
+#define P32768  stat_u_32768
+#define P65535  stat_u_65535
+
+/* unsigned int to unsigned statics compares */
+static void uint_loc_to_ustat_11(void)
+{
+    unsigned int v;
+
+    v = 0U;
+    marker = 0x1100; /* +8 for each macro */
+
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void uint_loc_to_ustat_13(void)
+{
+    unsigned int v;
+
+    v = 1U;
+    marker = 0x1300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void uint_loc_to_ustat_15(void)
+{
+    unsigned int v;
+
+    v = 2U;
+    marker = 0x1500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void uint_loc_to_ustat_17(void)
+{
+    unsigned int v;
+
+    v = 255U;
+    marker = 0x1700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_EQUAL(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void uint_loc_to_ustat_19(void)
+{
+    unsigned int v;
+
+    v = 256U;
+    marker = 0x1900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_EQUAL(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void uint_loc_to_ustat_1B(void)
+{
+    unsigned int v;
+
+    v = 257U;
+    marker = 0x1B00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_EQUAL(v, P257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void uint_loc_to_ustat_1D(void)
+{
+    unsigned int v;
+
+    v = 32767U;
+    marker = 0x1D00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_EQUAL(v, P32767);
+    MUST_BE_LESS_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void uint_loc_to_ustat_1F(void)
+{
+    unsigned int v;
+
+    v = 32768U;
+    marker = 0x1F00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32767);
+    MUST_BE_EQUAL(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void uint_loc_to_ustat_21(void)
+{
+    unsigned int v;
+
+    v = 65534U;
+    marker = 0x2100; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32767);
+    MUST_BE_GREATER_THAN(v, P32768);
+    MUST_BE_LESS_THAN(v, P65535);
+}
+
+static void uint_loc_to_ustat_23(void)
+{
+    unsigned int v;
+
+    v = 65535U;
+    marker = 0x2300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32767);
+    MUST_BE_GREATER_THAN(v, P32768);
+    MUST_BE_EQUAL(v, P65535);
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    uint_loc_to_ustat_11();
+    uint_loc_to_ustat_13();
+    uint_loc_to_ustat_15();
+    uint_loc_to_ustat_17();
+    uint_loc_to_ustat_19();
+    uint_loc_to_ustat_1B();
+    uint_loc_to_ustat_1D();
+    uint_loc_to_ustat_1F();
+    uint_loc_to_ustat_21();
+    uint_loc_to_ustat_23();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/val/compare-rev51.c
+++ b/test/val/compare-rev51.c
@@ -1,0 +1,347 @@
+/* Exercise compare operator expression cases in forward and reverse forms;
+**   various types: simple expressions.
+** Note: will cause some compiler warnings:
+** -- Result of comparison is constant
+** -- 'x_yyy' is defined but never used   [not all defined values used]
+** 
+** License: Public Domain
+**
+** This software is provided 'as-is', without any express or implied warranty.
+** In no event will the authors be held liable for any damages arising from
+** the use of this software.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_NAME  "compare-rev51"
+
+#include "compare-rev.h"
+
+/* The indexes of compared values are kept the same across different types */
+static int stat_i[16] = {
+    -32767-1, -32767, -257, -256, -255, -1, 0, 1, 255, 256, 257, 32766, 32767, 0, 0, 0
+};
+
+static unsigned stat_u[16] = {
+    0, 0, 0, 0, 0, -1U, 0U, 1U, 255U, 256U, 257U, 32766U, 32767U, 32768U, 65534U, 65535U
+};
+
+static unsigned char stat_uc[16] = {
+    0, 0, 0, 0, 0, 0, 0, 1, 255, 0, 0, 0, 0, 0, 0, 0
+};
+
+/* The indexes of compared values */
+static unsigned char x_m32768 = 0;
+static unsigned char x_m32767 = 1;
+static unsigned char x_m257 = 2;
+static unsigned char x_m256 = 3;
+static unsigned char x_m255 = 4;
+static unsigned char x_m1 = 5;
+static unsigned char x_0 = 6;
+static unsigned char x_1 = 7;
+static unsigned char x_255 = 8;
+static unsigned char x_256 = 9;
+static unsigned char x_257 = 10;
+static unsigned char x_32766 = 11;
+static unsigned char x_32767 = 12;
+static unsigned char x_32768 = 13;
+static unsigned char x_65534 = 14;
+static unsigned char x_65535 = 15;
+
+/* Compared values are static arrays. The actual types used in comparisons
+** are controlled here by the defines.
+*/
+#define N32768  stat_i[x_m32768]
+#define N32767  stat_i[x_m32767]
+#define N257    stat_i[x_m257]
+#define N256    stat_i[x_m256]
+#define N255    stat_i[x_m255]
+#define N1      stat_i[x_m1]
+#define ZERO    stat_i[x_0]
+#define P1      stat_uc[x_1]
+#define P255    stat_uc[x_255]
+#define U255    stat_u[x_255]
+#define P256    stat_i[x_256]
+#define U256    stat_u[x_256]
+#define P257    stat_i[x_257]
+#define U257    stat_u[x_257]
+#define P32766  stat_i[x_32766]
+#define P32767  stat_i[x_32767]
+#define U32767  stat_u[x_32767]
+#define U32768  stat_u[x_32768]
+#define U65534  stat_u[x_65534]
+#define U65535  stat_u[x_65535]
+
+/* signed int to static arrays compares */
+/* General form: if ((loc + 1) >= array[x_val]) */
+static void sint_expr_to_statarr_11(void)
+{
+#define v (loc + 1)
+    signed int loc;
+
+    loc = -32767-1; /* +1 = -32767 */
+    marker = 0x1100; /* +8 for each macro */
+
+    MUST_BE_EQUAL(v, N32767);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void sint_expr_to_statarr_13(void)
+{
+#define v (loc + 1)
+    signed int loc;
+
+    loc = -32767; /* +1 = -32766 */
+    marker = 0x1300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, P32766);
+}
+
+static void sint_expr_to_statarr_15(void)
+{
+#define v (loc + 1)
+    signed int loc;
+
+    loc = -258; /* +1 = 257 */
+    marker = 0x1500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_EQUAL(v, N257);
+    MUST_BE_LESS_THAN(v, N256);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P32766);
+}
+
+static void sint_expr_to_statarr_17(void)
+{
+#define v (loc + 1)
+    signed int loc;
+
+    loc = -257; /* +1 = 256 */
+    marker = 0x1700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_EQUAL(v, N256);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void schar_expr_to_statarr_19(void)
+{
+#define v (loc + 1)
+    signed char loc;
+
+    loc = -3; /* +1 = -2 */
+    marker = 0x1900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_LESS_THAN(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P32766);
+}
+
+static void sint_expr_to_statarr_1B(void)
+{
+#define v (loc + 1)
+    signed int loc;
+
+    loc = -2; /* +1 = -1 */
+    marker = 0x1B00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_EQUAL(v, N1);
+    MUST_BE_LESS_THAN(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P32767);
+}
+
+static void schar_expr_to_statarr_1D(void)
+{
+#define v (loc + 1)
+    signed char loc;
+
+    loc = -1; /* +1 = 0 */
+    marker = 0x1D00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_EQUAL(v, ZERO);
+    MUST_BE_LESS_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, U257);
+    MUST_BE_LESS_THAN(v, U32768);
+}
+
+static void uchar_expr_to_statarr_1F(void)
+{
+#define v (loc + 1)
+    unsigned char loc;
+
+    loc = 0; /* +1 = 1 */
+    marker = 0x1F00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_EQUAL(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, U257);
+    MUST_BE_LESS_THAN(v, P32766);
+}
+
+static void uchar_expr_to_statarr_21(void)
+{
+#define v (loc + 1)
+    unsigned char loc;
+
+    loc = 1; /* +1 = 2 */
+    marker = 0x2100; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N32767);
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_LESS_THAN(v, P255);
+    MUST_BE_LESS_THAN(v, U256);
+    MUST_BE_LESS_THAN(v, U257);
+    MUST_BE_LESS_THAN(v, U32768);
+}
+
+static void uchar_expr_to_statarr_23(void)
+{
+#define v (loc + 1)
+    unsigned char loc;
+
+    loc = 254; /* +1 = 255 */
+    marker = 0x2300; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N257);
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N255);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_EQUAL(v, P255);
+    MUST_BE_LESS_THAN(v, P256);
+    MUST_BE_LESS_THAN(v, U256);
+    MUST_BE_LESS_THAN(v, U257);
+}
+
+static void sint_expr_to_statarr_25(void)
+{
+#define v (loc + 1)
+    signed int loc;
+
+    loc = 255; /* +1 = 256 */
+    marker = 0x2500; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, N256);
+    MUST_BE_GREATER_THAN(v, N1);
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, U255);
+    MUST_BE_EQUAL(v, P256);
+    MUST_BE_LESS_THAN(v, P257);
+    MUST_BE_LESS_THAN(v, P32766);
+}
+
+static void uint_expr_to_statarr_27(void)
+{
+#define v (loc + 1)
+    unsigned int loc;
+
+    loc = 256; /* +1 = 257 */
+    marker = 0x2700; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, P256);
+    MUST_BE_EQUAL(v, U257);
+    MUST_BE_LESS_THAN(v, P32767);
+    MUST_BE_LESS_THAN(v, U32768);
+}
+
+static void uint_expr_to_statarr_29(void)
+{
+#define v (loc + 1)
+    unsigned int loc;
+
+    loc = 32766; /* +1 = 32767 */
+    marker = 0x2900; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, U255);
+    MUST_BE_GREATER_THAN(v, P257);
+    MUST_BE_GREATER_THAN(v, P32766);
+    MUST_BE_EQUAL(v, P32767);
+    MUST_BE_LESS_THAN(v, U32768);
+    MUST_BE_LESS_THAN(v, U65535);
+}
+
+static void uint_expr_to_statarr_2B(void)
+{
+#define v (loc + 1)
+    unsigned int loc;
+
+    loc = 32767; /* +1 = 32768 */
+    marker = 0x2B00; /* +8 for each macro */
+
+    MUST_BE_GREATER_THAN(v, ZERO);
+    MUST_BE_GREATER_THAN(v, P1);
+    MUST_BE_GREATER_THAN(v, P255);
+    MUST_BE_GREATER_THAN(v, U256);
+    MUST_BE_GREATER_THAN(v, P32767);
+    MUST_BE_EQUAL(v, U32768);
+    MUST_BE_LESS_THAN(v, U65534);
+    MUST_BE_LESS_THAN(v, U65535);
+}
+
+int main(void)
+{
+    marker = 0x01;
+
+    sint_expr_to_statarr_11();
+    sint_expr_to_statarr_13();
+    sint_expr_to_statarr_15();
+    sint_expr_to_statarr_17();
+    schar_expr_to_statarr_19();
+    sint_expr_to_statarr_1B();
+    schar_expr_to_statarr_1D();
+    uchar_expr_to_statarr_1F();
+    uchar_expr_to_statarr_21();
+    uchar_expr_to_statarr_23();
+    sint_expr_to_statarr_25();
+    uint_expr_to_statarr_27();
+    uint_expr_to_statarr_29();
+    uint_expr_to_statarr_2B();
+
+    printf(TEST_NAME " failures: %d\n", failures);
+
+    return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Compare operator test suite: forward and reverse compares; edge and corner cases; signed char, unsigned char, signed int, unsigned int; literals, autos, statics, simple expressions; some special cases. This is ahead of cc65/coptstop.c refactoring proposed in #2935.
There is overlap with existing `compare[1..10].c` and several other regression tests. It might be overkill, but it ensures just about every edge case is covered with forward and reverse forms. It may be more difficult to diagnose the failed cases due to the extensive use of preprocessor macros.

**Note:** Some of the compiled 6502 binaries are starting to push the limit. The largest is ~55KB.

## Checklist

- [ ] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
- [ ] The documentation has been updated if necessary
