### PR TITLE
Revert "Serial: Optimize SER_GET"

### DIFF
--- a/libsrc/apple2/ser/a2.ssc.s
+++ b/libsrc/apple2/ser/a2.ssc.s
@@ -354,8 +354,13 @@ Out:
 
 SER_GET:
         ldx     Index
+        ldy     SendFreeCnt     ; Send data if necessary
+        iny                     ; Y == $FF?
+        beq     :+
+        lda     #$00            ; TryHard = false
+        jsr     TryToSend
 
-        lda     RecvFreeCnt     ; Check for buffer empty
+:       lda     RecvFreeCnt     ; Check for buffer empty
         cmp     #$FF
         bne     :+
         lda     #SER_ERR_NO_DATA

--- a/libsrc/atmos/ser/atmos-acia.s
+++ b/libsrc/atmos/ser/atmos-acia.s
@@ -227,8 +227,14 @@ InvBaud:lda     #<SER_ERR_BAUD_UNAVAIL
 ; returned.
 
 SER_GET:
+        ldy     SendFreeCnt     ; Send data if necessary
+        iny                     ; Y == $FF?
+        beq     :+
+        lda     #$00            ; TryHard = false
+        jsr     TryToSend
+
         ; Check for buffer empty
-        lda     RecvFreeCnt     ; (25)
+:       lda     RecvFreeCnt     ; (25)
         cmp     #$FF
         bne     :+
         lda     #SER_ERR_NO_DATA

--- a/libsrc/c128/ser/c128-swlink.s
+++ b/libsrc/c128/ser/c128-swlink.s
@@ -314,10 +314,15 @@ SER_CLOSE:
 ;
 
 SER_GET:
+        ldx     SendFreeCnt             ; Send data if necessary
+        inx                             ; X == $FF?
+        beq     @L1
+        lda     #$00
+        jsr     TryToSend
 
 ; Check for buffer empty
 
-        lda     RecvFreeCnt             ; (25)
+@L1:    lda     RecvFreeCnt             ; (25)
         cmp     #$ff
         bne     @L2
         lda     #SER_ERR_NO_DATA

--- a/libsrc/c64/ser/c64-swlink.s
+++ b/libsrc/c64/ser/c64-swlink.s
@@ -288,10 +288,15 @@ SER_CLOSE:
 ;
 
 SER_GET:
+        ldx     SendFreeCnt             ; Send data if necessary
+        inx                             ; X == $FF?
+        beq     @L1
+        lda     #$00
+        jsr     TryToSend
 
 ; Check for buffer empty
 
-        lda     RecvFreeCnt             ; (25)
+@L1:    lda     RecvFreeCnt             ; (25)
         cmp     #$ff
         bne     @L2
         lda     #SER_ERR_NO_DATA

--- a/libsrc/cbm510/ser/cbm510-std.s
+++ b/libsrc/cbm510/ser/cbm510-std.s
@@ -244,10 +244,15 @@ InvBaud:
 ;
 
 SER_GET:
+        ldx     SendFreeCnt             ; Send data if necessary
+        inx                             ; X == $FF?
+        beq     @L1
+        lda     #$00
+        jsr     TryToSend
 
 ; Check for buffer empty
 
-        lda     RecvFreeCnt
+@L1:    lda     RecvFreeCnt
         cmp     #$ff
         bne     @L2
         lda     #SER_ERR_NO_DATA

--- a/libsrc/cbm610/ser/cbm610-std.s
+++ b/libsrc/cbm610/ser/cbm610-std.s
@@ -245,10 +245,15 @@ InvBaud:
 ;
 
 SER_GET:
+        ldx     SendFreeCnt             ; Send data if necessary
+        inx                             ; X == $FF?
+        beq     @L1
+        lda     #$00
+        jsr     TryToSend
 
 ; Check for buffer empty
 
-        lda     RecvFreeCnt
+@L1:    lda     RecvFreeCnt
         cmp     #$ff
         bne     @L2
         lda     #SER_ERR_NO_DATA

--- a/libsrc/plus4/ser/plus4-stdser.s
+++ b/libsrc/plus4/ser/plus4-stdser.s
@@ -252,10 +252,15 @@ InvBaud:
 ;
 
 SER_GET:
+        ldx     SendFreeCnt             ; Send data if necessary
+        inx                             ; X == $FF?
+        beq     @L1
+        lda     #$00
+        jsr     TryToSend
 
 ; Check for buffer empty
 
-        lda     RecvFreeCnt             ; (25)
+@L1:    lda     RecvFreeCnt             ; (25)
         cmp     #$ff
         bne     @L2
         lda     #SER_ERR_NO_DATA


### PR DESCRIPTION
This reverts commit 734541ee05000bad9e9dd2f903a2db754e8c36f3. 
Fixes #2974.
The ACIA can't send while RTS is off, so this commit was wrong.
