### PR TITLE
Fix RP6502 RIA readline error return

### DIFF
--- a/libsrc/rp6502/ria_rln_peek.c
+++ b/libsrc/rp6502/ria_rln_peek.c
@@ -4,13 +4,12 @@ int __fastcall__ ria_rln_peek (char* peek, unsigned char* pos)
 {
     int i, ax;
     ax = ria_call_int (RIA_OP_RLN_PEEK);
-    if (ax > 0) {
-        *pos = ria_pop_char ();
-        for (i = 0; i < ax; i++) {
-            peek[i] = ria_pop_char ();
-        }
-    } else {
-        *pos = 0;
+    if (ax < 0) {
+        return ax;
+    }
+    *pos = ria_pop_char ();
+    for (i = 0; i < ax; i++) {
+        peek[i] = ria_pop_char ();
     }
     peek[ax] = 0;
     return ax;


### PR DESCRIPTION
## Summary

- return immediately from `ria_rln_peek()` when the RIA call reports an error
- keep successful zero-length reads stack-balanced by still popping the returned position
- remove the `ria_execl()` / `ria_execv()` changes from this PR

## Why

This follows the RP6502 maintainer feedback in the discussion. The accepted part is the `ria_rln_peek()` error-path cleanup; the exec argument changes were dropped because XSTACK and OS-level validation already cover those cases.

## Validation

- `make checkstyle` passed
- `make bin` passed
- `make lib` passed
- `make test` was started after the reduced patch and progressed into `sim65c02` validation without a visible failure, but was stopped locally because the full matrix runtime was excessive
- GitHub PR CI is running the full Linux and Windows validation for the pushed commit