### PR TITLE
Fix sp65 PCX reader: 1bpp monochrome path wrote past bitmap allocation

### DIFF
--- a/src/sp65/pcx.c
+++ b/src/sp65/pcx.c
@@ -381,24 +381,15 @@ Bitmap* ReadPCXFile (const Collection* A)
 
         /* This is either monochrome or indexed */
         if (P->BPP == 1) {
-            /* Monochrome */
+            /* Monochrome (ReadPlane already expands bits to bytes) */
             for (Y = 0, Px = B->Data; Y < P->Height; ++Y) {
-
-                unsigned I;
-                unsigned char Mask;
 
                 /* Read the plane */
                 ReadPlane (F, P, L);
 
                 /* Create pixels */
-                for (X = 0, I = 0, Mask = 0x01; X < P->Width; ++Px) {
-                    Px->Index = (L[I] & Mask) != 0;
-                    if (Mask == 0x80) {
-                        Mask = 0x01;
-                        ++I;
-                    } else {
-                        Mask <<= 1;
-                    }
+                for (X = 0; X < P->Width; ++X, ++Px) {
+                    Px->Index = L[X];
                 }
 
             }


### PR DESCRIPTION
ReadPlane() already expands packed bits to one byte per pixel for case 1 (1bpp), but the loop in ReadPCXFile treated the buffer as still-packed bits using a mask-and-shift pattern. The for-loop also failed to increment X, causing an infinite loop that wrote past the allocated bitmap and triggered SIGBUS.

## Summary

Fix: use the same direct L[X] indexing as the 8bpp path, matching ReadPlane's pre-expanded output.

## Checklist

- [X] The fix meets the codestyle requirements
