### PR TITLE
RP6502 __argv_mem()

### DIFF
--- a/libsrc/rp6502/argv_mem.s
+++ b/libsrc/rp6502/argv_mem.s
@@ -1,12 +1,12 @@
 ;
-; Default argv_mem: returns NULL so argc/argv are silently skipped.
+; Default __argv_mem: returns NULL so argc/argv are silently skipped.
 ; Override by providing storage for argv, e.g.
-; void *__fastcall__ argv_mem(size_t size) { return malloc(size); }
+; void *__fastcall__ __argv_mem(size_t size) { return malloc(size); }
 ;
 
-.export _argv_mem
+.export ___argv_mem
 
-.proc _argv_mem
+.proc ___argv_mem
 
         lda     #0
         tax

--- a/libsrc/rp6502/crt0.s
+++ b/libsrc/rp6502/crt0.s
@@ -3,7 +3,7 @@
 ;
 ; crt0.s
 
-.export _init, _exit
+.export _exit
 .import callmain
 
 .export __STARTUP__ : absolute = 1
@@ -17,7 +17,7 @@
 .segment  "STARTUP"
 
 ; Essential 6502 startup the CPU doesn't do
-_init:
+init:
     ldx #$FF
     txs
     cld

--- a/libsrc/rp6502/mainargs.s
+++ b/libsrc/rp6502/mainargs.s
@@ -2,9 +2,9 @@
 ; mainargs.s
 ;
 
-; Lower priority than initheap so argv_mem() can use malloc().
+; Lower priority than initheap so __argv_mem() can use malloc().
 .constructor initmainargs, 23
-.import __argc, __argv, _argv_mem
+.import __argc, __argv, ___argv_mem
 .import incax2
 .importzp ptr1, ptr2
 .include "rp6502.inc"
@@ -26,12 +26,12 @@
     ora     ptr2
     beq     zxstack    ; count == 0
 
-    ; Request memory; _argv_mem may clobber.
+    ; Request memory; __argv_mem may clobber.
     lda     ptr2
     ldx     ptr2+1
     pha
     phx
-    jsr     _argv_mem
+    jsr     ___argv_mem
     ply
     sty     ptr2+1
     ply


### PR DESCRIPTION
The llvm-mos team wants double underbars here. Changing this to maintain parity.