### PR TITLE
fix: remove unsafe exec() in kimHello.c

### DIFF
--- a/samples/kim1/kimHello.c
+++ b/samples/kim1/kimHello.c
@@ -17,7 +17,7 @@ int main (void)
    printf ("\nHello World!\n\n");
    printf ("Type a line and press ENTER, please.\n\n");
 
-   gets( str );
+   fgets( str, sizeof(str), stdin );
 
    printf ("\n\nThanks: %s\n\n", str);
    return 0;


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `samples/kim1/kimHello.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `samples/kim1/kimHello.c:20` |

**Description**: The program uses gets() to read user input into a fixed-size buffer 'str' with absolutely no length restriction. gets() is a banned function that was removed from the C11 standard precisely because it cannot be used safely under any circumstances. Any input longer than the allocated buffer size will overwrite adjacent stack memory, including the saved return address, enabling an attacker to redirect program execution to arbitrary code.

## Changes
- `samples/kim1/kimHello.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
