### PR TITLE
Refactor: Split `OptStackOps` into 12 top-level optimizers

### DIFF
--- a/src/cc65/codeopt.c
+++ b/src/cc65/codeopt.c
@@ -122,6 +122,7 @@ static OptFunc DOptBNegAX1      = { OptBNegAX1,      "OptBNegAX1",      100, 0, 
 static OptFunc DOptBNegAX2      = { OptBNegAX2,      "OptBNegAX2",      100, 0, 0, 0, 0, 0 };
 static OptFunc DOptBNegAX3      = { OptBNegAX3,      "OptBNegAX3",      100, 0, 0, 0, 0, 0 };
 static OptFunc DOptBNegAX4      = { OptBNegAX4,      "OptBNegAX4",      100, 0, 0, 0, 0, 0 };
+static OptFunc DOptBZero        = { OptBZero,        "OptBZero",        100, 0, 0, 0, 0, 0 };
 static OptFunc DOptBinOps1      = { OptBinOps1,      "OptBinOps1",        0, 0, 0, 0, 0, 0 };
 static OptFunc DOptBinOps2      = { OptBinOps2,      "OptBinOps2",        0, 0, 0, 0, 0, 0 };
 static OptFunc DOptBoolCmp      = { OptBoolCmp,      "OptBoolCmp",      100, 0, 0, 0, 0, 0 };
@@ -187,6 +188,7 @@ static OptFunc DOptPtrLoad7     = { OptPtrLoad7,     "OptPtrLoad7",     140, 0, 
 static OptFunc DOptPtrStore1    = { OptPtrStore1,    "OptPtrStore1",     65, 0, 0, 0, 0, 0 };
 static OptFunc DOptPtrStore2    = { OptPtrStore2,    "OptPtrStore2",     65, 0, 0, 0, 0, 0 };
 static OptFunc DOptPtrStore3    = { OptPtrStore3,    "OptPtrStore3",    100, 0, 0, 0, 0, 0 };
+static OptFunc DOptPtrStore4    = { OptPtrStore4,    "OptPtrStore4",    100, 0, 0, 0, 0, 0 };
 static OptFunc DOptPush1        = { OptPush1,        "OptPush1",         65, 0, 0, 0, 0, 0 };
 static OptFunc DOptPush2        = { OptPush2,        "OptPush2",         50, 0, 0, 0, 0, 0 };
 static OptFunc DOptPushPop1     = { OptPushPop1,     "OptPushPop1",       0, 0, 0, 0, 0, 0 };
@@ -205,8 +207,17 @@ static OptFunc DOptShiftBack    = { OptShiftBack,    "OptShiftBack",      0, 0, 
 static OptFunc DOptSignExtended = { OptSignExtended, "OptSignExtended",   0, 0, 0, 0, 0, 0 };
 static OptFunc DOptSize1        = { OptSize1,        "OptSize1",        100, 0, 0, 0, 0, 0 };
 static OptFunc DOptSize2        = { OptSize2,        "OptSize2",        100, 0, 0, 0, 0, 0 };
-static OptFunc DOptStackOps     = { OptStackOps,     "OptStackOps",     100, 0, 0, 0, 0, 0 };
 static OptFunc DOptStackPtrOps  = { OptStackPtrOps,  "OptStackPtrOps",   50, 0, 0, 0, 0, 0 };
+static OptFunc DOptStkArith1    = { OptStkArith1,    "OptStkArith1",    100, 0, 0, 0, 0, 0 };
+static OptFunc DOptStkArith2    = { OptStkArith2,    "OptStkArith2",    100, 0, 0, 0, 0, 0 };
+static OptFunc DOptStkBitwise1  = { OptStkBitwise1,  "OptStkBitwise1",  100, 0, 0, 0, 0, 0 };
+static OptFunc DOptStkBitwise2  = { OptStkBitwise2,  "OptStkBitwise2",  100, 0, 0, 0, 0, 0 };
+static OptFunc DOptStkCmpOps1   = { OptStkCmpOps1,   "OptStkCmpOps1",   100, 0, 0, 0, 0, 0 };
+static OptFunc DOptStkCmpOps2   = { OptStkCmpOps2,   "OptStkCmpOps2",   100, 0, 0, 0, 0, 0 };
+static OptFunc DOptStkEqOps1    = { OptStkEqOps1,    "OptStkEqOps1",    100, 0, 0, 0, 0, 0 };
+static OptFunc DOptStkEqOps2    = { OptStkEqOps2,    "OptStkEqOps2",    100, 0, 0, 0, 0, 0 };
+static OptFunc DOptStkICmp1     = { OptStkICmp1,     "OptStkICmp1",     100, 0, 0, 0, 0, 0 };
+static OptFunc DOptStkShifts    = { OptStkShifts,    "OptStkShifts",    100, 0, 0, 0, 0, 0 };
 static OptFunc DOptStore1       = { OptStore1,       "OptStore1",        70, 0, 0, 0, 0, 0 };
 static OptFunc DOptStore2       = { OptStore2,       "OptStore2",       115, 0, 0, 0, 0, 0 };
 static OptFunc DOptStore3       = { OptStore3,       "OptStore3",       120, 0, 0, 0, 0, 0 };
@@ -251,6 +262,7 @@ static OptFunc* OptFuncs[] = {
     &DOptBNegAX2,
     &DOptBNegAX3,
     &DOptBNegAX4,
+    &DOptBZero,
     &DOptBinOps1,
     &DOptBinOps2,
     &DOptBoolCmp,
@@ -316,6 +328,7 @@ static OptFunc* OptFuncs[] = {
     &DOptPtrStore1,
     &DOptPtrStore2,
     &DOptPtrStore3,
+    &DOptPtrStore4,
     &DOptPush1,
     &DOptPush2,
     &DOptPushPop1,
@@ -334,8 +347,17 @@ static OptFunc* OptFuncs[] = {
     &DOptSignExtended,
     &DOptSize1,
     &DOptSize2,
-    &DOptStackOps,
     &DOptStackPtrOps,
+    &DOptStkArith1,
+    &DOptStkArith2,
+    &DOptStkBitwise1,
+    &DOptStkBitwise2,
+    &DOptStkCmpOps1,
+    &DOptStkCmpOps2,
+    &DOptStkEqOps1,
+    &DOptStkEqOps2,
+    &DOptStkICmp1,
+    &DOptStkShifts,
     &DOptStore1,
     &DOptStore2,
     &DOptStore3,
@@ -713,6 +735,7 @@ static unsigned RunOptGroup3 (CodeSeg* S)
 */
 {
     unsigned Changes, C;
+    unsigned I;
 
     Changes = 0;
     do {
@@ -720,7 +743,29 @@ static unsigned RunOptGroup3 (CodeSeg* S)
 
         C += RunOptFunc (S, &DOptNegAX1, 1);
         C += RunOptFunc (S, &DOptNegAX2, 1);
-        C += RunOptFunc (S, &DOptStackOps, 3);      /* Before OptBoolUnary1 */
+        C += RunOptFunc (S, &DOptBZero, 1);
+        C += RunOptFunc (S, &DOptPtrStore4, 1);
+
+        /* Run the subgroup up to twice for complex expressions */
+        for (I = 0; I < 2; ++I) {
+            unsigned SubC = 0;
+
+            SubC += RunOptFunc (S, &DOptStkArith1, 1);
+            SubC += RunOptFunc (S, &DOptStkArith2, 1);
+            SubC += RunOptFunc (S, &DOptStkBitwise1, 1);
+            SubC += RunOptFunc (S, &DOptStkBitwise2, 1);
+            SubC += RunOptFunc (S, &DOptStkShifts, 1);
+
+            C += SubC;
+            if (!SubC) {
+                break;  /* No changes; skip the rest */
+            }
+        }
+
+        C += RunOptFunc (S, &DOptStkCmpOps1, 1);
+        C += RunOptFunc (S, &DOptStkCmpOps2, 1);
+        C += RunOptFunc (S, &DOptStkEqOps1, 1);
+        C += RunOptFunc (S, &DOptStkEqOps2, 1);
         C += RunOptFunc (S, &DOptCmp8, 1);          /* Before OptBoolUnary1 */
         C += RunOptFunc (S, &DOptBoolUnary1, 3);
         C += RunOptFunc (S, &DOptBoolUnary2, 3);
@@ -747,6 +792,7 @@ static unsigned RunOptGroup3 (CodeSeg* S)
         C += RunOptFunc (S, &DOptRTSJumps1, 1);
         C += RunOptFunc (S, &DOptCmp6, 1);          /* After OptRTSJumps1 */
         C += RunOptFunc (S, &DOptBoolCmp, 1);
+        C += RunOptFunc (S, &DOptStkICmp1, 1);      /* After OptBoolCmp */
         C += RunOptFunc (S, &DOptBoolTrans, 1);
         C += RunOptFunc (S, &DOptBNegA2, 1);        /* After OptCondBranch's */
         C += RunOptFunc (S, &DOptBNegAX2, 1);       /* After OptCondBranch's */

--- a/src/cc65/coptstop.c
+++ b/src/cc65/coptstop.c
@@ -64,6 +64,9 @@ struct OptFuncDesc {
     PreCondFunc         PreCond;        /* Precondition predicate pointer */
 };
 
+/* Termination for OptFuncDesc tables */
+#define OPTFUNCDESC_SENTINEL    { 0, 0, 0 }
+
 
 
 /*****************************************************************************/
@@ -72,41 +75,28 @@ struct OptFuncDesc {
 
 
 
-static int SameRegAValueAtOp (const StackOpData* D, CodeEntry* OpEntry)
+static int SameRegAValueAtOp (const StackOpData* D)
 /* Check if Rhs Reg A at OpIndex == Lhs Reg A at PushIndex */
 {
-    CodeEntry* PushEntry;
-
-    CHECK (D->PushIndex >= 0);
-    PushEntry = CS_GetEntry (D->Code, D->PushIndex);
+    CHECK (D->PushEntry != 0 && D->OpEntry != 0);
 
     return
-        RegValIsKnown (PushEntry->RI->In.RegA) &&
-        RegValIsKnown (OpEntry->RI->In.RegA) &&
-        PushEntry->RI->In.RegA == OpEntry->RI->In.RegA;
+        RegValIsKnown (D->PushEntry->RI->In.RegA) &&
+        RegValIsKnown (D->OpEntry->RI->In.RegA) &&
+        D->PushEntry->RI->In.RegA == D->OpEntry->RI->In.RegA;
 }
 
 
 
-static int SameRegXValueAtOp (const StackOpData* D, CodeEntry* OpEntry)
+static int SameRegXValueAtOp (const StackOpData* D)
 /* Check if Rhs Reg X at OpIndex == Lhs Reg X at PushIndex */
 {
-    CodeEntry* PushEntry;
-
-    CHECK (D->PushIndex >= 0);
-    PushEntry = CS_GetEntry (D->Code, D->PushIndex);
-
-    /* ### This is a temporary workaround, removable in next phases. */
-    if (OpEntry == 0) {
-        /* Not provided; then OpIndex must be present */
-        CHECK (D->OpIndex >= 0);
-        OpEntry = CS_GetEntry (D->Code, D->OpIndex);
-    }
+    CHECK (D->PushEntry != 0 && D->OpEntry != 0);
 
     return
-        RegValIsKnown (PushEntry->RI->In.RegX) &&
-        RegValIsKnown (OpEntry->RI->In.RegX) &&
-        PushEntry->RI->In.RegX == OpEntry->RI->In.RegX;
+        RegValIsKnown (D->PushEntry->RI->In.RegX) &&
+        RegValIsKnown (D->OpEntry->RI->In.RegX) &&
+        D->PushEntry->RI->In.RegX == D->OpEntry->RI->In.RegX;
 }
 
 
@@ -351,7 +341,7 @@ static int WithSameXMustHaveTempZP (const StackOpData* D)
 ** ZP with AddStoreLhsA() or similar.
 */
 {
-    return SameRegXValueAtOp (D, 0) && HaveUnusedTempZPLoc (D);
+    return SameRegXValueAtOp (D) && HaveUnusedTempZPLoc (D);
 }
 
 
@@ -365,7 +355,7 @@ static int WithSameXCanUseRemovableRhsWithTempZP (const StackOpData* D)
 ** and a temp ZP location is available.
 */
 {
-    return SameRegXValueAtOp (D, 0) && RhsIsDirectLoad (D) &&
+    return SameRegXValueAtOp (D) && RhsIsDirectLoad (D) &&
            RhsIsRemovable (D) && HaveUnusedTempZPLoc (D);
 }
 
@@ -1549,7 +1539,7 @@ static unsigned Opt_a_tosicmp (StackOpData* D)
     RegInfo*    RI;
     const char* Arg;
 
-    if (!SameRegAValueAtOp (D, D->OpEntry)) {
+    if (!SameRegAValueAtOp (D)) {
         /* Because of SameRegAValueAtOp */
         CHECK (D->Rhs.A.ChgIndex >= 0);
 
@@ -1770,77 +1760,23 @@ static unsigned Opt_a_tosxor (StackOpData* D)
 
 
 
-/* Note: A subopt MUST commit to every use case (precondition) that it
-**  advertises here. Unhandled advertised cases will result in stack corruption,
-**  because OptStackOps() is committed at the point of call and cannot back out.
-*/
-/* The first column of these two tables must be sorted in lexical order */
-
-/* CAUTION: table must be sorted for bsearch */
-static const OptFuncDesc FuncTable[] = {
-/* BEGIN SORTED.SH */
-    { "___bzero",   Opt___bzero,   WithAXlt100CanUseRegVarOrTempZP       },
-    { "staspidx",   Opt_staspidx,  CanUseRegVarOrTempZP                  },
-    { "staxspidx",  Opt_staxspidx, WithUnusedACanUseRegVarOrTempZP       },
-    { "tosaddax",   Opt_tosaddax,  MustHaveTempZP                        },
-    { "tosandax",   Opt_tosandax,  MustHaveTempZP                        },
-    { "tosaslax",   Opt_tosaslax,  MustHaveTempZP                        },
-    { "tosasrax",   Opt_tosasrax,  MustHaveTempZP                        },
-    { "toseqax",    Opt_toseqax,   CanUseDirectWithRemovableRhsAndTempZP },
-    { "tosgeax",    Opt_tosgeax,   CanUseRemovableRhsWithTempZP          },
-    { "tosltax",    Opt_tosltax,   CanUseRemovableRhsWithTempZP          },
-    { "tosneax",    Opt_tosneax,   CanUseDirectWithRemovableRhsAndTempZP },
-    { "tosorax",    Opt_tosorax,   MustHaveTempZP                        },
-    { "tosshlax",   Opt_tosshlax,  MustHaveTempZP                        },
-    { "tosshrax",   Opt_tosshrax,  MustHaveTempZP                        },
-    { "tossubax",   Opt_tossubax,  CanUseRemovableRhsWithTempZP          },
-    { "tosugeax",   Opt_tosugeax,  CanUseRemovableRhsWithTempZP          },
-    { "tosugtax",   Opt_tosugtax,  CanUseRemovableRhsWithTempZP          },
-    { "tosuleax",   Opt_tosuleax,  CanUseRemovableRhsWithTempZP          },
-    { "tosultax",   Opt_tosultax,  CanUseRemovableRhsWithTempZP          },
-    { "tosxorax",   Opt_tosxorax,  MustHaveTempZP                        },
-/* END SORTED.SH */
-};
-
-/* CAUTION: table must be sorted for bsearch */
-static const OptFuncDesc FuncRegATable[] = {
-/* BEGIN SORTED.SH */
-    { "tosandax",   Opt_a_tosand,  WithSameXCanUseRemovableRhsWithTempZP },
-    { "toseqax",    Opt_a_toseq,   WithSameXMustHaveTempZP               },
-    { "tosgeax",    Opt_a_tosuge,  WithSameXMustHaveTempZP               },
-    { "tosgtax",    Opt_a_tosugt,  WithSameXMustHaveTempZP               },
-    { "tosicmp",    Opt_a_tosicmp, WithSameXMustHaveTempZP               },
-    { "tosleax",    Opt_a_tosule,  WithSameXMustHaveTempZP               },
-    { "tosltax",    Opt_a_tosult,  WithSameXMustHaveTempZP               },
-    { "tosneax",    Opt_a_tosne,   WithSameXMustHaveTempZP               },
-    { "tosorax",    Opt_a_tosor,   WithSameXCanUseRemovableRhsWithTempZP },
-    { "tossubax",   Opt_a_tossub,  WithSameXCanUseRemovableRhsWithTempZP },
-    { "tosugeax",   Opt_a_tosuge,  WithSameXMustHaveTempZP               },
-    { "tosugtax",   Opt_a_tosugt,  WithSameXMustHaveTempZP               },
-    { "tosuleax",   Opt_a_tosule,  WithSameXMustHaveTempZP               },
-    { "tosultax",   Opt_a_tosult,  WithSameXMustHaveTempZP               },
-    { "tosxorax",   Opt_a_tosxor,  WithSameXCanUseRemovableRhsWithTempZP },
-/* END SORTED.SH */
-};
-
-#define FUNC_COUNT(Table) (sizeof(Table) / sizeof(Table[0]))
-
-
-
-static int CmpFunc (const void* Key, const void* Func)
-/* Compare function for bsearch */
-{
-    return strcmp (Key, ((const OptFuncDesc*) Func)->Name);
-}
-
-
-
-static const OptFuncDesc* FindFunc (const OptFuncDesc FuncTable[], size_t Count, const char* Name)
+static const OptFuncDesc* FindFunc (const OptFuncDesc FuncTable[], const char* Name)
 /* Find the function with the given name. Return a pointer to the table entry
 ** or NULL if the function was not found.
 */
 {
-    return bsearch (Name, FuncTable, Count, sizeof(OptFuncDesc), CmpFunc);
+    const OptFuncDesc* Desc;
+
+    /* Scan through table and find OptFuncDesc matching the Name */
+    for (Desc = FuncTable; Desc->Name != 0; ++Desc) {
+        if (strcmp (Name, Desc->Name) == 0) {
+            /* Found a match */
+            return Desc;
+        }
+    }
+
+    /* Not found */
+    return 0;
 }
 
 
@@ -1868,13 +1804,13 @@ static int PreCondOk (StackOpData* D)
 
 
 
-/*****************************************************************************/
-/*                                   Code                                    */
-/*****************************************************************************/
+/* Note: A subopt MUST commit to every use case (precondition) that it
+**  advertises in its FuncTable. Unhandled advertised cases will result in
+**  stack corruption, because OptStackOps() is committed at the point of call
+**  and cannot back out.
+*/
 
-
-
-unsigned OptStackOps (CodeSeg* S)
+static unsigned OptStackOps (CodeSeg* S, const OptFuncDesc FuncTable[])
 /* Optimize operations that take operands via the stack */
 {
     unsigned        Changes = 0;        /* Number of changes in one run */
@@ -1978,20 +1914,7 @@ unsigned OptStackOps (CodeSeg* S)
                     /* Subroutine call: Check if this is one of the functions,
                     ** we're going to replace.
                     */
-                    /* ### Note: A-only subopts are greedy here. When an A-only
-                    **  subopt exists (by name), only its preconditions are ever
-                    **  checked. There is no fallback to the full A/X subopts.
-                    **  When the A-only preconditions fail, good A/X cases are
-                    **  left unoptimized.
-                    **  The FuncTables should be merged into a single precondition
-                    **  system.
-                    */
-                    if (SameRegXValueAtOp (&Data, E)) {
-                        Data.OptFunc = FindFunc (FuncRegATable, FUNC_COUNT (FuncRegATable), E->Arg);
-                    }
-                    if (Data.OptFunc == 0) {
-                        Data.OptFunc = FindFunc (FuncTable, FUNC_COUNT (FuncTable), E->Arg);
-                    }
+                    Data.OptFunc = FindFunc (FuncTable, E->Arg);
                     if (Data.OptFunc) {
                         /* Disallow removing Rhs loads if the registers are used */
                         SetIfOperandLoadUnremovable (&Data.Rhs, Data.UsedRegs);
@@ -2165,4 +2088,196 @@ unsigned OptStackOps (CodeSeg* S)
 
     /* Return the number of changes made */
     return Changes;
+}
+
+
+
+unsigned OptBZero (CodeSeg* S)
+/* Optimize __bzero operations that take operands via the stack */
+{
+    static const OptFuncDesc FuncTable[] = {
+        { "___bzero",   Opt___bzero,   WithAXlt100CanUseRegVarOrTempZP       },
+        OPTFUNCDESC_SENTINEL    /* Null-terminated list */
+    };
+
+    return OptStackOps (S, FuncTable);
+}
+
+
+
+unsigned OptPtrStore4 (CodeSeg* S)
+/* Optimize staspidx/staxspidx operations that take operands via the stack */
+{
+    static const OptFuncDesc FuncTable[] = {
+        { "staspidx",   Opt_staspidx,  CanUseRegVarOrTempZP                  },
+        { "staxspidx",  Opt_staxspidx, WithUnusedACanUseRegVarOrTempZP       },
+        OPTFUNCDESC_SENTINEL    /* Null-terminated list */
+    };
+
+    return OptStackOps (S, FuncTable);
+}
+
+
+
+unsigned OptStkArith1 (CodeSeg* S)
+/* Optimize arithmetic operations that take operands via the stack
+** where X reg has the same value on left and right sides.
+*/
+{
+    static const OptFuncDesc FuncTable[] = {
+        { "tossubax",   Opt_a_tossub,  WithSameXCanUseRemovableRhsWithTempZP },
+        OPTFUNCDESC_SENTINEL    /* Null-terminated list */
+    };
+
+    return OptStackOps (S, FuncTable);
+}
+
+
+
+unsigned OptStkArith2 (CodeSeg* S)
+/* Optimize arithmetic operations (add/sub) that take operands via the stack */
+{
+    static const OptFuncDesc FuncTable[] = {
+        { "tosaddax",   Opt_tosaddax,  MustHaveTempZP                        },
+        { "tossubax",   Opt_tossubax,  CanUseRemovableRhsWithTempZP          },
+        OPTFUNCDESC_SENTINEL    /* Null-terminated list */
+    };
+
+    return OptStackOps (S, FuncTable);
+}
+
+
+
+unsigned OptStkBitwise1 (CodeSeg* S)
+/* Optimize bitwise operations that take operands via the stack
+** where X reg has the same value on left and right sides.
+*/
+{
+    static const OptFuncDesc FuncTable[] = {
+        { "tosandax",   Opt_a_tosand,  WithSameXCanUseRemovableRhsWithTempZP },
+        { "tosorax",    Opt_a_tosor,   WithSameXCanUseRemovableRhsWithTempZP },
+        { "tosxorax",   Opt_a_tosxor,  WithSameXCanUseRemovableRhsWithTempZP },
+        OPTFUNCDESC_SENTINEL    /* Null-terminated list */
+    };
+
+    return OptStackOps (S, FuncTable);
+}
+
+
+
+unsigned OptStkBitwise2 (CodeSeg* S)
+/* Optimize bitwise operations (and/or/xor) that take operands via the stack */
+{
+    static const OptFuncDesc FuncTable[] = {
+        { "tosandax",   Opt_tosandax,  MustHaveTempZP                        },
+        { "tosorax",    Opt_tosorax,   MustHaveTempZP                        },
+        { "tosxorax",   Opt_tosxorax,  MustHaveTempZP                        },
+        OPTFUNCDESC_SENTINEL    /* Null-terminated list */
+    };
+
+    return OptStackOps (S, FuncTable);
+}
+
+
+
+unsigned OptStkEqOps1 (CodeSeg* S)
+/* Optimize ==/!= operators that take operands via the stack
+** where X reg has the same value on left and right sides.
+*/
+{
+    static const OptFuncDesc FuncTable[] = {
+        { "toseqax",    Opt_a_toseq,   WithSameXMustHaveTempZP               },
+        { "tosneax",    Opt_a_tosne,   WithSameXMustHaveTempZP               },
+        OPTFUNCDESC_SENTINEL    /* Null-terminated list */
+    };
+
+    return OptStackOps (S, FuncTable);
+}
+
+
+
+unsigned OptStkEqOps2 (CodeSeg* S)
+/* Optimize ==/!= operators that take operands via the stack */
+{
+    static const OptFuncDesc FuncTable[] = {
+        { "toseqax",    Opt_toseqax,   CanUseDirectWithRemovableRhsAndTempZP },
+        { "tosneax",    Opt_tosneax,   CanUseDirectWithRemovableRhsAndTempZP },
+        OPTFUNCDESC_SENTINEL    /* Null-terminated list */
+    };
+
+    return OptStackOps (S, FuncTable);
+}
+
+
+
+unsigned OptStkCmpOps1 (CodeSeg* S)
+/* Optimize compare operators that take operands via the stack
+** where X reg has the same value on left and right sides.
+*/
+{
+    static const OptFuncDesc FuncTable[] = {
+        { "tosgeax",    Opt_a_tosuge,  WithSameXMustHaveTempZP               },
+        { "tosgtax",    Opt_a_tosugt,  WithSameXMustHaveTempZP               },
+        { "tosleax",    Opt_a_tosule,  WithSameXMustHaveTempZP               },
+        { "tosltax",    Opt_a_tosult,  WithSameXMustHaveTempZP               },
+        { "tosugeax",   Opt_a_tosuge,  WithSameXMustHaveTempZP               },
+        { "tosugtax",   Opt_a_tosugt,  WithSameXMustHaveTempZP               },
+        { "tosuleax",   Opt_a_tosule,  WithSameXMustHaveTempZP               },
+        { "tosultax",   Opt_a_tosult,  WithSameXMustHaveTempZP               },
+        OPTFUNCDESC_SENTINEL    /* Null-terminated list */
+    };
+
+    return OptStackOps (S, FuncTable);
+}
+
+
+
+unsigned OptStkCmpOps2 (CodeSeg* S)
+/* Optimize compare operators that take operands via the stack */
+{
+    static const OptFuncDesc FuncTable[] = {
+        { "tosgeax",    Opt_tosgeax,   CanUseRemovableRhsWithTempZP          },
+        { "tosltax",    Opt_tosltax,   CanUseRemovableRhsWithTempZP          },
+        { "tosugeax",   Opt_tosugeax,  CanUseRemovableRhsWithTempZP          },
+        { "tosugtax",   Opt_tosugtax,  CanUseRemovableRhsWithTempZP          },
+        { "tosuleax",   Opt_tosuleax,  CanUseRemovableRhsWithTempZP          },
+        { "tosultax",   Opt_tosultax,  CanUseRemovableRhsWithTempZP          },
+        OPTFUNCDESC_SENTINEL    /* Null-terminated list */
+    };
+
+    return OptStackOps (S, FuncTable);
+}
+
+
+
+unsigned OptStkShifts (CodeSeg* S)
+/* Optimize shift operations that take operands via the stack */
+{
+    static const OptFuncDesc FuncTable[] = {
+        { "tosaslax",   Opt_tosaslax,  MustHaveTempZP                        },
+        { "tosasrax",   Opt_tosasrax,  MustHaveTempZP                        },
+        { "tosshlax",   Opt_tosshlax,  MustHaveTempZP                        },
+        { "tosshrax",   Opt_tosshrax,  MustHaveTempZP                        },
+        OPTFUNCDESC_SENTINEL    /* Null-terminated list */
+    };
+
+    return OptStackOps (S, FuncTable);
+}
+
+
+
+/* ### Note: this optimizer is not well-tested and not currently included
+**  in codeopt.c because of that.
+*/
+unsigned OptStkICmp1 (CodeSeg* S)
+/* Optimize tosicmp operations where X reg has the same value on
+** left and right sides.
+*/
+{
+    static const OptFuncDesc FuncTable[] = {
+        { "tosicmp",    Opt_a_tosicmp, WithSameXMustHaveTempZP               },
+        OPTFUNCDESC_SENTINEL    /* Null-terminated list */
+    };
+
+    return OptStackOps (S, FuncTable);
 }

--- a/src/cc65/coptstop.h
+++ b/src/cc65/coptstop.h
@@ -49,8 +49,72 @@
 
 
 
-unsigned OptStackOps (CodeSeg* S);
-/* Optimize operations that take operands via the stack */
+unsigned OptBZero (CodeSeg* S);
+/* Optimize __bzero operations that take operands via the stack */
+
+
+
+unsigned OptPtrStore4 (CodeSeg* S);
+/* Optimize staspidx/staxspidx operations that take operands via the stack */
+
+
+
+unsigned OptStkArith1 (CodeSeg* S);
+/* Optimize arithmetic operations that take operands via the stack
+** where X reg has the same value on left and right sides.
+*/
+
+
+unsigned OptStkArith2 (CodeSeg* S);
+/* Optimize arithmetic operations (add/sub) that take operands via the stack */
+
+
+
+unsigned OptStkBitwise1 (CodeSeg* S);
+/* Optimize bitwise operations that take operands via the stack
+** where X reg has the same value on left and right sides.
+*/
+
+
+
+unsigned OptStkBitwise2 (CodeSeg* S);
+/* Optimize bitwise operations (and/or/xor) that take operands via the stack */
+
+
+
+unsigned OptStkCmpOps1 (CodeSeg* S);
+/* Optimize compare operators that take operands via the stack
+** where X reg has the same value on left and right sides.
+*/
+
+
+
+unsigned OptStkCmpOps2 (CodeSeg* S);
+/* Optimize compare operators that take operands via the stack */
+
+
+
+unsigned OptStkEqOps1 (CodeSeg* S);
+/* Optimize ==/!= operators that take operands via the stack
+** where X reg has the same value on left and right sides.
+*/
+
+
+
+unsigned OptStkEqOps2 (CodeSeg* S);
+/* Optimize ==/!= operators that take operands via the stack */
+
+
+
+unsigned OptStkShifts (CodeSeg* S);
+/* Optimize shift operations that take operands via the stack */
+
+
+
+unsigned OptStkICmp1 (CodeSeg* S);
+/* Optimize tosicmp operations where X reg has the same value on
+** left and right sides.
+*/
 
 
 


### PR DESCRIPTION
## Summary

This splits the monolithic `OptStackOps` optimizer into 12 top-level optimizers with operations grouped by operand size + operator kind. The change immediately enables optimization cases previously left behind through: (a) better ordering of optimizer steps (arithmetic and bitwise before compares); (b) automatic fallback from reg A-only optimizers to full AX ones.
The code size factors assigned to the top-level optimizers is currently unchanged from `OptStackOps` (all 100), and may need to be reviewed in the future.

Benefits:
- Finer control over optimizer step ordering and enable/disable state.
- Improved optimizer step statistics.
- Easier optimizer troubleshooting.

The drawback is more passes to be made over the code segments. But that does not appear to have a significant effect on the compilation speed.

c65-Chess compiled binaries are ~20 bytes smaller.

Observed compiled binary size reduction in the testbench (`diff` over `ls -lUR testwrk`):
```diff
--- cc65-git-head-test-sizes.lst	2026-04-11 09:15:44.870373100 -0400
+++ cc65-refactor-2-test-sizes.lst	2026-04-11 09:16:57.716798700 -0400

-pointer2.O.6502.prg 2923
+pointer2.O.6502.prg 2902
-pointer2.O.65c02.prg 2905
+pointer2.O.65c02.prg 2885

-bitfield-1.O.6502.prg 2941
+bitfield-1.O.6502.prg 2901
-bitfield-1.O.65c02.prg 2909
+bitfield-1.O.65c02.prg 2876

-bitfield-union.O.6502.prg 2807
+bitfield-union.O.6502.prg 2753
-bitfield-union.O.65c02.prg 2767
+bitfield-union.O.65c02.prg 2726

-bug1462-biefield-assign-1.O.6502.prg 3374
+bug1462-biefield-assign-1.O.6502.prg 3350
-bug1462-biefield-assign-1.O.65c02.prg 3350
+bug1462-biefield-assign-1.O.65c02.prg 3327

-bug1462-biefield-assign-2.O.6502.prg 2694
+bug1462-biefield-assign-2.O.6502.prg 2672
-bug1462-biefield-assign-2.O.65c02.prg 2676
+bug1462-biefield-assign-2.O.65c02.prg 2655

-bug1462-biefield-assign-3.O.6502.prg 3646
+bug1462-biefield-assign-3.O.6502.prg 3596
-bug1462-biefield-assign-3.O.65c02.prg 3621
+bug1462-biefield-assign-3.O.65c02.prg 3572

-bug2395.O.6502.prg 4441
+bug2395.O.6502.prg 4335
-bug2395.O.65c02.prg 4421
+bug2395.O.65c02.prg 4318

-bug2947.O.6502.prg 3862
+bug2947.O.6502.prg 3786
-bug2947.O.65c02.prg 3837
+bug2947.O.65c02.prg 3759

-cq85.O.6502.prg 3323
+cq85.O.6502.prg 3293
-cq85.O.65c02.prg 3311
+cq85.O.65c02.prg 3282
```

## Checklist

- [ ] The fix meets the codestyle requirements
- [ ] New unit tests have been added to prevent future regressions
