### PR TITLE
Make noexec check portable across BSD and GNU find

### DIFF
--- a/.github/checks/noexec.sh
+++ b/.github/checks/noexec.sh
@@ -1,19 +1,22 @@
 #! /bin/bash
+
 OLDCWD=`pwd`
-SCRIPT_PATH=`dirname $0`
+SCRIPT_PATH=`dirname "$0"`
 CHECK_PATH=.
+FOUND=0
 
-cd $SCRIPT_PATH/../../
+cd "$SCRIPT_PATH/../../"
 
-FILES=`find $CHECK_PATH -executable -type f \( -name \*.inc -o -name Makefile -o -name \*.cfg -o -name \*.\[chs\] -o -name \*.mac -o -name \*.asm -o -name \*.sgml \) -print`
+while IFS= read -r FILE; do
+    if [ -x "$FILE" ]; then
+        if [ $FOUND -eq 0 ]; then
+            echo "error: executable flag is set for the following files:" >&2
+        fi
+        echo "$FILE" >&2
+        FOUND=1
+    fi
+done < <(find $CHECK_PATH -type f \( -name \*.inc -o -name Makefile -o -name \*.cfg -o -name \*.\[chs\] -o -name \*.mac -o -name \*.asm -o -name \*.sgml \) -print)
 
-cd $OLDCWD
+cd "$OLDCWD"
 
-if [ x"$FILES"x != xx ]; then
-    echo "error: executable flag is set for the following files:" >&2
-    for n in $FILES; do
-        echo $n >&2
-    done
-    exit -1
-fi
-exit 0
+exit $FOUND


### PR DESCRIPTION
## Summary

- avoid GNU-specific `find -executable` in the noexec style check
- keep the existing Makefile targets unchanged
- keep the check usable on both BSD/macOS and GNU/Linux find implementations

## Why

The existing check uses `find -executable`, which is not supported by BSD `find` on macOS. This makes `make checkstyle` emit a portability error on macOS even though the overall check can still complete.

## Validation

- `make checkstyle` on macOS

## Scope

This is a build/style portability fix only. No runtime code or user-facing behavior is changed.