### PR TITLE
Fix plus4 cgetc() returning a phantom key in bitmap mode

### DIFF
--- a/libsrc/plus4/cgetc.s
+++ b/libsrc/plus4/cgetc.s
@@ -18,15 +18,19 @@ _cgetc: lda     KEY_COUNT       ; Get number of characters
         ora     FKEY_COUNT      ; Or with number of function key chars
         bne     L2              ; Jump if there are already chars waiting
 
-        lda     #%00100000
-        bit     $FF06
-        bne     L2              ; always disable cursor if in bitmap mode
-
-; Switch on the cursor if needed
+; Save the character under the cursor, wait for a key, then put it back.  In
+; bitmap mode there is no cursor to show, so the save and restore are
+; effectively a no-op.
 
         ldy     CURS_X
         lda     (CRAM_PTR),y    ; Get current char
         pha                     ; And save it
+
+        lda     #%00100000
+        bit     $FF06
+        bne     L1              ; No cursor in bitmap mode
+
+; Switch on the cursor if needed
 
         lda     CHARCOLOR
         sta     (CRAM_PTR),y


### PR DESCRIPTION
## Summary

In bitmap mode `cgetc()` returns a character that was never typed.

The bitmap-mode test added with the Plus/4 TGI driver (3bd4d05) branches to
`L2`, which skips the `L1` wait loop as well as the cursor drawing. In bitmap
mode `cgetc()` therefore never blocks: it calls `KBDREAD` with an empty buffer,
and `KBDREAD` decrements `KEY_COUNT` past zero. From then on `kbhit()` reports
waiting characters and every read returns garbage.

This moves the test below the `pha`, so only the cursor drawing is skipped and
the existing wait loop is shared. The save/restore either side of the wait then
collapses to a no-op in bitmap mode, which is cheaper than a second wait loop.

## Verification

This test paints the border once `cgetc()` returns. Before the patch, the border
turns red when the program starts, with no key pressed. After the patch it stays
at its default colour until a key is pressed and then turns red, as expected.

```c
#include <conio.h>

int main(void)
{
    *(unsigned char*)0xFF06 |= 0x20;        /* TED bitmap mode            */
    cgetc();                                /* should wait for a key      */
    for(;;)
        *(unsigned char*)0xFF19 = 0x72;     /* red border once it returns */
}
```
After the patch, it changes the border after a key was pressed, as expected.