### PR TITLE
Fix scanning of /* when CComments is disabled

### DIFF
--- a/src/ca65/scanner.c
+++ b/src/ca65/scanner.c
@@ -1389,15 +1389,13 @@ CharAgain:
 
         case '/':
             NextChar ();
-            if (C != '*') {
-                CurTok.Tok = TOK_DIV;
-            } else if (CComments) {
+            if (C == '*' && CComments) {
                 /* Remember the position, then skip the '*' */
                 Collection LineInfos = STATIC_COLLECTION_INITIALIZER;
                 GetFullLineInfo (&LineInfos);
                 NextChar ();
                 do {
-                    while (C !=  '*') {
+                    while (C != '*') {
                         if (C == EOF) {
                             LIError (&LineInfos, "Unterminated comment");
                             ReleaseFullLineInfo (&LineInfos);
@@ -1412,6 +1410,8 @@ CharAgain:
                 ReleaseFullLineInfo (&LineInfos);
                 DoneCollection (&LineInfos);
                 goto Again;
+            } else {
+                CurTok.Tok = TOK_DIV;
             }
             return;
 

--- a/test/asm/val/ccomments.s
+++ b/test/asm/val/ccomments.s
@@ -2,8 +2,11 @@
 
 ; both expressions are valid with c_comments disabled
 .feature c_comments -
-.word 8 / *
-.word 8/*  
+
+.org $0002
+.assert 8 / * = 4, error, "8 / * should evaluate to 4"
+.assert 8/* = 4, error, "8/* should evaluate to 4"
+.reloc 
 
 _main:
     lda #0

--- a/test/asm/val/ccomments.s
+++ b/test/asm/val/ccomments.s
@@ -1,0 +1,11 @@
+.export _main
+
+; both expressions are valid with c_comments disabled
+.feature c_comments -
+.word 8 / *
+.word 8/*  
+
+_main:
+    lda #0
+    tax
+    rts


### PR DESCRIPTION
## Summary

An oversight in the ca65 scanner causes an error to be produced when a `*` token immediately follows a `/` token, even when the `c_comments` feature is disabled. Specifically:

```c
case '/':
    NextChar ();
    if (C != '*') {
        CurTok.Tok = TOK_DIV;
    } else if (CComments) {
         /* ... skip the comment ... */
         goto Again;
    }
    return;
```

In the case where `C` is `*`, but `CComments` is *disabled*, `CurTok.Tok` is never assigned and the previous token is simply repeated. This PR clarifies the conditional expression and ensures that the token is correctly assigned everywhere that is should be.

## Checklist

- [x] The fix meets the codestyle requirements
- [x] New unit tests have been added to prevent future regressions
- [x] The documentation has been updated if necessary
